### PR TITLE
Fixed warnings

### DIFF
--- a/CP77.CR2W/CR2W/CR2WExport.cs
+++ b/CP77.CR2W/CR2W/CR2WExport.cs
@@ -290,9 +290,9 @@ namespace CP77.CR2W
                         variable.Variables = TryGetClassVariables(variable.Size);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-
+                    // TODO: Are we intentionally swallowing this?
                 }
                 
 
@@ -300,7 +300,7 @@ namespace CP77.CR2W
                 br.BaseStream.Seek(endoffset, SeekOrigin.Begin);
                 o.Variables.Add(variable);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     return o;
                 }
@@ -358,7 +358,7 @@ namespace CP77.CR2W
                         br.BaseStream.Seek(endoffset, SeekOrigin.Begin);
                         ret.Add(variable);
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         return null;
                     }

--- a/CP77.CR2W/Extensions/StreamExtensions.cs
+++ b/CP77.CR2W/Extensions/StreamExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using RED.CRC32;
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using CP77.CR2W.Types;
 
 namespace CP77.CR2W
 {
@@ -11,29 +8,20 @@ namespace CP77.CR2W
     {
         public static T ReadStruct<T>(this Stream m_stream, Crc32Algorithm crc32 = null) where T : struct
         {
-            try
-            {
-                var size = Marshal.SizeOf<T>();
+            var size = Marshal.SizeOf<T>();
 
-                var m_temp = new byte[size];
-                m_stream.Read(m_temp, 0, size);
+            var m_temp = new byte[size];
+            m_stream.Read(m_temp, 0, size);
 
-                var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
-                var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
+            var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
 
-                if (crc32 != null)
-                    crc32.Append(m_temp);
+            if (crc32 != null)
+                crc32.Append(m_temp);
 
-                handle.Free();
+            handle.Free();
 
-                return item;
-            }
-            catch (Exception ex)
-            {
-
-                throw ex;
-            }
-            
+            return item;
         }
         public static T[] ReadStructs<T>(this Stream m_stream, uint count, Crc32Algorithm crc32 = null) where T : struct
         {

--- a/CP77.CR2W/Extensions/W3ReaderExtensions.cs
+++ b/CP77.CR2W/Extensions/W3ReaderExtensions.cs
@@ -1,8 +1,5 @@
-﻿using RED.CRC32;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using CP77.CR2W.Types;
 
@@ -185,7 +182,7 @@ namespace CP77.CR2W
             if (unknownFlag)
             {
                 throw new NotImplementedException();
-                readstring = Encoding.Unicode.GetString(br.ReadBytes((len * 2) - 1));
+                // readstring = Encoding.Unicode.GetString(br.ReadBytes((len * 2) - 1));
             }
             else
                 readstring = Encoding.GetEncoding("ISO-8859-1").GetString(br.ReadBytes(len - 1));

--- a/CP77.CR2W/Modkit/Import.cs
+++ b/CP77.CR2W/Modkit/Import.cs
@@ -1,14 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Catel.IoC;
-using WolvenKit.Common.Services;
-using CP77.CR2W.Archive;
 using CP77.CR2W.Types;
-using CP77Tools.Model;
 using WolvenKit.Common;
 using WolvenKit.Common.DDS;
 
@@ -69,7 +62,7 @@ namespace CP77.CR2W
                 {
                     TexconvWrapper.Convert(rawFile.Directory.FullName, $"{ddsPath}", EUncookExtension.dds);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     //TODO: proper exception handling
                     return null;

--- a/CP77.CR2W/Modkit/Rebuild.cs
+++ b/CP77.CR2W/Modkit/Rebuild.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Catel.IoC;
 using WolvenKit.Common.Services;
 using WolvenKit.Common;
@@ -41,7 +39,7 @@ namespace CP77.CR2W
                 br.BaseStream.Seek(0, SeekOrigin.Begin);
                 cr2w.Read(br);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }
@@ -73,7 +71,7 @@ namespace CP77.CR2W
                 br.BaseStream.Seek(0, SeekOrigin.Begin);
                 cr2w.ReadImportsAndBuffers(br);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }
@@ -299,9 +297,6 @@ namespace CP77.CR2W
                                 fs.Seek(128, SeekOrigin.Begin);
                                 return br.ReadBytes((int)fs.Length - 128);
                             }
-                            break;
-                        default:
-                            break;
                     }
                 }
                 else

--- a/CP77.CR2W/Modkit/Uncook.cs
+++ b/CP77.CR2W/Modkit/Uncook.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -254,7 +253,7 @@ namespace CP77.CR2W
                             TexconvWrapper.Convert(di.FullName, $"{newpath}", uncookext);
                             uncooksuccess = true;
                         }
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             uncooksuccess = false;
                         }

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemController.cs
@@ -1,7 +1,5 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.MSTests/ArchiveTests.cs
+++ b/CP77.MSTests/ArchiveTests.cs
@@ -1,20 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.IO;
-using System.IO.MemoryMappedFiles;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Catel.IoC;
-using WolvenKit.Common.Services;
-using CP77.CR2W;
-using CP77.CR2W.Archive;
-using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using WolvenKit.Common;
 
 namespace CP77.MSTests
 {
@@ -33,8 +17,7 @@ namespace CP77.MSTests
             
         }
 
-
-        private void test_archive(string extension = null)
+        /*private void test_archive(string extension = null)
         {
             var resultDir = Path.Combine(Environment.CurrentDirectory, TestResultsDirectory);
             Directory.CreateDirectory(resultDir);
@@ -42,9 +25,6 @@ namespace CP77.MSTests
             var success = true;
 
             List<Archive> archives;
-
-
-
-        }
+        }*/
     }
 }

--- a/CP77Tools/Commands/CR2WCommand.cs
+++ b/CP77Tools/Commands/CR2WCommand.cs
@@ -5,8 +5,8 @@ namespace CP77Tools.Commands
 {
     public class CR2WCommand : Command
     {
-        private static string Name = "cr2w";
-        private static string Description = "Target a specific cr2w (extracted) file and dumps file information.";
+        private new const string Name = "cr2w";
+        private new const string Description = "Target a specific cr2w (extracted) file and dumps file information.";
 
         public CR2WCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/DumpCommand.cs
+++ b/CP77Tools/Commands/DumpCommand.cs
@@ -6,8 +6,8 @@ namespace CP77Tools.Commands
 {
     public class DumpCommand : Command
     {
-        private static string Name = "dump";
-        private static string Description = "Target an archive or a directory to dump archive information.";
+        private new const string Name = "dump";
+        private new const string Description = "Target an archive or a directory to dump archive information.";
         
         public DumpCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/ExportCommand.cs
+++ b/CP77Tools/Commands/ExportCommand.cs
@@ -6,8 +6,8 @@ namespace CP77Tools.Commands
 {
     public class ExportCommand : Command
     {
-        private static string Name = "export";
-        private static string Description = "Export a file or a list of files into raw files.";
+        private new const string Name = "export";
+        private new const string Description = "Export a file or a list of files into raw files.";
         
         public ExportCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/HashCommand.cs
+++ b/CP77Tools/Commands/HashCommand.cs
@@ -6,8 +6,8 @@ namespace CP77Tools.Commands
 {
     public class HashCommand : Command
     {
-        private static string Name = "hash";
-        private static string Description = "Some helper functions related to hashes.";
+        private new const string Name = "hash";
+        private new const string Description = "Some helper functions related to hashes.";
 
         public HashCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/OodleCommand.cs
+++ b/CP77Tools/Commands/OodleCommand.cs
@@ -5,8 +5,8 @@ namespace CP77Tools.Commands
 {
     public class OodleCommand : Command
     {
-        private static string Name = "oodle";
-        private static string Description = "Some helper functions related to oodle compression.";
+        private new const string Name = "oodle";
+        private new const string Description = "Some helper functions related to oodle compression.";
 
         public OodleCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/PackCommand.cs
+++ b/CP77Tools/Commands/PackCommand.cs
@@ -5,8 +5,8 @@ namespace CP77Tools.Commands
 {
     public class PackCommand : Command
     {
-        private static string Name = "pack";
-        private static string Description = "Pack a folder of files into an .archive file.";
+        private new const string Name = "pack";
+        private new const string Description = "Pack a folder of files into an .archive file.";
         
         public PackCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/RebuildCommand.cs
+++ b/CP77Tools/Commands/RebuildCommand.cs
@@ -5,8 +5,8 @@ namespace CP77Tools.Commands
 {
     public class RebuildCommand : Command
     {
-        private static string Name = "rebuild";
-        private static string Description = "Recombine split buffers and textures in a folder.";
+        private new const string Name = "rebuild";
+        private new const string Description = "Recombine split buffers and textures in a folder.";
         
         public RebuildCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/UnbundleCommand.cs
+++ b/CP77Tools/Commands/UnbundleCommand.cs
@@ -6,8 +6,8 @@ namespace CP77Tools.Commands
 {
     public class UnbundleCommand : Command
     {
-        private static string Name = "unbundle";
-        private static string Description = "Target an archive to extract files.";
+        private new const string Name = "unbundle";
+        private new const string Description = "Target an archive to extract files.";
         
         public UnbundleCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/UncookCommand.cs
+++ b/CP77Tools/Commands/UncookCommand.cs
@@ -7,8 +7,8 @@ namespace CP77Tools.Commands
 {
     public class UncookCommand : Command
     {
-        private static string Name = "uncook";
-        private static string Description = "Target an archive to uncook files.";
+        private new const string Name = "uncook";
+        private new const string Description = "Target an archive to uncook files.";
         
         public UncookCommand() : base(Name, Description)
         {

--- a/CP77Tools/Commands/VerifyCommand.cs
+++ b/CP77Tools/Commands/VerifyCommand.cs
@@ -6,8 +6,8 @@ namespace CP77Tools.Commands
 {
     public class VerifyCommand : Command
     {
-        private static string Name = "verify";
-        private static string Description = "Some helper functions related to cr2w files.";
+        private new const string Name = "verify";
+        private new const string Description = "Some helper functions related to cr2w files.";
 
         public VerifyCommand() : base(Name, Description)
         {

--- a/CP77Tools/Program.cs
+++ b/CP77Tools/Program.cs
@@ -4,14 +4,11 @@ using System.Threading.Tasks;
 using Catel.IoC;
 using System.CommandLine;
 using System.ComponentModel;
-using System.Configuration;
 using System.IO;
-using System.Reflection;
 using CP77Tools.Commands;
 using CP77Tools.Extensions;
 using Luna.ConsoleProgressBar;
 using Microsoft.Win32;
-using WolvenKit.Common.Oodle;
 using WolvenKit.Common.Services;
 
 namespace CP77Tools
@@ -26,11 +23,10 @@ namespace CP77Tools
 
             var logger = ServiceLocator.Default.ResolveType<ILoggerService>();
             var hashService = ServiceLocator.Default.ResolveType<IHashService>();
-            logger.OnStringLogged += delegate (object? sender, LogStringEventArgs args)
+            logger.OnStringLogged += delegate (object sender, LogStringEventArgs args)
             {
                 switch (args.Logtype)
                 {
-                    
                     case Logtype.Error:
                         Console.ForegroundColor = ConsoleColor.Red;
                         break;
@@ -101,7 +97,7 @@ namespace CP77Tools
                     var parsed = CommandLineExtensions.ParseText(line, ' ', '"');
 
                     logger.PropertyChanged += OnLoggerOnPropertyChanged;
-                    void OnLoggerOnPropertyChanged(object? sender, PropertyChangedEventArgs args)
+                    void OnLoggerOnPropertyChanged(object sender, PropertyChangedEventArgs args)
                     {
                         switch (args.PropertyName)
                         {
@@ -150,8 +146,12 @@ namespace CP77Tools
                     return;
 
                 var t = DateTime.Now.ToString("yyyyMMddHHmmss");
-                var fi = new FileInfo(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                    $"errorlogs/log_{t}.txt"));
+
+                var baseDirectory = AppContext.BaseDirectory;
+
+                if (string.IsNullOrEmpty(baseDirectory)) return;
+                
+                var fi = new FileInfo(Path.Combine(baseDirectory, $"errorlogs/log_{t}.txt"));
                 if (fi.Directory != null)
                 {
                     Directory.CreateDirectory(fi.Directory.FullName);
@@ -230,9 +230,9 @@ namespace CP77Tools
                 if (File.Exists(cp77exe))
                     cp77BinDir = new FileInfo(cp77exe).Directory.FullName;
             }
-            catch (Exception e)
+            catch (Exception)
             {
-
+                return null;
             }
 
             if (string.IsNullOrEmpty(cp77BinDir))

--- a/CP77Tools/Tasks/DumpTask.cs
+++ b/CP77Tools/Tasks/DumpTask.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-//using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -35,8 +34,7 @@ namespace CP77Tools.Tasks
 
         public List<CR2WExportWrapper> Chunks { get; set; }
 
-        public List<CR2WExportWrapper.Cr2wVariableDumpObject> ChunkData { get; } =
-            new List<CR2WExportWrapper.Cr2wVariableDumpObject>();
+        public List<CR2WExportWrapper.Cr2wVariableDumpObject> ChunkData { get; } = new();
 
         public string Filename { get; set; }
     }
@@ -162,7 +160,7 @@ namespace CP77Tools.Tasks
                                 {
                                     cr2w.ReadImportsAndBuffers(br);
                                 }
-                                catch (Exception e)
+                                catch (Exception)
                                 {
                                     return;
                                 }

--- a/WolvenKit.Bundles/WolvenKit.Bundles.csproj
+++ b/WolvenKit.Bundles/WolvenKit.Bundles.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows</TargetFrameworks>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 

--- a/WolvenKit.CR2W/CR2W/CR2WEmbedded.cs
+++ b/WolvenKit.CR2W/CR2W/CR2WEmbedded.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Linq;
 using System.Threading.Tasks;
 using WolvenKit.Common;
-using WolvenKit.Common.Model;
 
 namespace WolvenKit.CR2W
 {
@@ -97,12 +96,12 @@ namespace WolvenKit.CR2W
         public async Task<CR2WFile> GetParsedFile()
         {
             var parsedFile = new CR2WFile();
-            switch (await parsedFile.Read(Data))
+            switch (await parsedFile.ReadAsync(Data))
             {
-                case (EFileReadErrorCodes)EFileReadErrorCodes.NoError:
+                case EFileReadErrorCodes.NoError:
                     break;
-                case (EFileReadErrorCodes)EFileReadErrorCodes.NoCr2w:
-                case (EFileReadErrorCodes)EFileReadErrorCodes.UnsupportedVersion:
+                case EFileReadErrorCodes.NoCr2w:
+                case EFileReadErrorCodes.UnsupportedVersion:
                     return null;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/WolvenKit.CR2W/Extensions/StreamExtensions.cs
+++ b/WolvenKit.CR2W/Extensions/StreamExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using RED.CRC32;
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using WolvenKit.CR2W.Types;
 
 namespace WolvenKit.CR2W
 {
@@ -11,29 +8,20 @@ namespace WolvenKit.CR2W
     {
         public static T ReadStruct<T>(this Stream m_stream, Crc32Algorithm crc32 = null) where T : struct
         {
-            try
-            {
-                var size = Marshal.SizeOf<T>();
+            var size = Marshal.SizeOf<T>();
 
-                var m_temp = new byte[size];
-                m_stream.Read(m_temp, 0, size);
+            var m_temp = new byte[size];
+            m_stream.Read(m_temp, 0, size);
 
-                var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
-                var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
+            var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
 
-                if (crc32 != null)
-                    crc32.Append(m_temp);
+            if (crc32 != null)
+                crc32.Append(m_temp);
 
-                handle.Free();
+            handle.Free();
 
-                return item;
-            }
-            catch (Exception ex)
-            {
-
-                throw ex;
-            }
-            
+            return item;
         }
         public static T[] ReadStructs<T>(this Stream m_stream, uint count, Crc32Algorithm crc32 = null) where T : struct
         {

--- a/WolvenKit.CR2W/Extensions/W3ReaderExtensions.cs
+++ b/WolvenKit.CR2W/Extensions/W3ReaderExtensions.cs
@@ -1,8 +1,5 @@
-﻿using RED.CRC32;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 using WolvenKit.CR2W.Types;
 
@@ -184,7 +181,7 @@ namespace WolvenKit.CR2W
             if (unknownFlag)
             {
                 throw new NotImplementedException();
-                readstring = Encoding.Unicode.GetString(br.ReadBytes((len * 2) - 1));
+                // readstring = Encoding.Unicode.GetString(br.ReadBytes((len * 2) - 1));
             }
             else
                 readstring = Encoding.GetEncoding("ISO-8859-1").GetString(br.ReadBytes(len - 1));

--- a/WolvenKit.CR2W/SRT/Srtfile.cs
+++ b/WolvenKit.CR2W/SRT/Srtfile.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.CodeDom;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -70,7 +68,7 @@ namespace WolvenKit.CR2W.SRT
         #endregion
 
         #region Read
-        public async Task<EFileReadErrorCodes> Read(BinaryReader br)
+        public EFileReadErrorCodes Read(BinaryReader br)
         {
             m_stream = br.BaseStream;
 

--- a/WolvenKit.CR2W/Types/W3/RTTIConvert/CAnimatedComponentAnimationSyncToken.cs
+++ b/WolvenKit.CR2W/Types/W3/RTTIConvert/CAnimatedComponentAnimationSyncToken.cs
@@ -1,9 +1,5 @@
-using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
-using FastMember;
-using static WolvenKit.CR2W.Types.Enums;
-
 
 namespace WolvenKit.CR2W.Types
 {
@@ -13,11 +9,6 @@ namespace WolvenKit.CR2W.Types
 	{
 		public CAnimatedComponentAnimationSyncToken(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name){ }
 
-		public static new CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new CAnimatedComponentAnimationSyncToken(cr2w, parent, name);
-
-		public override void Read(BinaryReader file, uint size) => base.Read(file, size);
-
-		public override void Write(BinaryWriter file) => base.Write(file);
-
+		public static CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new CAnimatedComponentAnimationSyncToken(cr2w, parent, name);
 	}
 }

--- a/WolvenKit.CR2W/Types/W3/RTTIConvert/IAnalyzer.cs
+++ b/WolvenKit.CR2W/Types/W3/RTTIConvert/IAnalyzer.cs
@@ -1,9 +1,5 @@
-using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
-using FastMember;
-using static WolvenKit.CR2W.Types.Enums;
-
 
 namespace WolvenKit.CR2W.Types
 {
@@ -13,11 +9,6 @@ namespace WolvenKit.CR2W.Types
 	{
 		public IAnalyzer(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name){ }
 
-		public static new CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new IAnalyzer(cr2w, parent, name);
-
-		public override void Read(BinaryReader file, uint size) => base.Read(file, size);
-
-		public override void Write(BinaryWriter file) => base.Write(file);
-
+		public static CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new IAnalyzer(cr2w, parent, name);
 	}
 }

--- a/WolvenKit.CR2W/Types/W3/RTTIConvert/IBaseCacheSplitter.cs
+++ b/WolvenKit.CR2W/Types/W3/RTTIConvert/IBaseCacheSplitter.cs
@@ -1,8 +1,5 @@
-using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
-using FastMember;
-using static WolvenKit.CR2W.Types.Enums;
 
 
 namespace WolvenKit.CR2W.Types
@@ -13,11 +10,6 @@ namespace WolvenKit.CR2W.Types
 	{
 		public IBaseCacheSplitter(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name){ }
 
-		public static new CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new IBaseCacheSplitter(cr2w, parent, name);
-
-		public override void Read(BinaryReader file, uint size) => base.Read(file, size);
-
-		public override void Write(BinaryWriter file) => base.Write(file);
-
+		public static CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new IBaseCacheSplitter(cr2w, parent, name);
 	}
 }

--- a/WolvenKit.CR2W/Types/W3/RTTIConvert/ICacheBuilder.cs
+++ b/WolvenKit.CR2W/Types/W3/RTTIConvert/ICacheBuilder.cs
@@ -1,9 +1,5 @@
-using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
-using FastMember;
-using static WolvenKit.CR2W.Types.Enums;
-
 
 namespace WolvenKit.CR2W.Types
 {
@@ -13,11 +9,6 @@ namespace WolvenKit.CR2W.Types
 	{
 		public ICacheBuilder(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name){ }
 
-		public static new CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new ICacheBuilder(cr2w, parent, name);
-
-		public override void Read(BinaryReader file, uint size) => base.Read(file, size);
-
-		public override void Write(BinaryWriter file) => base.Write(file);
-
+		public static CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new ICacheBuilder(cr2w, parent, name);
 	}
 }

--- a/WolvenKit.CR2W/Types/W3/RTTIConvert/SRecordedInput.cs
+++ b/WolvenKit.CR2W/Types/W3/RTTIConvert/SRecordedInput.cs
@@ -1,8 +1,5 @@
-using System.IO;
 using System.Runtime.Serialization;
 using WolvenKit.CR2W.Reflection;
-using FastMember;
-using static WolvenKit.CR2W.Types.Enums;
 
 
 namespace WolvenKit.CR2W.Types
@@ -13,11 +10,7 @@ namespace WolvenKit.CR2W.Types
 	{
 		public SRecordedInput(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name){ }
 
-		public static new CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new SRecordedInput(cr2w, parent, name);
-
-		public override void Read(BinaryReader file, uint size) => base.Read(file, size);
-
-		public override void Write(BinaryWriter file) => base.Write(file);
+		public static CVariable Create(CR2WFile cr2w, CVariable parent, string name) => new SRecordedInput(cr2w, parent, name);
 
 	}
 }

--- a/WolvenKit.Common/Extensions/StreamExtensions.cs
+++ b/WolvenKit.Common/Extensions/StreamExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Runtime.InteropServices;
 
 namespace WolvenKit.Common
@@ -10,26 +8,17 @@ namespace WolvenKit.Common
     {
         public static T ReadStruct<T>(this Stream m_stream) where T : struct
         {
-            try
-            {
-                var size = Marshal.SizeOf<T>();
+            var size = Marshal.SizeOf<T>();
 
-                var m_temp = new byte[size];
-                m_stream.Read(m_temp, 0, size);
+            var m_temp = new byte[size];
+            m_stream.Read(m_temp, 0, size);
 
-                var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
-                var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            var handle = GCHandle.Alloc(m_temp, GCHandleType.Pinned);
+            var item = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
 
-                handle.Free();
+            handle.Free();
 
-                return item;
-            }
-            catch (Exception ex)
-            {
-
-                throw ex;
-            }
-            
+            return item;
         }
         public static T[] ReadStructs<T>(this Stream m_stream, uint count) where T : struct
         {

--- a/WolvenKit.Common/Model/Wcc/wcc_task.cs
+++ b/WolvenKit.Common/Model/Wcc/wcc_task.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -131,7 +129,7 @@ namespace WolvenKit.Common.Wcc
                 catch (Exception ex)
                 {
                     _logger.LogString(ex.ToString(), Logtype.Error);
-                    throw ex;
+                    throw;
                 }
             }
         }

--- a/WolvenKit.Common/Oodle/OodleHelper.cs
+++ b/WolvenKit.Common/Oodle/OodleHelper.cs
@@ -195,17 +195,13 @@ namespace WolvenKit.Common.Oodle
                                 $"Unpacked size {unpackedSize} doesn't match real size {size}");
                         bw.Write(outputBuffer);
                     }
-                    catch (DecompressionException e)
+                    catch (DecompressionException)
                     {
                         //logger.LogString(e.Message, Logtype.Error);
                         //logger.LogString(
                         //    $"Unable to decompress file {hash.ToString()}. Exporting uncompressed file",
                         //    Logtype.Error);
                         bw.Write(inputBuffer);
-                    }
-                    catch (Exception e)
-                    {
-                        throw e;
                     }
 
                 }

--- a/WolvenKit.Nvidia/Program.cs
+++ b/WolvenKit.Nvidia/Program.cs
@@ -13,7 +13,7 @@ namespace WolvenKit.Nvidia
         {
             var br = new BinaryReader(new FileStream("C:\\Users\\bence.hambalko\\Documents\\Apex\\hw.redfur",FileMode.Open));
             var redfur = new CR2WFile();
-            redfur.Read(br);
+            redfur.ReadAsync(br).GetAwaiter().GetResult();
             Apex.HairWorks.ConvertToApexXml(redfur).Save("C:\\Users\\bence.hambalko\\Documents\\Apex\\out.apx");
             NvidiaXML.BreakXmlHeader("C:\\Users\\bence.hambalko\\Documents\\Apex\\out.apx");
         }

--- a/WolvenKit/Commands/ApplicationOpenProjectCommandContainer.cs
+++ b/WolvenKit/Commands/ApplicationOpenProjectCommandContainer.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using Catel;
-using Catel.IoC;
 using Catel.MVVM;
 using Catel.Services;
-using Orchestra;
-using Orchestra.Services;
 using System.Threading.Tasks;
-using Catel.Logging;
 using Orc.FileSystem;
 using Orc.ProjectManagement;
 using Orc.Notifications;
@@ -19,7 +15,7 @@ namespace WolvenKit
     {
         private readonly IOpenFileService _openFileService;
         private readonly IFileService _fileService;
-        private readonly IPleaseWaitService _pleaseWaitService;
+        private new readonly IPleaseWaitService _pleaseWaitService;
 
         public ApplicationOpenProjectCommandContainer(
             ICommandManager commandManager,
@@ -71,8 +67,9 @@ namespace WolvenKit
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
+                // TODO: Are we intentionally swallowing this?
                 //Log.Error(ex, "Failed to open file");
             }
         }

--- a/WolvenKit/Commands/ProjectCommandContainerBase.cs
+++ b/WolvenKit/Commands/ProjectCommandContainerBase.cs
@@ -5,7 +5,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
-using System;
 using Catel.IoC;
 using Catel.Services;
 using Orc.Notifications;
@@ -55,25 +54,21 @@ namespace WolvenKit
         #endregion
 
         #region Methods
-        private Task OnProjectActivatedAsync(object sender, ProjectUpdatedEventArgs e)
+        private async Task OnProjectActivatedAsync(object sender, ProjectUpdatedEventArgs e)
         {
             //await Task.Run(() => ProjectActivated((Project) e.OldProject, (Project) e.NewProject));
-            ProjectActivated((EditorProject)e.OldProject, (EditorProject)e.NewProject);
+            await ProjectActivatedAsync((EditorProject)e.OldProject, (EditorProject)e.NewProject);
 
             //TODO: why is that here?
             _commandManager.InvalidateCommands();
-
-            return TaskHelper.Completed;
         }
 
-        protected virtual async Task ProjectActivated(EditorProject oldEditorProject, EditorProject newEditorProject)
+        protected virtual async Task ProjectActivatedAsync(EditorProject oldEditorProject, EditorProject newEditorProject)
         {
             if (newEditorProject == null)
                 return;
 
             await Task.Run(() => newEditorProject.Initialize());
-
-            
         }
 
         protected override bool CanExecute(object parameter)

--- a/WolvenKit/Controllers/Cp77Controller.cs
+++ b/WolvenKit/Controllers/Cp77Controller.cs
@@ -1,13 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Catel.IoC;
 using Newtonsoft.Json;
-using ProtoBuf;
 using WolvenKit.Common;
 
 namespace WolvenKit.Controllers
@@ -47,7 +43,7 @@ namespace WolvenKit.Controllers
                 {
                     archiveManager = new ArchiveManager();
                     archiveManager.LoadAll(Path.GetDirectoryName(_settings.ExecutablePath));
-                    File.WriteAllText(Cp77Controller.GetManagerPath(EManagerType.ArchiveManager), JsonConvert.SerializeObject(archiveManager, Formatting.None, new JsonSerializerSettings()
+                    File.WriteAllText(GetManagerPath(EManagerType.ArchiveManager), JsonConvert.SerializeObject(archiveManager, Formatting.None, new JsonSerializerSettings()
                     {
                         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                         PreserveReferencesHandling = PreserveReferencesHandling.Objects,
@@ -56,10 +52,10 @@ namespace WolvenKit.Controllers
                     _settings.ManagerVersions[(int)EManagerType.ArchiveManager] = ArchiveManager.SerializationVersion;
                 }
             }
-            catch (System.Exception ex)
+            catch (Exception)
             {
-                if (File.Exists(Cp77Controller.GetManagerPath(EManagerType.ArchiveManager)))
-                    File.Delete(Cp77Controller.GetManagerPath(EManagerType.ArchiveManager));
+                if (File.Exists(GetManagerPath(EManagerType.ArchiveManager)))
+                    File.Delete(GetManagerPath(EManagerType.ArchiveManager));
                 archiveManager = new ArchiveManager();
                 archiveManager.LoadAll(Path.GetDirectoryName(_settings.ExecutablePath));
             }
@@ -69,7 +65,7 @@ namespace WolvenKit.Controllers
 
         public override List<IGameArchiveManager> GetArchiveManagersManagers()
         {
-            return new List<IGameArchiveManager>()
+            return new()
             {
                 archiveManager
             };

--- a/WolvenKit/Controllers/MainController.cs
+++ b/WolvenKit/Controllers/MainController.cs
@@ -1,15 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Catel.IoC;
-using Microsoft.CodeAnalysis.CSharp;
-using ProtoBuf;
-using System.Diagnostics;
-using System.IO.Compression;
-using System.Reflection;
 
 namespace WolvenKit
 {
@@ -195,7 +188,7 @@ namespace WolvenKit
         /// Initializes the archive managers in an async thread
         /// </summary>
         /// <returns></returns>
-        public async Task Initialize()
+        public Task Initialize()
         {
             try
             {
@@ -265,8 +258,10 @@ namespace WolvenKit
             catch (Exception ex)
             {
                 mainController.Loaded = false;
-                System.Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
             }
+            
+            return Task.CompletedTask;
         }
 
         

--- a/WolvenKit/Controllers/Tw3Controller.cs
+++ b/WolvenKit/Controllers/Tw3Controller.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using Catel.IoC;
-using CP77.CR2W.Archive;
 using Newtonsoft.Json;
 using ProtoBuf;
 using WolvenKit.Common;
@@ -62,10 +58,10 @@ namespace WolvenKit.Controllers
                     _settings.ManagerVersions[(int)EManagerType.BundleManager] = BundleManager.SerializationVersion;
                 }
             }
-            catch (System.Exception ex)
+            catch (Exception)
             {
-                if (File.Exists(Tw3Controller.GetManagerPath(EManagerType.BundleManager)))
-                    File.Delete(Tw3Controller.GetManagerPath(EManagerType.BundleManager));
+                if (File.Exists(GetManagerPath(EManagerType.BundleManager)))
+                    File.Delete(GetManagerPath(EManagerType.BundleManager));
                 bundleManager = new BundleManager();
                 bundleManager.LoadAll(Path.GetDirectoryName(_settings.ExecutablePath));
             }
@@ -220,7 +216,7 @@ namespace WolvenKit.Controllers
                 {
                     soundManager = new SoundManager();
                     soundManager.LoadAll(Path.GetDirectoryName(_settings.ExecutablePath));
-                    File.WriteAllText(Tw3Controller.GetManagerPath(EManagerType.SoundManager), JsonConvert.SerializeObject(soundManager, Formatting.None, new JsonSerializerSettings()
+                    File.WriteAllText(GetManagerPath(EManagerType.SoundManager), JsonConvert.SerializeObject(soundManager, Formatting.None, new JsonSerializerSettings()
                     {
                         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                         PreserveReferencesHandling = PreserveReferencesHandling.Objects,
@@ -229,10 +225,10 @@ namespace WolvenKit.Controllers
                     _settings.ManagerVersions[(int)EManagerType.SoundManager] = SoundManager.SerializationVersion;
                 }
             }
-            catch (System.Exception ex)
+            catch (Exception)
             {
-                if (File.Exists(Tw3Controller.GetManagerPath(EManagerType.SoundManager)))
-                    File.Delete(Tw3Controller.GetManagerPath(EManagerType.SoundManager));
+                if (File.Exists(GetManagerPath(EManagerType.SoundManager)))
+                    File.Delete(GetManagerPath(EManagerType.SoundManager));
                 soundManager = new SoundManager();
                 soundManager.LoadAll(Path.GetDirectoryName(_settings.ExecutablePath));
             }

--- a/WolvenKit/Layout/MLib/LayoutLoader.cs
+++ b/WolvenKit/Layout/MLib/LayoutLoader.cs
@@ -219,7 +219,9 @@ namespace WolvenKit.Layout.MLib
 		{
 			// Analyze the BOM
 			if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76)
+#pragma warning disable 618
 				return Encoding.UTF7;
+#pragma warning restore 618
 
 			if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf)
 				return Encoding.UTF8;

--- a/WolvenKit/Model/CsvCommonFunctions.cs
+++ b/WolvenKit/Model/CsvCommonFunctions.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace WolvenKit.Model
 {
@@ -35,7 +34,7 @@ namespace WolvenKit.Model
                     return s;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 MainController.LogString("Creating Csv file failed, please double-check your input.", Logtype.Error);
                 return null;
@@ -73,7 +72,7 @@ namespace WolvenKit.Model
                     return records;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 MainController.LogString("Creating Csv file failed, please double-check your input.", Logtype.Error);
                 return null;

--- a/WolvenKit/Model/Project/Cp77Project.cs
+++ b/WolvenKit/Model/Project/Cp77Project.cs
@@ -373,7 +373,7 @@ namespace WolvenKit.Model
         // TODO: debug
         public override void Check() => _logger.LogString($"{initializeTask.Status.ToString()}", Logtype.Error);
 
-        public sealed override async Task Initialize()
+        public sealed override Task Initialize()
         {
             // if initializeTask is null
             if (initializeTask == null)
@@ -396,9 +396,10 @@ namespace WolvenKit.Model
                 }
             }
 
+            return initializeTask;
         }
 
-        private async Task InitializeAsync()
+        private Task InitializeAsync()
         {
             // Hash all filepaths
             _logger.LogString("Starting additional tasks...", Logtype.Important);
@@ -413,6 +414,7 @@ namespace WolvenKit.Model
 
             ServiceLocator.Default.ResolveType<INotificationService>().ShowNotification("WolvenKit", $"Project {Name} has finished loading.");
 
+            return Task.CompletedTask;
         }
 
 

--- a/WolvenKit/Model/Project/Tw3Project.cs
+++ b/WolvenKit/Model/Project/Tw3Project.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
-using Catel;
 using Catel.IoC;
-using Catel.Threading;
-using Newtonsoft.Json;
 using Orc.Notifications;
-using ProtoBuf;
 namespace WolvenKit.Model
 {
     using Controllers;
@@ -389,7 +383,7 @@ namespace WolvenKit.Model
         // TODO: debug
         public override void Check() => _logger.LogString($"{initializeTask.Status.ToString()}", Logtype.Error);
 
-        public sealed override async Task Initialize()
+        public sealed override Task Initialize()
         {
             // if initializeTask is null
             if (initializeTask == null)
@@ -412,6 +406,7 @@ namespace WolvenKit.Model
                 }
             }
             
+            return initializeTask;
         }
 
         private async Task InitializeAsync()

--- a/WolvenKit/Model/ProjectManagement/InitialProjectLocationService.cs
+++ b/WolvenKit/Model/ProjectManagement/InitialProjectLocationService.cs
@@ -7,12 +7,10 @@
 
 namespace WolvenKit.Model.ProjectManagement
 {
-    using System.IO;
     using System.Threading.Tasks;
     using Catel;
     using Catel.Configuration;
     using Catel.Logging;
-    using Catel.Services;
     using Orc.CommandLine;
     using Orc.FileSystem;
 
@@ -47,12 +45,12 @@ namespace WolvenKit.Model.ProjectManagement
         #endregion
 
         #region Methods
-        public async Task<string> GetInitialProjectLocationAsync()
+        public Task<string> GetInitialProjectLocationAsync()
         {
             var commandLineContext = new CommandLineContext();
             _commandLineParser.Parse(_commandLineService.GetCommandLine(), commandLineContext);
 
-            return commandLineContext.InitialFile;
+            return Task.FromResult(commandLineContext.InitialFile);
         }
         #endregion
     }

--- a/WolvenKit/Model/ProjectManagement/Serializers/ProjectReader.cs
+++ b/WolvenKit/Model/ProjectManagement/Serializers/ProjectReader.cs
@@ -1,12 +1,8 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using Catel;
-using Catel.Logging;
 using Orc.Notifications;
 using Orc.ProjectManagement;
-using WolvenKit.Model;
-using WolvenKit.Common;
 using WolvenKit.Controllers;
 
 namespace WolvenKit.Model.ProjectManagement
@@ -27,7 +23,7 @@ namespace WolvenKit.Model.ProjectManagement
         #endregion
 
         #region Methods
-        protected override async Task<IProject> ReadFromLocationAsync(string location)
+        protected override Task<IProject> ReadFromLocationAsync(string location)
         {
             try
             {
@@ -54,9 +50,9 @@ namespace WolvenKit.Model.ProjectManagement
 
                 _notificationService.ShowNotification("Success", "Project " + Path.GetFileNameWithoutExtension(location) +
                                                       " loaded!");
-                return project;
+                return Task.FromResult<IProject>(project);
 
-            } catch (System.IO.IOException ex)
+            } catch (IOException ex)
             {
                 _notificationService.ShowNotification("Could not open file", ex.Message);
             }

--- a/WolvenKit/Model/ProjectManagement/WkitProjectValidator.cs
+++ b/WolvenKit/Model/ProjectManagement/WkitProjectValidator.cs
@@ -7,21 +7,21 @@ namespace WolvenKit.Model.ProjectManagement
     public class WkitProjectValidator : ProjectValidatorBase
     {
         #region IProjectValidator 
-        public override async Task<bool> CanStartLoadingProjectAsync(string location)
+        public override Task<bool> CanStartLoadingProjectAsync(string location)
         {
             // first check if w3modproj or cpmodproj exist
             if (!File.Exists(location))
-                return false;
+                return Task.FromResult(false);
 
             // redundant check
             var projectInfo = new FileInfo(location);
             if (projectInfo.Directory == null)
-                return false;
+                return Task.FromResult(false);
 
             // all wkit projects have a folder with the same name 
             var projectName = Path.GetFileNameWithoutExtension(location);
             var projectDirInfo = Path.Combine(projectInfo.Directory.FullName, projectName);
-            return Directory.Exists(projectDirInfo);
+            return Task.FromResult(Directory.Exists(projectDirInfo));
         }
         #endregion
     }

--- a/WolvenKit/Model/WccHelper.cs
+++ b/WolvenKit/Model/WccHelper.cs
@@ -617,9 +617,9 @@ namespace WolvenKit.Model
 
                     addedFilesCount++;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    Logger.LogString($"Unable to move uncooked file to ModProject, perhaps a file of that name is cuurrently open in Wkit.", Logtype.Error);
+                    Logger.LogString("Unable to move uncooked file to ModProject, perhaps a file of that name is currently open in Wkit.", Logtype.Error);
                 }
             }
             #endregion
@@ -760,7 +760,7 @@ namespace WolvenKit.Model
             {
                 exportedExtension = REDTypes.ExportExtensionToRawExtension((EExportable)Enum.Parse(typeof(EExportable), importedExtension));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Logger.LogString($"Not an exportable filetype: {importedExtension}.", Logtype.Error);
                 return;
@@ -778,7 +778,7 @@ namespace WolvenKit.Model
             //string workDir = "";                                            // add to mod
             //string workDir = MainController.Get().Configuration.DepotPath;  // r4depot
 
-            AddAllImports(fullpath, true, true, workDir);
+            await AddAllImportsAsync(fullpath, true, true, workDir);
 
             // copy the w2mesh and all imports to the depot
             var depotInfo = new FileInfo(Path.Combine(workDir, relativePath));
@@ -815,7 +815,7 @@ namespace WolvenKit.Model
         /// <param name="silent"></param>
         /// <param name="alternateOutDirectory"></param>
         /// <returns></returns>
-        public static async Task AddAllImports(string importfilepath, 
+        public static async Task AddAllImportsAsync(string importfilepath, 
             bool recursive = false, bool silent = false, string alternateOutDirectory = "", bool logonly = false)
         {
             if (!File.Exists(importfilepath))
@@ -842,7 +842,6 @@ namespace WolvenKit.Model
                 (importslist, hasinternalBuffer, bufferlist) = cr2w.ReadImportsAndBuffers(reader);
             }
 
-            bool success = true;
             // add imports
             foreach (var import in importslist)
             {
@@ -862,7 +861,7 @@ namespace WolvenKit.Model
                 {
                     // recursively add all 1st order dependencies :Gp:
                     if (recursive)
-                        AddAllImports(path, true, silent, alternateOutDirectory, logonly);
+                        await AddAllImportsAsync(path, true, silent, alternateOutDirectory, logonly);
                 }
             }
 

--- a/WolvenKit/Services/ApplicationInitializationService.cs
+++ b/WolvenKit/Services/ApplicationInitializationService.cs
@@ -2,20 +2,13 @@
 using Catel.IoC;
 using Catel.Logging;
 using Catel.MVVM;
-using Orchestra.Models;
 using Orchestra.Services;
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Catel.Services;
 using Orc.ProjectManagement;
-using Orc.Squirrel;
-using WolvenKit;
-using WolvenKit.Services;
 using WolvenKit.Common.Services;
-using Settings = WolvenKit.Settings;
 using WolvenKit.Model.ProjectManagement;
 using System.Windows.Media;
 using WolvenKit.Commands;
@@ -71,12 +64,10 @@ namespace WolvenKit.Services
             });
         }
 
-        public override async Task InitializeAfterCreatingShellAsync()
+        // TODO: update main window title?
+        /*public override Task InitializeAfterCreatingShellAsync()
         {
-            // TODO: update main window title?
-
-            
-        }
+        }*/
 
         public override async Task InitializeAfterShowingShellAsync()
         {
@@ -96,12 +87,14 @@ namespace WolvenKit.Services
         #endregion
 
         #region methods
-        private async Task InitializePerformanceAsync()
+        private Task InitializePerformanceAsync()
         {
             Log.Info("Improving performance");
 
             Catel.Windows.Controls.UserControl.DefaultCreateWarningAndErrorValidatorForViewModelValue = false;
             Catel.Windows.Controls.UserControl.DefaultSkipSearchingForInfoBarMessageControlValue = true;
+            
+            return Task.CompletedTask;
         }
 
         private void InitializeFonts()
@@ -180,9 +173,10 @@ namespace WolvenKit.Services
             _serviceLocator.RegisterTypeAndInstantiate<RecentlyUsedItemsProjectWatcher>();
         }
 
-        private async Task CheckForUpdatesAsync()
+        private Task CheckForUpdatesAsync()
         {
             //TODO: enable
+            return Task.CompletedTask;
 //            Log.Info("Checking for updates");
 
 //            var updateService = _serviceLocator.ResolveType<IUpdateService>();

--- a/WolvenKit/Services/SettingsManager.cs
+++ b/WolvenKit/Services/SettingsManager.cs
@@ -1,12 +1,7 @@
 ﻿using MLib.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Xml.Serialization;
-using Catel.IoC;
-using Catel.MVVM;
-using WolvenKit.Commands;
 
 namespace WolvenKit.Services
 {
@@ -99,7 +94,7 @@ namespace WolvenKit.Services
                     };
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // Defaults
                 config = new SettingsManager

--- a/WolvenKit/ViewModels/AD/DocumentViewModel.cs
+++ b/WolvenKit/ViewModels/AD/DocumentViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Catel.MVVM;
 using System.IO;
@@ -170,7 +169,7 @@ namespace WolvenKit.ViewModels
 		}
 
 		/// <summary>Gets/sets whether the documents content has been changed without saving into file system or not.</summary>
-		public bool IsDirty
+		public new bool IsDirty
 		{
 			get => _isDirty;
 			set
@@ -273,12 +272,12 @@ namespace WolvenKit.ViewModels
 
 				// This is the same default buffer size as
 				// <see cref="StreamReader"/> and <see cref="FileStream"/>.
-				int DefaultBufferSize = 4096;
+				// int DefaultBufferSize = 4096;
 
 				// Indicates that
 				// 1. The file is to be used for asynchronous reading.
 				// 2. The file is to be accessed sequentially from beginning to end.
-				FileOptions DefaultOptions = FileOptions.Asynchronous | FileOptions.SequentialScan;
+				// FileOptions DefaultOptions = FileOptions.Asynchronous | FileOptions.SequentialScan;
 
                 var logger = ServiceLocator.Default.ResolveType<ILoggerService>();
                 logger.LogString("Opening file: " + path + "...");
@@ -328,7 +327,7 @@ namespace WolvenKit.ViewModels
 
 				return true;
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
 				// Not processing this catch in any other way than rejecting to initialize this
 				_isInitialized = false;
@@ -347,7 +346,9 @@ namespace WolvenKit.ViewModels
 		{
 			// Analyze the BOM
 			if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76)
+#pragma warning disable 618
 				return Encoding.UTF7;
+#pragma warning restore 618
 
 			if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf)
 				return Encoding.UTF8;

--- a/WolvenKit/ViewModels/AD/ImportViewModel.cs
+++ b/WolvenKit/ViewModels/AD/ImportViewModel.cs
@@ -1,13 +1,11 @@
 ﻿using CsvHelper;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 using Catel;
 using Catel.Services;
@@ -248,20 +246,8 @@ namespace WolvenKit.ViewModels
                 else
                 {
                     // import with wcc_lite
-                    try
-                    {
-                        await StartImport(file);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw ex;
-                    }
+                    await StartImport(file);
                 }
-               
-
-                
-
-                
             }
 
             async Task StartImport(ImportableFile file)

--- a/WolvenKit/ViewModels/AD/ProjectExplorerViewModel.cs
+++ b/WolvenKit/ViewModels/AD/ProjectExplorerViewModel.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
-using System.IO.Packaging;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media.Imaging;
 using Catel;
 using Catel.IoC;
 using Catel.MVVM;
@@ -171,7 +166,7 @@ namespace WolvenKit.ViewModels
         /// </summary>
         public ICommand ExpandAllCommand { get; private set; }
         private bool CanExpandAll() => _projectManager.ActiveProject is EditorProject;
-        private async void ExecuteExpandAll()
+        private void ExecuteExpandAll()
         {
             foreach (var node in Treenodes) node.ExpandChildren(true);
         }
@@ -181,7 +176,7 @@ namespace WolvenKit.ViewModels
         /// </summary>
         public ICommand CollapseAllCommand { get; private set; }
         private bool CanCollapseAll() => _projectManager.ActiveProject is EditorProject;
-        private async void ExecuteCollapseAll()
+        private void ExecuteCollapseAll()
         {
             foreach (var node in Treenodes) node.CollapseChildren(true);
         }
@@ -191,14 +186,14 @@ namespace WolvenKit.ViewModels
         /// </summary>
         public ICommand ExpandCommand { get; private set; }
         private bool CanExpand() => _projectManager.ActiveProject is EditorProject && SelectedItem != null;
-        private async void ExecuteExpand() => SelectedItem.ExpandChildren(true);
+        private void ExecuteExpand() => SelectedItem.ExpandChildren(true);
 
         /// <summary>
         /// Collapses all children of the selected node.
         /// </summary>
         public ICommand CollapseCommand { get; private set; }
         private bool CanCollapse() => _projectManager.ActiveProject is EditorProject && SelectedItem != null;
-        private async void ExecuteCollapse() => SelectedItem.CollapseChildren(true);
+        private void ExecuteCollapse() => SelectedItem.CollapseChildren(true);
 
         /// <summary>
         /// Delets selected node.
@@ -261,7 +256,7 @@ namespace WolvenKit.ViewModels
 
                 SelectedItem.RaiseRequestRefresh();
             }
-            catch (Exception exception)
+            catch (Exception)
             {
                 MainController.LogString("Failed to delete " + fullpath + "!\r\n", Common.Services.Logtype.Error);
             }
@@ -278,7 +273,7 @@ namespace WolvenKit.ViewModels
             
             var visualizerService = ServiceLocator.Default.ResolveType<IUIVisualizerService>();
             var viewModel = new InputDialogViewModel() {Text = filename};
-            await visualizerService.ShowDialogAsync(viewModel, delegate(object? sender, UICompletedEventArgs args)
+            await visualizerService.ShowDialogAsync(viewModel, delegate(object sender, UICompletedEventArgs args)
             {
                 if (args.Result != true)
                     return;
@@ -422,7 +417,7 @@ namespace WolvenKit.ViewModels
         /// </summary>
         public ICommand AddAllImportsCommand { get; private set; }
         private bool CanAddAllImports() => _projectManager.ActiveProject is Tw3Project && SelectedItem != null && SelectedItem.IsFile;
-        private async void AddAllImports() => await WccHelper.AddAllImports(SelectedItem.FullName, true);
+        private async void AddAllImports() => await WccHelper.AddAllImportsAsync(SelectedItem.FullName, true);
 
 
         // legacy

--- a/WolvenKit/ViewModels/AD/WorkSpaceViewModel.cs
+++ b/WolvenKit/ViewModels/AD/WorkSpaceViewModel.cs
@@ -1,6 +1,4 @@
-﻿
-using Catel.Services;
-using WolvenKit.ViewModels;
+﻿using Catel.Services;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
@@ -10,16 +8,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
 using Catel.MVVM;
 using Catel;
 using Catel.IoC;
-using Catel.Threading;
-using ControlzEx.Standard;
 using Orc.ProjectManagement;
 using NativeMethods = WolvenKit.NativeWin.NativeMethods;
 
@@ -188,14 +182,14 @@ namespace WolvenKit.ViewModels
 		/// </summary>
 		public ICommand ShowImportUtilityCommand { get; private set; }
         private bool CanShowImportUtility() => true;
-        private async void ExecuteShowImportUtility() => ImportViewModel.IsVisible = !ImportViewModel.IsVisible;
+        private void ExecuteShowImportUtility() => ImportViewModel.IsVisible = !ImportViewModel.IsVisible;
 
         /// <summary>
         /// Displays the Properties View
         /// </summary>
         public ICommand ShowPropertiesCommand { get; private set; }
         private bool CanShowProperties() => true;
-        private async void ExecuteShowProperties() => PropertiesViewModel.IsVisible = !PropertiesViewModel.IsVisible;
+        private void ExecuteShowProperties() => PropertiesViewModel.IsVisible = !PropertiesViewModel.IsVisible;
 
 		/// <summary>
 		/// Opens a physical file in WolvenKit.
@@ -244,20 +238,20 @@ namespace WolvenKit.ViewModels
 		/// </summary>
 		public ICommand PackModCommand { get; private set; }
         private bool CanPackMod() => _projectManager.ActiveProject is EditorProject proj;
-        private async void ExecutePackMod()
+        private void ExecutePackMod()
         {
             //TODO
-		}
+        }
 
 		/// <summary>
 		/// Git-backup current mod project
 		/// </summary>
 		public ICommand BackupModCommand { get; private set; }
         private bool CanBackupMod() => _projectManager.ActiveProject is EditorProject;
-        private async void ExecuteBackupMod()
+        private void ExecuteBackupMod()
         {
             //TODO
-		}
+        }
 
 		
 
@@ -480,14 +474,10 @@ namespace WolvenKit.ViewModels
                     var proc = new ProcessStartInfo(path) { UseShellExecute = true };
                     Process.Start(proc);
                 }
-                catch (Win32Exception winex)
+                catch (Win32Exception)
                 {
                     // eat this: no default app set for filetype
-                    _loggerService.LogString($"No default prgram set in Windows to open file extension {Path.GetExtension(path)}", Common.Services.Logtype.Error);
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
+                    _loggerService.LogString($"No default prgram set in Windows to open file extension {Path.GetExtension(path)}", Logtype.Error);
                 }
             }
 
@@ -507,13 +497,13 @@ namespace WolvenKit.ViewModels
             }
         }
 
-        private async Task OnProjectActivationAsync(object sender, ProjectUpdatingCancelEventArgs e)
+        private Task OnProjectActivationAsync(object sender, ProjectUpdatingCancelEventArgs e)
         {
             var newProject = (EditorProject)e.NewProject;
-            if (newProject is null)
-                return;
+            if (newProject is not null)
+	            EditorProject = newProject;
 
-            EditorProject = newProject;
+            return Task.CompletedTask;
         }
 
         //

--- a/WolvenKit/ViewModels/BulkEditViewModel.cs
+++ b/WolvenKit/ViewModels/BulkEditViewModel.cs
@@ -2,16 +2,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Policy;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Windows.Media;
 
 namespace WolvenKit.ViewModels
 {
@@ -257,7 +252,7 @@ namespace WolvenKit.ViewModels
                 using (var reader = new BinaryReader(fs))
                 {
                     cr2w = new CR2WFile();
-                    cr2w.Read(reader);
+                    await cr2w.ReadAsync(reader);
                     fs.Close();
                 }
 

--- a/WolvenKit/ViewModels/MainViewModel.cs
+++ b/WolvenKit/ViewModels/MainViewModel.cs
@@ -1021,7 +1021,6 @@ namespace WolvenKit.ViewModels
                 case EArchiveType.ANY:
                 default:
                     throw new NotImplementedException();
-                    break;
             }
             #endregion
 

--- a/WolvenKit/ViewModels/SettingsViewModel.cs
+++ b/WolvenKit/ViewModels/SettingsViewModel.cs
@@ -14,12 +14,9 @@ namespace WolvenKit.ViewModels
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Threading.Tasks;
     using Catel;
-    using Catel.Configuration;
-    using Catel.IoC;
     using Catel.MVVM;
     using Catel.Services;
     using Orc.Squirrel;
@@ -165,16 +162,15 @@ namespace WolvenKit.ViewModels
 
         private bool CanOpenMod() => true;
 
-        private async void ExecuteOpenMod()
+        private void ExecuteOpenMod()
         {
-            
         }
 
         public ICommand OpenDlcDirectoryCommand { get; private set; }
 
         private bool CanOpenDlc() => true;
 
-        private async void ExecuteOpenDlc()
+        private void ExecuteOpenDlc()
         {
             
         }
@@ -329,9 +325,9 @@ namespace WolvenKit.ViewModels
                     wccdel.Invoke(wcc);
                 });
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                
+                // TODO: Are we intentionally swallowing this?
             }
 
             if (File.Exists(witcherexe))

--- a/WolvenKit/Views/HomePage/HomePageView.xaml.cs
+++ b/WolvenKit/Views/HomePage/HomePageView.xaml.cs
@@ -1,9 +1,7 @@
-﻿
-using HandyControl.Controls;
+﻿using HandyControl.Controls;
 using HandyControl.Data;
 using HandyControl.Tools;
 using Octokit;
-using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -66,8 +64,8 @@ namespace WolvenKit.Views.HomePage
 
                 var item = new GithubTimeLine() { TitleLabel = latest.TagName, TitleInfo = latest.Name, TitleStyle = ResourceHelper.GetResource<Style>(ResourceToken.LabelViolet) };
 
-                var unresolvedbody = latest.Body;
-                var body = await ResolveBody(unresolvedbody);
+                var unresolvedBody = latest.Body;
+                var body = ResolveBody(unresolvedBody);
 
                 foreach (var line in body)
                 {
@@ -110,10 +108,10 @@ namespace WolvenKit.Views.HomePage
             catch { }
         }
 
-        private async Task<string[]> ResolveBody(string unresolvedbody)
+        private string[] ResolveBody(string unresolvedbody)
         {
-            var Step1 = Regex.Replace(unresolvedbody, @"^\s+$[\r\n]*", string.Empty, RegexOptions.Multiline);
-            var result = Regex.Split(Step1, "\r\n|\r|\n");
+            var step1 = Regex.Replace(unresolvedbody, @"^\s+$[\r\n]*", string.Empty, RegexOptions.Multiline);
+            var result = Regex.Split(step1, "\r\n|\r|\n");
 
             return result;
         }

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows</TargetFrameworks>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <AssemblyName>WolvenKit</AssemblyName>
     <RootNamespace>WolvenKit</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
@@ -54,7 +54,6 @@
     <PackageReference Include="MahApps.Metro.IconPacks.BoxIcons" Version="4.8.0" />
     <PackageReference Include="MahApps.Metro.IconPacks.Codicons" Version="4.8.0" />
     <PackageReference Include="MarkerMetro.Unity.Ionic.Zlib" Version="2.0.0.14" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.8.0" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
@@ -68,7 +67,6 @@
     <PackageReference Include="Orc.Theming" Version="4.2.0" />
     <PackageReference Include="Pfim" Version="0.9.1" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
-    <PackageReference Include="RoslynPad.Editor.Windows" Version="1.2.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="Snappy.NET" Version="1.1.1.8" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />


### PR DESCRIPTION
#### Initial Warning Fixes

Fixed a handful of warnings but there's still many more to address

> Disclaimer: I haven't tested *everything* after making these changes, however the solutions build, the projects run and functionally nothing should have changed :)

Fixed:
- Exception handling:
  - Caught exceptions where the exception was incorrectly re-thrown
  - Caught exceptions where the exception was correctly re-thrown but nothing else was being done
  - Caught exceptions where the exception was correctly re-thrown but the exception instance was unused
- Async/Task methods:
  - Renamed some async methods that didn't have Async in their name
    - e.g. `WolvenKit.CR2W.Read` -> `WolvenKit.CR2W.ReadAsync` - assuming this will move back to an async MemoryMappedFile implementation in the future
  - Methods marked as async that didn't contain awaiter have had their async modifier removed. These will now return `Task.CompletedTask` or `Task.FromResult` where appropriate. Not sure why these are returning Task at all - maybe left behind from some older refactoring...?!
- Removed a few places were methods were being overriden to do nothing more than call their base implementation
- Removed a few places where code was unreachable
- Removed `RoslynPad.Editor.Windows` from WolvenKit as it was both unused and demanding a conflicting version of `Microsoft.CodeAnalysis.Common`
- Removed a bunch of unused usings 

---

#### Remaining warnings

Mostly fall under the following categories:
 - Classes that hide an inherited member of their base class without using the `new` keyword
   - I think most of these should be safe to have `new` added. However, there's some instances, like `W3Mod` where the inherited member that's being hidden has the exact same implementation? Can these just be removed?
 - Dependencies that aren't fully compatible with `.net5.0-windows`
 - Unused fields
 - Usage of `System.Reflection.Assembly.Location` that should be replaced with `System.AppContext.BaseDirectory`
   - Fairly sure this should be a safe change in all places, just didn't have time to test
