### PR TITLE
Updated MSBuild.Sdk.Extras & Turned on TreatWarningsAsErrors for all …

### DIFF
--- a/CP77.CR2W/Archive/ArchiveManager.cs
+++ b/CP77.CR2W/Archive/ArchiveManager.cs
@@ -121,7 +121,7 @@ namespace CP77.CR2W.Archive
         public override void LoadModArchive(string filename)
         {
             return;
-            if (Archives.ContainsKey(filename))
+            /*if (Archives.ContainsKey(filename))
                 return;
 
             var bundle = new Archive(filename);
@@ -134,7 +134,7 @@ namespace CP77.CR2W.Archive
                 Items[GetModFolder(filename) + "\\" + item.Key].Add(item.Value);
             }
 
-            Archives.Add(filename, bundle);
+            Archives.Add(filename, bundle);*/
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace CP77.CR2W.Archive
         public override void LoadModsArchives(string mods, string dlc)
         {
             return;
-            if (!Directory.Exists(mods))
+            /*if (!Directory.Exists(mods))
                 Directory.CreateDirectory(mods);
             var modsdirs = new List<string>(Directory.GetDirectories(mods));
             modsdirs.Sort(new AlphanumComparator<string>());
@@ -205,7 +205,7 @@ namespace CP77.CR2W.Archive
                     LoadModArchive(file);
                 }
             }
-            RebuildRootNode();
+            RebuildRootNode();*/
         }
 
         #endregion

--- a/CP77.CR2W/Reflection/REDReflection.cs
+++ b/CP77.CR2W/Reflection/REDReflection.cs
@@ -216,7 +216,7 @@ namespace CP77.CR2W.Reflection
             // get only RED
             else
             {
-                return redproperties.Where(z => !(z.GetMemberAttribute<REDAttribute>() is REDBufferAttribute)); ;
+                return redproperties.Where(z => !(z.GetMemberAttribute<REDAttribute>() is REDBufferAttribute));
             }
         }
 

--- a/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator.cs
@@ -1,14 +1,12 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {
 	[REDMeta]
 	public class animAnimNode_ReferencePoseTerminator : animAnimNode_Base
 	{
-        [Ordinal(999)] [RED("visWhenActive")] public CBool visWhenActive { get; set; }
+        [Ordinal(999)] [RED("visWhenActive")] public new CBool visWhenActive { get; set; }
 
 		public animAnimNode_ReferencePoseTerminator(CR2WFile cr2w, CVariable parent, string name) : base(cr2w, parent, name) { }
 	}

--- a/CP77.CR2W/WolvenKit.Cyberformats.csproj
+++ b/CP77.CR2W/WolvenKit.Cyberformats.csproj
@@ -14,6 +14,7 @@
 		<AssemblyVersion>1.0.6.0</AssemblyVersion>
 		<FileVersion>1.0.6.0</FileVersion>
 		<Version>1.0.6</Version>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<NoWarn>$(NoWarn);NU5104</NoWarn>
 	</PropertyGroup>
 

--- a/CP77.MSTests/CP77.MSTests.csproj
+++ b/CP77.MSTests/CP77.MSTests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CP77Tools/CP77Tools.csproj
+++ b/CP77Tools/CP77Tools.csproj
@@ -5,15 +5,16 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
-	<PublishSingleFile>true</PublishSingleFile>
-	  <SelfContained>false</SelfContained>
-	  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	  <PublishTrimmed>true</PublishTrimmed>
-	  <PublishReadyToRun>true</PublishReadyToRun>
-	<DebugType>embedded</DebugType>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <DebugType>embedded</DebugType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
     <None Remove="lib\kraken.so" />
   </ItemGroup>
 

--- a/WolvenKit.Bundles/WolvenKit.Bundles.csproj
+++ b/WolvenKit.Bundles/WolvenKit.Bundles.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 

--- a/WolvenKit.CR2W/WolvenKit.CR2W.csproj
+++ b/WolvenKit.CR2W/WolvenKit.CR2W.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 

--- a/WolvenKit.Cache/WolvenKit.Cache.csproj
+++ b/WolvenKit.Cache/WolvenKit.Cache.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 

--- a/WolvenKit.Common/WolvenKit.Common.csproj
+++ b/WolvenKit.Common/WolvenKit.Common.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/WolvenKit/Wolven-kit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>wolvenkit</PackageTags>
-    <Version>1.0.3</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WolvenKit.Net/WolvenKit.Net.csproj
+++ b/WolvenKit.Net/WolvenKit.Net.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 

--- a/WolvenKit.Nvidia/WolvenKit.Nvidia.csproj
+++ b/WolvenKit.Nvidia/WolvenKit.Nvidia.csproj
@@ -3,11 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-
-
-
 
   <ItemGroup>
     <ProjectReference Include="..\WolvenKit.Common\WolvenKit.Common.csproj" />

--- a/WolvenKit.Save/WolvenKit.Save.csproj
+++ b/WolvenKit.Save/WolvenKit.Save.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">

--- a/WolvenKit.Scaleform/WolvenKit.Scaleform.csproj
+++ b/WolvenKit.Scaleform/WolvenKit.Scaleform.csproj
@@ -3,13 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
   </ItemGroup>
-
-
-
 
 </Project>

--- a/WolvenKit.W3Speech/WolvenKit.W3Speech.csproj
+++ b/WolvenKit.W3Speech/WolvenKit.W3Speech.csproj
@@ -3,11 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-
-
-
 
   <ItemGroup>
     <ProjectReference Include="..\WolvenKit.Common\WolvenKit.Common.csproj" />

--- a/WolvenKit.W3Strings/WolvenKit.W3Strings.csproj
+++ b/WolvenKit.W3Strings/WolvenKit.W3Strings.csproj
@@ -3,11 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-
-
-
 
   <ItemGroup>
     <ProjectReference Include="..\WolvenKit.Common\WolvenKit.Common.csproj" />

--- a/WolvenKit.Wwise/WolvenKit.Wwise.csproj
+++ b/WolvenKit.Wwise/WolvenKit.Wwise.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -83,7 +83,7 @@
     <PackageReference Include="WpfAnalyzers" Version="3.5.2" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="NETStandard.Library" Version="2.0.1" />
+    <!--<PackageReference Update="NETStandard.Library" Version="2.0.1" />-->
   </ItemGroup>
   
   <ItemGroup>

--- a/Wolvenkit.Radish/Wolvenkit.Radish.csproj
+++ b/Wolvenkit.Radish/Wolvenkit.Radish.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0-windows</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.1.2"
+        "MSBuild.Sdk.Extras": "3.0.23"
     }
 }


### PR DESCRIPTION
One last commit to end all warnings (:

Fixed:
- Updated `MSBuild.Sdk.Extras` -> there was a bug in the version previously referenced that caused targets to be imported twice
- Fixed warning in `animAnimNode_ReferencePoseTerminator`
  - Here `visWhenActive` was hiding a base member - I've added the `new` keyword, assuming the ordinal in the inherited class is correct
- Fixed unreachable code warnings in `ArchiveManager`
- Turned on **TreatWarningsAsErrors for ALL projects**
  - This might be annoying to some, but it's a good thing to have IMO... and will hopefully stop contributors introducing new warnings, whether intentional or not.

Warnings are now completely gone 👍 
