### PR TITLE
Remove unused namespace from generated types

### DIFF
--- a/CP77.CR2W/Types/cp77/ABaseQuestObjectiveWrapper.cs
+++ b/CP77.CR2W/Types/cp77/ABaseQuestObjectiveWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ABaseWrapper.cs
+++ b/CP77.CR2W/Types/cp77/ABaseWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ABaseWrapper.cs
+++ b/CP77.CR2W/Types/cp77/ABaseWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AGenericTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/AGenericTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AHintItemController.cs
+++ b/CP77.CR2W/Types/cp77/AHintItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAIBlackboardSerializableID.cs
+++ b/CP77.CR2W/Types/cp77/AIAIBlackboardSerializableID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAIEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIAIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAbsoluteZLimiter.cs
+++ b/CP77.CR2W/Types/cp77/AIAbsoluteZLimiter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAbsoluteZLimiter.cs
+++ b/CP77.CR2W/Types/cp77/AIAbsoluteZLimiter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionBossDataDef.cs
+++ b/CP77.CR2W/Types/cp77/AIActionBossDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionChecks.cs
+++ b/CP77.CR2W/Types/cp77/AIActionChecks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionChecks.cs
+++ b/CP77.CR2W/Types/cp77/AIActionChecks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionDataDef.cs
+++ b/CP77.CR2W/Types/cp77/AIActionDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionHelper.cs
+++ b/CP77.CR2W/Types/cp77/AIActionHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionHelper.cs
+++ b/CP77.CR2W/Types/cp77/AIActionHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionHelperTask.cs
+++ b/CP77.CR2W/Types/cp77/AIActionHelperTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionLookat.cs
+++ b/CP77.CR2W/Types/cp77/AIActionLookat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionLookat.cs
+++ b/CP77.CR2W/Types/cp77/AIActionLookat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionLookatParams.cs
+++ b/CP77.CR2W/Types/cp77/AIActionLookatParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionMovePolicy.cs
+++ b/CP77.CR2W/Types/cp77/AIActionMovePolicy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionMovePolicy.cs
+++ b/CP77.CR2W/Types/cp77/AIActionMovePolicy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionNPCStates.cs
+++ b/CP77.CR2W/Types/cp77/AIActionNPCStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionParams.cs
+++ b/CP77.CR2W/Types/cp77/AIActionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionParams.cs
+++ b/CP77.CR2W/Types/cp77/AIActionParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionPlayerStates.cs
+++ b/CP77.CR2W/Types/cp77/AIActionPlayerStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionSlideParams.cs
+++ b/CP77.CR2W/Types/cp77/AIActionSlideParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionSpot.cs
+++ b/CP77.CR2W/Types/cp77/AIActionSpot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIActionSpotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIActionSpotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionTarget.cs
+++ b/CP77.CR2W/Types/cp77/AIActionTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionTarget.cs
+++ b/CP77.CR2W/Types/cp77/AIActionTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIActionTargetStates.cs
+++ b/CP77.CR2W/Types/cp77/AIActionTargetStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionTransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIActionTransactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIActionTransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIActionTransactionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAdjustableStreamingRangeTarget.cs
+++ b/CP77.CR2W/Types/cp77/AIAdjustableStreamingRangeTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAggressiveReactionPresetCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIAggressiveReactionPresetCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAggressiveReactionPresetCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIAggressiveReactionPresetCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAimAtTargetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIAimAtTargetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAimAtTargetCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIAimAtTargetCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAlertedPatrolDef.cs
+++ b/CP77.CR2W/Types/cp77/AIAlertedPatrolDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAlertedStateDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIAlertedStateDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelectionRuntimeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AIAngleDistanceCoverSelectionRuntimeData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAnimMoveOnSplineCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIAnimMoveOnSplineCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAnimationTask.cs
+++ b/CP77.CR2W/Types/cp77/AIAnimationTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIApproachingAreaEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIApproachingAreaEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIApproachingAreaResponseEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIApproachingAreaResponseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArchetype.cs
+++ b/CP77.CR2W/Types/cp77/AIArchetype.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArchetypeSet.cs
+++ b/CP77.CR2W/Types/cp77/AIArchetypeSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArchetypeSetEntry.cs
+++ b/CP77.CR2W/Types/cp77/AIArchetypeSetEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentBoolValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentBoolValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentCNameValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentCNameValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentEnumValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentEnumValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentFloatValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentFloatValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentGlobalNodeIdValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentGlobalNodeIdValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentIntValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentIntValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentMapping.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentNodeRefValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentNodeRefValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentObjectValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentObjectValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentOverrideWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentOverrideWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentPuppetRefValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentPuppetRefValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentReference.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentSerializableValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentSerializableValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentTreeRefValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentTreeRefValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentUint64Value.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentUint64Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIArgumentVectorValue.cs
+++ b/CP77.CR2W/Types/cp77/AIArgumentVectorValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAssignGuardAreaCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIAssignGuardAreaCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAssignRoleCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIAssignRoleCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAssignRoleCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIAssignRoleCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAssignRoleTask.cs
+++ b/CP77.CR2W/Types/cp77/AIAssignRoleTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAudioSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIAudioSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAudioSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIAudioSquad.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAutonomousConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIAutonomousConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAutonomousConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIAutonomousConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIAvoidLineOfSightCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIAvoidLineOfSightCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIAvoidLineOfSightCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIAvoidLineOfSightCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIBackgroundCombatCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIBackgroundCombatCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBackgroundCombatCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIBackgroundCombatCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBackgroundCombatDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIBackgroundCombatDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBackgroundCombatStep.cs
+++ b/CP77.CR2W/Types/cp77/AIBackgroundCombatStep.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBaseMountCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIBaseMountCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBaseUseWorkspotCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIBaseUseWorkspotCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBehaviorCallbackExpression.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviorCallbackExpression.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBehaviorScript.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviorScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBehaviorScript.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviorScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIBehaviourSpot.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviourSpot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBehaviourSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviourSpotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBehaviourSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIBehaviourSpotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/AIBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/AIBlackboardDef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIBoolArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIBoolArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICAgent.cs
+++ b/CP77.CR2W/Types/cp77/AICAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICAgent.cs
+++ b/CP77.CR2W/Types/cp77/AICAgent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICArchetypeManager.cs
+++ b/CP77.CR2W/Types/cp77/AICArchetypeManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICArchetypeManager.cs
+++ b/CP77.CR2W/Types/cp77/AICArchetypeManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICMovementTarget.cs
+++ b/CP77.CR2W/Types/cp77/AICMovementTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICMovementTarget.cs
+++ b/CP77.CR2W/Types/cp77/AICMovementTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICNameArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AICNameArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeExtendableNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeExtendableNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeInstance.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeInstance.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeLazyNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeLazyNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionAnimationCurvePathDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionAnimationCurvePathDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionAnimationCurvePathDynamicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionAnimationCurvePathDynamicDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionDieDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionDieDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionDieDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionDieDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionDynamicMoveToDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionDynamicMoveToDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionReloadWeaponDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionReloadWeaponDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionReloadWeaponDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionReloadWeaponDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionTeleportToNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionTeleportToNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeActionTeleportToPositionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeActionTeleportToPositionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeAtomicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeAtomicDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeAtomicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeAtomicDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeBoolSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeBoolSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeBoolSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeBoolSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeBrainDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeBrainDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeChildrenListDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeChildrenListDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeCompleteImmediatelyDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeCompleteImmediatelyDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeCompositeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeCompositeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeCompositeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeCompositeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDebugLogDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDebugLogDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDecisionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDecisionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDoNothingDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDoNothingDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDoNothingDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDoNothingDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDynamicBindDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDynamicBindDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDynamicBindDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDynamicBindDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDynamicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDynamicDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeDynamicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeDynamicDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeFSMDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeFSMDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeFloatSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeFloatSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeFloatSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeFloatSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeForcedBehaviourDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeForcedBehaviourDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeForcedBehaviourDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeForcedBehaviourDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeIncludedTreeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeIncludedTreeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeInt32SharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeInt32SharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeInt32SharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeInt32SharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeNameSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeNameSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeNameSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeNameSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeParallelDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeParallelDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodePlayerControlledDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodePlayerControlledDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodePlayerControlledDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodePlayerControlledDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodePositionSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodePositionSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodePositionSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodePositionSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeReadWorkspotParamsDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeReadWorkspotParamsDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeScriptDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeScriptDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSequenceDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSequenceDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSequenceDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSequenceDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSetSplineMovementTargetDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSetSplineMovementTargetDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsBaseDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsBaseDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsBaseDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsBaseDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSharedVarsDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSimpleSelectorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSimpleSelectorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSimpleSelectorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSimpleSelectorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeSingleSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeSingleSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeTargetNodeSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeTargetNodeSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeTargetNodeSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeTargetNodeSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeTargetSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeTargetSharedVarDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICTreeNodeTargetSharedVarDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeTargetSharedVarDecoratorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICTreeNodeTimeoutDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AICTreeNodeTimeoutDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelectionRuntimeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AIClearLineOfSightCoverSelectionRuntimeData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIClearRoleCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIClearRoleCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIClearRoleCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIClearRoleCommandParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICombatAlley.cs
+++ b/CP77.CR2W/Types/cp77/AICombatAlley.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatAlley.cs
+++ b/CP77.CR2W/Types/cp77/AICombatAlley.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICombatGuardAreaConnectedCommunity.cs
+++ b/CP77.CR2W/Types/cp77/AICombatGuardAreaConnectedCommunity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatGuardAreaScriptCondition.cs
+++ b/CP77.CR2W/Types/cp77/AICombatGuardAreaScriptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatGuardAreaScriptCondition.cs
+++ b/CP77.CR2W/Types/cp77/AICombatGuardAreaScriptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICombatRelatedCommand.cs
+++ b/CP77.CR2W/Types/cp77/AICombatRelatedCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatSquad.cs
+++ b/CP77.CR2W/Types/cp77/AICombatSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatSquad.cs
+++ b/CP77.CR2W/Types/cp77/AICombatSquad.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICombatSquadScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/AICombatSquadScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatSquadScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/AICombatSquadScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICombatSquadTacticRatio.cs
+++ b/CP77.CR2W/Types/cp77/AICombatSquadTacticRatio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatTargetHelper.cs
+++ b/CP77.CR2W/Types/cp77/AICombatTargetHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICombatTargetHelper.cs
+++ b/CP77.CR2W/Types/cp77/AICombatTargetHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICommand.cs
+++ b/CP77.CR2W/Types/cp77/AICommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICommandDeviceHandler.cs
+++ b/CP77.CR2W/Types/cp77/AICommandDeviceHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICommandHandlerBase.cs
+++ b/CP77.CR2W/Types/cp77/AICommandHandlerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICommandQueuePS.cs
+++ b/CP77.CR2W/Types/cp77/AICommandQueuePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICommandsManager.cs
+++ b/CP77.CR2W/Types/cp77/AICommandsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICommandsManager.cs
+++ b/CP77.CR2W/Types/cp77/AICommandsManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICondition.cs
+++ b/CP77.CR2W/Types/cp77/AICondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICondition.cs
+++ b/CP77.CR2W/Types/cp77/AICondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICooldown.cs
+++ b/CP77.CR2W/Types/cp77/AICooldown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoreTasks.cs
+++ b/CP77.CR2W/Types/cp77/AICoreTasks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoreTasks.cs
+++ b/CP77.CR2W/Types/cp77/AICoreTasks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverDataDef.cs
+++ b/CP77.CR2W/Types/cp77/AICoverDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverDemandHolder.cs
+++ b/CP77.CR2W/Types/cp77/AICoverDemandHolder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverDemandHolder.cs
+++ b/CP77.CR2W/Types/cp77/AICoverDemandHolder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverHealthCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AICoverHealthCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverHealthCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AICoverHealthCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverHelper.cs
+++ b/CP77.CR2W/Types/cp77/AICoverHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverHelper.cs
+++ b/CP77.CR2W/Types/cp77/AICoverHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverScoringData.cs
+++ b/CP77.CR2W/Types/cp77/AICoverScoringData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverScoringData.cs
+++ b/CP77.CR2W/Types/cp77/AICoverScoringData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverSelectionParameters.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverSelectionParameters.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionRuntimeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverSelectionRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionRuntimeData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverSelectionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverSelectionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AICoverSelectionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICoverTypeCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AICoverTypeCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICoverTypeCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AICoverTypeCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AICustomComponents.cs
+++ b/CP77.CR2W/Types/cp77/AICustomComponents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AICustomComponents.cs
+++ b/CP77.CR2W/Types/cp77/AICustomComponents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDeathConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIDeathConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDeathConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIDeathConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDeathReactionsTask.cs
+++ b/CP77.CR2W/Types/cp77/AIDeathReactionsTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDebugConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIDebugConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDebugConditions.cs
+++ b/CP77.CR2W/Types/cp77/AIDebugConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDebugLogScope.cs
+++ b/CP77.CR2W/Types/cp77/AIDebugLogScope.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDefAI.cs
+++ b/CP77.CR2W/Types/cp77/AIDefAI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDefAI.cs
+++ b/CP77.CR2W/Types/cp77/AIDefAI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDefTreeVariableComparison.cs
+++ b/CP77.CR2W/Types/cp77/AIDefTreeVariableComparison.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDeviceFeedbackData.cs
+++ b/CP77.CR2W/Types/cp77/AIDeviceFeedbackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDeviceFeedbackData.cs
+++ b/CP77.CR2W/Types/cp77/AIDeviceFeedbackData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDirectorSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIDirectorSystemSquadAudioMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDirectorSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIDirectorSystemSquadAudioMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDistanceFromOthersCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIDistanceFromOthersCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDistanceFromOthersCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIDistanceFromOthersCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIDriveCommandsDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveCommandsDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDriveFollowCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveFollowCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDriveJoinTrafficCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveJoinTrafficCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDriveOnSplineCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveOnSplineCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDriveRacingCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveRacingCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIDriveToNodeCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIDriveToNodeCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEnemy.cs
+++ b/CP77.CR2W/Types/cp77/AIEnemy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEnemy.cs
+++ b/CP77.CR2W/Types/cp77/AIEnemy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIEnemyPushedToSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIEnemyPushedToSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEnemyThreatDetected.cs
+++ b/CP77.CR2W/Types/cp77/AIEnemyThreatDetected.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEntityLost.cs
+++ b/CP77.CR2W/Types/cp77/AIEntityLost.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEntityReuseEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIEntityReuseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEntitySpotted.cs
+++ b/CP77.CR2W/Types/cp77/AIEntitySpotted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEntityStubHandlerProviderSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIEntityStubHandlerProviderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEntityStubHandlerProviderSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIEntityStubHandlerProviderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIEquipCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIEquipCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEvents.cs
+++ b/CP77.CR2W/Types/cp77/AIEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIEvents.cs
+++ b/CP77.CR2W/Types/cp77/AIEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFSMEventTransitionsListDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIFSMEventTransitionsListDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFSMStateDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIFSMStateDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFSMTransitionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIFSMTransitionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFSMTransitionListDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIFSMTransitionListDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFindForwardPositionAround.cs
+++ b/CP77.CR2W/Types/cp77/AIFindForwardPositionAround.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFindForwardPositionAround.cs
+++ b/CP77.CR2W/Types/cp77/AIFindForwardPositionAround.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFindPositionAroundSelf.cs
+++ b/CP77.CR2W/Types/cp77/AIFindPositionAroundSelf.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFindPositionAroundTarget.cs
+++ b/CP77.CR2W/Types/cp77/AIFindPositionAroundTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFindPositionAroundTarget.cs
+++ b/CP77.CR2W/Types/cp77/AIFindPositionAroundTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFlatheadSetSoloModeCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFlatheadSetSoloModeCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFlatheadSetSoloModeCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIFlatheadSetSoloModeCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFloatArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIFloatArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowSlotDef.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowSlotDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowTargetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowTargetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerBeforeTakedown.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerBeforeTakedown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerBeforeTakedown.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerBeforeTakedown.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFollowerCombatCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerCombatCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerCombatCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerCombatCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFollowerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerDeviceCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerDeviceCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerInterpolateFollowingSpeed.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerInterpolateFollowingSpeed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerRole.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerRole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerSquad.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFollowerSquadMember.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerSquadMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerSquadMember.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerSquadMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFollowerTakedownCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerTakedownCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIFollowerTakedownCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIForceShootCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIForceShootCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIForceShootCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIForceShootCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFriendlyTargetAngleDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIFriendlyTargetAngleDistanceCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFriendlyTargetAngleDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIFriendlyTargetAngleDistanceCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIFriendlyTargetDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIFriendlyTargetDistanceCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIFriendlyTargetDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIFriendlyTargetDistanceCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIGameToneDetectorSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIGameToneDetectorSquadAudioMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGameToneDetectorSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIGameToneDetectorSquadAudioMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIGateSignal.cs
+++ b/CP77.CR2W/Types/cp77/AIGateSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGateSignalSender.cs
+++ b/CP77.CR2W/Types/cp77/AIGateSignalSender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGenericAdvancedLookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AIGenericAdvancedLookatTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGenericEntityLookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AIGenericEntityLookatTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGenericLookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AIGenericLookatTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGenericLookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AIGenericLookatTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIGenericStaticLookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AIGenericStaticLookatTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGuardArea.cs
+++ b/CP77.CR2W/Types/cp77/AIGuardArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGuardArea.cs
+++ b/CP77.CR2W/Types/cp77/AIGuardArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIGuardAreaConnectedCommunity.cs
+++ b/CP77.CR2W/Types/cp77/AIGuardAreaConnectedCommunity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGuardAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/AIGuardAreaManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIGuardAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/AIGuardAreaManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIHitReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/AIHitReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHoldPositionCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIHoldPositionCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHoldPositionCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIHoldPositionCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHostJoinedSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIHostJoinedSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHostLeftSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIHostLeftSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHostileThreatDetected.cs
+++ b/CP77.CR2W/Types/cp77/AIHostileThreatDetected.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHumanComponent.cs
+++ b/CP77.CR2W/Types/cp77/AIHumanComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIHumanComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/AIHumanComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIArchetypeManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIArchetypeManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIArchetypeManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIArchetypeManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIICombatGuardAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIICombatGuardAreaCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIICombatGuardAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIICombatGuardAreaCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIICommandsManager.cs
+++ b/CP77.CR2W/Types/cp77/AIICommandsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIICommandsManager.cs
+++ b/CP77.CR2W/Types/cp77/AIICommandsManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIICoverSelectionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIICoverSelectionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIICoverSelectionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIICoverSelectionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIEntityStubHandlerProviderSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIEntityStubHandlerProviderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIEntityStubHandlerProviderSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIEntityStubHandlerProviderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIGuardAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIGuardAreaManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIGuardAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIGuardAreaManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIInformationSpreadSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIInformationSpreadSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIInformationSpreadSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIInformationSpreadSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIINavigationSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIINavigationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIINavigationSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIINavigationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIObjectSelectionDebugProxy.cs
+++ b/CP77.CR2W/Types/cp77/AIIObjectSelectionDebugProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIObjectSelectionDebugProxy.cs
+++ b/CP77.CR2W/Types/cp77/AIIObjectSelectionDebugProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIReactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIReactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIReactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIIReactionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIISerializableArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIISerializableArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIISmartCoverManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISmartCoverManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIISmartCoverManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISmartCoverManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIISmartObjectManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISmartObjectManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIISmartObjectManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISmartObjectManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIISquadManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISquadManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIISquadManager.cs
+++ b/CP77.CR2W/Types/cp77/AIISquadManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIISystem.cs
+++ b/CP77.CR2W/Types/cp77/AIISystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIISystem.cs
+++ b/CP77.CR2W/Types/cp77/AIISystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIITarget.cs
+++ b/CP77.CR2W/Types/cp77/AIITarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIITarget.cs
+++ b/CP77.CR2W/Types/cp77/AIITarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIITargetTrackingListener.cs
+++ b/CP77.CR2W/Types/cp77/AIITargetTrackingListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIITargetTrackingListener.cs
+++ b/CP77.CR2W/Types/cp77/AIITargetTrackingListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIITrafficMovementSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIITrafficMovementSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIITrafficMovementSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIITrafficMovementSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIIWorkspotManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIWorkspotManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIIWorkspotManager.cs
+++ b/CP77.CR2W/Types/cp77/AIIWorkspotManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIInjectCombatTargetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIInjectCombatTargetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInjectCombatThreatCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIInjectCombatThreatCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInjectCombatThreatCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIInjectCombatThreatCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInjectLookatTargetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIInjectLookatTargetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInt32ArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIInt32ArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInt64ArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIInt64ArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerAllowDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerAllowDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerAllowDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerAllowDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerBehaviorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerBehaviorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerDenyDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerDenyDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIInterruptionHandlerDenyDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionHandlerDenyDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIInterruptionSignal.cs
+++ b/CP77.CR2W/Types/cp77/AIInterruptionSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIItemHandlingCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIItemHandlingCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIItemHandlingCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIItemHandlingCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIJoinTargetsSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIJoinTargetsSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIJoinTargetsSquadCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIJoinTargetsSquadCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIJoinTargetsSquadTask.cs
+++ b/CP77.CR2W/Types/cp77/AIJoinTargetsSquadTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIKeepCurrentCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIKeepCurrentCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIKeepCurrentCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIKeepCurrentCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AILocationInformation.cs
+++ b/CP77.CR2W/Types/cp77/AILocationInformation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AILookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AILookatTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AILookatTask.cs
+++ b/CP77.CR2W/Types/cp77/AILookatTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIMandatoryComponents.cs
+++ b/CP77.CR2W/Types/cp77/AIMandatoryComponents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMandatoryComponents.cs
+++ b/CP77.CR2W/Types/cp77/AIMandatoryComponents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIMeleeAttackCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMeleeAttackCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMeleeAttackCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIMeleeAttackCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMixingOutputSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIMixingOutputSystemSquadAudioMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMixingOutputSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIMixingOutputSystemSquadAudioMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIMountCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMountCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMountCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMountCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIMoveCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveCommandsDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveCommandsDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveOnSplineCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveOnSplineCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveOnSplineCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveOnSplineCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveRotateToCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveRotateToCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveToCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveToCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveToCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveToCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveToCoverCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveToCoverCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMoveToCoverCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIMoveToCoverCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMovementTypeSpec.cs
+++ b/CP77.CR2W/Types/cp77/AIMovementTypeSpec.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMusicSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIMusicSystemSquadAudioMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIMusicSystemSquadAudioMember.cs
+++ b/CP77.CR2W/Types/cp77/AIMusicSystemSquadAudioMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINPCCommandEvent.cs
+++ b/CP77.CR2W/Types/cp77/AINPCCommandEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCCommandStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/AINPCCommandStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCHighLevelStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCHighLevelStateCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCHighLevelStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCHighLevelStateCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINPCStanceStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCStanceStateCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCStanceStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCStanceStateCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINPCStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCStateCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCStateCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINPCUpperBodyStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCUpperBodyStateCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINPCUpperBodyStateCheck.cs
+++ b/CP77.CR2W/Types/cp77/AINPCUpperBodyStateCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINavigationSystem.cs
+++ b/CP77.CR2W/Types/cp77/AINavigationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINavigationSystem.cs
+++ b/CP77.CR2W/Types/cp77/AINavigationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AINavigationSystemQuery.cs
+++ b/CP77.CR2W/Types/cp77/AINavigationSystemQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINavigationSystemResult.cs
+++ b/CP77.CR2W/Types/cp77/AINavigationSystemResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINewThreat.cs
+++ b/CP77.CR2W/Types/cp77/AINewThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINoRole.cs
+++ b/CP77.CR2W/Types/cp77/AINoRole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AINoRole.cs
+++ b/CP77.CR2W/Types/cp77/AINoRole.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIObjectId.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionComponent.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionComponent.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionManager.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionManager.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionManagerInterface.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionManagerInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIObjectSelectionManagerInterface.cs
+++ b/CP77.CR2W/Types/cp77/AIObjectSelectionManagerInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIOffMeshConnectionComponent.cs
+++ b/CP77.CR2W/Types/cp77/AIOffMeshConnectionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIOwnerAngleCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerAngleCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIOwnerAngleCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerAngleCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIOwnerDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerDistanceCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIOwnerDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerDistanceCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIOwnerThreatCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerThreatCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIOwnerThreatCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIOwnerThreatCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIParametrizedResourceReference.cs
+++ b/CP77.CR2W/Types/cp77/AIParametrizedResourceReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPathLengthCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIPathLengthCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPathLengthCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIPathLengthCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIPathSecurityCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIPathSecurityCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPathSecurityCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIPathSecurityCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIPatrolCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIPatrolCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPatrolCommandPrologue.cs
+++ b/CP77.CR2W/Types/cp77/AIPatrolCommandPrologue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPatrolDef.cs
+++ b/CP77.CR2W/Types/cp77/AIPatrolDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPatrolPathParameters.cs
+++ b/CP77.CR2W/Types/cp77/AIPatrolPathParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPatrolRole.cs
+++ b/CP77.CR2W/Types/cp77/AIPatrolRole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPhaseStateEventHandlerComponent.cs
+++ b/CP77.CR2W/Types/cp77/AIPhaseStateEventHandlerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPlayMountedSlotWorkspotCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIPlayMountedSlotWorkspotCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPosition.cs
+++ b/CP77.CR2W/Types/cp77/AIPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPositionSpec.cs
+++ b/CP77.CR2W/Types/cp77/AIPositionSpec.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPrepareTakedownData.cs
+++ b/CP77.CR2W/Types/cp77/AIPrepareTakedownData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPrepareTakedownData.cs
+++ b/CP77.CR2W/Types/cp77/AIPrepareTakedownData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIPuppetBlackboardListener.cs
+++ b/CP77.CR2W/Types/cp77/AIPuppetBlackboardListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIPuppetBlackboardListener.cs
+++ b/CP77.CR2W/Types/cp77/AIPuppetBlackboardListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIQuickHackAction.cs
+++ b/CP77.CR2W/Types/cp77/AIQuickHackAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRagdollDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIRagdollDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRandomCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIRandomCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRandomCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIRandomCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIRandomTasks.cs
+++ b/CP77.CR2W/Types/cp77/AIRandomTasks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRandomTasks.cs
+++ b/CP77.CR2W/Types/cp77/AIRandomTasks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIReactionData.cs
+++ b/CP77.CR2W/Types/cp77/AIReactionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIReactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIReactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIReactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIReactionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIRelatedComponents.cs
+++ b/CP77.CR2W/Types/cp77/AIRelatedComponents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRelatedComponents.cs
+++ b/CP77.CR2W/Types/cp77/AIRelatedComponents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIResource.cs
+++ b/CP77.CR2W/Types/cp77/AIResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIResourceReference.cs
+++ b/CP77.CR2W/Types/cp77/AIResourceReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIResourceReference.cs
+++ b/CP77.CR2W/Types/cp77/AIResourceReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementArea.cs
+++ b/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementArea.cs
+++ b/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementAreaCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIReturnToRestrictMovementAreaCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIRole.cs
+++ b/CP77.CR2W/Types/cp77/AIRole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRole.cs
+++ b/CP77.CR2W/Types/cp77/AIRole.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIRoleCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIRoleCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRootMotionCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIRootMotionCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIRotateToCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIRotateToCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScanTargetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIScanTargetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScanTargetCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIScanTargetCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScanTargetTask.cs
+++ b/CP77.CR2W/Types/cp77/AIScanTargetTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptActionDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptActionDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptGuardArea.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptGuardArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptGuardArea.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptGuardArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIScriptSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptSquad.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptSquad.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListener.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListener.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIScriptsTargetTrackingListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISearchingLookat.cs
+++ b/CP77.CR2W/Types/cp77/AISearchingLookat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetAutocraftingState.cs
+++ b/CP77.CR2W/Types/cp77/AISetAutocraftingState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetCombatPresetCommand.cs
+++ b/CP77.CR2W/Types/cp77/AISetCombatPresetCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetCombatPresetCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AISetCombatPresetCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetCombatPresetTask.cs
+++ b/CP77.CR2W/Types/cp77/AISetCombatPresetTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetHealthRegenerationState.cs
+++ b/CP77.CR2W/Types/cp77/AISetHealthRegenerationState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISetSoloModeHandler.cs
+++ b/CP77.CR2W/Types/cp77/AISetSoloModeHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISharedVarDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AISharedVarDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISharedVarTableDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AISharedVarTableDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIShootCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIShootCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIShootingDataDef.cs
+++ b/CP77.CR2W/Types/cp77/AIShootingDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISignalCondition.cs
+++ b/CP77.CR2W/Types/cp77/AISignalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISignalEvent.cs
+++ b/CP77.CR2W/Types/cp77/AISignalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISignalEvent.cs
+++ b/CP77.CR2W/Types/cp77/AISignalEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISignalHandlerComponent.cs
+++ b/CP77.CR2W/Types/cp77/AISignalHandlerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISignalHandlerComponent.cs
+++ b/CP77.CR2W/Types/cp77/AISignalHandlerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISignalSenderTask.cs
+++ b/CP77.CR2W/Types/cp77/AISignalSenderTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISmartCoverManager.cs
+++ b/CP77.CR2W/Types/cp77/AISmartCoverManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISmartCoverManager.cs
+++ b/CP77.CR2W/Types/cp77/AISmartCoverManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISmartObjectManager.cs
+++ b/CP77.CR2W/Types/cp77/AISmartObjectManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISmartObjectManager.cs
+++ b/CP77.CR2W/Types/cp77/AISmartObjectManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISmartSpot.cs
+++ b/CP77.CR2W/Types/cp77/AISmartSpot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISmartSpot.cs
+++ b/CP77.CR2W/Types/cp77/AISmartSpot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISmartSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AISmartSpotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISmartSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AISmartSpotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISpiderbotCheckIfFriendlyMoved.cs
+++ b/CP77.CR2W/Types/cp77/AISpiderbotCheckIfFriendlyMoved.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISpiderbotFindBoredMovePosition.cs
+++ b/CP77.CR2W/Types/cp77/AISpiderbotFindBoredMovePosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISpot.cs
+++ b/CP77.CR2W/Types/cp77/AISpot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISpot.cs
+++ b/CP77.CR2W/Types/cp77/AISpot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AISpotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/AISpotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISpotPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/AISpotPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISpotUsageToken.cs
+++ b/CP77.CR2W/Types/cp77/AISpotUsageToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadAudioMemberBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadAudioMemberBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadAudioMemberBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadAudioMemberBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadBlackBoardDef.cs
+++ b/CP77.CR2W/Types/cp77/AISquadBlackBoardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AISquadCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AISquadCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadHelper.cs
+++ b/CP77.CR2W/Types/cp77/AISquadHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadHelper.cs
+++ b/CP77.CR2W/Types/cp77/AISquadHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadManager.cs
+++ b/CP77.CR2W/Types/cp77/AISquadManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadManager.cs
+++ b/CP77.CR2W/Types/cp77/AISquadManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadMemberBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadMemberBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadMemberBase.cs
+++ b/CP77.CR2W/Types/cp77/AISquadMemberBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadNPCMember.cs
+++ b/CP77.CR2W/Types/cp77/AISquadNPCMember.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadNPCMember.cs
+++ b/CP77.CR2W/Types/cp77/AISquadNPCMember.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISquadScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/AISquadScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISquadScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/AISquadScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIStackSignalCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIStackSignalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStackSignalConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIStackSignalConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStatListener.cs
+++ b/CP77.CR2W/Types/cp77/AIStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStatusEffectCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIStatusEffectCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStatusEffectCondition.cs
+++ b/CP77.CR2W/Types/cp77/AIStatusEffectCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIStopCoverCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIStopCoverCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStopCoverCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIStopCoverCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIStopCoverCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIStopCoverCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIStopCoverCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/AIStopCoverCommandParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionActivateLightPreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionActivateLightPreset_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionActivateLightPreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionActivateLightPreset_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionActivateStrongArmsFX_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionActivateStrongArmsFX_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionActivateStrongArmsFX_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionActivateStrongArmsFX_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionAddFact_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionAddFact_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionAddFact_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionAddFact_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionApplyTimeDilation_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionApplyTimeDilation_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionApplyTimeDilation_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionApplyTimeDilation_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionAttackWithWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionAttackWithWeapon_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionAttackWithWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionAttackWithWeapon_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCallReinforcements_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCallReinforcements_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCallReinforcements_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCallReinforcements_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCallSquadSearchBackUp_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCallSquadSearchBackUp_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCallSquadSearchBackUp_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCallSquadSearchBackUp_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionChangeAttitude_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionChangeAttitude_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionChangeAttitude_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionChangeAttitude_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionChangeCoverSelectionPreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionChangeCoverSelectionPreset_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionChangeCoverSelectionPreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionChangeCoverSelectionPreset_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCompleteCommand_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCompleteCommand_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCompleteCommand_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCompleteCommand_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionConditionalFailure_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionConditionalFailure_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionConditionalFailure_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionConditionalFailure_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCover_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCover_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCover_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCover_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCreateGameEffect_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCreateGameEffect_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCreateGameEffect_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCreateGameEffect_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionCustomEffectors_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCustomEffectors_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionCustomEffectors_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionCustomEffectors_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionDisableAimAssist_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDisableAimAssist_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionDisableAimAssist_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDisableAimAssist_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionDisableCollider_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDisableCollider_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionDisableCollider_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDisableCollider_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionDroneModifyAltitude_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDroneModifyAltitude_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionDroneModifyAltitude_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionDroneModifyAltitude_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionEquipOnBody_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionEquipOnBody_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionEquipOnBody_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionEquipOnBody_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionEquipOnSlot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionEquipOnSlot_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionEquipOnSlot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionEquipOnSlot_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionFailIfFriendlyFire_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFailIfFriendlyFire_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionFailIfFriendlyFire_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFailIfFriendlyFire_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionFail_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFail_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionFail_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFail_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionFastExitWorkspot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFastExitWorkspot_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionFastExitWorkspot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionFastExitWorkspot_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionForceDeath_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceDeath_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionForceDeath_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceDeath_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionForceEquip_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceEquip_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionForceEquip_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceEquip_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionForceHitReaction_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceHitReaction_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionForceHitReaction_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceHitReaction_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionForceUnequip_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceUnequip_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionForceUnequip_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionForceUnequip_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionGameplayLogicPackage_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionGameplayLogicPackage_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionGameplayLogicPackage_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionGameplayLogicPackage_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionGeneratePointOfInterestTarget_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionGeneratePointOfInterestTarget_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionGeneratePointOfInterestTarget_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionGeneratePointOfInterestTarget_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionHitData_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionHitData_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionHitData_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionHitData_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionInitialReactionParams_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionInitialReactionParams_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionInitialReactionParams_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionInitialReactionParams_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionLeaveCover_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionLeaveCover_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionLeaveCover_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionLeaveCover_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionMeleeAttackAttemptEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMeleeAttackAttemptEvent_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionMeleeAttackAttemptEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMeleeAttackAttemptEvent_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionMeleeAttackManager_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMeleeAttackManager_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionMeleeAttackManager_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMeleeAttackManager_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionMissileRainCircular_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMissileRainCircular_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionMissileRainCircular_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMissileRainCircular_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionMissileRainGrid_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMissileRainGrid_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionMissileRainGrid_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMissileRainGrid_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionModifyStatPool_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionModifyStatPool_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionModifyStatPool_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionModifyStatPool_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionMountVehicle_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMountVehicle_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionMountVehicle_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionMountVehicle_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionPlaySound_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionPlaySound_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionPlaySound_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionPlaySound_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionPlayVoiceOver_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionPlayVoiceOver_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionPlayVoiceOver_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionPlayVoiceOver_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionQueueAIEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQueueAIEvent_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionQueueAIEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQueueAIEvent_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionQueueCommunicationEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQueueCommunicationEvent_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionQueueCommunicationEvent_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQueueCommunicationEvent_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionQuickHack_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQuickHack_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionQuickHack_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionQuickHack_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionRandomize_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionRandomize_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionRandomize_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionRandomize_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionRegisterActionName_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionRegisterActionName_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionRegisterActionName_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionRegisterActionName_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionReloadWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionReloadWeapon_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionReloadWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionReloadWeapon_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionScaleDurationWithDistance_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionScaleDurationWithDistance_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionScaleDurationWithDistance_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionScaleDurationWithDistance_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSecuritySystemNotification_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSecuritySystemNotification_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSecuritySystemNotification_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSecuritySystemNotification_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSendSignal_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSendSignal_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSendSignal_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSendSignal_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipPrimaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipPrimaryWeapons_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipPrimaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipPrimaryWeapons_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipSecondaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipSecondaryWeapons_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipSecondaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipSecondaryWeapons_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipWeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipWeaponsUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetEquipWeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetEquipWeaponsUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetInfluenceMap_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetInfluenceMap_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetInfluenceMap_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetInfluenceMap_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetInt_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetInt_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetInt_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetInt_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetStimSource_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetStimSource_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetStimSource_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetStimSource_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetTargetByTag_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetTargetByTag_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetTargetByTag_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetTargetByTag_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipPrimaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipPrimaryWeapons_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipPrimaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipPrimaryWeapons_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipSecondaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipSecondaryWeapons_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipSecondaryWeapons_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipSecondaryWeapons_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipWeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipWeaponsUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetUnequipWeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetUnequipWeaponsUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetWaypointByTag_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetWaypointByTag_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetWaypointByTag_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetWaypointByTag_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSetWorldPosition_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetWorldPosition_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSetWorldPosition_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSetWorldPosition_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionShootToPoint_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionShootToPoint_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionShootToPoint_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionShootToPoint_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionShootWithWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionShootWithWeapon_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionShootWithWeapon_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionShootWithWeapon_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSpawnFX_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSpawnFX_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSpawnFX_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSpawnFX_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionSquadSync_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSquadSync_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionSquadSync_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionSquadSync_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionStartCooldown_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionStartCooldown_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionStartCooldown_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionStartCooldown_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionStatusEffect_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionStatusEffect_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionStatusEffect_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionStatusEffect_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionThrowItem_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionThrowItem_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionThrowItem_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionThrowItem_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionTriggerItemActivation_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionTriggerItemActivation_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionTriggerItemActivation_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionTriggerItemActivation_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionTriggerStim_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionTriggerStim_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionTriggerStim_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionTriggerStim_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionUnequipOnSlot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUnequipOnSlot_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionUnequipOnSlot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUnequipOnSlot_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionUpdateFriendlyFireParams_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUpdateFriendlyFireParams_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionUpdateFriendlyFireParams_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUpdateFriendlyFireParams_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionUseSensePreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUseSensePreset_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionUseSensePreset_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionUseSensePreset_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISubActionWorkspot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionWorkspot_Record_Implementation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISubActionWorkspot_Record_Implementation.cs
+++ b/CP77.CR2W/Types/cp77/AISubActionWorkspot_Record_Implementation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AISwitchToPrimaryWeaponCommand.cs
+++ b/CP77.CR2W/Types/cp77/AISwitchToPrimaryWeaponCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISwitchToSecondaryWeaponCommand.cs
+++ b/CP77.CR2W/Types/cp77/AISwitchToSecondaryWeaponCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISystemImpl.cs
+++ b/CP77.CR2W/Types/cp77/AISystemImpl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AISystemImpl.cs
+++ b/CP77.CR2W/Types/cp77/AISystemImpl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITacticLimiter.cs
+++ b/CP77.CR2W/Types/cp77/AITacticLimiter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITacticLimiter.cs
+++ b/CP77.CR2W/Types/cp77/AITacticLimiter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITaggedAIEvent.cs
+++ b/CP77.CR2W/Types/cp77/AITaggedAIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITakedownHandler.cs
+++ b/CP77.CR2W/Types/cp77/AITakedownHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITarget.cs
+++ b/CP77.CR2W/Types/cp77/AITarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITarget.cs
+++ b/CP77.CR2W/Types/cp77/AITarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITargetNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/AITargetNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITargetNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/AITargetNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITargetTrackerComponent.cs
+++ b/CP77.CR2W/Types/cp77/AITargetTrackerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITargetTrackerManager.cs
+++ b/CP77.CR2W/Types/cp77/AITargetTrackerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITargetTrackerManager.cs
+++ b/CP77.CR2W/Types/cp77/AITargetTrackerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITargetTrackerManagerInterface.cs
+++ b/CP77.CR2W/Types/cp77/AITargetTrackerManagerInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITargetTrackerManagerInterface.cs
+++ b/CP77.CR2W/Types/cp77/AITargetTrackerManagerInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITeleportCommand.cs
+++ b/CP77.CR2W/Types/cp77/AITeleportCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatBeliefPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatBeliefPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatBeliefPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatBeliefPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatCalculationEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatCalculationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatDeath.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatDeath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatDefeated.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatDefeated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatDistanceCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatDistanceCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatDistanceCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatExpectationInvalid.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatExpectationInvalid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatInvalid.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatInvalid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatLastKnownPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatLastKnownPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatLastKnownPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatLastKnownPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatRemoved.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatRemoved.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatSharedBeliefPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatSharedBeliefPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatSharedBeliefPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatSharedBeliefPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatSharedLastKnownPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatSharedLastKnownPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatSharedLastKnownPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatSharedLastKnownPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIThreatUnconscious.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatUnconscious.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThreatValid.cs
+++ b/CP77.CR2W/Types/cp77/AIThreatValid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIThrowGrenadeCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIThrowGrenadeCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITicketCondition.cs
+++ b/CP77.CR2W/Types/cp77/AITicketCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITicketCondition.cs
+++ b/CP77.CR2W/Types/cp77/AITicketCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITimeCondition.cs
+++ b/CP77.CR2W/Types/cp77/AITimeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITimeCondition.cs
+++ b/CP77.CR2W/Types/cp77/AITimeCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITimeoutCondition.cs
+++ b/CP77.CR2W/Types/cp77/AITimeoutCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITrackedLocation.cs
+++ b/CP77.CR2W/Types/cp77/AITrackedLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITrafficExternalWorkspotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficExternalWorkspotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITrafficMovementSystem.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficMovementSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITrafficMovementSystem.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficMovementSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITrafficWorkspotCompiled_.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficWorkspotCompiled_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITrafficWorkspotCompiled_.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficWorkspotCompiled_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITrafficWorkspotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITrafficWorkspotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITreeArgumentsDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITreeArgumentsDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITreeNodeDeathDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITreeNodeDeathDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITreeNodeDeathDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITreeNodeDeathDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AITreeNodeInterruptionDecoratorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITreeNodeInterruptionDecoratorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITreeNodeRepeatDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AITreeNodeRepeatDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITweakParams.cs
+++ b/CP77.CR2W/Types/cp77/AITweakParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AITweakParams.cs
+++ b/CP77.CR2W/Types/cp77/AITweakParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIUint64ArgumentInstancePS.cs
+++ b/CP77.CR2W/Types/cp77/AIUint64ArgumentInstancePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUnequipCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIUnequipCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUnmountCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIUnmountCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUnmountCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIUnmountCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIUseCoverCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIUseCoverCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUseWorkspotCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIUseWorkspotCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUtilityLossCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilityLossCoverSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUtilityLossCoverSelection.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilityLossCoverSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIUtilsCachedBoolValue.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilsCachedBoolValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUtilsCachedBoolValue.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilsCachedBoolValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIUtilsCombatSpaceHelper.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilsCombatSpaceHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIUtilsCombatSpaceHelper.cs
+++ b/CP77.CR2W/Types/cp77/AIUtilsCombatSpaceHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIVehicleAgent.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleAgent.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleAgent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIVehicleCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleConditionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleConditionAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleConditionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleConditionAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIVehicleFollowCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleFollowCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleJoinTrafficCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleJoinTrafficCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleJoinTrafficCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleJoinTrafficCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIVehicleOnSplineCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleOnSplineCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleRacingCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleRacingCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleTaskAbstract.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleTaskAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIVehicleTaskAbstract.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleTaskAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIVehicleToNodeCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIVehicleToNodeCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIWeapon.cs
+++ b/CP77.CR2W/Types/cp77/AIWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIWeapon.cs
+++ b/CP77.CR2W/Types/cp77/AIWeapon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIWorkspotManager.cs
+++ b/CP77.CR2W/Types/cp77/AIWorkspotManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIWorkspotManager.cs
+++ b/CP77.CR2W/Types/cp77/AIWorkspotManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionAnimationCurvePathDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionAnimationCurvePathDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionDieTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionDieTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionDieTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionDieTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionDroneMoveSplineTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionDroneMoveSplineTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionDroneMoveTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionDroneMoveTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionDynamicMoveTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionDynamicMoveTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionEquipItemNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionEquipItemNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionItemHandlingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionItemHandlingNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionItemHandlingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionItemHandlingNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMountHandlingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMountHandlingNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMountHandlingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMountHandlingNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMountNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMountNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMoveOnSplineNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMoveOnSplineNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMoveToSmartObjectNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMoveToSmartObjectNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMoveToWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMoveToWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMoveTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMoveTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionMoveWithPolicyTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionMoveWithPolicyTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateBaseTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateBaseTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateByAngleTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateByAngleTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectConstTimeTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectConstTimeTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectHeadingTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectHeadingTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectHeadingTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectHeadingTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToObjectTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToPositionTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToPositionTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToPositionTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionRotateToPositionTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionSceneAnimationMotionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionSceneAnimationMotionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionSlideNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionSlideNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToLocalPositionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToLocalPositionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToObjectNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToObjectNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToWorldPositionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionSlideToWorldPositionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionTeleportTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionTeleportTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionUnequipItemNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionUnequipItemNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionUnmountNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionUnmountNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionUseCommunityWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionUseCommunityWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorActionUseWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorActionUseWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAdvancedParameterizedBehavior.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAdvancedParameterizedBehavior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAdvancedParameterizedBehavior.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAdvancedParameterizedBehavior.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorAgentInfoDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAgentInfoDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAgentInfoDebuggerCommandEntry.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAgentInfoDebuggerCommandEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAndConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAndConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAndConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAndConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorAssignTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAssignTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAssignTaskItem.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAssignTaskItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAsyncCallbackToken.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAsyncCallbackToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAsyncCallbackToken.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAsyncCallbackToken.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorAttachToElevatorCommandTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAttachToElevatorCommandTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorAvoidThreatTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorAvoidThreatTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorBlackboard.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorComponentDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorComponentDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorComponentDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorComponentDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDebugInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDebugInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorDelegate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorIncludedDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorIncludedDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorIncludedDebuggerCommandEntry.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorIncludedDebuggerCommandEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorBehaviorInstanceCallStack.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorBehaviorInstanceCallStack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCTreeNodeControlledByQuestNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCTreeNodeControlledByQuestNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCTreeNodeControlledByQuestNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCTreeNodeControlledByQuestNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorChangeGuardAreaTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorChangeGuardAreaTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCheckDistanceToCompanionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCheckDistanceToCompanionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCheckLineOfFireTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCheckLineOfFireTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorClearActiveNodesDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorClearActiveNodesDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorClearActiveNodesDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorClearActiveNodesDebuggerCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorClearSearchInfluenceTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorClearSearchInfluenceTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorClearUsedAlertedSpotsTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorClearUsedAlertedSpotsTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCombatModeTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCombatModeTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCommandConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCommandConditionExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCommandConditionExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCommandHandlerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCommandHandlerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCompanionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCompanionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorComparisonExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorComparisonExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCompleteOnEventNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCompleteOnEventNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCompositeConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCompositeConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCompositeTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCompositeTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorConstantExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorConstantExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorConvertCommandToDynamicWorkspotTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorConvertCommandToDynamicWorkspotTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorConvertToDynamicWorkspotTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorConvertToDynamicWorkspotTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCreateAlertedInfluenceMapTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCreateAlertedInfluenceMapTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorCreateAlertedInfluenceMapTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorCreateAlertedInfluenceMapTaskDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDebugFailsafeConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDebugFailsafeConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDebugInfoBase.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDebugInfoBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDebugger.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDebugger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDebugger.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDebugger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDecoratorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDecoratorNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDelegateAttrRef.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDelegateAttrRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDelegateExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDelegateExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDelegateTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDelegateTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDelegateTaskRef.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDelegateTaskRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetObjectConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetObjectConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetObjectConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetObjectConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetPositionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDistanceToTargetPositionConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowPositionTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowPositionTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowPositionTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowPositionTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSlotTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSlotTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSlotTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSlotTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSplineTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowSplineTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowTargetTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveFollowTargetTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveIdleTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveIdleTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveIdleTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveIdleTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveJoinTrafficTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveJoinTrafficTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveJoinTrafficTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveJoinTrafficTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveRacingTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveRacingTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveSplineReverseTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveSplineReverseTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveStunnedTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveStunnedTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveStunnedTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveStunnedTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveSummoningTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveSummoningTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveSummoningTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveSummoningTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveToNodeTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveToNodeTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveToPointTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveToPointTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorDriveTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorDriveTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorEdgeConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEdgeConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEntityLODConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEntityLODConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEntityReuseEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEntityReuseEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventHandler.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventHandlerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventHandlerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventResolverDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorEventWithTagConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorEventWithTagConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorExitWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorExitWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorExpressionSocket.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorExpressionSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorExtractMountDataTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorExtractMountDataTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorExtractMountParentStubPositionTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorExtractMountParentStubPositionTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorExtractVehicleSlotWorkspotTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorExtractVehicleSlotWorkspotTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFSMStateDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFSMStateDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFSMStateWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFSMStateWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFSMStateWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFSMStateWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorFSMTransitionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFSMTransitionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFSMTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFSMTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFailerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFailerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFailerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFailerNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorFindAlertedWorkspotTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFindAlertedWorkspotTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFindClosestPointOnPathTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFindClosestPointOnPathTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFindClosestPointOnTrafficPathTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFindClosestPointOnTrafficPathTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFindLaneTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFindLaneTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFindNavigablePointTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFindNavigablePointTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorForcedBehaviorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorForcedBehaviorNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorForcedBehaviorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorForcedBehaviorNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorFreeReservedWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFreeReservedWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorFreeReservedWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorFreeReservedWorkspotNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorGenerateSearchInfluenceTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorGenerateSearchInfluenceTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorGetSelectedAgentDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorGetSelectedAgentDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorGetSelectedAgentDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorGetSelectedAgentDebuggerCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorHasDriverConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHasDriverConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorHasDriverConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHasDriverConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorHasPendingForcedBehaviorConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHasPendingForcedBehaviorConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorHasPendingForcedBehaviorConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHasPendingForcedBehaviorConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorHostilesDetectedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHostilesDetectedConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorHostilesDetectedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorHostilesDetectedConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorIDebugger.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIDebugger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIDebugger.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIDebugger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorIDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIDebuggerCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorIdleTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIdleTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIdleTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIdleTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorIfElseNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIfElseNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIncludedTreeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIncludedTreeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInfluenceExcludeObstaclePointTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInfluenceExcludeObstaclePointTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstance.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantConditionNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantMountConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantMountConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantTaskNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantTaskNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorInstantTaskNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorInstantTaskNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorIsBlockedByCompanionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIsBlockedByCompanionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIsInDesiredRangeConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIsInDesiredRangeConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIsNodeStreamedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIsNodeStreamedConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIsThreatOnPathConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIsThreatOnPathConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorIsValueValidConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorIsValueValidConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorJoinFollowerSquadWithTargetDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorJoinFollowerSquadWithTargetDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorLeafTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLeafTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorLeafTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLeafTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorLeaveCoverImmediatelyNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLeaveCoverImmediatelyNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorLeaveCoverImmediatelyNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLeaveCoverImmediatelyNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorLimiterNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLimiterNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorLineOfSightClearConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorLineOfSightClearConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMappingConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMappingConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMappingExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMappingExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMaybeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMaybeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMonitorConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMonitorConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMonitorConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMonitorConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMonitorTaskNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMonitorTaskNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMountEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMountEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMountRequestConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMountRequestConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMountToEntTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMountToEntTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMoveAlongTrafficPathActionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMoveAlongTrafficPathActionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMovementPolicyTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMovementPolicyTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorMovementPolicyTaskItemDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorMovementPolicyTaskItemDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNaryOperatorExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNaryOperatorExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNestedTreeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNestedTreeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeRefConverterTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeRefConverterTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToInstanceTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToInstanceTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToInstanceTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToInstanceTaskDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToObjectTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToObjectTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToObjectTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeRefToObjectTaskDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeStatusDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeStatusDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorNodeStatusDebuggerCommandEntry.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorNodeStatusDebuggerCommandEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorOrConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorOrConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorOrConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorOrConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorParallelNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorParallelNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorParameterizedBehavior.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorParameterizedBehavior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveEventTagConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveEventTagConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveExpressionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorPassiveSignalConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPassiveSignalConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPatrolActionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPatrolActionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPickSearchDestinationTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPickSearchDestinationTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPredictTargetMovementDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPredictTargetMovementDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPrepareReservedCrowdWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPrepareReservedCrowdWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorPuppetRefToGameObjectTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorPuppetRefToGameObjectTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorRandomConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorRandomConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorRecalculateVehicleWorkspotPositionTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorRecalculateVehicleWorkspotPositionTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorReevaluateOnEventNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorReevaluateOnEventNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorRepeatNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorRepeatNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorResource.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSaveEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSaveEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptBase.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptBase.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptBehaviorDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptBehaviorDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptBehaviorDelegate.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptBehaviorDelegate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptExecutionContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptExecutionContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptPassiveExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptPassiveExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptUtils.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorScriptUtils.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorScriptUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectCombatTargetTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectCombatTargetTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectCoverTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectCoverTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectWorkspotEntryTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectWorkspotEntryTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectedCoversData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectedCoversData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectionStagePtrWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectionStagePtrWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectionStagePtrWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectionStagePtrWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectorTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectorTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSelectorTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSelectorTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSendActionEventTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSendActionEventTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSendSignalTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSendSignalTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSequenceTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSequenceTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSequenceTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSequenceTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorShouldEnterCrowdConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorShouldEnterCrowdConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorShouldEnterCrowdConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorShouldEnterCrowdConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSignalConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSignalConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSimpleParameterizedBehavior.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSimpleParameterizedBehavior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSimpleParameterizedBehavior.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSimpleParameterizedBehavior.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSlotOccupiedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSlotOccupiedConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorStackScriptPassiveExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStackScriptPassiveExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorStackScriptPassiveExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStackScriptPassiveExpressionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorStackScriptTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStackScriptTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorStoryActionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStoryActionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorStoryEventResolverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStoryEventResolverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorStoryTierConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorStoryTierConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSubtreeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSubtreeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSucceederNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSucceederNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSucceederNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSucceederNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorSuspiciousObjectEvent.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSuspiciousObjectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorSystemVariableExpressionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorSystemVariableExpressionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTaskDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTaskDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTaskNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTaskNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTimeoutNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTimeoutNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTrackPatrolProgressNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTrackPatrolProgressNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDebugInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDebugInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTreeNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorTrueConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTrueConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorTrueConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTrueConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorTypeRef.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorTypeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorUnaryConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorUnaryConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorUniqueActiveCommandList.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorUniqueActiveCommandList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorUniqueActiveCommandList.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorUniqueActiveCommandList.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorUnmountImmediatelyNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorUnmountImmediatelyNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorUsedSpotTokensList.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorUsedSpotTokensList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitFormationPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitFormationPositionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitFormationPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitFormationPositionConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitJoinTrafficConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitJoinTrafficConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitJoinTrafficConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitJoinTrafficConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitRefPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitRefPositionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitRefPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitRefPositionConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSlotConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSlotConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSlotConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSlotConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineBackwardToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineBackwardToFollowConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineBackwardToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineBackwardToFollowConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineToFollowConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSplineToFollowConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitStunnedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitStunnedConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitStunnedConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitStunnedConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSummonConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSummonConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitSummonConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitSummonConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToFollowConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToFollowConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToFollowConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToReachConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToReachConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToReachConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitTargetToReachConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitWorldPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitWorldPositionConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitWorldPositionConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitWorldPositionConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitingKeepMountedCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitingKeepMountedCommandConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitingKeepMountedCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitingKeepMountedCommandConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitingMountCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitingMountCommandConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitingNotMountedCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitingNotMountedCommandConditionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWaitingNotMountedCommandConditionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWaitingNotMountedCommandConditionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorWorkspotList.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWorkspotList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWorkspotListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWorkspotListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorWorkspotListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorWorkspotListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorconditionScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorconditionScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorconditionScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorconditionScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehavioreventResolverScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehavioreventResolverScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehavioreventResolverScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehavioreventResolverScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviorexpressionScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorexpressionScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviorexpressionScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviorexpressionScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortaskScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortaskScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortaskScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortaskScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortaskStackScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortaskStackScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortaskStackScript.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortaskStackScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakAmmoCountConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakAmmoCountConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakAmmoCountConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakAmmoCountConditionData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakCompiledActionConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakCompiledActionConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakCompiledActionConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakCompiledActionConditionData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakConditionStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakConditionStatusEffectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakConditionStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakConditionStatusEffectListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakDetectionListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakDetectionListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakDetectionListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakDetectionListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakExecutionContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakExecutionContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakItemsInInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakItemsInInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakItemsInInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakItemsInInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakNPCCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakNPCCallbacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakNPCCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakNPCCallbacks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakPlayerCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakPlayerCallbacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakPlayerCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakPlayerCallbacks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakStateCallback.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakStateCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakStateCallback.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakStateCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakStateConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakStateConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakStateConditionData.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakStateConditionData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakTargetLocation.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakTargetLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakTargetStates.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakTargetStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakTargetStates.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakTargetStates.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakTweakActionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakTweakActionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AIbehaviortweakTweakActionSystem.cs
+++ b/CP77.CR2W/Types/cp77/AIbehaviortweakTweakActionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AIsquadsOrder.cs
+++ b/CP77.CR2W/Types/cp77/AIsquadsOrder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AJournalEntryWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AJournalEntryWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEArea.cs
+++ b/CP77.CR2W/Types/cp77/AOEArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEAreaController.cs
+++ b/CP77.CR2W/Types/cp77/AOEAreaController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEAreaController.cs
+++ b/CP77.CR2W/Types/cp77/AOEAreaController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AOEAreaControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/AOEAreaControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEAreaSetup.cs
+++ b/CP77.CR2W/Types/cp77/AOEAreaSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEEffector.cs
+++ b/CP77.CR2W/Types/cp77/AOEEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEEffector.cs
+++ b/CP77.CR2W/Types/cp77/AOEEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AOEEffectorController.cs
+++ b/CP77.CR2W/Types/cp77/AOEEffectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AOEEffectorController.cs
+++ b/CP77.CR2W/Types/cp77/AOEEffectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AOEEffectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/AOEEffectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ATooltipData.cs
+++ b/CP77.CR2W/Types/cp77/ATooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ATooltipData.cs
+++ b/CP77.CR2W/Types/cp77/ATooltipData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AVComponent.cs
+++ b/CP77.CR2W/Types/cp77/AVComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AVComponent.cs
+++ b/CP77.CR2W/Types/cp77/AVComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AbilityData.cs
+++ b/CP77.CR2W/Types/cp77/AbilityData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AbsolutePathSerializable.cs
+++ b/CP77.CR2W/Types/cp77/AbsolutePathSerializable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AbstractLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AbstractLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AbstractLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AbstractLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AbstractLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/AbstractLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessBreach.cs
+++ b/CP77.CR2W/Types/cp77/AccessBreach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessBreachListener.cs
+++ b/CP77.CR2W/Types/cp77/AccessBreachListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessBreachListener.cs
+++ b/CP77.CR2W/Types/cp77/AccessBreachListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/AccessPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointCompatibleWithUser.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointCompatibleWithUser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointCompatibleWithUser.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointCompatibleWithUser.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AccessPointController.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointController.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AccessPointControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointHasCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointHasCPOMissionDataPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointHasCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointHasCPOMissionDataPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AccessPointIsBlocked.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointIsBlocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccessPointIsBlocked.cs
+++ b/CP77.CR2W/Types/cp77/AccessPointIsBlocked.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AccumulatedDamageDigitLogicController.cs
+++ b/CP77.CR2W/Types/cp77/AccumulatedDamageDigitLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AccumulatedDamageDigitsNode.cs
+++ b/CP77.CR2W/Types/cp77/AccumulatedDamageDigitsNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AcquireDeviceLink.cs
+++ b/CP77.CR2W/Types/cp77/AcquireDeviceLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AcquireDeviceLink.cs
+++ b/CP77.CR2W/Types/cp77/AcquireDeviceLink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionAnimationScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionAnimationScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionAnimationScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionAnimationScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionBool.cs
+++ b/CP77.CR2W/Types/cp77/ActionBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionBool.cs
+++ b/CP77.CR2W/Types/cp77/ActionBool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionCooldownEvent.cs
+++ b/CP77.CR2W/Types/cp77/ActionCooldownEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionDemolition.cs
+++ b/CP77.CR2W/Types/cp77/ActionDemolition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionDemolition.cs
+++ b/CP77.CR2W/Types/cp77/ActionDemolition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionDisposal.cs
+++ b/CP77.CR2W/Types/cp77/ActionDisposal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionDisposal.cs
+++ b/CP77.CR2W/Types/cp77/ActionDisposal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionDodgeScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionDodgeScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionDodgeScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionDodgeScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionEngineering.cs
+++ b/CP77.CR2W/Types/cp77/ActionEngineering.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionEngineering.cs
+++ b/CP77.CR2W/Types/cp77/ActionEngineering.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionEntityReference.cs
+++ b/CP77.CR2W/Types/cp77/ActionEntityReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionEntityReference.cs
+++ b/CP77.CR2W/Types/cp77/ActionEntityReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionEnum.cs
+++ b/CP77.CR2W/Types/cp77/ActionEnum.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionEnum.cs
+++ b/CP77.CR2W/Types/cp77/ActionEnum.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionFloat.cs
+++ b/CP77.CR2W/Types/cp77/ActionFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionFloat.cs
+++ b/CP77.CR2W/Types/cp77/ActionFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionForceResetDevice.cs
+++ b/CP77.CR2W/Types/cp77/ActionForceResetDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionHacking.cs
+++ b/CP77.CR2W/Types/cp77/ActionHacking.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionHacking.cs
+++ b/CP77.CR2W/Types/cp77/ActionHacking.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionHitReactionScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionHitReactionScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionHitReactionScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionHitReactionScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionInt.cs
+++ b/CP77.CR2W/Types/cp77/ActionInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionInt.cs
+++ b/CP77.CR2W/Types/cp77/ActionInt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionInteractivityInfo.cs
+++ b/CP77.CR2W/Types/cp77/ActionInteractivityInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionName.cs
+++ b/CP77.CR2W/Types/cp77/ActionName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionName.cs
+++ b/CP77.CR2W/Types/cp77/ActionName.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionNodeRef.cs
+++ b/CP77.CR2W/Types/cp77/ActionNodeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionNodeRef.cs
+++ b/CP77.CR2W/Types/cp77/ActionNodeRef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionNotifier.cs
+++ b/CP77.CR2W/Types/cp77/ActionNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionOverride.cs
+++ b/CP77.CR2W/Types/cp77/ActionOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionOverride.cs
+++ b/CP77.CR2W/Types/cp77/ActionOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionScavenge.cs
+++ b/CP77.CR2W/Types/cp77/ActionScavenge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionScavenge.cs
+++ b/CP77.CR2W/Types/cp77/ActionScavenge.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/ActionSkillCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionSlideToScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionSlideToScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionSlideToScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionSlideToScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionTargetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ActionTargetPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionTeleportScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionTeleportScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionTeleportScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/ActionTeleportScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionUploadListener.cs
+++ b/CP77.CR2W/Types/cp77/ActionUploadListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionWeightCondition.cs
+++ b/CP77.CR2W/Types/cp77/ActionWeightCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionWeightManagerDelegate.cs
+++ b/CP77.CR2W/Types/cp77/ActionWeightManagerDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionWorkSpot.cs
+++ b/CP77.CR2W/Types/cp77/ActionWorkSpot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionsSequence.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionsSequencer.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequencer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionsSequencer.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequencer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionsSequencerController.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequencerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActionsSequencerController.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequencerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActionsSequencerControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ActionsSequencerControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivateC4.cs
+++ b/CP77.CR2W/Types/cp77/ActivateC4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivateCoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ActivateCoverDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivateCoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ActivateCoverDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActivateCoverEvents.cs
+++ b/CP77.CR2W/Types/cp77/ActivateCoverEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivateDevice.cs
+++ b/CP77.CR2W/Types/cp77/ActivateDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceAnimSetup.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceAnimSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceCover.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceCover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceIndustrialArm.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceIndustrialArm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceNPC.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceNPCController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceNPCController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceNPCController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceNPCController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceNPCControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceNPCControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceNPCSetup.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceNPCSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceSetup.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceTransfromAnim.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceTransfromAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceTrap.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceTrap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatedDeviceTrapDestruction.cs
+++ b/CP77.CR2W/Types/cp77/ActivatedDeviceTrapDestruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Activator.cs
+++ b/CP77.CR2W/Types/cp77/Activator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatorController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatorController.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActivatorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatorOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivatorOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorOperationTriggerData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ActivatorOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/ActivatorOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActivePerkChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ActivePerkChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActiveSkillScreenChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ActiveSkillScreenChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ActiveSkillScreenChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ActiveSkillScreenChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdHocAnimationDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdHocAnimationDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdHocAnimationDef.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdHocAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdHocAnimationEvents.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdHocAnimationEvents.cs
+++ b/CP77.CR2W/Types/cp77/AdHocAnimationEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdamSmasherComponent.cs
+++ b/CP77.CR2W/Types/cp77/AdamSmasherComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdamSmasherHealthChangeListener.cs
+++ b/CP77.CR2W/Types/cp77/AdamSmasherHealthChangeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddAchievementRequest.cs
+++ b/CP77.CR2W/Types/cp77/AddAchievementRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddActiveContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddActiveContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddActiveStimuli.cs
+++ b/CP77.CR2W/Types/cp77/AddActiveStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddDevelopmentPointEffector.cs
+++ b/CP77.CR2W/Types/cp77/AddDevelopmentPointEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddDevelopmentPoints.cs
+++ b/CP77.CR2W/Types/cp77/AddDevelopmentPoints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddExperience.cs
+++ b/CP77.CR2W/Types/cp77/AddExperience.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddForceHighlightTargetEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddForceHighlightTargetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddHitFlagToAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/AddHitFlagToAttackEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddInvestigatorEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddInvestigatorEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddItemForPlayerToPickUp.cs
+++ b/CP77.CR2W/Types/cp77/AddItemForPlayerToPickUp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddItemToVendorRequest.cs
+++ b/CP77.CR2W/Types/cp77/AddItemToVendorRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddItemsEffector.cs
+++ b/CP77.CR2W/Types/cp77/AddItemsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddOrRemoveListenerEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddOrRemoveListenerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddOrRemoveListenerForGOEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddOrRemoveListenerForGOEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddRecipeRequest.cs
+++ b/CP77.CR2W/Types/cp77/AddRecipeRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddStatusEffectListenerEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddStatusEffectListenerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddStatusEffectToAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/AddStatusEffectToAttackEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/AddSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddTargetToHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddTargetToHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddUserEvent.cs
+++ b/CP77.CR2W/Types/cp77/AddUserEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AddWeapon.cs
+++ b/CP77.CR2W/Types/cp77/AddWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForDeescalatingFearPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForDeescalatingFearPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForDeescalatingFearPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForDeescalatingFearPhase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingFearPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingFearPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingFearPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingFearPhase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingPanicPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingPanicPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingPanicPhase.cs
+++ b/CP77.CR2W/Types/cp77/AdjustAnimWrappersForEscalatingPanicPhase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AdvanceChangeLightEvent.cs
+++ b/CP77.CR2W/Types/cp77/AdvanceChangeLightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AdvertisementWidgetComponent.cs
+++ b/CP77.CR2W/Types/cp77/AdvertisementWidgetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Agent.cs
+++ b/CP77.CR2W/Types/cp77/Agent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AgentDistanceToTarget.cs
+++ b/CP77.CR2W/Types/cp77/AgentDistanceToTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AgentMovingHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/AgentMovingHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AgentRegistry.cs
+++ b/CP77.CR2W/Types/cp77/AgentRegistry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AiControlledDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AiControlledDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AiControlledDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AiControlledDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AiControlledEvents.cs
+++ b/CP77.CR2W/Types/cp77/AiControlledEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AiControlledEvents.cs
+++ b/CP77.CR2W/Types/cp77/AiControlledEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimAssist.cs
+++ b/CP77.CR2W/Types/cp77/AimAssist.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimAssist.cs
+++ b/CP77.CR2W/Types/cp77/AimAssist.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimAssistModule.cs
+++ b/CP77.CR2W/Types/cp77/AimAssistModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimAssistSettingsListener.cs
+++ b/CP77.CR2W/Types/cp77/AimAssistSettingsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimAtTargetCommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/AimAtTargetCommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimAtTargetCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/AimAtTargetCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimAtTargetCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/AimAtTargetCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimDownSightController.cs
+++ b/CP77.CR2W/Types/cp77/AimDownSightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimWalkDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AimWalkDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimWalkDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AimWalkDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimWalkEvents.cs
+++ b/CP77.CR2W/Types/cp77/AimWalkEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimWalkEvents.cs
+++ b/CP77.CR2W/Types/cp77/AimWalkEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimingContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AimingContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimingContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AimingContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimingContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/AimingContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimingContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/AimingContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AimingStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AimingStateDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AimingStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/AimingStateEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Air.cs
+++ b/CP77.CR2W/Types/cp77/Air.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Air.cs
+++ b/CP77.CR2W/Types/cp77/Air.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AirHoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AirHoverDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AirHoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AirHoverDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AirHoverEvents.cs
+++ b/CP77.CR2W/Types/cp77/AirHoverEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AirHoverEvents.cs
+++ b/CP77.CR2W/Types/cp77/AirHoverEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AirThrustersDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AirThrustersDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AirThrustersDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AirThrustersDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AirThrustersEvents.cs
+++ b/CP77.CR2W/Types/cp77/AirThrustersEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AirThrustersEvents.cs
+++ b/CP77.CR2W/Types/cp77/AirThrustersEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlarmEvent.cs
+++ b/CP77.CR2W/Types/cp77/AlarmEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlarmLight.cs
+++ b/CP77.CR2W/Types/cp77/AlarmLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlarmLightController.cs
+++ b/CP77.CR2W/Types/cp77/AlarmLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlarmLightController.cs
+++ b/CP77.CR2W/Types/cp77/AlarmLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlarmLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/AlarmLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlertedAnimWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AlertedAnimWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlertedAnimWrapper.cs
+++ b/CP77.CR2W/Types/cp77/AlertedAnimWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlertedConditions.cs
+++ b/CP77.CR2W/Types/cp77/AlertedConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlertedConditions.cs
+++ b/CP77.CR2W/Types/cp77/AlertedConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlertedRoleHandler.cs
+++ b/CP77.CR2W/Types/cp77/AlertedRoleHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlertedRoleHandler.cs
+++ b/CP77.CR2W/Types/cp77/AlertedRoleHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlertedState.cs
+++ b/CP77.CR2W/Types/cp77/AlertedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlertedState.cs
+++ b/CP77.CR2W/Types/cp77/AlertedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AltimeterController.cs
+++ b/CP77.CR2W/Types/cp77/AltimeterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlwaysTruePrereq.cs
+++ b/CP77.CR2W/Types/cp77/AlwaysTruePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlwaysTruePrereq.cs
+++ b/CP77.CR2W/Types/cp77/AlwaysTruePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AlwaysTruePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/AlwaysTruePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AlwaysTruePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/AlwaysTruePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AmbientOverrideAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/AmbientOverrideAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoLogicController.cs
+++ b/CP77.CR2W/Types/cp77/AmmoLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitCallback.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitCallback.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AmmoStateHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredCallback.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredCallback.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/AmmoStateHitTriggeredPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AndroidTurnOffEffector.cs
+++ b/CP77.CR2W/Types/cp77/AndroidTurnOffEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AndroidTurnOffEffector.cs
+++ b/CP77.CR2W/Types/cp77/AndroidTurnOffEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AndroidTurnOnEffector.cs
+++ b/CP77.CR2W/Types/cp77/AndroidTurnOnEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AndroidTurnOnEffector.cs
+++ b/CP77.CR2W/Types/cp77/AndroidTurnOnEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AnimFeatureCustom.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeatureCustom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeatureCustom.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeatureCustom.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AnimFeatureDoor.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeatureDoor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeatureShieldState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeatureShieldState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_AdHocAnimation.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_AdHocAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_AerialTakedown.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_AerialTakedown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_AirHover.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_AirHover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_AirThrusterData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_AirThrusterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_AnimatedDevice.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_AnimatedDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_BulletBend.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_BulletBend.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CamberData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CamberData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CameraBodyOffset.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CameraBodyOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CameraBreathing.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CameraBreathing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CameraGameplay.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CameraGameplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CameraRecoil.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CameraRecoil.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CameraSceneMode.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CameraSceneMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Carry.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Carry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_ChestPress.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_ChestPress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CombatGadget.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CombatGadget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CombatState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CombatState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Container.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Container.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CoverState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CoverState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_CrowdRunningAway.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_CrowdRunningAway.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DOFControl.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DOFControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DelayEntry.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DelayEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DeviceWorkspot.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DeviceWorkspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DistractionState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DistractionState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DoorDevice.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DoorDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DroneActionAltitudeOffset.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DroneActionAltitudeOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DroneProcedural.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DroneProcedural.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_DroneStateAnimationData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_DroneStateAnimationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_EquipType.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_EquipType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_FacialReaction.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_FacialReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_FocusMode.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_FocusMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_ForkliftDevice.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_ForkliftDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Grapple.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Grapple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_HoverJumpData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_HoverJumpData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_IconicItem.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_IconicItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_IndustrialArm.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_IndustrialArm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Inspection.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Inspection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_LadderEnterStyleData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_LadderEnterStyleData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Landing.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Landing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_LeftHandAnimation.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_LeftHandAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_LeftHandCyberware.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_LeftHandCyberware.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_LookAt.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_LookAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_MeleeAttack.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_MeleeAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Mounting.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Mounting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_MuzzleData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_MuzzleData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_OwnerType.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_OwnerType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Paperdoll.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Paperdoll.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PartData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PartData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PhotomodeFacial.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PhotomodeFacial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PhotomodePoseCategory.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PhotomodePoseCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerCoverActionWeaponHolster.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerCoverActionWeaponHolster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerDeathAnimation.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerDeathAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerHitReactionData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerHitReactionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerLocomotionStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerLocomotionStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerPeekScale.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerPeekScale.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PlayerVitals.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PlayerVitals.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_PreClimbing.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_PreClimbing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_ProceduralIronsightData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_ProceduralIronsightData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_ProceduralLean.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_ProceduralLean.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_RagdollState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_RagdollState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Reprimand.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Reprimand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_RoadBlock.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_RoadBlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_RotatingObject.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_RotatingObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SafeAction.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SafeAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SceneGameplayOverrides.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SceneGameplayOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SceneSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SceneSystemCarrying.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SceneSystemCarrying.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SecurityTurretData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SecurityTurretData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SelectRandomAnimSync.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SelectRandomAnimSync.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SensorDevice.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SensorDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SimpleDevice.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SimpleDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SimpleIkSystem.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SimpleIkSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Stamina.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Stamina.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_StatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_StatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_StimReactions.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_StimReactions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SuperheroLand.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SuperheroLand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_SwimmingData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_SwimmingData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Throwable.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Throwable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_TriggerModeChange.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_TriggerModeChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_VehicleData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_VehicleData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_VehicleNPCData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_VehicleNPCData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_VehicleNPCDeathData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_VehicleNPCDeathData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_VehicleState.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_VehicleState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_VehicleSteeringLimit.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_VehicleSteeringLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponBlur.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponBlur.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponHandlingStats.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponHandlingStats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponOverride.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponReload.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponReload.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponReloadSpeedData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponReloadSpeedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponScopeData.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponScopeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WeaponStats.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WeaponStats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Whip.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Whip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_WorkspotIK.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_WorkspotIK.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimFeature_Zoom.cs
+++ b/CP77.CR2W/Types/cp77/AnimFeature_Zoom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimateAnchorOnHoverView.cs
+++ b/CP77.CR2W/Types/cp77/AnimateAnchorOnHoverView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimatedListItemController.cs
+++ b/CP77.CR2W/Types/cp77/AnimatedListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimatedSign.cs
+++ b/CP77.CR2W/Types/cp77/AnimatedSign.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationChain.cs
+++ b/CP77.CR2W/Types/cp77/AnimationChain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationChainPlayer.cs
+++ b/CP77.CR2W/Types/cp77/AnimationChainPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationElement.cs
+++ b/CP77.CR2W/Types/cp77/AnimationElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationLogicController.cs
+++ b/CP77.CR2W/Types/cp77/AnimationLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationSystemForcedVisibilityEntityData.cs
+++ b/CP77.CR2W/Types/cp77/AnimationSystemForcedVisibilityEntityData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationSystemForcedVisibilityManager.cs
+++ b/CP77.CR2W/Types/cp77/AnimationSystemForcedVisibilityManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationsConstructor.cs
+++ b/CP77.CR2W/Types/cp77/AnimationsConstructor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationsLoaded.cs
+++ b/CP77.CR2W/Types/cp77/AnimationsLoaded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationsLoaded.cs
+++ b/CP77.CR2W/Types/cp77/AnimationsLoaded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AnimationsLoadedCondition.cs
+++ b/CP77.CR2W/Types/cp77/AnimationsLoadedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AnimationsLoadedTask.cs
+++ b/CP77.CR2W/Types/cp77/AnimationsLoadedTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AntiRadar.cs
+++ b/CP77.CR2W/Types/cp77/AntiRadar.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApartmentScreen.cs
+++ b/CP77.CR2W/Types/cp77/ApartmentScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApartmentScreenController.cs
+++ b/CP77.CR2W/Types/cp77/ApartmentScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApartmentScreenController.cs
+++ b/CP77.CR2W/Types/cp77/ApartmentScreenController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ApartmentScreenControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ApartmentScreenControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApartmentScreenInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ApartmentScreenInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AppearanceRandomizerComponent.cs
+++ b/CP77.CR2W/Types/cp77/AppearanceRandomizerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyAnimWrappersOnWeapon.cs
+++ b/CP77.CR2W/Types/cp77/ApplyAnimWrappersOnWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyDamageDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ApplyDamageDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyDiodeLightPresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/ApplyDiodeLightPresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyDroneLocomotionWrapperEvent.cs
+++ b/CP77.CR2W/Types/cp77/ApplyDroneLocomotionWrapperEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyDroneProceduralAnimFeatureEvent.cs
+++ b/CP77.CR2W/Types/cp77/ApplyDroneProceduralAnimFeatureEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyEffectorEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyEffectorEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyJammer.cs
+++ b/CP77.CR2W/Types/cp77/ApplyJammer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyJammer.cs
+++ b/CP77.CR2W/Types/cp77/ApplyJammer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ApplyJammerFromCw.cs
+++ b/CP77.CR2W/Types/cp77/ApplyJammerFromCw.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyJammerFromCw.cs
+++ b/CP77.CR2W/Types/cp77/ApplyJammerFromCw.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ApplyLightPresetEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyLightPresetEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyNewStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/ApplyNewStatusEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyObjectActionEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyObjectActionEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyRandomStatusEffectEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyRandomStatusEffectEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyShaderEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyShaderEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyShaderOnEquipmentEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyShaderOnEquipmentEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyShaderOnObjectEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyShaderOnObjectEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyStatGroupEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyStatGroupEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyStatusEffectByChanceEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyStatusEffectByChanceEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyStatusEffectDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ApplyStatusEffectDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyStatusEffectEffector.cs
+++ b/CP77.CR2W/Types/cp77/ApplyStatusEffectEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApplyStatusEffectOnOwner.cs
+++ b/CP77.CR2W/Types/cp77/ApplyStatusEffectOnOwner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ApproachVehicleDecorator.cs
+++ b/CP77.CR2W/Types/cp77/ApproachVehicleDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArcadeMachine.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArcadeMachineBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArcadeMachineBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineBlackboardDef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ArcadeMachineController.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArcadeMachineController.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ArcadeMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArcadeMachineInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ArcadeMachineInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/AreaDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaEffectData.cs
+++ b/CP77.CR2W/Types/cp77/AreaEffectData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaEffectTargetData.cs
+++ b/CP77.CR2W/Types/cp77/AreaEffectTargetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaEffectVisualisationRequest.cs
+++ b/CP77.CR2W/Types/cp77/AreaEffectVisualisationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaEffectVisualizationComponent.cs
+++ b/CP77.CR2W/Types/cp77/AreaEffectVisualizationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaEntry.cs
+++ b/CP77.CR2W/Types/cp77/AreaEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaShapeOutline.cs
+++ b/CP77.CR2W/Types/cp77/AreaShapeOutline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AreaTypeTransition.cs
+++ b/CP77.CR2W/Types/cp77/AreaTypeTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Arm.cs
+++ b/CP77.CR2W/Types/cp77/Arm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArmorEquipGameController.cs
+++ b/CP77.CR2W/Types/cp77/ArmorEquipGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArmorEquipInventoryItemController.cs
+++ b/CP77.CR2W/Types/cp77/ArmorEquipInventoryItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ArmorStatListener.cs
+++ b/CP77.CR2W/Types/cp77/ArmorStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssignHotkeyIfEmptySlot.cs
+++ b/CP77.CR2W/Types/cp77/AssignHotkeyIfEmptySlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssignRestrictMovementAreaHandler.cs
+++ b/CP77.CR2W/Types/cp77/AssignRestrictMovementAreaHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssignRestrictMovementAreaTask.cs
+++ b/CP77.CR2W/Types/cp77/AssignRestrictMovementAreaTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssignToCyberwareWheelRequest.cs
+++ b/CP77.CR2W/Types/cp77/AssignToCyberwareWheelRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssualtRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AssualtRifleLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssualtRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/AssualtRifleLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AssualtRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/AssualtRifleLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AssualtRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/AssualtRifleLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AsyncSpawnData.cs
+++ b/CP77.CR2W/Types/cp77/AsyncSpawnData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AtmosphereAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/AtmosphereAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttachVendorRequest.cs
+++ b/CP77.CR2W/Types/cp77/AttachVendorRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttachVendorRequest.cs
+++ b/CP77.CR2W/Types/cp77/AttachVendorRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AttachmentSlotCacheData.cs
+++ b/CP77.CR2W/Types/cp77/AttachmentSlotCacheData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttackSubtypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/AttackSubtypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttackTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/AttackTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Attack_Beam.cs
+++ b/CP77.CR2W/Types/cp77/Attack_Beam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Attack_Beam.cs
+++ b/CP77.CR2W/Types/cp77/Attack_Beam.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AttributeBoughtEvent.cs
+++ b/CP77.CR2W/Types/cp77/AttributeBoughtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttributeData.cs
+++ b/CP77.CR2W/Types/cp77/AttributeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttributeDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/AttributeDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttributeTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/AttributeTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttributeUpdatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/AttributeUpdatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AttributeUpgradePurchased.cs
+++ b/CP77.CR2W/Types/cp77/AttributeUpgradePurchased.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AudioFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/AudioFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AudioFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/AudioFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AuthorisationNotification.cs
+++ b/CP77.CR2W/Types/cp77/AuthorisationNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AuthorisationNotification.cs
+++ b/CP77.CR2W/Types/cp77/AuthorisationNotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AuthorisationNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/AuthorisationNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AuthorisationNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/AuthorisationNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AuthorizationData.cs
+++ b/CP77.CR2W/Types/cp77/AuthorizationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AuthorizePlayerInSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/AuthorizePlayerInSecuritySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AuthorizeUser.cs
+++ b/CP77.CR2W/Types/cp77/AuthorizeUser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoKillDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/AutoKillDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoKillDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/AutoKillDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AutoRevealStatListener.cs
+++ b/CP77.CR2W/Types/cp77/AutoRevealStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoSaveRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutoSaveRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoSaveRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutoSaveRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AutocraftActivateRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftActivateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutocraftActivateRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftActivateRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AutocraftDeactivateRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftDeactivateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutocraftEndCycleRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftEndCycleRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutocraftEndCycleRequest.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftEndCycleRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AutocraftSystem.cs
+++ b/CP77.CR2W/Types/cp77/AutocraftSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutomaticDeescalationEvent.cs
+++ b/CP77.CR2W/Types/cp77/AutomaticDeescalationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoplayVideoController.cs
+++ b/CP77.CR2W/Types/cp77/AutoplayVideoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AutoplayVideoController.cs
+++ b/CP77.CR2W/Types/cp77/AutoplayVideoController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/AwacsAlertNotification.cs
+++ b/CP77.CR2W/Types/cp77/AwacsAlertNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/AwacsAlertNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/AwacsAlertNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackActionCallback.cs
+++ b/CP77.CR2W/Types/cp77/BackActionCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackActionCallback.cs
+++ b/CP77.CR2W/Types/cp77/BackActionCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BackDoorDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/BackDoorDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackDoorObjectiveData.cs
+++ b/CP77.CR2W/Types/cp77/BackDoorObjectiveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackDoorObjectiveData.cs
+++ b/CP77.CR2W/Types/cp77/BackDoorObjectiveData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BackdoorDataStreamController.cs
+++ b/CP77.CR2W/Types/cp77/BackdoorDataStreamController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackdoorInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/BackdoorInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackgroundDisplayVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/BackgroundDisplayVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackgroundDisplayVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/BackgroundDisplayVirtualController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BackpackDataView.cs
+++ b/CP77.CR2W/Types/cp77/BackpackDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserCloseData.cs
+++ b/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserData.cs
+++ b/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserPopup.cs
+++ b/CP77.CR2W/Types/cp77/BackpackEquipSlotChooserPopup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackpackFilterButtonController.cs
+++ b/CP77.CR2W/Types/cp77/BackpackFilterButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BackpackInventoryListenerCallback.cs
+++ b/CP77.CR2W/Types/cp77/BackpackInventoryListenerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BarbedWire.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWire.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BarbedWire.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWire.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BarbedWireController.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWireController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BarbedWireController.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWireController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BarbedWireControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWireControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BarbedWireControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BarbedWireControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseActionOperations.cs
+++ b/CP77.CR2W/Types/cp77/BaseActionOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseAnimatedDevice.cs
+++ b/CP77.CR2W/Types/cp77/BaseAnimatedDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseAnimatedDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BaseAnimatedDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseAnimatedDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BaseAnimatedDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseAnimatedDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BaseAnimatedDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseBullet.cs
+++ b/CP77.CR2W/Types/cp77/BaseBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseButtonView.cs
+++ b/CP77.CR2W/Types/cp77/BaseButtonView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseChunkGameController.cs
+++ b/CP77.CR2W/Types/cp77/BaseChunkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseCodexLinkController.cs
+++ b/CP77.CR2W/Types/cp77/BaseCodexLinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BaseContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BaseContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseCrosshairState.cs
+++ b/CP77.CR2W/Types/cp77/BaseCrosshairState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseCrosshairState.cs
+++ b/CP77.CR2W/Types/cp77/BaseCrosshairState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/BaseCrosshairStateEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/BaseCrosshairStateEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseDestructibleController.cs
+++ b/CP77.CR2W/Types/cp77/BaseDestructibleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseDestructibleController.cs
+++ b/CP77.CR2W/Types/cp77/BaseDestructibleController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseDestructibleControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BaseDestructibleControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseDestructibleControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BaseDestructibleControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseDestructibleDevice.cs
+++ b/CP77.CR2W/Types/cp77/BaseDestructibleDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/BaseDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseDeviceStatus.cs
+++ b/CP77.CR2W/Types/cp77/BaseDeviceStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/BaseGameEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/BaseGameEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseGameplayFunctionalTest.cs
+++ b/CP77.CR2W/Types/cp77/BaseGameplayFunctionalTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseGrenade.cs
+++ b/CP77.CR2W/Types/cp77/BaseGrenade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/BaseHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseHubMenuController.cs
+++ b/CP77.CR2W/Types/cp77/BaseHubMenuController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseItemAction.cs
+++ b/CP77.CR2W/Types/cp77/BaseItemAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseModalListPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/BaseModalListPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseModalListPopupTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/BaseModalListPopupTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseModalListPopupTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/BaseModalListPopupTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseNetworkSystemController.cs
+++ b/CP77.CR2W/Types/cp77/BaseNetworkSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseNetworkSystemController.cs
+++ b/CP77.CR2W/Types/cp77/BaseNetworkSystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseNetworkSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BaseNetworkSystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseNetworkSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BaseNetworkSystemControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BasePerkDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/BasePerkDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasePerksMenuTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/BasePerksMenuTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseProjectile.cs
+++ b/CP77.CR2W/Types/cp77/BaseProjectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseResaveData.cs
+++ b/CP77.CR2W/Types/cp77/BaseResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseScriptableAction.cs
+++ b/CP77.CR2W/Types/cp77/BaseScriptableAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseSkillCheckContainer.cs
+++ b/CP77.CR2W/Types/cp77/BaseSkillCheckContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseStatPoolPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/BaseStatPoolPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseStatPoolPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/BaseStatPoolPrereqListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BaseStateOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/BaseStateOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseStateOperations.cs
+++ b/CP77.CR2W/Types/cp77/BaseStateOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseStateOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/BaseStateOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseSubtitleLineLogicController.cs
+++ b/CP77.CR2W/Types/cp77/BaseSubtitleLineLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseSubtitlesGameController.cs
+++ b/CP77.CR2W/Types/cp77/BaseSubtitlesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseTechCrosshairController.cs
+++ b/CP77.CR2W/Types/cp77/BaseTechCrosshairController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BaseToggleView.cs
+++ b/CP77.CR2W/Types/cp77/BaseToggleView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/BasicAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicDistractionDevice.cs
+++ b/CP77.CR2W/Types/cp77/BasicDistractionDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicDistractionDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BasicDistractionDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicDistractionDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BasicDistractionDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BasicDistractionDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BasicDistractionDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicInteractionInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/BasicInteractionInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicInteractionInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/BasicInteractionInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BasicViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/BasicViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BasicViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/BasicViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeamData.cs
+++ b/CP77.CR2W/Types/cp77/BeamData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginFive.cs
+++ b/CP77.CR2W/Types/cp77/BeginFive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginFive.cs
+++ b/CP77.CR2W/Types/cp77/BeginFive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeginFour.cs
+++ b/CP77.CR2W/Types/cp77/BeginFour.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginFour.cs
+++ b/CP77.CR2W/Types/cp77/BeginFour.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeginOne.cs
+++ b/CP77.CR2W/Types/cp77/BeginOne.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginOne.cs
+++ b/CP77.CR2W/Types/cp77/BeginOne.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeginThree.cs
+++ b/CP77.CR2W/Types/cp77/BeginThree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginThree.cs
+++ b/CP77.CR2W/Types/cp77/BeginThree.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeginTwo.cs
+++ b/CP77.CR2W/Types/cp77/BeginTwo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BeginTwo.cs
+++ b/CP77.CR2W/Types/cp77/BeginTwo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BeingTargetByLaserSightUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/BeingTargetByLaserSightUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BillboardDevice.cs
+++ b/CP77.CR2W/Types/cp77/BillboardDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BillboardDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BillboardDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BillboardDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/BillboardDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BillboardDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BillboardDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Bink.cs
+++ b/CP77.CR2W/Types/cp77/Bink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Bink.cs
+++ b/CP77.CR2W/Types/cp77/Bink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BinkVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/BinkVideoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlackBoardRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/BlackBoardRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Blacklist.cs
+++ b/CP77.CR2W/Types/cp77/Blacklist.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Blacklist.cs
+++ b/CP77.CR2W/Types/cp77/Blacklist.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlacklistEntry.cs
+++ b/CP77.CR2W/Types/cp77/BlacklistEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlacklistPeriodEnded.cs
+++ b/CP77.CR2W/Types/cp77/BlacklistPeriodEnded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlacklistPlayer.cs
+++ b/CP77.CR2W/Types/cp77/BlacklistPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BleedingEffectDamageUpdate.cs
+++ b/CP77.CR2W/Types/cp77/BleedingEffectDamageUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BleedingEffectDamageUpdate.cs
+++ b/CP77.CR2W/Types/cp77/BleedingEffectDamageUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlindManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/BlindManagerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlindManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/BlindManagerTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlindingLight.cs
+++ b/CP77.CR2W/Types/cp77/BlindingLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlindingLightController.cs
+++ b/CP77.CR2W/Types/cp77/BlindingLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlindingLightController.cs
+++ b/CP77.CR2W/Types/cp77/BlindingLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlindingLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/BlindingLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlinkingEvent.cs
+++ b/CP77.CR2W/Types/cp77/BlinkingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlockAmmoDrop.cs
+++ b/CP77.CR2W/Types/cp77/BlockAmmoDrop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlockAmmoDrop.cs
+++ b/CP77.CR2W/Types/cp77/BlockAmmoDrop.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlockHealingConsumableDrop.cs
+++ b/CP77.CR2W/Types/cp77/BlockHealingConsumableDrop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlockHealingConsumableDrop.cs
+++ b/CP77.CR2W/Types/cp77/BlockHealingConsumableDrop.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlockReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/BlockReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BlockReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/BlockReactionTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BloodPuddleEvent.cs
+++ b/CP77.CR2W/Types/cp77/BloodPuddleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BloomAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/BloomAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BluelineConditionTypeBase.cs
+++ b/CP77.CR2W/Types/cp77/BluelineConditionTypeBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BluelineConditionTypeBase.cs
+++ b/CP77.CR2W/Types/cp77/BluelineConditionTypeBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BlurAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/BlurAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyCarryContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryFriendlyContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/BodyCarryingPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/BodyDisposalPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyInvestigated.cs
+++ b/CP77.CR2W/Types/cp77/BodyInvestigated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyInvestigated.cs
+++ b/CP77.CR2W/Types/cp77/BodyInvestigated.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyInvestigatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/BodyInvestigatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyInvestigatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/BodyInvestigatedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyPartHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/BodyPartHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyPickUpContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyPickUpContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyPickUpContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BodyPickUpContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BodyPickUpContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyPickUpContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BodyPickUpContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/BodyPickUpContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Bombus_Flame_Beam.cs
+++ b/CP77.CR2W/Types/cp77/Bombus_Flame_Beam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Bombus_Flame_Beam.cs
+++ b/CP77.CR2W/Types/cp77/Bombus_Flame_Beam.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BonusCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/BonusCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BoothModeGameController.cs
+++ b/CP77.CR2W/Types/cp77/BoothModeGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BossCombatNotifier.cs
+++ b/CP77.CR2W/Types/cp77/BossCombatNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BossHealthBarGameController.cs
+++ b/CP77.CR2W/Types/cp77/BossHealthBarGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BossHealthStatListener.cs
+++ b/CP77.CR2W/Types/cp77/BossHealthStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BossStealthComponent.cs
+++ b/CP77.CR2W/Types/cp77/BossStealthComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Bounty.cs
+++ b/CP77.CR2W/Types/cp77/Bounty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyCollectedNotification.cs
+++ b/CP77.CR2W/Types/cp77/BountyCollectedNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyCollectedNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/BountyCollectedNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyCollectedNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/BountyCollectedNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyCollectedNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/BountyCollectedNotificationViewData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BountyCompletionEvent.cs
+++ b/CP77.CR2W/Types/cp77/BountyCompletionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyManager.cs
+++ b/CP77.CR2W/Types/cp77/BountyManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyManager.cs
+++ b/CP77.CR2W/Types/cp77/BountyManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BountyResetRequest.cs
+++ b/CP77.CR2W/Types/cp77/BountyResetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BountyResetRequest.cs
+++ b/CP77.CR2W/Types/cp77/BountyResetRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BountyUI.cs
+++ b/CP77.CR2W/Types/cp77/BountyUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Box.cs
+++ b/CP77.CR2W/Types/cp77/Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceBarLogicController.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceBarLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceClueData.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceClueData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceClueLogicController.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceClueLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceControlsTransition.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceControlsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceControlsTransition.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceControlsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceFastFlyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFastFlyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceFastFlyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFastFlyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceFastFlyEvents.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFastFlyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceFastFlyEvents.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFastFlyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceFlyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFlyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceFlyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFlyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceFlyEvents.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFlyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceFlyEvents.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceFlyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceGameController.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceInputChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceInputChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceInstance.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceInstance.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceModule.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BraindanceModule.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BraindanceSystem.cs
+++ b/CP77.CR2W/Types/cp77/BraindanceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BreachAccessPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/BreachAccessPointEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BreachAccessPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/BreachAccessPointEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BreachViewTimeListener.cs
+++ b/CP77.CR2W/Types/cp77/BreachViewTimeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BriefingScreen.cs
+++ b/CP77.CR2W/Types/cp77/BriefingScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BriefingScreenLogic.cs
+++ b/CP77.CR2W/Types/cp77/BriefingScreenLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BrightnessSettingsGameController.cs
+++ b/CP77.CR2W/Types/cp77/BrightnessSettingsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BrightnessSettingsVarListener.cs
+++ b/CP77.CR2W/Types/cp77/BrightnessSettingsVarListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BroadcastEvent.cs
+++ b/CP77.CR2W/Types/cp77/BroadcastEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BrowserController.cs
+++ b/CP77.CR2W/Types/cp77/BrowserController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BrowserGameController.cs
+++ b/CP77.CR2W/Types/cp77/BrowserGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuffListVisibilityChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/BuffListVisibilityChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuildBluelinePart.cs
+++ b/CP77.CR2W/Types/cp77/BuildBluelinePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuildButtonItemController.cs
+++ b/CP77.CR2W/Types/cp77/BuildButtonItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Build_ScriptConditionType.cs
+++ b/CP77.CR2W/Types/cp77/Build_ScriptConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BulletCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/BulletCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BumpNetrunnerMinigameLevel.cs
+++ b/CP77.CR2W/Types/cp77/BumpNetrunnerMinigameLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BurstDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BurstDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BurstDecisions.cs
+++ b/CP77.CR2W/Types/cp77/BurstDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BurstEvents.cs
+++ b/CP77.CR2W/Types/cp77/BurstEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BurstEvents.cs
+++ b/CP77.CR2W/Types/cp77/BurstEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ButtonCursorStateView.cs
+++ b/CP77.CR2W/Types/cp77/ButtonCursorStateView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ButtonHelpBarMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/ButtonHelpBarMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ButtonHelpBarMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/ButtonHelpBarMenuGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ButtonHintListItem.cs
+++ b/CP77.CR2W/Types/cp77/ButtonHintListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ButtonHints.cs
+++ b/CP77.CR2W/Types/cp77/ButtonHints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ButtonPlaySoundView.cs
+++ b/CP77.CR2W/Types/cp77/ButtonPlaySoundView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyAttribute.cs
+++ b/CP77.CR2W/Types/cp77/BuyAttribute.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyAttributeEffector.cs
+++ b/CP77.CR2W/Types/cp77/BuyAttributeEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyItemFromVendor.cs
+++ b/CP77.CR2W/Types/cp77/BuyItemFromVendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyPerk.cs
+++ b/CP77.CR2W/Types/cp77/BuyPerk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyRequest.cs
+++ b/CP77.CR2W/Types/cp77/BuyRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuyRequest.cs
+++ b/CP77.CR2W/Types/cp77/BuyRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/BuybackRequest.cs
+++ b/CP77.CR2W/Types/cp77/BuybackRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/BuybackRequest.cs
+++ b/CP77.CR2W/Types/cp77/BuybackRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/C2dArray_.cs
+++ b/CP77.CR2W/Types/cp77/C2dArray_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/C4.cs
+++ b/CP77.CR2W/Types/cp77/C4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/C4.cs
+++ b/CP77.CR2W/Types/cp77/C4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/C4Controller.cs
+++ b/CP77.CR2W/Types/cp77/C4Controller.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/C4Controller.cs
+++ b/CP77.CR2W/Types/cp77/C4Controller.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/C4ControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/C4ControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CActionScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/CActionScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CActionScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/CActionScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CBaseEngine.cs
+++ b/CP77.CR2W/Types/cp77/CBaseEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CBaseEngine.cs
+++ b/CP77.CR2W/Types/cp77/CBaseEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CBitmapTexture.cs
+++ b/CP77.CR2W/Types/cp77/CBitmapTexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CCTVCamera.cs
+++ b/CP77.CR2W/Types/cp77/CCTVCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CComStaticSkeletonData.cs
+++ b/CP77.CR2W/Types/cp77/CComStaticSkeletonData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CComStaticSkeletonDataEntry.cs
+++ b/CP77.CR2W/Types/cp77/CComStaticSkeletonDataEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CCombatTargetData.cs
+++ b/CP77.CR2W/Types/cp77/CCombatTargetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CCombatTargetData.cs
+++ b/CP77.CR2W/Types/cp77/CCombatTargetData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CCombatTargetDataPtr.cs
+++ b/CP77.CR2W/Types/cp77/CCombatTargetDataPtr.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CCombatTargetDataPtr.cs
+++ b/CP77.CR2W/Types/cp77/CCombatTargetDataPtr.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CCubeTexture.cs
+++ b/CP77.CR2W/Types/cp77/CCubeTexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CDebugConsole.cs
+++ b/CP77.CR2W/Types/cp77/CDebugConsole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CDebugConsole.cs
+++ b/CP77.CR2W/Types/cp77/CDebugConsole.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CDecalSpawner.cs
+++ b/CP77.CR2W/Types/cp77/CDecalSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CDistantLightsResource.cs
+++ b/CP77.CR2W/Types/cp77/CDistantLightsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEnvDisplaySettingsParams.cs
+++ b/CP77.CR2W/Types/cp77/CEnvDisplaySettingsParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorColorConst.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorColorConst.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorColorCurve.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorColorCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorColorMultiCurve.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorColorMultiCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorColorRandom.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorColorRandom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorColorStartEnd.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorColorStartEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorFloatConst.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorFloatConst.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorFloatCurve.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorFloatCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorFloatRandomUniform.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorFloatRandomUniform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorFloatStartEnd.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorFloatStartEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorVectorConst.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorVectorConst.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorVectorCurve.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorVectorCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorVectorMultiCurve.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorVectorMultiCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorVectorRandomUniform.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorVectorRandomUniform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CEvaluatorVectorStartEnd.cs
+++ b/CP77.CR2W/Types/cp77/CEvaluatorVectorStartEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CFoliageProfile.cs
+++ b/CP77.CR2W/Types/cp77/CFoliageProfile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CFrustum.cs
+++ b/CP77.CR2W/Types/cp77/CFrustum.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CFrustum.cs
+++ b/CP77.CR2W/Types/cp77/CFrustum.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CGIDataResource.cs
+++ b/CP77.CR2W/Types/cp77/CGIDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/CGameEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/CGameEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CGlobalIlluminationSceneData.cs
+++ b/CP77.CR2W/Types/cp77/CGlobalIlluminationSceneData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CGlobalIlluminationSceneData.cs
+++ b/CP77.CR2W/Types/cp77/CGlobalIlluminationSceneData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CGradient.cs
+++ b/CP77.CR2W/Types/cp77/CGradient.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CHairProfile.cs
+++ b/CP77.CR2W/Types/cp77/CHairProfile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CIESDataResource.cs
+++ b/CP77.CR2W/Types/cp77/CIESDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CLSWeatherListener.cs
+++ b/CP77.CR2W/Types/cp77/CLSWeatherListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialInstance_.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialInstance_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialLayerLibrary.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialLayerLibrary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameter.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterColor.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterCpuNameU64.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterCpuNameU64.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterCube.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterCube.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterFoliageParameters.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterFoliageParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterGradient.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterGradient.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterHairParameters.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterHairParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterMultilayerMask.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterMultilayerMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterMultilayerSetup.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterMultilayerSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterScalar.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterScalar.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterSkinParameters.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterSkinParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterStructBuffer.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterStructBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterStructBuffer.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterStructBuffer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CMaterialParameterTerrainSetup.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterTerrainSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterTexture.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterTexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterTextureArray.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterTextureArray.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialParameterVector.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialParameterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMaterialTemplate_.cs
+++ b/CP77.CR2W/Types/cp77/CMaterialTemplate_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMeshMaterialEntry.cs
+++ b/CP77.CR2W/Types/cp77/CMeshMaterialEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CMesh_.cs
+++ b/CP77.CR2W/Types/cp77/CMesh_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOChoiceTokenDrawTextEvent.cs
+++ b/CP77.CR2W/Types/cp77/CPOChoiceTokenDrawTextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOChoiceTokenDrawTextEvent.cs
+++ b/CP77.CR2W/Types/cp77/CPOChoiceTokenDrawTextEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CPOMissionDataAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDataAccessPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionDataState.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDataState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionDataTransferred.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDataTransferred.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionDataUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDataUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionDataUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDataUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CPOMissionDevice.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionPlayerNotVoted.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionPlayerNotVoted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionPlayerNotVoted.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionPlayerNotVoted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CPOMissionPlayerVoted.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionPlayerVoted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOMissionPlayerVoted.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionPlayerVoted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CPOMissionPlayerVotedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CPOMissionPlayerVotedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPOVotingDevice.cs
+++ b/CP77.CR2W/Types/cp77/CPOVotingDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerBeam.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerBeam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerBillboard.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerBillboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerEmitterOrientation.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerEmitterOrientation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerFacingBeam.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerFacingBeam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerFacingTrail.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerFacingTrail.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerFacingTrail.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerFacingTrail.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CParticleDrawerMesh.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerMesh.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerMotionBlur.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerMotionBlur.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerScreen.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerSphereAligned.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerSphereAligned.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleDrawerTrail.cs
+++ b/CP77.CR2W/Types/cp77/CParticleDrawerTrail.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleEmitter.cs
+++ b/CP77.CR2W/Types/cp77/CParticleEmitter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleEventGenerator.cs
+++ b/CP77.CR2W/Types/cp77/CParticleEventGenerator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleEventReceiverSpawn.cs
+++ b/CP77.CR2W/Types/cp77/CParticleEventReceiverSpawn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerAlpha.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerAlpha.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerColor.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerLifeTime.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerLifeTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerPosition.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerRotation.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerRotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerRotation3D.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerRotation3D.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerRotationRate.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerRotationRate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerRotationRate3D.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerRotationRate3D.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerSize.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerSize.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerSpawnBox.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerSpawnBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerSpawnCircle.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerSpawnCircle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerSpawnSphere.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerSpawnSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerVelocity.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerVelocity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerVelocityInherit.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerVelocityInherit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleInitializerVelocitySpread.cs
+++ b/CP77.CR2W/Types/cp77/CParticleInitializerVelocitySpread.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorAcceleration.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorAcceleration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorAlphaByDistance.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorAlphaByDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverEffect.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverEffect.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorAlphaOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorCollision.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorCollision.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorColorOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorColorOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorDepthCollision.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorDepthCollision.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorDrag.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorDrag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorForce.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorForce.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorNoise.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorNoise.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorOrbit.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorOrbit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorRotation3DOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorRotation3DOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorRotationOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorRotationOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorRotationRate3DOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorRotationRate3DOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorRotationRateOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorRotationRateOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorSizeByDistance.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorSizeByDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorSizeOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorSizeOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorTarget.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorTargetNode.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorTargetNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorTextureAnimation.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorTextureAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorVectorFieldAttractor.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorVectorFieldAttractor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorVelocityOverLife.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorVelocityOverLife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleModificatorVelocityTurbulize.cs
+++ b/CP77.CR2W/Types/cp77/CParticleModificatorVelocityTurbulize.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CParticleSystem.cs
+++ b/CP77.CR2W/Types/cp77/CParticleSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPhysicsDecorationResource.cs
+++ b/CP77.CR2W/Types/cp77/CPhysicsDecorationResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CPhysicsDecorationResource.cs
+++ b/CP77.CR2W/Types/cp77/CPhysicsDecorationResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CReflectionProbeDataResource.cs
+++ b/CP77.CR2W/Types/cp77/CReflectionProbeDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderDistantIrradiancetData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderDistantIrradiancetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderDistantIrradiancetData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderDistantIrradiancetData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderDistantLightData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderDistantLightData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderDistantLightData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderDistantLightData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderLightVolumeAllocator.cs
+++ b/CP77.CR2W/Types/cp77/CRenderLightVolumeAllocator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderLightVolumeAllocator.cs
+++ b/CP77.CR2W/Types/cp77/CRenderLightVolumeAllocator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderLightVolumeCollector.cs
+++ b/CP77.CR2W/Types/cp77/CRenderLightVolumeCollector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderLightVolumeCollector.cs
+++ b/CP77.CR2W/Types/cp77/CRenderLightVolumeCollector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderResourceBlobContainer.cs
+++ b/CP77.CR2W/Types/cp77/CRenderResourceBlobContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderSimWaterFFT.cs
+++ b/CP77.CR2W/Types/cp77/CRenderSimWaterFFT.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderSkyData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderSkyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderSkyData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderSkyData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderStateManagerData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderStateManagerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderStateManagerData.cs
+++ b/CP77.CR2W/Types/cp77/CRenderStateManagerData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderTerrainCellCollector.cs
+++ b/CP77.CR2W/Types/cp77/CRenderTerrainCellCollector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderTerrainCellCollector.cs
+++ b/CP77.CR2W/Types/cp77/CRenderTerrainCellCollector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CRenderTextureMaterial.cs
+++ b/CP77.CR2W/Types/cp77/CRenderTextureMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CRenderTextureMaterial.cs
+++ b/CP77.CR2W/Types/cp77/CRenderTextureMaterial.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CResource.cs
+++ b/CP77.CR2W/Types/cp77/CResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CSH.cs
+++ b/CP77.CR2W/Types/cp77/CSH.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CSH.cs
+++ b/CP77.CR2W/Types/cp77/CSH.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CSkinProfile.cs
+++ b/CP77.CR2W/Types/cp77/CSkinProfile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CSourceTexture.cs
+++ b/CP77.CR2W/Types/cp77/CSourceTexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CSpeedTreeWindDataUpdater.cs
+++ b/CP77.CR2W/Types/cp77/CSpeedTreeWindDataUpdater.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CSpeedTreeWindDataUpdater.cs
+++ b/CP77.CR2W/Types/cp77/CSpeedTreeWindDataUpdater.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CTerrainSetup.cs
+++ b/CP77.CR2W/Types/cp77/CTerrainSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CTextureArray.cs
+++ b/CP77.CR2W/Types/cp77/CTextureArray.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CTextureArrayEntry.cs
+++ b/CP77.CR2W/Types/cp77/CTextureArrayEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CTextureRegionSet.cs
+++ b/CP77.CR2W/Types/cp77/CTextureRegionSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CVariableStoragePtr.cs
+++ b/CP77.CR2W/Types/cp77/CVariableStoragePtr.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CVariableStoragePtr.cs
+++ b/CP77.CR2W/Types/cp77/CVariableStoragePtr.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CVisualDebug.cs
+++ b/CP77.CR2W/Types/cp77/CVisualDebug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CVisualDebug.cs
+++ b/CP77.CR2W/Types/cp77/CVisualDebug.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CW_MuteArmDef.cs
+++ b/CP77.CR2W/Types/cp77/CW_MuteArmDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CWindImpulseCollector.cs
+++ b/CP77.CR2W/Types/cp77/CWindImpulseCollector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CWindImpulseCollector.cs
+++ b/CP77.CR2W/Types/cp77/CWindImpulseCollector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CacheAnimationForPotentialRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/CacheAnimationForPotentialRagdoll.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CacheFXOnDefeated.cs
+++ b/CP77.CR2W/Types/cp77/CacheFXOnDefeated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CacheItemEquippedToHandsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CacheItemEquippedToHandsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CacheStatusEffectAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/CacheStatusEffectAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CacheStatusEffectAnimationTask.cs
+++ b/CP77.CR2W/Types/cp77/CacheStatusEffectAnimationTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CacheStatusEffectAnimationTask.cs
+++ b/CP77.CR2W/Types/cp77/CacheStatusEffectAnimationTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CacheStatusEffectFXEvent.cs
+++ b/CP77.CR2W/Types/cp77/CacheStatusEffectFXEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallAction.cs
+++ b/CP77.CR2W/Types/cp77/CallAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/CallActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallElevator.cs
+++ b/CP77.CR2W/Types/cp77/CallElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallOffReactionAction.cs
+++ b/CP77.CR2W/Types/cp77/CallOffReactionAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallPolice.cs
+++ b/CP77.CR2W/Types/cp77/CallPolice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallPolice.cs
+++ b/CP77.CR2W/Types/cp77/CallPolice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CallVehicleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CallVehicleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallVehicleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CallVehicleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CallVehicleEvents.cs
+++ b/CP77.CR2W/Types/cp77/CallVehicleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CallVehicleEvents.cs
+++ b/CP77.CR2W/Types/cp77/CallVehicleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/CameraAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCompensationAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/CameraCompensationAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraContextBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CameraContextBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraContextBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CameraContextBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraContextBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/CameraContextBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraContextBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/CameraContextBaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_CPFocusMode.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_CPFocusMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_CPFocusMode.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_CPFocusMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_DataMoshing.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_DataMoshing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_DataMoshing.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_DataMoshing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_Histogram.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_Histogram.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_Histogram.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_Histogram.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_Persistent.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_Persistent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_Persistent.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_Persistent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_ReflectionProbes.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_ReflectionProbes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_ReflectionProbes.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_ReflectionProbes.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraCustomData_RenderProxyData.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_RenderProxyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraCustomData_RenderProxyData.cs
+++ b/CP77.CR2W/Types/cp77/CameraCustomData_RenderProxyData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraDeadBodyData.cs
+++ b/CP77.CR2W/Types/cp77/CameraDeadBodyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraDeadBodyInternalData.cs
+++ b/CP77.CR2W/Types/cp77/CameraDeadBodyInternalData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraDeadBodySessionDataModule.cs
+++ b/CP77.CR2W/Types/cp77/CameraDeadBodySessionDataModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraQuestProperties.cs
+++ b/CP77.CR2W/Types/cp77/CameraQuestProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraRotationData.cs
+++ b/CP77.CR2W/Types/cp77/CameraRotationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraSetup.cs
+++ b/CP77.CR2W/Types/cp77/CameraSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/CameraSystemHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/CameraSystemHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CameraTagEnemyLimitDataModule.cs
+++ b/CP77.CR2W/Types/cp77/CameraTagEnemyLimitDataModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraTagLimitData.cs
+++ b/CP77.CR2W/Types/cp77/CameraTagLimitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraTagLockEvent.cs
+++ b/CP77.CR2W/Types/cp77/CameraTagLockEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraTagSeenEnemies.cs
+++ b/CP77.CR2W/Types/cp77/CameraTagSeenEnemies.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CameraTagSeenEnemies.cs
+++ b/CP77.CR2W/Types/cp77/CameraTagSeenEnemies.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CanDoReactionAction.cs
+++ b/CP77.CR2W/Types/cp77/CanDoReactionAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CanMountVehicle.cs
+++ b/CP77.CR2W/Types/cp77/CanMountVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CanMountVehicle.cs
+++ b/CP77.CR2W/Types/cp77/CanMountVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CanNPCRun.cs
+++ b/CP77.CR2W/Types/cp77/CanNPCRun.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CanPlayerHijackMountedNpcPrereq.cs
+++ b/CP77.CR2W/Types/cp77/CanPlayerHijackMountedNpcPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CanPlayerHijackMountedNpcPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/CanPlayerHijackMountedNpcPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CancelDeviceUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CancelDeviceUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CancelDeviceUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CancelDeviceUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CancelSmartDespawnRequest.cs
+++ b/CP77.CR2W/Types/cp77/CancelSmartDespawnRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CancelSmartDespawnRequest.cs
+++ b/CP77.CR2W/Types/cp77/CancelSmartDespawnRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Candle.cs
+++ b/CP77.CR2W/Types/cp77/Candle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Candle.cs
+++ b/CP77.CR2W/Types/cp77/Candle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CandleController.cs
+++ b/CP77.CR2W/Types/cp77/CandleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CandleController.cs
+++ b/CP77.CR2W/Types/cp77/CandleController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CandleControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/CandleControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CandleDevice.cs
+++ b/CP77.CR2W/Types/cp77/CandleDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CandleDevice.cs
+++ b/CP77.CR2W/Types/cp77/CandleDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CaptionImageIconsLogicController.cs
+++ b/CP77.CR2W/Types/cp77/CaptionImageIconsLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarComponent.cs
+++ b/CP77.CR2W/Types/cp77/CarComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarComponent.cs
+++ b/CP77.CR2W/Types/cp77/CarComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CarHotkeyController.cs
+++ b/CP77.CR2W/Types/cp77/CarHotkeyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarRadioGameController.cs
+++ b/CP77.CR2W/Types/cp77/CarRadioGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarriedObject.cs
+++ b/CP77.CR2W/Types/cp77/CarriedObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarriedObject.cs
+++ b/CP77.CR2W/Types/cp77/CarriedObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CarriedObjectData.cs
+++ b/CP77.CR2W/Types/cp77/CarriedObjectData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarriedObjectEvents.cs
+++ b/CP77.CR2W/Types/cp77/CarriedObjectEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CarryDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CarryDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CarryEvents.cs
+++ b/CP77.CR2W/Types/cp77/CarryEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CarryEvents.cs
+++ b/CP77.CR2W/Types/cp77/CarryEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CategoryClickedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CategoryClickedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CellData.cs
+++ b/CP77.CR2W/Types/cp77/CellData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CentaurShieldController.cs
+++ b/CP77.CR2W/Types/cp77/CentaurShieldController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CentaurShieldLookatController.cs
+++ b/CP77.CR2W/Types/cp77/CentaurShieldLookatController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CentaurShieldStateChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/CentaurShieldStateChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeActiveContextRequest.cs
+++ b/CP77.CR2W/Types/cp77/ChangeActiveContextRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeAppearanceEffector.cs
+++ b/CP77.CR2W/Types/cp77/ChangeAppearanceEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeCurveEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeCurveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeDiodeLightSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeDiodeLightSettingsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeHalfLights.cs
+++ b/CP77.CR2W/Types/cp77/ChangeHalfLights.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeHighLevelStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChangeHighLevelStateAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeHighLevelStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChangeHighLevelStateAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChangeJuryrigTrapState.cs
+++ b/CP77.CR2W/Types/cp77/ChangeJuryrigTrapState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeLightByNameEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeLightByNameEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeLightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeLightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeLoopCurveEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeLoopCurveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeMusicAction.cs
+++ b/CP77.CR2W/Types/cp77/ChangeMusicAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeNPCState.cs
+++ b/CP77.CR2W/Types/cp77/ChangeNPCState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeNPCState.cs
+++ b/CP77.CR2W/Types/cp77/ChangeNPCState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChangePresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangePresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeRewardSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeRewardSettingsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeStanceState.cs
+++ b/CP77.CR2W/Types/cp77/ChangeStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeStanceStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChangeStanceStateAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeUIAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChangeUIAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/ChangeUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeUpperBodyStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChangeUpperBodyStateAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChangeUpperBodyStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChangeUpperBodyStateAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChaosWeaponCustomEffector.cs
+++ b/CP77.CR2W/Types/cp77/ChaosWeaponCustomEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChaosWeaponDamageTypeEffector.cs
+++ b/CP77.CR2W/Types/cp77/ChaosWeaponDamageTypeEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharParamTimeout.cs
+++ b/CP77.CR2W/Types/cp77/CharParamTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationAttributeData.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationAttributeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationBackstorySelectionMenu.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationBackstorySelectionMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationGenderBackstoryPathHeader.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationGenderBackstoryPathHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationGenderSelectionMenu.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationGenderSelectionMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationPersistantElements.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationPersistantElements.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationStatsMenu.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationStatsMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationSummaryListItemData.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationSummaryListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationTooltip.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterCreationTopBarHeader.cs
+++ b/CP77.CR2W/Types/cp77/CharacterCreationTopBarHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/CharacterDataPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterDataPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/CharacterDataPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CharacterDataPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/CharacterDataPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CharacterLevelUpGameController.cs
+++ b/CP77.CR2W/Types/cp77/CharacterLevelUpGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeEndedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChargeEndedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeEndedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChargeEndedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeEventsAbstract.cs
+++ b/CP77.CR2W/Types/cp77/ChargeEventsAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeJumpDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeJumpDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeJumpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeJumpEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ChargeLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ChargeLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeMaxDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeMaxDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeMaxDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeMaxDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeMaxEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeMaxEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeMaxEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeMaxEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ChargeReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/ChargeReadyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargeStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChargeStartedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargeStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ChargeStartedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChargebarController.cs
+++ b/CP77.CR2W/Types/cp77/ChargebarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChargebarStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/ChargebarStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChatterKeyValuePair.cs
+++ b/CP77.CR2W/Types/cp77/ChatterKeyValuePair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChatterLineLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ChatterLineLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChattersGameController.cs
+++ b/CP77.CR2W/Types/cp77/ChattersGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckAllStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/CheckAllStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckAnimSetTags.cs
+++ b/CP77.CR2W/Types/cp77/CheckAnimSetTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentBoolean.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentBoolean.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentFloat.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentInt.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentName.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentObjectSet.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentObjectSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckArgumentObjectSet.cs
+++ b/CP77.CR2W/Types/cp77/CheckArgumentObjectSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckArguments.cs
+++ b/CP77.CR2W/Types/cp77/CheckArguments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckBoolisValid.cs
+++ b/CP77.CR2W/Types/cp77/CheckBoolisValid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckComfortZoneEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckComfortZoneEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckComfortZoneEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckComfortZoneEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckCurrentHitReaction.cs
+++ b/CP77.CR2W/Types/cp77/CheckCurrentHitReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckCurrentStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/CheckCurrentStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckCurrentWorkspotTag.cs
+++ b/CP77.CR2W/Types/cp77/CheckCurrentWorkspotTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckCurrentWoundedState.cs
+++ b/CP77.CR2W/Types/cp77/CheckCurrentWoundedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckDeadPuppetDisposedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckDeadPuppetDisposedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckDeadPuppetDisposedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckDeadPuppetDisposedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckDroppedThreat.cs
+++ b/CP77.CR2W/Types/cp77/CheckDroppedThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckDroppedThreat.cs
+++ b/CP77.CR2W/Types/cp77/CheckDroppedThreat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckEquippedWeapon.cs
+++ b/CP77.CR2W/Types/cp77/CheckEquippedWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckEquippedWeaponType.cs
+++ b/CP77.CR2W/Types/cp77/CheckEquippedWeaponType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckFloatIsValid.cs
+++ b/CP77.CR2W/Types/cp77/CheckFloatIsValid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckFollowTarget.cs
+++ b/CP77.CR2W/Types/cp77/CheckFollowTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckFollowTarget.cs
+++ b/CP77.CR2W/Types/cp77/CheckFollowTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckFreeWorkspot.cs
+++ b/CP77.CR2W/Types/cp77/CheckFreeWorkspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckFriendlyNPCAboutToBeHit.cs
+++ b/CP77.CR2W/Types/cp77/CheckFriendlyNPCAboutToBeHit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/CheckHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckHitReactionStimID.cs
+++ b/CP77.CR2W/Types/cp77/CheckHitReactionStimID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckHitReactionStimID.cs
+++ b/CP77.CR2W/Types/cp77/CheckHitReactionStimID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckIfCombatAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfCombatAllowed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckIfCombatAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfCombatAllowed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckIfPatrolAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfPatrolAllowed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckIfPatrolAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfPatrolAllowed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckIfSearchAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfSearchAllowed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckIfSearchAllowed.cs
+++ b/CP77.CR2W/Types/cp77/CheckIfSearchAllowed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckLastHitReaction.cs
+++ b/CP77.CR2W/Types/cp77/CheckLastHitReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckLastTriggeredStimuli.cs
+++ b/CP77.CR2W/Types/cp77/CheckLastTriggeredStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckLastTriggeredStimuli.cs
+++ b/CP77.CR2W/Types/cp77/CheckLastTriggeredStimuli.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckPathToCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/CheckPathToCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckPhaseState.cs
+++ b/CP77.CR2W/Types/cp77/CheckPhaseState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckPuppetRagdollStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckPuppetRagdollStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckPuppetRagdollStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckPuppetRagdollStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckRagdollOutOfNavmeshTask.cs
+++ b/CP77.CR2W/Types/cp77/CheckRagdollOutOfNavmeshTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckReaction.cs
+++ b/CP77.CR2W/Types/cp77/CheckReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckReactionStimType.cs
+++ b/CP77.CR2W/Types/cp77/CheckReactionStimType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckReactionValueThreshold.cs
+++ b/CP77.CR2W/Types/cp77/CheckReactionValueThreshold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckRemovedItemWithSlotActiveItem.cs
+++ b/CP77.CR2W/Types/cp77/CheckRemovedItemWithSlotActiveItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckSettingsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckSettingsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckStanceState.cs
+++ b/CP77.CR2W/Types/cp77/CheckStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/CheckStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckStatusEffectState.cs
+++ b/CP77.CR2W/Types/cp77/CheckStatusEffectState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckStimID.cs
+++ b/CP77.CR2W/Types/cp77/CheckStimID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckStimID.cs
+++ b/CP77.CR2W/Types/cp77/CheckStimID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckStimRevealsInstigatorPosition.cs
+++ b/CP77.CR2W/Types/cp77/CheckStimRevealsInstigatorPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckStimTag.cs
+++ b/CP77.CR2W/Types/cp77/CheckStimTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckTargetInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/CheckTargetInVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckTargetInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/CheckTargetInVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckThreat.cs
+++ b/CP77.CR2W/Types/cp77/CheckThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckTimestamp.cs
+++ b/CP77.CR2W/Types/cp77/CheckTimestamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckUncontrolledMovementStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckUncontrolledMovementStatusEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckUncontrolledMovementStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/CheckUncontrolledMovementStatusEffectEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckUnregisteredWeapon.cs
+++ b/CP77.CR2W/Types/cp77/CheckUnregisteredWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckUnregisteredWeapon.cs
+++ b/CP77.CR2W/Types/cp77/CheckUnregisteredWeapon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CheckUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/CheckUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckVectorIsValid.cs
+++ b/CP77.CR2W/Types/cp77/CheckVectorIsValid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CheckWoundedStatusEffectState.cs
+++ b/CP77.CR2W/Types/cp77/CheckWoundedStatusEffectState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChestPress.cs
+++ b/CP77.CR2W/Types/cp77/ChestPress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChestPressController.cs
+++ b/CP77.CR2W/Types/cp77/ChestPressController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChestPressController.cs
+++ b/CP77.CR2W/Types/cp77/ChestPressController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChestPressControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ChestPressControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChestPressWeightHack.cs
+++ b/CP77.CR2W/Types/cp77/ChestPressWeightHack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ChestPressWeightHack.cs
+++ b/CP77.CR2W/Types/cp77/ChestPressWeightHack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ChromaticAberrationAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ChromaticAberrationAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CityFluffMessageSelector.cs
+++ b/CP77.CR2W/Types/cp77/CityFluffMessageSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CityFluffScreenSelector.cs
+++ b/CP77.CR2W/Types/cp77/CityFluffScreenSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CityLightSystem.cs
+++ b/CP77.CR2W/Types/cp77/CityLightSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CityLightSystemUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CityLightSystemUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CityLightSystemUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/CityLightSystemUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClaymoreMine.cs
+++ b/CP77.CR2W/Types/cp77/ClaymoreMine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CleanEnvironmentalHazardEvent.cs
+++ b/CP77.CR2W/Types/cp77/CleanEnvironmentalHazardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CleanUpTimeDilationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CleanUpTimeDilationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CleaningMachine.cs
+++ b/CP77.CR2W/Types/cp77/CleaningMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CleaningMachine.cs
+++ b/CP77.CR2W/Types/cp77/CleaningMachine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CleaningMachineController.cs
+++ b/CP77.CR2W/Types/cp77/CleaningMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CleaningMachineController.cs
+++ b/CP77.CR2W/Types/cp77/CleaningMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CleaningMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/CleaningMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearAllRevealRequestsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearAllRevealRequestsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearAllRevealRequestsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearAllRevealRequestsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearAllWeaponSlotsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearAllWeaponSlotsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearAllWeaponSlotsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearAllWeaponSlotsRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearArgumentObject.cs
+++ b/CP77.CR2W/Types/cp77/ClearArgumentObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearArgumentObject.cs
+++ b/CP77.CR2W/Types/cp77/ClearArgumentObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearBeingNoticedBB.cs
+++ b/CP77.CR2W/Types/cp77/ClearBeingNoticedBB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearBeingNoticedBB.cs
+++ b/CP77.CR2W/Types/cp77/ClearBeingNoticedBB.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearBraindancePauseRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearBraindancePauseRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearBraindancePauseRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearBraindancePauseRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearBraindanceStateRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearBraindanceStateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearBraindanceStateRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearBraindanceStateRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/ClearCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/ClearCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearCustomObjectDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearCustomObjectDescriptionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearCustomObjectDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearCustomObjectDescriptionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearEquipmentRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearEquipmentRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearEquipmentRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearEquipmentRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearHitStimEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearHitStimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearHitStimEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearHitStimEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearItemAppearanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearItemAppearanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearOutlinesRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearOutlinesRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearOutlinesRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClearOutlinesRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClearSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearSubCharacterRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClearVisibilityInAnimSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/ClearVisibilityInAnimSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClimbDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ClimbDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClimbEvents.cs
+++ b/CP77.CR2W/Types/cp77/ClimbEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClimbLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ClimbLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClimbLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ClimbLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClimbLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/ClimbLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClimbLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/ClimbLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CloseAd.cs
+++ b/CP77.CR2W/Types/cp77/CloseAd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CloseAd.cs
+++ b/CP77.CR2W/Types/cp77/CloseAd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CloseQHmenu.cs
+++ b/CP77.CR2W/Types/cp77/CloseQHmenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CloseQHmenu.cs
+++ b/CP77.CR2W/Types/cp77/CloseQHmenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ClueLockNotification.cs
+++ b/CP77.CR2W/Types/cp77/ClueLockNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CluePSData.cs
+++ b/CP77.CR2W/Types/cp77/CluePSData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClueRecordData.cs
+++ b/CP77.CR2W/Types/cp77/ClueRecordData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClueScannedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ClueScannedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ClueStatusNotification.cs
+++ b/CP77.CR2W/Types/cp77/ClueStatusNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Coder.cs
+++ b/CP77.CR2W/Types/cp77/Coder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Coder.cs
+++ b/CP77.CR2W/Types/cp77/Coder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CoderController.cs
+++ b/CP77.CR2W/Types/cp77/CoderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoderController.cs
+++ b/CP77.CR2W/Types/cp77/CoderController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CoderControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/CoderControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexAddRecordRequest.cs
+++ b/CP77.CR2W/Types/cp77/CodexAddRecordRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexBaseGameController.cs
+++ b/CP77.CR2W/Types/cp77/CodexBaseGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexBaseGameController.cs
+++ b/CP77.CR2W/Types/cp77/CodexBaseGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CodexEntryData.cs
+++ b/CP77.CR2W/Types/cp77/CodexEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexEntrySelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CodexEntrySelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexEntryViewController.cs
+++ b/CP77.CR2W/Types/cp77/CodexEntryViewController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexFilterButtonClicked.cs
+++ b/CP77.CR2W/Types/cp77/CodexFilterButtonClicked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexFilterButtonController.cs
+++ b/CP77.CR2W/Types/cp77/CodexFilterButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexForceSelectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/CodexForceSelectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexGameController.cs
+++ b/CP77.CR2W/Types/cp77/CodexGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexImageButton.cs
+++ b/CP77.CR2W/Types/cp77/CodexImageButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexLinkQuestLog.cs
+++ b/CP77.CR2W/Types/cp77/CodexLinkQuestLog.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexLinkQuestLog.cs
+++ b/CP77.CR2W/Types/cp77/CodexLinkQuestLog.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CodexListItemController.cs
+++ b/CP77.CR2W/Types/cp77/CodexListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexListSyncData.cs
+++ b/CP77.CR2W/Types/cp77/CodexListSyncData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexListVirtualEntry.cs
+++ b/CP77.CR2W/Types/cp77/CodexListVirtualEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexListVirtualGroup.cs
+++ b/CP77.CR2W/Types/cp77/CodexListVirtualGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexListVirtualNestedDataView.cs
+++ b/CP77.CR2W/Types/cp77/CodexListVirtualNestedDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexListVirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/CodexListVirtualNestedListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexLockRecordRequest.cs
+++ b/CP77.CR2W/Types/cp77/CodexLockRecordRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexPopupData.cs
+++ b/CP77.CR2W/Types/cp77/CodexPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/CodexPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexPrintRecordsRequest.cs
+++ b/CP77.CR2W/Types/cp77/CodexPrintRecordsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexPrintRecordsRequest.cs
+++ b/CP77.CR2W/Types/cp77/CodexPrintRecordsRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CodexSelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/CodexSelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/CodexSyncBackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/CodexSyncBackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CodexSystem.cs
+++ b/CP77.CR2W/Types/cp77/CodexSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexUnlockRecordRequest.cs
+++ b/CP77.CR2W/Types/cp77/CodexUnlockRecordRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexUserData.cs
+++ b/CP77.CR2W/Types/cp77/CodexUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexUtils.cs
+++ b/CP77.CR2W/Types/cp77/CodexUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CodexUtils.cs
+++ b/CP77.CR2W/Types/cp77/CodexUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CollectDropPointRewards.cs
+++ b/CP77.CR2W/Types/cp77/CollectDropPointRewards.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CollectDropPointRewards.cs
+++ b/CP77.CR2W/Types/cp77/CollectDropPointRewards.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CollisionExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CollisionExitingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CollisionExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CollisionExitingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CollisionExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/CollisionExitingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ColorBalance.cs
+++ b/CP77.CR2W/Types/cp77/ColorBalance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ColorGradingAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ColorGradingAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ColorGradingLutParams.cs
+++ b/CP77.CR2W/Types/cp77/ColorGradingLutParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Color_.cs
+++ b/CP77.CR2W/Types/cp77/Color_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComDeviceTransition.cs
+++ b/CP77.CR2W/Types/cp77/ComDeviceTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComDeviceTransition.cs
+++ b/CP77.CR2W/Types/cp77/ComDeviceTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/CombatConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/CombatConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargeEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetChargedThrowEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetDataDef.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetEquipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetEquipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetEquipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetEquipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetHelper.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetHelper.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetInactiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetInactiveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetInactiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetInactiveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetInactiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetInactiveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetInactiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetInactiveEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetQuickThrowEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetTransitions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetTransitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetTransitions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetTransitions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetUnequipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/CombatGadgetWaitForUnequipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatHUDManager.cs
+++ b/CP77.CR2W/Types/cp77/CombatHUDManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/CombatPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/CombatPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/CombatPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/CombatPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatQueriesRequest.cs
+++ b/CP77.CR2W/Types/cp77/CombatQueriesRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatQueriesRequest.cs
+++ b/CP77.CR2W/Types/cp77/CombatQueriesRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaAllDeadCondition.cs
+++ b/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaAllDeadCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaAllDeadCondition.cs
+++ b/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaAllDeadCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaPlayerEnterMainRMACondition.cs
+++ b/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaPlayerEnterMainRMACondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaPlayerEnterMainRMACondition.cs
+++ b/CP77.CR2W/Types/cp77/CombatRestrictMovementAreaPlayerEnterMainRMACondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatState.cs
+++ b/CP77.CR2W/Types/cp77/CombatState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatState.cs
+++ b/CP77.CR2W/Types/cp77/CombatState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/CombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatTransitions.cs
+++ b/CP77.CR2W/Types/cp77/CombatTransitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CombatTransitions.cs
+++ b/CP77.CR2W/Types/cp77/CombatTransitions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/CommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CommandSignal.cs
+++ b/CP77.CR2W/Types/cp77/CommandSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CommunicationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CommunicationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CommunityProxyPS.cs
+++ b/CP77.CR2W/Types/cp77/CommunityProxyPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CommunityProxyPS.cs
+++ b/CP77.CR2W/Types/cp77/CommunityProxyPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompanionHealthBarGameController.cs
+++ b/CP77.CR2W/Types/cp77/CompanionHealthBarGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompanionHealthStatListener.cs
+++ b/CP77.CR2W/Types/cp77/CompanionHealthStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArguments.cs
+++ b/CP77.CR2W/Types/cp77/CompareArguments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsBooleans.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsBooleans.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsBooleans.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsBooleans.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompareArgumentsFloats.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsFloats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsInts.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsInts.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsNames.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsNames.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsNames.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompareArgumentsNodeRefs.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsNodeRefs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsNodeRefs.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsNodeRefs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompareArgumentsObjects.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsObjects.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsObjects.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsObjects.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompareArgumentsVectors.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsVectors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompareArgumentsVectors.cs
+++ b/CP77.CR2W/Types/cp77/CompareArgumentsVectors.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CompareBuilder.cs
+++ b/CP77.CR2W/Types/cp77/CompareBuilder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompassController.cs
+++ b/CP77.CR2W/Types/cp77/CompassController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompleteCommand.cs
+++ b/CP77.CR2W/Types/cp77/CompleteCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CompletionOfFirstEquipRequest.cs
+++ b/CP77.CR2W/Types/cp77/CompletionOfFirstEquipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Computer.cs
+++ b/CP77.CR2W/Types/cp77/Computer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerBannerWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerBannerWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ComputerControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ComputerControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/ComputerDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerDocumentThumbnailWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerDocumentThumbnailWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerDocumentWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerDocumentWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerFullBannerWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerFullBannerWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerMainLayoutWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerMainLayoutWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerMainMenuWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerMainMenuWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerMenuButtonController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerMenuButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerMenuWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/ComputerMenuWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/ComputerPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerQuickHackData.cs
+++ b/CP77.CR2W/Types/cp77/ComputerQuickHackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ComputerSetup.cs
+++ b/CP77.CR2W/Types/cp77/ComputerSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Condition.cs
+++ b/CP77.CR2W/Types/cp77/Condition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConditionData.cs
+++ b/CP77.CR2W/Types/cp77/ConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConditionGroupData.cs
+++ b/CP77.CR2W/Types/cp77/ConditionGroupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConeAOCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ConeAOCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConeAOCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ConeAOCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Confess.cs
+++ b/CP77.CR2W/Types/cp77/Confess.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Confess.cs
+++ b/CP77.CR2W/Types/cp77/Confess.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConfessionBooth.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionBooth.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConfessionBoothController.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionBoothController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConfessionBoothController.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionBoothController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConfessionBoothControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionBoothControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConfessionBoothControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionBoothControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConfessionCompletedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionCompletedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConfessionCompletedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionCompletedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConfessionalBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionalBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConfessionalInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ConfessionalInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConnectedClassTypes.cs
+++ b/CP77.CR2W/Types/cp77/ConnectedClassTypes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConnectedToBackdoorPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ConnectedToBackdoorPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConstantStatPoolPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ConstantStatPoolPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConstantStatPoolPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ConstantStatPoolPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConstantStatPoolPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/ConstantStatPoolPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConstantStatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/ConstantStatPoolPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableCleanupDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableCleanupDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableCleanupDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableCleanupDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableCleanupEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableCleanupEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableCleanupEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableCleanupEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableStartupDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableStartupDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableStartupDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableStartupDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableStartupEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableStartupEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableStartupEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableStartupEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableTransitions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableTransitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableTransitions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableTransitions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableUseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableUseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableUseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableUseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableUseEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableUseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableWheelDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableWheelDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumableWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableWheelEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumableWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/ConsumableWheelEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumeAction.cs
+++ b/CP77.CR2W/Types/cp77/ConsumeAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConsumeAction.cs
+++ b/CP77.CR2W/Types/cp77/ConsumeAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConsumeGateSignal.cs
+++ b/CP77.CR2W/Types/cp77/ConsumeGateSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContactData.cs
+++ b/CP77.CR2W/Types/cp77/ContactData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContactShadowsConfig.cs
+++ b/CP77.CR2W/Types/cp77/ContactShadowsConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContactShadowsSettings.cs
+++ b/CP77.CR2W/Types/cp77/ContactShadowsSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContainerObjectSingleItemPS.cs
+++ b/CP77.CR2W/Types/cp77/ContainerObjectSingleItemPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContainerObjectSingleItemPS.cs
+++ b/CP77.CR2W/Types/cp77/ContainerObjectSingleItemPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ContainerStateInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/ContainerStateInteractionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ContainerStateInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/ContainerStateInteractionCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ControlPanelObjectiveData.cs
+++ b/CP77.CR2W/Types/cp77/ControlPanelObjectiveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlPanelObjectiveData.cs
+++ b/CP77.CR2W/Types/cp77/ControlPanelObjectiveData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ControlledDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/ControlledDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlledDeviceLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ControlledDeviceLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlledDevicesInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ControlledDevicesInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControllerSettingsGameController.cs
+++ b/CP77.CR2W/Types/cp77/ControllerSettingsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlsActiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ControlsActiveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlsActiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ControlsActiveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ControlsActiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/ControlsActiveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlsInactiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ControlsInactiveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlsInactiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ControlsInactiveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ControlsInactiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/ControlsInactiveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ControlsInactiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/ControlsInactiveEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConvexHull.cs
+++ b/CP77.CR2W/Types/cp77/ConvexHull.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConveyorController.cs
+++ b/CP77.CR2W/Types/cp77/ConveyorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConveyorController.cs
+++ b/CP77.CR2W/Types/cp77/ConveyorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ConveyorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ConveyorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ConveyorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ConveyorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CookedMultilayer_Setup.cs
+++ b/CP77.CR2W/Types/cp77/CookedMultilayer_Setup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownOnActivation.cs
+++ b/CP77.CR2W/Types/cp77/CooldownOnActivation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownOnActivation.cs
+++ b/CP77.CR2W/Types/cp77/CooldownOnActivation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CooldownOnDeactivation.cs
+++ b/CP77.CR2W/Types/cp77/CooldownOnDeactivation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownOnDeactivation.cs
+++ b/CP77.CR2W/Types/cp77/CooldownOnDeactivation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CooldownPackage.cs
+++ b/CP77.CR2W/Types/cp77/CooldownPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownPackageDelayIDs.cs
+++ b/CP77.CR2W/Types/cp77/CooldownPackageDelayIDs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownRequest.cs
+++ b/CP77.CR2W/Types/cp77/CooldownRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownStorage.cs
+++ b/CP77.CR2W/Types/cp77/CooldownStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CooldownStorageID.cs
+++ b/CP77.CR2W/Types/cp77/CooldownStorageID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoopIrritationDelayCallback.cs
+++ b/CP77.CR2W/Types/cp77/CoopIrritationDelayCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoverActionDataDef.cs
+++ b/CP77.CR2W/Types/cp77/CoverActionDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoverActionEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/CoverActionEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoverActionEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/CoverActionEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CoverActionTransition.cs
+++ b/CP77.CR2W/Types/cp77/CoverActionTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CoverActionTransition.cs
+++ b/CP77.CR2W/Types/cp77/CoverActionTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CoverCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/CoverCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CpoCharacterButtonItemController.cs
+++ b/CP77.CR2W/Types/cp77/CpoCharacterButtonItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CpoCharacterSelectionWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/CpoCharacterSelectionWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CpoHudRootGameController.cs
+++ b/CP77.CR2W/Types/cp77/CpoHudRootGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrackAction.cs
+++ b/CP77.CR2W/Types/cp77/CrackAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrackAction.cs
+++ b/CP77.CR2W/Types/cp77/CrackAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrafringMaterialItemController.cs
+++ b/CP77.CR2W/Types/cp77/CrafringMaterialItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftBook.cs
+++ b/CP77.CR2W/Types/cp77/CraftBook.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftItemForTarget.cs
+++ b/CP77.CR2W/Types/cp77/CraftItemForTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftItemRequest.cs
+++ b/CP77.CR2W/Types/cp77/CraftItemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftableItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/CraftableItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingDataView.cs
+++ b/CP77.CR2W/Types/cp77/CraftingDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingItemPreviewEvent.cs
+++ b/CP77.CR2W/Types/cp77/CraftingItemPreviewEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingItemTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/CraftingItemTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingItemTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/CraftingItemTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CraftingMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/CraftingMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingNotification.cs
+++ b/CP77.CR2W/Types/cp77/CraftingNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CraftingNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/CraftingNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/CraftingNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingPopupController.cs
+++ b/CP77.CR2W/Types/cp77/CraftingPopupController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingPopupData.cs
+++ b/CP77.CR2W/Types/cp77/CraftingPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingSkillWidget.cs
+++ b/CP77.CR2W/Types/cp77/CraftingSkillWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingSystem.cs
+++ b/CP77.CR2W/Types/cp77/CraftingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingSystemInventoryCallback.cs
+++ b/CP77.CR2W/Types/cp77/CraftingSystemInventoryCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CraftingUserData.cs
+++ b/CP77.CR2W/Types/cp77/CraftingUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CreateCustomBlackboardEvent.cs
+++ b/CP77.CR2W/Types/cp77/CreateCustomBlackboardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CreditsData.cs
+++ b/CP77.CR2W/Types/cp77/CreditsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CreditsGameController.cs
+++ b/CP77.CR2W/Types/cp77/CreditsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Basic.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Basic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Power.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Power.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Power.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Power.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Smart.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Smart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Smart.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Smart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Tech.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Tech.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Tech.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Jailbreak_Tech.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Launcher.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Launcher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Mantis_Blade.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Mantis_Blade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Melee.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Melee.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_NoWeapon.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_NoWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Simple.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Simple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Smart_Rifl.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Smart_Rifl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Tech_Hex.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Tech_Hex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairGameController_Tech_Round.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairGameController_Tech_Round.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairHealthChangeListener.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairHealthChangeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairModule.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrosshairWeaponStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/CrosshairWeaponStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_ChargeBar.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_ChargeBar.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Custom_HMG.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Custom_HMG.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Melee_Hammer.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Melee_Hammer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Melee_Knife.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Melee_Knife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Melee_Misc.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Melee_Misc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Melee_Nano_Wire.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Melee_Nano_Wire.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Power_Defender.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Power_Defender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Power_Overture.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Power_Overture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Power_Saratoga.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Power_Saratoga.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Power_Tactician.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Power_Tactician.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Smart_Rifl_Bucket.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Smart_Rifl_Bucket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Crosshair_Tech_Omaha.cs
+++ b/CP77.CR2W/Types/cp77/Crosshair_Tech_Omaha.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrossingLight.cs
+++ b/CP77.CR2W/Types/cp77/CrossingLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrossingLightController.cs
+++ b/CP77.CR2W/Types/cp77/CrossingLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrossingLightController.cs
+++ b/CP77.CR2W/Types/cp77/CrossingLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrossingLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/CrossingLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrossingLightSetup.cs
+++ b/CP77.CR2W/Types/cp77/CrossingLightSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CrouchDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CrouchDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrouchEvents.cs
+++ b/CP77.CR2W/Types/cp77/CrouchEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchEvents.cs
+++ b/CP77.CR2W/Types/cp77/CrouchEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrouchIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/CrouchIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CrouchLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CrouchLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/CrouchLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/CrouchLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrowdCallingPoliceEvent.cs
+++ b/CP77.CR2W/Types/cp77/CrowdCallingPoliceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrowdCallingPoliceEvent.cs
+++ b/CP77.CR2W/Types/cp77/CrowdCallingPoliceEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrowdMemberBaseComponent.cs
+++ b/CP77.CR2W/Types/cp77/CrowdMemberBaseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CrowdMemberBaseComponent.cs
+++ b/CP77.CR2W/Types/cp77/CrowdMemberBaseComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CrowdSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CrowdSettingsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurrencyChangeInventoryCallback.cs
+++ b/CP77.CR2W/Types/cp77/CurrencyChangeInventoryCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurrencyNotification.cs
+++ b/CP77.CR2W/Types/cp77/CurrencyNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurrencyUpdateNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/CurrencyUpdateNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurrentHighLevelNPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/CurrentHighLevelNPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurrentStanceNPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/CurrentStanceNPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CursorGameController.cs
+++ b/CP77.CR2W/Types/cp77/CursorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurveResourceSet.cs
+++ b/CP77.CR2W/Types/cp77/CurveResourceSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurveResourceSetEntry.cs
+++ b/CP77.CR2W/Types/cp77/CurveResourceSetEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurveSet.cs
+++ b/CP77.CR2W/Types/cp77/CurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CurveSetEntry.cs
+++ b/CP77.CR2W/Types/cp77/CurveSetEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomActionOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/CustomActionOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomActionOperations.cs
+++ b/CP77.CR2W/Types/cp77/CustomActionOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomActionOperationsTriggers.cs
+++ b/CP77.CR2W/Types/cp77/CustomActionOperationsTriggers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomAnimationsGameController.cs
+++ b/CP77.CR2W/Types/cp77/CustomAnimationsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomAnimationsHudGameController.cs
+++ b/CP77.CR2W/Types/cp77/CustomAnimationsHudGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/CustomBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/CustomBlackboardDef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CustomCentaurBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/CustomCentaurBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomDeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/CustomDeviceAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomDeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/CustomDeviceAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CustomEventCondition.cs
+++ b/CP77.CR2W/Types/cp77/CustomEventCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomEventSender.cs
+++ b/CP77.CR2W/Types/cp77/CustomEventSender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomEventSender.cs
+++ b/CP77.CR2W/Types/cp77/CustomEventSender.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CustomLightAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/CustomLightAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CustomNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomQuestNotificationGameController.cs
+++ b/CP77.CR2W/Types/cp77/CustomQuestNotificationGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomQuestNotificationUserData.cs
+++ b/CP77.CR2W/Types/cp77/CustomQuestNotificationUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/CustomSystemUIPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/CustomSystemUIPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CustomUIAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CustomUIAnimationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomValueFromMappingTimeout.cs
+++ b/CP77.CR2W/Types/cp77/CustomValueFromMappingTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CustomValueTimeout.cs
+++ b/CP77.CR2W/Types/cp77/CustomValueTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CutCone.cs
+++ b/CP77.CR2W/Types/cp77/CutCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeAddAxisRotationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeAddAxisRotationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeAddAxisRotationEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeAddAxisRotationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeDespawnEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeDespawnEffectsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeDespawnEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeDespawnEffectsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CuttingGrenadePotentialTarget.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadePotentialTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeSpawnBlinkEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeSpawnBlinkEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeSpawnBlinkEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeSpawnBlinkEffectEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeStopAttackEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeStopAttackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CuttingGrenadeStopAttackEvent.cs
+++ b/CP77.CR2W/Types/cp77/CuttingGrenadeStopAttackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CyberEquipGameController.cs
+++ b/CP77.CR2W/Types/cp77/CyberEquipGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberdeckDeviceHackIcon.cs
+++ b/CP77.CR2W/Types/cp77/CyberdeckDeviceHackIcon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberdeckDeviceQuickhackData.cs
+++ b/CP77.CR2W/Types/cp77/CyberdeckDeviceQuickhackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberdeckStatController.cs
+++ b/CP77.CR2W/Types/cp77/CyberdeckStatController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberdeckTooltip.cs
+++ b/CP77.CR2W/Types/cp77/CyberdeckTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberspaceMappinController.cs
+++ b/CP77.CR2W/Types/cp77/CyberspaceMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareAttributesSkills.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareAttributesSkills.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareAttributes_ContainersStruct.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareAttributes_ContainersStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareAttributes_Logic.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareAttributes_Logic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareAttributes_ResistancesStruct.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareAttributes_ResistancesStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareDataView.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareDataWrapper.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareDataWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareDisplayWrapper.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareDisplayWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareInventoryMiniGrid.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareInventoryMiniGrid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareSlot.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareSlotTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareSlotTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareTabModsRequest.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTabModsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CyberwareTooltip.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareTooltipSlotListItem.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareTooltipSlotListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareUtility.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareUtility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CyberwareUtility.cs
+++ b/CP77.CR2W/Types/cp77/CyberwareUtility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CyclableRadialSlot.cs
+++ b/CP77.CR2W/Types/cp77/CyclableRadialSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleObjectiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleObjectiveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleObjectiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleObjectiveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CycleObjectiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/CycleObjectiveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleObjectiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/CycleObjectiveEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CycleRoundDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleRoundDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleRoundDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleRoundDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CycleRoundEvents.cs
+++ b/CP77.CR2W/Types/cp77/CycleRoundEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleTriggerModeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleTriggerModeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleTriggerModeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/CycleTriggerModeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/CycleTriggerModeEvents.cs
+++ b/CP77.CR2W/Types/cp77/CycleTriggerModeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/CycleTriggerModeEvents.cs
+++ b/CP77.CR2W/Types/cp77/CycleTriggerModeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Cylinder.cs
+++ b/CP77.CR2W/Types/cp77/Cylinder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_DamageInputReceiver.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_DamageInputReceiver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_IconErrorInfo.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_IconErrorInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_ItemRebalancer.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_ItemRebalancer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_RebalanceItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_RebalanceItemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_VirtualShopkeeper.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_VirtualShopkeeper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_VisualRecord.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_VisualRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_VisualizerComponent.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_VisualizerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEBUG_actorsClassNamesCount.cs
+++ b/CP77.CR2W/Types/cp77/DEBUG_actorsClassNamesCount.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEVICE_Actor.cs
+++ b/CP77.CR2W/Types/cp77/DEVICE_Actor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DEVICE_Actor.cs
+++ b/CP77.CR2W/Types/cp77/DEVICE_Actor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DOTContinuousEffector.cs
+++ b/CP77.CR2W/Types/cp77/DOTContinuousEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DOTContinuousEffector.cs
+++ b/CP77.CR2W/Types/cp77/DOTContinuousEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DPADActionPerformed.cs
+++ b/CP77.CR2W/Types/cp77/DPADActionPerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DPSPackage.cs
+++ b/CP77.CR2W/Types/cp77/DPSPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageDigitLogicController.cs
+++ b/CP77.CR2W/Types/cp77/DamageDigitLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageDigitsGameController.cs
+++ b/CP77.CR2W/Types/cp77/DamageDigitsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageEffectUIEntry.cs
+++ b/CP77.CR2W/Types/cp77/DamageEffectUIEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageEntry.cs
+++ b/CP77.CR2W/Types/cp77/DamageEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageHistoryEntry.cs
+++ b/CP77.CR2W/Types/cp77/DamageHistoryEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageInflictedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DamageInflictedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageInflictedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DamageInflictedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DamageManager.cs
+++ b/CP77.CR2W/Types/cp77/DamageManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageManager.cs
+++ b/CP77.CR2W/Types/cp77/DamageManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DamageOverTimeTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/DamageOverTimeTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamagePreviewController.cs
+++ b/CP77.CR2W/Types/cp77/DamagePreviewController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageStatListener.cs
+++ b/CP77.CR2W/Types/cp77/DamageStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/DamageSystemHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/DamageSystemHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DamageTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/DamageTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageTypeIndicator.cs
+++ b/CP77.CR2W/Types/cp77/DamageTypeIndicator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageTypePrereq.cs
+++ b/CP77.CR2W/Types/cp77/DamageTypePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageTypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DamageTypePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DamageTypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DamageTypePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DataEntryRequest.cs
+++ b/CP77.CR2W/Types/cp77/DataEntryRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTerm.cs
+++ b/CP77.CR2W/Types/cp77/DataTerm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTermController.cs
+++ b/CP77.CR2W/Types/cp77/DataTermController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTermController.cs
+++ b/CP77.CR2W/Types/cp77/DataTermController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DataTermControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DataTermControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTermDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/DataTermDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTermInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/DataTermInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DataTrackingSystem.cs
+++ b/CP77.CR2W/Types/cp77/DataTrackingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DayPassedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DayPassedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DayPassedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DayPassedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeactivateAllNetworkLinksRequest.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateAllNetworkLinksRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeactivateAllNetworkLinksRequest.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateAllNetworkLinksRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeactivateC4.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateC4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeactivateDevice.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeactivateDevice.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeactivateQuickHackIndicatorEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateQuickHackIndicatorEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeactivateQuickHackIndicatorEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeactivateQuickHackIndicatorEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeadBodyEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeadBodyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeadBodyEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeadBodyEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeadContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeadContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeadContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeadContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeadOnInitTask.cs
+++ b/CP77.CR2W/Types/cp77/DeadOnInitTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeadState.cs
+++ b/CP77.CR2W/Types/cp77/DeadState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeadState.cs
+++ b/CP77.CR2W/Types/cp77/DeadState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeathEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathExitingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathExitingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeathExitingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeathExitingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathIsRagdollCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathIsRagdollCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathIsRagdollCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathIsRagdollCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeathLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeathLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeathLandEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathMenuDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeathMenuDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathMenuDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeathMenuDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/DeathMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathMenuUserData.cs
+++ b/CP77.CR2W/Types/cp77/DeathMenuUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathWithoutAnimationCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathWithoutAnimationCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathWithoutAnimationCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathWithoutAnimationCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeathWithoutRagdollCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathWithoutRagdollCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeathWithoutRagdollCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeathWithoutRagdollCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DebugDataDef.cs
+++ b/CP77.CR2W/Types/cp77/DebugDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/DebugGameEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/DebugGameEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DebugHubMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/DebugHubMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugHubMenuLogicController.cs
+++ b/CP77.CR2W/Types/cp77/DebugHubMenuLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugInteractionObject.cs
+++ b/CP77.CR2W/Types/cp77/DebugInteractionObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugMenuScenario_HubMenu.cs
+++ b/CP77.CR2W/Types/cp77/DebugMenuScenario_HubMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugNpcNameplateGameController.cs
+++ b/CP77.CR2W/Types/cp77/DebugNpcNameplateGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugOutlineEvent.cs
+++ b/CP77.CR2W/Types/cp77/DebugOutlineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugRemoteConnectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DebugRemoteConnectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DebugRemoteConnectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DebugRemoteConnectionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DebugTextDrawer.cs
+++ b/CP77.CR2W/Types/cp77/DebugTextDrawer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Debug_AimingLookatTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_AimingLookatTestEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Debug_AimingLookatTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_AimingLookatTestEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Debug_CheckIfShouldReturnToSpawn.cs
+++ b/CP77.CR2W/Types/cp77/Debug_CheckIfShouldReturnToSpawn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Debug_CheckIfShouldReturnToSpawn.cs
+++ b/CP77.CR2W/Types/cp77/Debug_CheckIfShouldReturnToSpawn.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Debug_LookatTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_LookatTestEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Debug_LookatTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_LookatTestEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Debug_RotationTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_RotationTestEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Debug_RotationTestEnabled.cs
+++ b/CP77.CR2W/Types/cp77/Debug_RotationTestEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DebuggerProperties.cs
+++ b/CP77.CR2W/Types/cp77/DebuggerProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeescalationEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeescalationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DefaultActionsParametersHolder.cs
+++ b/CP77.CR2W/Types/cp77/DefaultActionsParametersHolder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DefaultActionsParametersHolder.cs
+++ b/CP77.CR2W/Types/cp77/DefaultActionsParametersHolder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DefaultTest.cs
+++ b/CP77.CR2W/Types/cp77/DefaultTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DefaultTest.cs
+++ b/CP77.CR2W/Types/cp77/DefaultTest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DefaultTransition.cs
+++ b/CP77.CR2W/Types/cp77/DefaultTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DefaultTransition.cs
+++ b/CP77.CR2W/Types/cp77/DefaultTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayHackedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayHackedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayInitPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/DelayInitPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayInitPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/DelayInitPopupGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayPassiveConditionEvaluationEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayPassiveConditionEvaluationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayPassiveConditionEvaluationEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayPassiveConditionEvaluationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayPrereqEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayPrereqEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelaySpawning.cs
+++ b/CP77.CR2W/Types/cp77/DelaySpawning.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelaySpawning.cs
+++ b/CP77.CR2W/Types/cp77/DelaySpawning.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayStimEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayStimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedComDeviceClose.cs
+++ b/CP77.CR2W/Types/cp77/DelayedComDeviceClose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedComDeviceClose.cs
+++ b/CP77.CR2W/Types/cp77/DelayedComDeviceClose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedCrowdReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedCrowdReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedDescriptionIntro.cs
+++ b/CP77.CR2W/Types/cp77/DelayedDescriptionIntro.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedDescriptionIntro.cs
+++ b/CP77.CR2W/Types/cp77/DelayedDescriptionIntro.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedDeviceActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedDeviceActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedDeviceOperationTriggerEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedDeviceOperationTriggerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedGameEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedGameEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedHUDInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedHUDInitializeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedHUDInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedHUDInitializeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedJournalUpdate.cs
+++ b/CP77.CR2W/Types/cp77/DelayedJournalUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedOperationEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedOperationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedRegisterToGlobalInputCallbackEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedRegisterToGlobalInputCallbackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedRegisterToGlobalInputCallbackEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedRegisterToGlobalInputCallbackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedStatusEffectApplicationEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedStatusEffectApplicationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedTimetableEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedTimetableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedUIRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedUIRefreshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedUIRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedUIRefreshEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedUpdateDeviceStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedUpdateDeviceStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DelayedUpdateDeviceStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/DelayedUpdateDeviceStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DelayedVisibilityInAnimSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/DelayedVisibilityInAnimSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeleteEquipmentSetRequest.cs
+++ b/CP77.CR2W/Types/cp77/DeleteEquipmentSetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DemolitionContainer.cs
+++ b/CP77.CR2W/Types/cp77/DemolitionContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DemolitionSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/DemolitionSkillCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DemolitionSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/DemolitionSkillCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DepleteCharges.cs
+++ b/CP77.CR2W/Types/cp77/DepleteCharges.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DepleteCharges.cs
+++ b/CP77.CR2W/Types/cp77/DepleteCharges.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DepositQuestItems.cs
+++ b/CP77.CR2W/Types/cp77/DepositQuestItems.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DepositQuestItems.cs
+++ b/CP77.CR2W/Types/cp77/DepositQuestItems.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DespawnSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/DespawnSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DespawnSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/DespawnSubCharacterRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DespawnUniqueSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/DespawnUniqueSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestroyLink.cs
+++ b/CP77.CR2W/Types/cp77/DestroyLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestroyLink.cs
+++ b/CP77.CR2W/Types/cp77/DestroyLink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestroyWeakspot.cs
+++ b/CP77.CR2W/Types/cp77/DestroyWeakspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestroyWeakspotDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DestroyWeakspotDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestroyWeakspotDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DestroyWeakspotDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestroyWeakspotEffector.cs
+++ b/CP77.CR2W/Types/cp77/DestroyWeakspotEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestructibleMasterDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestructibleMasterDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterLight.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterLightController.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterLightController.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestructibleMasterLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructibleMasterLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleMasterLightControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DestructibleRoadSign.cs
+++ b/CP77.CR2W/Types/cp77/DestructibleRoadSign.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DestructionData.cs
+++ b/CP77.CR2W/Types/cp77/DestructionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DetailedLocomotionPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DetectionParameters.cs
+++ b/CP77.CR2W/Types/cp77/DetectionParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetectionRiseEvent.cs
+++ b/CP77.CR2W/Types/cp77/DetectionRiseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetectionRiseEvent.cs
+++ b/CP77.CR2W/Types/cp77/DetectionRiseEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DetectorModuleComponent.cs
+++ b/CP77.CR2W/Types/cp77/DetectorModuleComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DetectorModuleComponent.cs
+++ b/CP77.CR2W/Types/cp77/DetectorModuleComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DetonateC4.cs
+++ b/CP77.CR2W/Types/cp77/DetonateC4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DevelopmentCheckPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DevelopmentCheckPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Device.cs
+++ b/CP77.CR2W/Types/cp77/Device.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceActionOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/DeviceActionOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceActionOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/DeviceActionOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceActionPropertyFunctions.cs
+++ b/CP77.CR2W/Types/cp77/DeviceActionPropertyFunctions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceActionPropertyFunctions.cs
+++ b/CP77.CR2W/Types/cp77/DeviceActionPropertyFunctions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceActionWidgetControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceActionWidgetControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceBaseBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/DeviceBaseBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceButtonLogicControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceButtonLogicControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceConnectionHighlightComponent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceConnectionHighlightComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceConnectionHighlightComponent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceConnectionHighlightComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceConnectionScannerData.cs
+++ b/CP77.CR2W/Types/cp77/DeviceConnectionScannerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceConnectionsHighlightSystem.cs
+++ b/CP77.CR2W/Types/cp77/DeviceConnectionsHighlightSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceControlContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeviceControlContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceControlContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DeviceControlContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceControlContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeviceControlContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceControlContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/DeviceControlContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceCounter.cs
+++ b/CP77.CR2W/Types/cp77/DeviceCounter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceDebugDef.cs
+++ b/CP77.CR2W/Types/cp77/DeviceDebugDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceDebuggerComponent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceDebuggerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceDirectInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeviceDirectInteractionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceDirectInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeviceDirectInteractionCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceHelper.cs
+++ b/CP77.CR2W/Types/cp77/DeviceHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceHelper.cs
+++ b/CP77.CR2W/Types/cp77/DeviceHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceInkGameControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceInkGameControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceInkLogicControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceInkLogicControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceLink.cs
+++ b/CP77.CR2W/Types/cp77/DeviceLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceLinkComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/DeviceLinkComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceLinkEstablished.cs
+++ b/CP77.CR2W/Types/cp77/DeviceLinkEstablished.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceLinkRequest.cs
+++ b/CP77.CR2W/Types/cp77/DeviceLinkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceMappinsContainer.cs
+++ b/CP77.CR2W/Types/cp77/DeviceMappinsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperationBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperationBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperations.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperationsContainer.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperationsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/DeviceOperationsTrigger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceRemoteInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeviceRemoteInteractionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceRemoteInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/DeviceRemoteInteractionCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceScanningDescription.cs
+++ b/CP77.CR2W/Types/cp77/DeviceScanningDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceSystemBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceSystemBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceSystemBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceSystemBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceSystemBaseController.cs
+++ b/CP77.CR2W/Types/cp77/DeviceSystemBaseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceSystemBaseController.cs
+++ b/CP77.CR2W/Types/cp77/DeviceSystemBaseController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceSystemBaseControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DeviceSystemBaseControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceTakeControlDef.cs
+++ b/CP77.CR2W/Types/cp77/DeviceTakeControlDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceThumbnailWidgetControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceThumbnailWidgetControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceTimeTableManager.cs
+++ b/CP77.CR2W/Types/cp77/DeviceTimeTableManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceTimetable.cs
+++ b/CP77.CR2W/Types/cp77/DeviceTimetable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceTimetableEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceTimetableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DeviceUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/DeviceUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DeviceWidgetControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DeviceWidgetControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialerContactDataView.cs
+++ b/CP77.CR2W/Types/cp77/DialerContactDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialerContactTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/DialerContactTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialerContactTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/DialerContactTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DialogChoiceLogicController.cs
+++ b/CP77.CR2W/Types/cp77/DialogChoiceLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogChoiceTimerController.cs
+++ b/CP77.CR2W/Types/cp77/DialogChoiceTimerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogHubLogicController.cs
+++ b/CP77.CR2W/Types/cp77/DialogHubLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogHubPostInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/DialogHubPostInitializeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogHubPostInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/DialogHubPostInitializeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DialogueChoiceHubPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DifficultySelectionMenu.cs
+++ b/CP77.CR2W/Types/cp77/DifficultySelectionMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DiodeControlComponent.cs
+++ b/CP77.CR2W/Types/cp77/DiodeControlComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DiodeLightPreset.cs
+++ b/CP77.CR2W/Types/cp77/DiodeLightPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableAlarmEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableAlarmEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableAlarmEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableAlarmEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableAllVehicleInteractionsNotEnabledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DisableAllVehicleInteractionsNotEnabledPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableAllVehicleInteractionsNotEnabledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DisableAllVehicleInteractionsNotEnabledPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableAllWorldInteractionsNotEnabledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DisableAllWorldInteractionsNotEnabledPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableAllWorldInteractionsNotEnabledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DisableAllWorldInteractionsNotEnabledPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableAreaIndicatorEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableAreaIndicatorEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableAreaIndicatorEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableAreaIndicatorEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableBraindanceActions.cs
+++ b/CP77.CR2W/Types/cp77/DisableBraindanceActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableFields.cs
+++ b/CP77.CR2W/Types/cp77/DisableFields.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableObjectDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableObjectDescriptionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableRPGRequirementsForDeviceActions.cs
+++ b/CP77.CR2W/Types/cp77/DisableRPGRequirementsForDeviceActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableRagdollComponentEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableRagdollComponentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableRagdollComponentEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableRagdollComponentEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableScannerEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableScannerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableTargetingEffector.cs
+++ b/CP77.CR2W/Types/cp77/DisableTargetingEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableTimeCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/DisableTimeCallbacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableTimeCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/DisableTimeCallbacks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisableWeakspotDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableWeakspotDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisableWeakspotDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisableWeakspotDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Disarm.cs
+++ b/CP77.CR2W/Types/cp77/Disarm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisarmComponent.cs
+++ b/CP77.CR2W/Types/cp77/DisarmComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassemblableComponent.cs
+++ b/CP77.CR2W/Types/cp77/DisassemblableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassemblableEntitySimple.cs
+++ b/CP77.CR2W/Types/cp77/DisassemblableEntitySimple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleAction.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleAction.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassembleDevice.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleDevice.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassembleEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleEvent.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassembleItemRequest.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleItemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleManager.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleMasterController.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleMasterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleMasterController.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleMasterController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassembleMasterControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleMasterControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleMasterControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleMasterControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassembleOptions.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleOwnedJunkEffector.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleOwnedJunkEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleOwnedJunkEffector.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleOwnedJunkEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisassemblePopupLogicController.cs
+++ b/CP77.CR2W/Types/cp77/DisassemblePopupLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisassembleTargetRequest.cs
+++ b/CP77.CR2W/Types/cp77/DisassembleTargetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DischargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DischargeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DischargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DischargeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DischargeEvents.cs
+++ b/CP77.CR2W/Types/cp77/DischargeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismemberEffector.cs
+++ b/CP77.CR2W/Types/cp77/DismemberEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentDebrisEvent.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentDebrisEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentEvent.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentExplosionEvent.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentExplosionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentInstigated.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentInstigated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentTriggeredHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentTriggeredHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentTriggeredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentTriggeredPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DismembermentTriggeredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/DismembermentTriggeredPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DispenceItemFromVendor.cs
+++ b/CP77.CR2W/Types/cp77/DispenceItemFromVendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DispenseFreeItem.cs
+++ b/CP77.CR2W/Types/cp77/DispenseFreeItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DispenseFreeItem.cs
+++ b/CP77.CR2W/Types/cp77/DispenseFreeItem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DispenseFreeSpecificItem.cs
+++ b/CP77.CR2W/Types/cp77/DispenseFreeSpecificItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DispenseRequest.cs
+++ b/CP77.CR2W/Types/cp77/DispenseRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisplayGlass.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisplayGlassController.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlassController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisplayGlassController.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlassController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisplayGlassControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlassControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisplayGlassInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlassInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisplayGlassInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/DisplayGlassInkGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisposalDevice.cs
+++ b/CP77.CR2W/Types/cp77/DisposalDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposalDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/DisposalDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposalDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/DisposalDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisposalDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DisposalDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposalDeviceSetup.cs
+++ b/CP77.CR2W/Types/cp77/DisposalDeviceSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/DisposeBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/DisposeBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisposeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DisposeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DisposeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisposeEvents.cs
+++ b/CP77.CR2W/Types/cp77/DisposeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisposeEvents.cs
+++ b/CP77.CR2W/Types/cp77/DisposeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DistanceCoveredHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/DistanceCoveredHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistantFogAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/DistantFogAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistantIrradianceeSettings.cs
+++ b/CP77.CR2W/Types/cp77/DistantIrradianceeSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistantLightsAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/DistantLightsAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistantProxiesSettings.cs
+++ b/CP77.CR2W/Types/cp77/DistantProxiesSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Distraction.cs
+++ b/CP77.CR2W/Types/cp77/Distraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Distraction.cs
+++ b/CP77.CR2W/Types/cp77/Distraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DistractionSetup.cs
+++ b/CP77.CR2W/Types/cp77/DistractionSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/District.cs
+++ b/CP77.CR2W/Types/cp77/District.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistrictManager.cs
+++ b/CP77.CR2W/Types/cp77/DistrictManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistrurbComfortZoneAggressiveEvent.cs
+++ b/CP77.CR2W/Types/cp77/DistrurbComfortZoneAggressiveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DistrurbComfortZoneAggressiveEvent.cs
+++ b/CP77.CR2W/Types/cp77/DistrurbComfortZoneAggressiveEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DisturbingComfortZone.cs
+++ b/CP77.CR2W/Types/cp77/DisturbingComfortZone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DisturbingComfortZone.cs
+++ b/CP77.CR2W/Types/cp77/DisturbingComfortZone.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DocumentCustomData.cs
+++ b/CP77.CR2W/Types/cp77/DocumentCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeAirDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeAirDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeAirEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeAirEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeAirLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeAirLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeAirLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeAirLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeAirLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeCrouchLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DodgeLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/DodgeLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DodgeReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/DodgeReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DodgeReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/DodgeReactionTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoesVehicleSupportCombat.cs
+++ b/CP77.CR2W/Types/cp77/DoesVehicleSupportCombat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoesVehicleSupportCombat.cs
+++ b/CP77.CR2W/Types/cp77/DoesVehicleSupportCombat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Door.cs
+++ b/CP77.CR2W/Types/cp77/Door.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorColliderEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/DoorColliderEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorColliderEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/DoorColliderEnableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorController.cs
+++ b/CP77.CR2W/Types/cp77/DoorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorController.cs
+++ b/CP77.CR2W/Types/cp77/DoorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/DoorInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorOpeningToken.cs
+++ b/CP77.CR2W/Types/cp77/DoorOpeningToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorOpeningToken.cs
+++ b/CP77.CR2W/Types/cp77/DoorOpeningToken.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/DoorPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorProximityDetector.cs
+++ b/CP77.CR2W/Types/cp77/DoorProximityDetector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorProximityDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/DoorProximityDetectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorProximityDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/DoorProximityDetectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorProximityDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorProximityDetectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorProximityDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorProximityDetectorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/DoorReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorResaveData.cs
+++ b/CP77.CR2W/Types/cp77/DoorResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorSetup.cs
+++ b/CP77.CR2W/Types/cp77/DoorSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorStateOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/DoorStateOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorStateOperations.cs
+++ b/CP77.CR2W/Types/cp77/DoorStateOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorStateOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/DoorStateOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorStatus.cs
+++ b/CP77.CR2W/Types/cp77/DoorStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorStatus.cs
+++ b/CP77.CR2W/Types/cp77/DoorStatus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorSystem.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorSystem.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorSystemController.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorSystemController.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystemControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/DoorSystemUIPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorTerminalMasterInkGameControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/DoorTerminalMasterInkGameControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorTriggerDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DoorTriggerDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/DoorViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoorViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/DoorViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoorWidgetCustomData.cs
+++ b/CP77.CR2W/Types/cp77/DoorWidgetCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoubleJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DoubleJumpDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoubleJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DoubleJumpDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoubleJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/DoubleJumpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoubleJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/DoubleJumpEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DoublePointsCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/DoublePointsCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DoublePointsCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/DoublePointsCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DownloadFundsAction.cs
+++ b/CP77.CR2W/Types/cp77/DownloadFundsAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DownloadFundsAction.cs
+++ b/CP77.CR2W/Types/cp77/DownloadFundsAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DpadWheelGameController.cs
+++ b/CP77.CR2W/Types/cp77/DpadWheelGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DpadWheelItemController.cs
+++ b/CP77.CR2W/Types/cp77/DpadWheelItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrawBetweenEntitiesEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrawBetweenEntitiesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrawNetworkSquadEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrawNetworkSquadEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DressPlayer.cs
+++ b/CP77.CR2W/Types/cp77/DressPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DressPlayer.cs
+++ b/CP77.CR2W/Types/cp77/DressPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DrillMachineScanManager.cs
+++ b/CP77.CR2W/Types/cp77/DrillMachineScanManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrillScanEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrillScanEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrillScanPostProcessEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrillScanPostProcessEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrillerScanEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrillerScanEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DrillerUIEvent.cs
+++ b/CP77.CR2W/Types/cp77/DrillerUIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DriveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DriveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DriveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DriveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DriveEvents.cs
+++ b/CP77.CR2W/Types/cp77/DriveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DriveEvents.cs
+++ b/CP77.CR2W/Types/cp77/DriveEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DriverCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DriverCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DriverCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DriverCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DriverCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/DriverCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DriverCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/DriverCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DroneComponent.cs
+++ b/CP77.CR2W/Types/cp77/DroneComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropAction.cs
+++ b/CP77.CR2W/Types/cp77/DropAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropAction.cs
+++ b/CP77.CR2W/Types/cp77/DropAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DropDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DropDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropDecisions.cs
+++ b/CP77.CR2W/Types/cp77/DropDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DropEvents.cs
+++ b/CP77.CR2W/Types/cp77/DropEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPoint.cs
+++ b/CP77.CR2W/Types/cp77/DropPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointCallback.cs
+++ b/CP77.CR2W/Types/cp77/DropPointCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointController.cs
+++ b/CP77.CR2W/Types/cp77/DropPointController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointController.cs
+++ b/CP77.CR2W/Types/cp77/DropPointController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DropPointControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/DropPointControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointMappinRegistrationData.cs
+++ b/CP77.CR2W/Types/cp77/DropPointMappinRegistrationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointModule.cs
+++ b/CP77.CR2W/Types/cp77/DropPointModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointModule.cs
+++ b/CP77.CR2W/Types/cp77/DropPointModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DropPointPackage.cs
+++ b/CP77.CR2W/Types/cp77/DropPointPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointRequest.cs
+++ b/CP77.CR2W/Types/cp77/DropPointRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointSystem.cs
+++ b/CP77.CR2W/Types/cp77/DropPointSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropPointTerminalInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/DropPointTerminalInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropQueueUpdatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DropQueueUpdatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownButtonController.cs
+++ b/CP77.CR2W/Types/cp77/DropdownButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownElementController.cs
+++ b/CP77.CR2W/Types/cp77/DropdownElementController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownItemClickedEvent.cs
+++ b/CP77.CR2W/Types/cp77/DropdownItemClickedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownItemController.cs
+++ b/CP77.CR2W/Types/cp77/DropdownItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownItemController.cs
+++ b/CP77.CR2W/Types/cp77/DropdownItemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DropdownItemData.cs
+++ b/CP77.CR2W/Types/cp77/DropdownItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DropdownListController.cs
+++ b/CP77.CR2W/Types/cp77/DropdownListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DroppedThreatData.cs
+++ b/CP77.CR2W/Types/cp77/DroppedThreatData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DummyEvent.cs
+++ b/CP77.CR2W/Types/cp77/DummyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DurabilityComponent.cs
+++ b/CP77.CR2W/Types/cp77/DurabilityComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DurabilityComponent.cs
+++ b/CP77.CR2W/Types/cp77/DurabilityComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DurabilityLimitReach.cs
+++ b/CP77.CR2W/Types/cp77/DurabilityLimitReach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/DurabilityLimitReach.cs
+++ b/CP77.CR2W/Types/cp77/DurabilityLimitReach.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/DynamicTexture.cs
+++ b/CP77.CR2W/Types/cp77/DynamicTexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/E3EndMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/E3EndMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/E3EndMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/E3EndMenuGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationKillNPC.cs
+++ b/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationKillNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationKillNPC.cs
+++ b/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationKillNPC.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationWeightLift.cs
+++ b/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationWeightLift.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationWeightLift.cs
+++ b/CP77.CR2W/Types/cp77/E3Hack_QuestPlayAnimationWeightLift.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EFirstEquipData.cs
+++ b/CP77.CR2W/Types/cp77/EFirstEquipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EMP.cs
+++ b/CP77.CR2W/Types/cp77/EMP.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EMP.cs
+++ b/CP77.CR2W/Types/cp77/EMP.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EMPEnded.cs
+++ b/CP77.CR2W/Types/cp77/EMPEnded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EMPEnded.cs
+++ b/CP77.CR2W/Types/cp77/EMPEnded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EMPExplosion.cs
+++ b/CP77.CR2W/Types/cp77/EMPExplosion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EMPExplosion.cs
+++ b/CP77.CR2W/Types/cp77/EMPExplosion.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EMPHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/EMPHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EasingFunction.cs
+++ b/CP77.CR2W/Types/cp77/EasingFunction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EditableGameLightSettings.cs
+++ b/CP77.CR2W/Types/cp77/EditableGameLightSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/EffectDataHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/EffectDataHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_ApplyEffector.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_ApplyEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_Device.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_Device.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_GameObjectOutline.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_GameObjectOutline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_GrenadeTargetTracker.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_GrenadeTargetTracker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_MuteBubble.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_MuteBubble.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_MuteBubble.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_MuteBubble.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_NanowireGrenadePull.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_NanowireGrenadePull.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_NanowireGrenadePull.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_NanowireGrenadePull.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_PingNetwork.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_PingNetwork.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_PuppetForceVisionAppearance.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_PuppetForceVisionAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_PuppetForceVisionAppearance.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_PuppetForceVisionAppearance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_ReactionStimuli.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_ReactionStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_ReactionStimuli.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_ReactionStimuli.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SendActionSignal.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SendActionSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceOFF.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceOFF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceOFF.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceOFF.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceON.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceON.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SetDeviceON.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SlashEffect.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SlashEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_SlashEffect_Entry.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_SlashEffect_Entry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_Spread.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_Spread.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_ToggleDevice.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_ToggleDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_ToggleDevice.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_ToggleDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_TrackTargets.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_TrackTargets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectExecutor_TrackTargets.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_TrackTargets.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectExecutor_VisualEffectAtTarget.cs
+++ b/CP77.CR2W/Types/cp77/EffectExecutor_VisualEffectAtTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectFilter_DamageOverTime.cs
+++ b/CP77.CR2W/Types/cp77/EffectFilter_DamageOverTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectFilter_DamageOverTime.cs
+++ b/CP77.CR2W/Types/cp77/EffectFilter_DamageOverTime.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_AOEAreaEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_AOEAreaEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_AOEAreaEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_AOEAreaEntities.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_PhysicalCollisionTrapEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_PhysicalCollisionTrapEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_PhysicalCollisionTrapEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_PhysicalCollisionTrapEntities.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_TrapEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_TrapEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_TrapEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_TrapEntities.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_VentilationAreaEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_VentilationAreaEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectObjectProvider_VentilationAreaEntities.cs
+++ b/CP77.CR2W/Types/cp77/EffectObjectProvider_VentilationAreaEntities.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectPostAction_BulletExplode.cs
+++ b/CP77.CR2W/Types/cp77/EffectPostAction_BulletExplode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectPostAction_BulletExplode.cs
+++ b/CP77.CR2W/Types/cp77/EffectPostAction_BulletExplode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack.cs
+++ b/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack_WithFriendlyFire.cs
+++ b/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack_WithFriendlyFire.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack_WithFriendlyFire.cs
+++ b/CP77.CR2W/Types/cp77/EffectPreAction_PreAttack_WithFriendlyFire.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EffectSharedDataDef.cs
+++ b/CP77.CR2W/Types/cp77/EffectSharedDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricBox.cs
+++ b/CP77.CR2W/Types/cp77/ElectricBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricBox.cs
+++ b/CP77.CR2W/Types/cp77/ElectricBox.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElectricBoxController.cs
+++ b/CP77.CR2W/Types/cp77/ElectricBoxController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricBoxController.cs
+++ b/CP77.CR2W/Types/cp77/ElectricBoxController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElectricBoxControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ElectricBoxControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricLight.cs
+++ b/CP77.CR2W/Types/cp77/ElectricLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricLightController.cs
+++ b/CP77.CR2W/Types/cp77/ElectricLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElectricLightController.cs
+++ b/CP77.CR2W/Types/cp77/ElectricLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElectricLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ElectricLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElementData.cs
+++ b/CP77.CR2W/Types/cp77/ElementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorArrowsLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorArrowsLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorSetup.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorTerminal.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorTerminal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorTerminal.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorTerminal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElevatorFloorTerminalController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorTerminalController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorTerminalController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorTerminalController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElevatorFloorTerminalControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorTerminalControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorFloorViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorFloorViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ElevatorInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorTerminalFakeGameController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorTerminalFakeGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ElevatorTerminalLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ElevatorTerminalLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmissiveColorSettings.cs
+++ b/CP77.CR2W/Types/cp77/EmissiveColorSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmitterDelaySettings.cs
+++ b/CP77.CR2W/Types/cp77/EmitterDelaySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmitterDurationSettings.cs
+++ b/CP77.CR2W/Types/cp77/EmitterDurationSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmitterGroupAreaParams.cs
+++ b/CP77.CR2W/Types/cp77/EmitterGroupAreaParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmitterGroupAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/EmitterGroupAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmitterGroupParams.cs
+++ b/CP77.CR2W/Types/cp77/EmitterGroupParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmptyHandsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EmptyHandsDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmptyHandsEvents.cs
+++ b/CP77.CR2W/Types/cp77/EmptyHandsEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EmptyHandsEvents.cs
+++ b/CP77.CR2W/Types/cp77/EmptyHandsEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnableBraindanceActions.cs
+++ b/CP77.CR2W/Types/cp77/EnableBraindanceActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableColliderDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/EnableColliderDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableColliderDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/EnableColliderDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnableDocumentEvent.cs
+++ b/CP77.CR2W/Types/cp77/EnableDocumentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableFastTravelRequest.cs
+++ b/CP77.CR2W/Types/cp77/EnableFastTravelRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableFields.cs
+++ b/CP77.CR2W/Types/cp77/EnableFields.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableTimeCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/EnableTimeCallbacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnableTimeCallbacks.cs
+++ b/CP77.CR2W/Types/cp77/EnableTimeCallbacks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EncumbranceEvaluationEffector.cs
+++ b/CP77.CR2W/Types/cp77/EncumbranceEvaluationEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EncumbranceEvaluationEffector.cs
+++ b/CP77.CR2W/Types/cp77/EncumbranceEvaluationEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndFive.cs
+++ b/CP77.CR2W/Types/cp77/EndFive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndFive.cs
+++ b/CP77.CR2W/Types/cp77/EndFive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndFour.cs
+++ b/CP77.CR2W/Types/cp77/EndFour.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndFour.cs
+++ b/CP77.CR2W/Types/cp77/EndFour.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndGracePeriodAfterSpawn.cs
+++ b/CP77.CR2W/Types/cp77/EndGracePeriodAfterSpawn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndGracePeriodAfterSpawn.cs
+++ b/CP77.CR2W/Types/cp77/EndGracePeriodAfterSpawn.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/EndLookatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndOne.cs
+++ b/CP77.CR2W/Types/cp77/EndOne.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndOne.cs
+++ b/CP77.CR2W/Types/cp77/EndOne.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndScreenData.cs
+++ b/CP77.CR2W/Types/cp77/EndScreenData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndThree.cs
+++ b/CP77.CR2W/Types/cp77/EndThree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndThree.cs
+++ b/CP77.CR2W/Types/cp77/EndThree.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EndTwo.cs
+++ b/CP77.CR2W/Types/cp77/EndTwo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EndTwo.cs
+++ b/CP77.CR2W/Types/cp77/EndTwo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EngDemoContainer.cs
+++ b/CP77.CR2W/Types/cp77/EngDemoContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EngagementScreenGameController.cs
+++ b/CP77.CR2W/Types/cp77/EngagementScreenGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EngineTime.cs
+++ b/CP77.CR2W/Types/cp77/EngineTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EngineTime.cs
+++ b/CP77.CR2W/Types/cp77/EngineTime.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EngineeringContainer.cs
+++ b/CP77.CR2W/Types/cp77/EngineeringContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EngineeringSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/EngineeringSkillCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EngineeringSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/EngineeringSkillCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnterLadder.cs
+++ b/CP77.CR2W/Types/cp77/EnterLadder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnterLadder.cs
+++ b/CP77.CR2W/Types/cp77/EnterLadder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnterVehicle.cs
+++ b/CP77.CR2W/Types/cp77/EnterVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnterVehicle.cs
+++ b/CP77.CR2W/Types/cp77/EnterVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnteredPathWithDoors.cs
+++ b/CP77.CR2W/Types/cp77/EnteredPathWithDoors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnteredPathWithDoors.cs
+++ b/CP77.CR2W/Types/cp77/EnteredPathWithDoors.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnteringCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EnteringCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnteringCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EnteringCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnteringCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/EnteringCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnteringCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/EnteringCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnteringDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EnteringDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnteringDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EnteringDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnteringEvents.cs
+++ b/CP77.CR2W/Types/cp77/EnteringEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EnteringEvents.cs
+++ b/CP77.CR2W/Types/cp77/EnteringEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EntitiesAtGate.cs
+++ b/CP77.CR2W/Types/cp77/EntitiesAtGate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityAttachementComponent.cs
+++ b/CP77.CR2W/Types/cp77/EntityAttachementComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityAttachementComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/EntityAttachementComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityAttachementData.cs
+++ b/CP77.CR2W/Types/cp77/EntityAttachementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityAttachementRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/EntityAttachementRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityHasVisualTag.cs
+++ b/CP77.CR2W/Types/cp77/EntityHasVisualTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityHasVisualTagPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/EntityHasVisualTagPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityHasVisualTagPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/EntityHasVisualTagPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EntityNoticedPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/EntityNoticedPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityNoticedPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/EntityNoticedPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityStubComponent.cs
+++ b/CP77.CR2W/Types/cp77/EntityStubComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EntityStubComponent.cs
+++ b/CP77.CR2W/Types/cp77/EntityStubComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EnvironmentColorGroupsSettings.cs
+++ b/CP77.CR2W/Types/cp77/EnvironmentColorGroupsSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipAction.cs
+++ b/CP77.CR2W/Types/cp77/EquipAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipAction.cs
+++ b/CP77.CR2W/Types/cp77/EquipAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipCycleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipCycleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipCycleEvents.cs
+++ b/CP77.CR2W/Types/cp77/EquipCycleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipCycleInitDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipCycleInitDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipCycleInitEvents.cs
+++ b/CP77.CR2W/Types/cp77/EquipCycleInitEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipItemCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/EquipItemCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipItemLeftDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipItemLeftDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipItemLeftDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipItemLeftDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipItemRightDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipItemRightDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipItemRightDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipItemRightDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipPrimaryWeaponCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/EquipPrimaryWeaponCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipSecondaryWeaponCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/EquipSecondaryWeaponCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentAreaCategory.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentAreaCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentAreaCategoryCreated.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentAreaCategoryCreated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentAreaDisplays.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentAreaDisplays.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipmentBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipmentBaseTransition.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentBaseTransition.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentBaseTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipmentManipulationRequest.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentManipulationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentSystemPlayerData.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentSystemPlayerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentSystemWeaponManipulationRequest.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentSystemWeaponManipulationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentUIBBRequest.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentUIBBRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquipmentUIBBRequest.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentUIBBRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EquipmentWidgets.cs
+++ b/CP77.CR2W/Types/cp77/EquipmentWidgets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquippedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/EquippedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquippedEvents.cs
+++ b/CP77.CR2W/Types/cp77/EquippedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EquippedWeaponTypeCondition.cs
+++ b/CP77.CR2W/Types/cp77/EquippedWeaponTypeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EscalateProvoke.cs
+++ b/CP77.CR2W/Types/cp77/EscalateProvoke.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EscalateProvoke.cs
+++ b/CP77.CR2W/Types/cp77/EscalateProvoke.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EulerAngles.cs
+++ b/CP77.CR2W/Types/cp77/EulerAngles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateEncumbranceEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateEncumbranceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateEncumbranceEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateEncumbranceEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EvaluateGameplayRoleEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateGameplayRoleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateLootQualityEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateLootQualityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateLootQualityEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateLootQualityEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EvaluateMappinsVisualStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateMappinsVisualStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateMappinsVisualStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateMappinsVisualStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EvaluateMinigame.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateMinigame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EvaluateVisionModeRequest.cs
+++ b/CP77.CR2W/Types/cp77/EvaluateVisionModeRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EveningPreset.cs
+++ b/CP77.CR2W/Types/cp77/EveningPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EveningPreset.cs
+++ b/CP77.CR2W/Types/cp77/EveningPreset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/EventEquipSlotSelectDelayedInventoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/EventEquipSlotSelectDelayedInventoryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EventInventorySlotSelectDelayedInventoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/EventInventorySlotSelectDelayedInventoryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/EventsFilters.cs
+++ b/CP77.CR2W/Types/cp77/EventsFilters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExampleNavigationTask.cs
+++ b/CP77.CR2W/Types/cp77/ExampleNavigationTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Example_FxSpawning.cs
+++ b/CP77.CR2W/Types/cp77/Example_FxSpawning.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExecutePuppetActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExecutePuppetActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExhaustedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExhaustedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExhaustedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExhaustedDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExhaustedEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExhaustedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitFromVehicle.cs
+++ b/CP77.CR2W/Types/cp77/ExitFromVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitLight.cs
+++ b/CP77.CR2W/Types/cp77/ExitLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitLight.cs
+++ b/CP77.CR2W/Types/cp77/ExitLight.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitLightController.cs
+++ b/CP77.CR2W/Types/cp77/ExitLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitLightController.cs
+++ b/CP77.CR2W/Types/cp77/ExitLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ExitLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ExitLightControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitWorkspotSequenceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExitWorkspotSequenceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitWorkspotSequenceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExitWorkspotSequenceEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitingCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExitingCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitingCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExitingCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitingCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitingCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitingCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitingCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExitingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExitingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExitingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExitingEventsBase.cs
+++ b/CP77.CR2W/Types/cp77/ExitingEventsBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExitingEventsBase.cs
+++ b/CP77.CR2W/Types/cp77/ExitingEventsBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExperiencePointsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExperiencePointsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplodingBullet.cs
+++ b/CP77.CR2W/Types/cp77/ExplodingBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplorationDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExplorationDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplorationDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ExplorationDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExplorationEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExplorationEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplorationEvents.cs
+++ b/CP77.CR2W/Types/cp77/ExplorationEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceHideDeviceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceHideDeviceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceHideDeviceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceHideDeviceEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExplosiveDeviceResourceDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveDeviceResourceDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveTriggerDevice.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveTriggerDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceProximityEvent.cs
+++ b/CP77.CR2W/Types/cp77/ExplosiveTriggerDeviceProximityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExposureAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ExposureAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExposureCompensationAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ExposureCompensationAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCAINodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCAINodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCAINodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCAINodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCConstBoolNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCConstBoolNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCConstFloatNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCConstFloatNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralAndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralAndNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralAndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralAndNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralCompositeNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralCompositeNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralIfNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralIfNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralOrNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralOrNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralOrNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCGeneralOrNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeReadIntDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeReadIntDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeReadIntDefinition.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeCParametrizationNodeReadIntDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ExpressionTreeExecutionListenerRef.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeExecutionListenerRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ExpressionTreeExecutionListenerRef.cs
+++ b/CP77.CR2W/Types/cp77/ExpressionTreeExecutionListenerRef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FUNC_TEST_Container.cs
+++ b/CP77.CR2W/Types/cp77/FUNC_TEST_Container.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FUNC_TEST_Container_2.cs
+++ b/CP77.CR2W/Types/cp77/FUNC_TEST_Container_2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FUNC_TEST_inkGameController.cs
+++ b/CP77.CR2W/Types/cp77/FUNC_TEST_inkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/FactOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/FactOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactQuickHack.cs
+++ b/CP77.CR2W/Types/cp77/FactQuickHack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactValuePrereq.cs
+++ b/CP77.CR2W/Types/cp77/FactValuePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactValuePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/FactValuePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FactsDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/FactsDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FadeOutOutlinesUpdate.cs
+++ b/CP77.CR2W/Types/cp77/FadeOutOutlinesUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FadeOutOutlinesUpdate.cs
+++ b/CP77.CR2W/Types/cp77/FadeOutOutlinesUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FailedActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/FailedActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FailedLandingAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FailedLandingAbstractDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FailedLandingAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FailedLandingAbstractDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FailedLandingAbstractEvents.cs
+++ b/CP77.CR2W/Types/cp77/FailedLandingAbstractEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FailedLandingAbstractEvents.cs
+++ b/CP77.CR2W/Types/cp77/FailedLandingAbstractEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FakeDoor.cs
+++ b/CP77.CR2W/Types/cp77/FakeDoor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FakeFeature.cs
+++ b/CP77.CR2W/Types/cp77/FakeFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FakeUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/FakeUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FakeUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/FakeUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FallDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FallDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallEvents.cs
+++ b/CP77.CR2W/Types/cp77/FallEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallEvents.cs
+++ b/CP77.CR2W/Types/cp77/FallEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FallLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FallLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/FallLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/FallLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/FallPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/FallPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FallPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/FallPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FallPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/FallPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Fan.cs
+++ b/CP77.CR2W/Types/cp77/Fan.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FanController.cs
+++ b/CP77.CR2W/Types/cp77/FanController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FanController.cs
+++ b/CP77.CR2W/Types/cp77/FanController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FanControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/FanControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FanResaveData.cs
+++ b/CP77.CR2W/Types/cp77/FanResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FanSetup.cs
+++ b/CP77.CR2W/Types/cp77/FanSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardActiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardActiveDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardActiveDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardActiveDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FastForwardActiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardActiveEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardActiveEvents.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardActiveEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FastForwardAvailableDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardAvailableDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardAvailableDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardAvailableDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FastForwardAvailableEvents.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardAvailableEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardUnavailableDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardUnavailableDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardUnavailableDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardUnavailableDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FastForwardUnavailableEvents.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardUnavailableEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastForwardUnavailableEvents.cs
+++ b/CP77.CR2W/Types/cp77/FastForwardUnavailableEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FastTRavelSystemDef.cs
+++ b/CP77.CR2W/Types/cp77/FastTRavelSystemDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelButtonLogicController.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelButtonLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelComponent.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelConsoleInstructionRequest.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelConsoleInstructionRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelDeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelDeviceAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelGameController.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelPointsUpdated.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelPointsUpdated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelSystem.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FastTravelSystemLock.cs
+++ b/CP77.CR2W/Types/cp77/FastTravelSystemLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FeatureFlagsMask.cs
+++ b/CP77.CR2W/Types/cp77/FeatureFlagsMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FeedEvent.cs
+++ b/CP77.CR2W/Types/cp77/FeedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FillAnimWrapperInfoBasedOnEquippedItem.cs
+++ b/CP77.CR2W/Types/cp77/FillAnimWrapperInfoBasedOnEquippedItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FillTakeOverChainBBoardEvent.cs
+++ b/CP77.CR2W/Types/cp77/FillTakeOverChainBBoardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilmGrainAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/FilmGrainAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilterNPCDodgeOpportunity.cs
+++ b/CP77.CR2W/Types/cp77/FilterNPCDodgeOpportunity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilterNPCsByType.cs
+++ b/CP77.CR2W/Types/cp77/FilterNPCsByType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilterRadioGroup.cs
+++ b/CP77.CR2W/Types/cp77/FilterRadioGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilterStimTargets.cs
+++ b/CP77.CR2W/Types/cp77/FilterStimTargets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FilterStimTargets.cs
+++ b/CP77.CR2W/Types/cp77/FilterStimTargets.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FilterTargetsByDistanceFromRoot.cs
+++ b/CP77.CR2W/Types/cp77/FilterTargetsByDistanceFromRoot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FindClosestScavengeTarget.cs
+++ b/CP77.CR2W/Types/cp77/FindClosestScavengeTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FindClosestScavengeTarget.cs
+++ b/CP77.CR2W/Types/cp77/FindClosestScavengeTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FindNavmeshPointAroundThePlayer.cs
+++ b/CP77.CR2W/Types/cp77/FindNavmeshPointAroundThePlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FindServersMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/FindServersMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FinishedPathWithDoors.cs
+++ b/CP77.CR2W/Types/cp77/FinishedPathWithDoors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FinishedPathWithDoors.cs
+++ b/CP77.CR2W/Types/cp77/FinishedPathWithDoors.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FinishedVendettaTimeEvent.cs
+++ b/CP77.CR2W/Types/cp77/FinishedVendettaTimeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FinishedVendettaTimeEvent.cs
+++ b/CP77.CR2W/Types/cp77/FinishedVendettaTimeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FinisherEffector.cs
+++ b/CP77.CR2W/Types/cp77/FinisherEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FinisherEffector.cs
+++ b/CP77.CR2W/Types/cp77/FinisherEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FinisherEffectorActionOn.cs
+++ b/CP77.CR2W/Types/cp77/FinisherEffectorActionOn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FirstEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FirstEquipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FirstEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/FirstEquipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FirstEquipSystem.cs
+++ b/CP77.CR2W/Types/cp77/FirstEquipSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FistsLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FistsLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FistsLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FistsLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FistsLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/FistsLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FistsLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/FistsLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FitToContetDelay.cs
+++ b/CP77.CR2W/Types/cp77/FitToContetDelay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FitToContetDelay.cs
+++ b/CP77.CR2W/Types/cp77/FitToContetDelay.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FixDevice.cs
+++ b/CP77.CR2W/Types/cp77/FixDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FixDevice.cs
+++ b/CP77.CR2W/Types/cp77/FixDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FixedCapsule.cs
+++ b/CP77.CR2W/Types/cp77/FixedCapsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FixedPoint.cs
+++ b/CP77.CR2W/Types/cp77/FixedPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FlickerEvent.cs
+++ b/CP77.CR2W/Types/cp77/FlickerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Flush.cs
+++ b/CP77.CR2W/Types/cp77/Flush.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Flush.cs
+++ b/CP77.CR2W/Types/cp77/Flush.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FocusClueDefinition.cs
+++ b/CP77.CR2W/Types/cp77/FocusClueDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusCluesSystem.cs
+++ b/CP77.CR2W/Types/cp77/FocusCluesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusForcedHighlightData.cs
+++ b/CP77.CR2W/Types/cp77/FocusForcedHighlightData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusForcedHighlightPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/FocusForcedHighlightPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusModeOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/FocusModeOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusModeOperations.cs
+++ b/CP77.CR2W/Types/cp77/FocusModeOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusModeOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/FocusModeOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FocusModeTaggingSystem.cs
+++ b/CP77.CR2W/Types/cp77/FocusModeTaggingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FoliageShadowConfig.cs
+++ b/CP77.CR2W/Types/cp77/FoliageShadowConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FollowNPCDef.cs
+++ b/CP77.CR2W/Types/cp77/FollowNPCDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FollowSlot.cs
+++ b/CP77.CR2W/Types/cp77/FollowSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FollowSlotsComponent.cs
+++ b/CP77.CR2W/Types/cp77/FollowSlotsComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FollowVehicleTask.cs
+++ b/CP77.CR2W/Types/cp77/FollowVehicleTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FollowVehicleTask.cs
+++ b/CP77.CR2W/Types/cp77/FollowVehicleTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FollowerFindTeleportPositionAroundTarget.cs
+++ b/CP77.CR2W/Types/cp77/FollowerFindTeleportPositionAroundTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceAnimationOffScreen.cs
+++ b/CP77.CR2W/Types/cp77/ForceAnimationOffScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceAnimationOffScreen.cs
+++ b/CP77.CR2W/Types/cp77/ForceAnimationOffScreen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceBraindanceCameraToggle.cs
+++ b/CP77.CR2W/Types/cp77/ForceBraindanceCameraToggle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceCLSStateRequest.cs
+++ b/CP77.CR2W/Types/cp77/ForceCLSStateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceCarAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ForceCarAlarm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceCarAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ForceCarAlarm.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceCloseHubMenuEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceCloseHubMenuEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceCloseHubMenuEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceCloseHubMenuEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceDetonate.cs
+++ b/CP77.CR2W/Types/cp77/ForceDetonate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceDetonate.cs
+++ b/CP77.CR2W/Types/cp77/ForceDetonate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceDisableCarAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ForceDisableCarAlarm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceDisableCarAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ForceDisableCarAlarm.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceDismembermentEffector.cs
+++ b/CP77.CR2W/Types/cp77/ForceDismembermentEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceDropBodyEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceDropBodyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceDropBodyEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceDropBodyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceEmptyHandsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceEmptyHandsDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceEmptyHandsEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceEmptyHandsEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceEmptyHandsEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceEmptyHandsEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceFadeOutlineEventForWeapon.cs
+++ b/CP77.CR2W/Types/cp77/ForceFadeOutlineEventForWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceFreezeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceFreezeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceFreezeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceFreezeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceFreezeEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceFreezeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceFreezeEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceFreezeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceIdleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceIdleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceIdleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceIdleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceIgnoreTargets.cs
+++ b/CP77.CR2W/Types/cp77/ForceIgnoreTargets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceIgnoreTargets.cs
+++ b/CP77.CR2W/Types/cp77/ForceIgnoreTargets.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceLockElevator.cs
+++ b/CP77.CR2W/Types/cp77/ForceLockElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceLockElevator.cs
+++ b/CP77.CR2W/Types/cp77/ForceLockElevator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceMoveInCombatCallInEffector.cs
+++ b/CP77.CR2W/Types/cp77/ForceMoveInCombatCallInEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceMoveInCombatEffector.cs
+++ b/CP77.CR2W/Types/cp77/ForceMoveInCombatEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceOpen.cs
+++ b/CP77.CR2W/Types/cp77/ForceOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceOpen.cs
+++ b/CP77.CR2W/Types/cp77/ForceOpen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceRadialWheelShutdown.cs
+++ b/CP77.CR2W/Types/cp77/ForceRadialWheelShutdown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceRadialWheelShutdown.cs
+++ b/CP77.CR2W/Types/cp77/ForceRadialWheelShutdown.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/ForceRagdoll.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/ForceRagdoll.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceReactivateHighlightsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceReactivateHighlightsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceReactivateHighlightsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceReactivateHighlightsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceSafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceSafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceSafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceShootCommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/ForceShootCommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceShootCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/ForceShootCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceShootCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/ForceShootCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceUIRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceUIRefreshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceUnlockAndOpenElevator.cs
+++ b/CP77.CR2W/Types/cp77/ForceUnlockAndOpenElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceUnlockAndOpenElevator.cs
+++ b/CP77.CR2W/Types/cp77/ForceUnlockAndOpenElevator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceUpdateDefaultHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceUpdateDefaultHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceUpdateDefaultHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceUpdateDefaultHighlightEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceVisionApperanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForceVisionApperanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceWalkDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceWalkDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForceWalkDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForceWalkDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForceWalkEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForceWalkEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedDeathEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForcedDeathEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedHitReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForcedHitReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedKnockdownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForcedKnockdownDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedKnockdownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ForcedKnockdownDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForcedKnockdownEvents.cs
+++ b/CP77.CR2W/Types/cp77/ForcedKnockdownEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedRagdollDeathSignal.cs
+++ b/CP77.CR2W/Types/cp77/ForcedRagdollDeathSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedRagdollDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/ForcedRagdollDeathTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedRagdollDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/ForcedRagdollDeathTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForcedStateData.cs
+++ b/CP77.CR2W/Types/cp77/ForcedStateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForcedVisibilityInAnimSystemData.cs
+++ b/CP77.CR2W/Types/cp77/ForcedVisibilityInAnimSystemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForkliftCompleteActivateEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftCompleteActivateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForkliftCompleteActivateEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftCompleteActivateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForkliftController.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForkliftController.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForkliftControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForkliftSetup.cs
+++ b/CP77.CR2W/Types/cp77/ForkliftSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForwardAction.cs
+++ b/CP77.CR2W/Types/cp77/ForwardAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForwardPingToSquadEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForwardPingToSquadEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForwardPingToSquadEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForwardPingToSquadEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ForwardVehicleQuestEnableUIEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForwardVehicleQuestEnableUIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForwardVehicleQuestUIEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForwardVehicleQuestUIEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ForwardVehicleRaceUIEvent.cs
+++ b/CP77.CR2W/Types/cp77/ForwardVehicleRaceUIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Fridge.cs
+++ b/CP77.CR2W/Types/cp77/Fridge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FridgeController.cs
+++ b/CP77.CR2W/Types/cp77/FridgeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FridgeController.cs
+++ b/CP77.CR2W/Types/cp77/FridgeController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FridgeControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/FridgeControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FriendlyTargetWeaponChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/FriendlyTargetWeaponChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FullAutoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FullAutoDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FullAutoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/FullAutoDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FullAutoEvents.cs
+++ b/CP77.CR2W/Types/cp77/FullAutoEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FullAutoEvents.cs
+++ b/CP77.CR2W/Types/cp77/FullAutoEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FullSystemRestart.cs
+++ b/CP77.CR2W/Types/cp77/FullSystemRestart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FullscreenVendorGameController.cs
+++ b/CP77.CR2W/Types/cp77/FullscreenVendorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryPoolRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryPoolRuntimeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryPoolStaticData.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryPoolStaticData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryStatsData.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsDataMemoryStatsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsDataRenderingStatsData.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsDataRenderingStatsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsDataTimeStatsData.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsDataTimeStatsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsGameEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsGameEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsIGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsIGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsIGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsIGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsIRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsIRuntimeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsIRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsIRuntimeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsResult.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsRuntimeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsRuntimeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsState_FunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsState_FunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FunctionalTestsState_FunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsState_FunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FunctionalTestsTimeChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/FunctionalTestsTimeChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Fuse.cs
+++ b/CP77.CR2W/Types/cp77/Fuse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Fuse.cs
+++ b/CP77.CR2W/Types/cp77/Fuse.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FuseBox.cs
+++ b/CP77.CR2W/Types/cp77/FuseBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FuseBoxController.cs
+++ b/CP77.CR2W/Types/cp77/FuseBoxController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FuseBoxController.cs
+++ b/CP77.CR2W/Types/cp77/FuseBoxController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FuseBoxControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/FuseBoxControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FuseController.cs
+++ b/CP77.CR2W/Types/cp77/FuseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FuseController.cs
+++ b/CP77.CR2W/Types/cp77/FuseController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/FuseControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/FuseControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FuseData.cs
+++ b/CP77.CR2W/Types/cp77/FuseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FxResourceMapData.cs
+++ b/CP77.CR2W/Types/cp77/FxResourceMapData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/FxResourceMapperComponent.cs
+++ b/CP77.CR2W/Types/cp77/FxResourceMapperComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GAMEOBJECT_Actor.cs
+++ b/CP77.CR2W/Types/cp77/GAMEOBJECT_Actor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GAMEOBJECT_Actor.cs
+++ b/CP77.CR2W/Types/cp77/GAMEOBJECT_Actor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GICGIEditSettings.cs
+++ b/CP77.CR2W/Types/cp77/GICGIEditSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GICGIEditSettings.cs
+++ b/CP77.CR2W/Types/cp77/GICGIEditSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GOGProfileGameController.cs
+++ b/CP77.CR2W/Types/cp77/GOGProfileGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GadgetWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GadgetWheelDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GadgetWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GadgetWheelDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GadgetWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/GadgetWheelEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GadgetWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/GadgetWheelEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameAttachedEvent.cs
+++ b/CP77.CR2W/Types/cp77/GameAttachedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameEffectExecutor_StimOnHit.cs
+++ b/CP77.CR2W/Types/cp77/GameEffectExecutor_StimOnHit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameEffectTargetVisualizationData.cs
+++ b/CP77.CR2W/Types/cp77/GameEffectTargetVisualizationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectListener.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereq.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereq.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedGreenPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectRevealedRedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameObjectScanStats.cs
+++ b/CP77.CR2W/Types/cp77/GameObjectScanStats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameSessionDataModule.cs
+++ b/CP77.CR2W/Types/cp77/GameSessionDataModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameSessionDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/GameSessionDataSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameTime.cs
+++ b/CP77.CR2W/Types/cp77/GameTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameTimePrereq.cs
+++ b/CP77.CR2W/Types/cp77/GameTimePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameTimePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/GameTimePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameTimeUtils.cs
+++ b/CP77.CR2W/Types/cp77/GameTimeUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameTimeUtils.cs
+++ b/CP77.CR2W/Types/cp77/GameTimeUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameTimeWrapper.cs
+++ b/CP77.CR2W/Types/cp77/GameTimeWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GamepadHoldIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/GamepadHoldIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayCameraData.cs
+++ b/CP77.CR2W/Types/cp77/GameplayCameraData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayConditionBase.cs
+++ b/CP77.CR2W/Types/cp77/GameplayConditionBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayConditionContainer.cs
+++ b/CP77.CR2W/Types/cp77/GameplayConditionContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayCyberwareCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplayCyberwareCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayEquipRequest.cs
+++ b/CP77.CR2W/Types/cp77/GameplayEquipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayFactCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplayFactCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayFunctionalTestReturnValue.cs
+++ b/CP77.CR2W/Types/cp77/GameplayFunctionalTestReturnValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayItemCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplayItemCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayLight.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayLight.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLight.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameplayLightController.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayLightController.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameplayLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/GameplayLightControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GameplayMappinController.cs
+++ b/CP77.CR2W/Types/cp77/GameplayMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayPerkCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplayPerkCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayQuestSystem.cs
+++ b/CP77.CR2W/Types/cp77/GameplayQuestSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayRoleChangeNotification.cs
+++ b/CP77.CR2W/Types/cp77/GameplayRoleChangeNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayRoleComponent.cs
+++ b/CP77.CR2W/Types/cp77/GameplayRoleComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayRoleMappinData.cs
+++ b/CP77.CR2W/Types/cp77/GameplayRoleMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplaySettingsDef.cs
+++ b/CP77.CR2W/Types/cp77/GameplaySettingsDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplaySettingsListener.cs
+++ b/CP77.CR2W/Types/cp77/GameplaySettingsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplaySettingsSystem.cs
+++ b/CP77.CR2W/Types/cp77/GameplaySettingsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplaySkillCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplaySkillCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GameplayStatCondition.cs
+++ b/CP77.CR2W/Types/cp77/GameplayStatCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GamplayQuestData.cs
+++ b/CP77.CR2W/Types/cp77/GamplayQuestData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GarmentItemPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/GarmentItemPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GateSignal.cs
+++ b/CP77.CR2W/Types/cp77/GateSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GateSignalInstance.cs
+++ b/CP77.CR2W/Types/cp77/GateSignalInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GemplayObjectiveData.cs
+++ b/CP77.CR2W/Types/cp77/GemplayObjectiveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenerateHeatAroundLastTriggeredStimuli.cs
+++ b/CP77.CR2W/Types/cp77/GenerateHeatAroundLastTriggeredStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenerateHeatAroundLastTriggeredStimuli.cs
+++ b/CP77.CR2W/Types/cp77/GenerateHeatAroundLastTriggeredStimuli.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GenericCodexEntryData.cs
+++ b/CP77.CR2W/Types/cp77/GenericCodexEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericContainer.cs
+++ b/CP77.CR2W/Types/cp77/GenericContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericDevice.cs
+++ b/CP77.CR2W/Types/cp77/GenericDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericDeviceActionsData.cs
+++ b/CP77.CR2W/Types/cp77/GenericDeviceActionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/GenericDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/GenericDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GenericDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/GenericDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/GenericDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericHitPrereq.cs
+++ b/CP77.CR2W/Types/cp77/GenericHitPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericHitPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/GenericHitPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericHotkeyController.cs
+++ b/CP77.CR2W/Types/cp77/GenericHotkeyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericMessageNotification.cs
+++ b/CP77.CR2W/Types/cp77/GenericMessageNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericMessageNotificationCloseData.cs
+++ b/CP77.CR2W/Types/cp77/GenericMessageNotificationCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericMessageNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/GenericMessageNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericNotificationBaseAction.cs
+++ b/CP77.CR2W/Types/cp77/GenericNotificationBaseAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericNotificationBaseAction.cs
+++ b/CP77.CR2W/Types/cp77/GenericNotificationBaseAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GenericNotificationController.cs
+++ b/CP77.CR2W/Types/cp77/GenericNotificationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GenericStreetSignSelector.cs
+++ b/CP77.CR2W/Types/cp77/GenericStreetSignSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GeometryShape.cs
+++ b/CP77.CR2W/Types/cp77/GeometryShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GeometryShapeFace.cs
+++ b/CP77.CR2W/Types/cp77/GeometryShapeFace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GestureSystem.cs
+++ b/CP77.CR2W/Types/cp77/GestureSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GestureSystem.cs
+++ b/CP77.CR2W/Types/cp77/GestureSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GetAccess.cs
+++ b/CP77.CR2W/Types/cp77/GetAccess.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetAccess.cs
+++ b/CP77.CR2W/Types/cp77/GetAccess.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GetCurrentPatrolSpotActionPath.cs
+++ b/CP77.CR2W/Types/cp77/GetCurrentPatrolSpotActionPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetFollowTarget.cs
+++ b/CP77.CR2W/Types/cp77/GetFollowTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetOnWindowCombatDecorator.cs
+++ b/CP77.CR2W/Types/cp77/GetOnWindowCombatDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetOwnPosition.cs
+++ b/CP77.CR2W/Types/cp77/GetOwnPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetRandomPositionAroundPoint.cs
+++ b/CP77.CR2W/Types/cp77/GetRandomPositionAroundPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetRandomThreat.cs
+++ b/CP77.CR2W/Types/cp77/GetRandomThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GetTargetLastKnownPosition.cs
+++ b/CP77.CR2W/Types/cp77/GetTargetLastKnownPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GiveRewardEffector.cs
+++ b/CP77.CR2W/Types/cp77/GiveRewardEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchData.cs
+++ b/CP77.CR2W/Types/cp77/GlitchData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchScreen.cs
+++ b/CP77.CR2W/Types/cp77/GlitchScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchScreen.cs
+++ b/CP77.CR2W/Types/cp77/GlitchScreen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GlitchedTurret.cs
+++ b/CP77.CR2W/Types/cp77/GlitchedTurret.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchedTurretController.cs
+++ b/CP77.CR2W/Types/cp77/GlitchedTurretController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchedTurretController.cs
+++ b/CP77.CR2W/Types/cp77/GlitchedTurretController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GlitchedTurretControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/GlitchedTurretControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlitchedTurretControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/GlitchedTurretControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GlobalDeathCondition.cs
+++ b/CP77.CR2W/Types/cp77/GlobalDeathCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlobalDeathCondition.cs
+++ b/CP77.CR2W/Types/cp77/GlobalDeathCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GlobalIlluminationSettings.cs
+++ b/CP77.CR2W/Types/cp77/GlobalIlluminationSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlobalLightOverrideAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/GlobalLightOverrideAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlobalLightingTrajectory.cs
+++ b/CP77.CR2W/Types/cp77/GlobalLightingTrajectory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GlobalLightingTrajectoryOverride.cs
+++ b/CP77.CR2W/Types/cp77/GlobalLightingTrajectoryOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/GoToFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/GoToFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GoToMenuEvent.cs
+++ b/CP77.CR2W/Types/cp77/GoToMenuEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GodModeStatListener.cs
+++ b/CP77.CR2W/Types/cp77/GodModeStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GogErrorNotificationController.cs
+++ b/CP77.CR2W/Types/cp77/GogErrorNotificationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GogRegisterController.cs
+++ b/CP77.CR2W/Types/cp77/GogRegisterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GogRewardEntryController.cs
+++ b/CP77.CR2W/Types/cp77/GogRewardEntryController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GogRewardsController.cs
+++ b/CP77.CR2W/Types/cp77/GogRewardsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GpuWrapApiVertexLayoutDesc.cs
+++ b/CP77.CR2W/Types/cp77/GpuWrapApiVertexLayoutDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GpuWrapApiVertexPackingPackingElement.cs
+++ b/CP77.CR2W/Types/cp77/GpuWrapApiVertexPackingPackingElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrabReferenceToWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrabReferenceToWeaponEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrabReferenceToWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrabReferenceToWeaponEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleBreakFreeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleBreakFreeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleBreakFreeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleBreakFreeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleBreakFreeEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleBreakFreeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleFallDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleFallDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleFallEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleForceShovePreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleForceShovePreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleForceShovePreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleForceShovePreyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleForceShovePreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleForceShovePreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/GrappleInteractionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleInteractionCondition.cs
+++ b/CP77.CR2W/Types/cp77/GrappleInteractionCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleMountDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleMountDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleMountEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleMountEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleMountEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleMountEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrapplePreyDeadDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrapplePreyDeadDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrapplePreyDeadDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrapplePreyDeadDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrapplePreyDeadEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrapplePreyDeadEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrapplePreyDeadEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrapplePreyDeadEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrappleStandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleStandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleStandEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleStandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleStruggleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrappleStruggleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleStruggleEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleStruggleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrappleStruggleEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrappleStruggleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GravityChangeTrigger.cs
+++ b/CP77.CR2W/Types/cp77/GravityChangeTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeAnimFeatureChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeAnimFeatureChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeDespawnRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeDespawnRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeDespawnRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeDespawnRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeDetonateRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeDetonateRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeDetonateRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeDetonateRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadePotentialHomingTarget.cs
+++ b/CP77.CR2W/Types/cp77/GrenadePotentialHomingTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeProximitySensorTargetAcquiredEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeProximitySensorTargetAcquiredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeProximitySensorTargetAcquiredEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeProximitySensorTargetAcquiredEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeQuickhackKillEntry.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeQuickhackKillEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeReleaseRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeReleaseRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeReleaseRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeReleaseRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeSetTargetTrackerStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeSetTargetTrackerStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeStopDrillingRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeStopDrillingRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeStopDrillingRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeStopDrillingRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GrenadeTrackerTargetAcquiredEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeTrackerTargetAcquiredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeTrackerTargetLostEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeTrackerTargetLostEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeTriggerSmartTrajectoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeTriggerSmartTrajectoryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GrenadeTriggerSmartTrajectoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/GrenadeTriggerSmartTrajectoryEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GridUserData.cs
+++ b/CP77.CR2W/Types/cp77/GridUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ground.cs
+++ b/CP77.CR2W/Types/cp77/Ground.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ground.cs
+++ b/CP77.CR2W/Types/cp77/Ground.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GuardbreakReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/GuardbreakReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GunnerDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GunnerDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GunnerDecisions.cs
+++ b/CP77.CR2W/Types/cp77/GunnerDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/GunnerEvents.cs
+++ b/CP77.CR2W/Types/cp77/GunnerEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/GunnerEvents.cs
+++ b/CP77.CR2W/Types/cp77/GunnerEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HACK_AREA_Settings.cs
+++ b/CP77.CR2W/Types/cp77/HACK_AREA_Settings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HDRColor.cs
+++ b/CP77.CR2W/Types/cp77/HDRColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HDRSettingsVarListener.cs
+++ b/CP77.CR2W/Types/cp77/HDRSettingsVarListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDActorUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/HUDActorUpdateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDButtonHints.cs
+++ b/CP77.CR2W/Types/cp77/HUDButtonHints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDButtonHints.cs
+++ b/CP77.CR2W/Types/cp77/HUDButtonHints.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HUDClueData.cs
+++ b/CP77.CR2W/Types/cp77/HUDClueData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDInstruction.cs
+++ b/CP77.CR2W/Types/cp77/HUDInstruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDJob.cs
+++ b/CP77.CR2W/Types/cp77/HUDJob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDManager.cs
+++ b/CP77.CR2W/Types/cp77/HUDManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDManagerDef.cs
+++ b/CP77.CR2W/Types/cp77/HUDManagerDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDManagerRegistrationRequest.cs
+++ b/CP77.CR2W/Types/cp77/HUDManagerRegistrationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDManagerRequest.cs
+++ b/CP77.CR2W/Types/cp77/HUDManagerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDModule.cs
+++ b/CP77.CR2W/Types/cp77/HUDModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDPhoneElement.cs
+++ b/CP77.CR2W/Types/cp77/HUDPhoneElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDProgressBarController.cs
+++ b/CP77.CR2W/Types/cp77/HUDProgressBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDProgressBarData.cs
+++ b/CP77.CR2W/Types/cp77/HUDProgressBarData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HUDSignalProgressBarController.cs
+++ b/CP77.CR2W/Types/cp77/HUDSignalProgressBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackEngContainer.cs
+++ b/CP77.CR2W/Types/cp77/HackEngContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackPlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/HackPlayerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingContainer.cs
+++ b/CP77.CR2W/Types/cp77/HackingContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingDataDef.cs
+++ b/CP77.CR2W/Types/cp77/HackingDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingMinigameDef.cs
+++ b/CP77.CR2W/Types/cp77/HackingMinigameDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingRewardNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/HackingRewardNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/HackingSkillCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HackingSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/HackingSkillCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HammerLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HammerLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HammerLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HammerLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HammerLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HammerLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HammerLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HammerLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HandgunLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HandgunLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HandgunLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HandgunLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HandgunLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HandgunLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HandgunLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HandgunLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HandleReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/HandleReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HardLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HardLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HardLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HardLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HardLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/HardLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HardLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/HardLandEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HasMeleeWeaponEquippedCondition.cs
+++ b/CP77.CR2W/Types/cp77/HasMeleeWeaponEquippedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasMeleeWeaponEquippedCondition.cs
+++ b/CP77.CR2W/Types/cp77/HasMeleeWeaponEquippedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HasNetworkPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HasNetworkPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasNewMountRequest.cs
+++ b/CP77.CR2W/Types/cp77/HasNewMountRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasPatrolAction.cs
+++ b/CP77.CR2W/Types/cp77/HasPatrolAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasPatrolAction.cs
+++ b/CP77.CR2W/Types/cp77/HasPatrolAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HasPositionFarFromThreat.cs
+++ b/CP77.CR2W/Types/cp77/HasPositionFarFromThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasRangedWeaponEquippedCondition.cs
+++ b/CP77.CR2W/Types/cp77/HasRangedWeaponEquippedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasRangedWeaponEquippedCondition.cs
+++ b/CP77.CR2W/Types/cp77/HasRangedWeaponEquippedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HasVehicleAssigned.cs
+++ b/CP77.CR2W/Types/cp77/HasVehicleAssigned.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HasVehicleAssigned.cs
+++ b/CP77.CR2W/Types/cp77/HasVehicleAssigned.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HaveScavengeTargets.cs
+++ b/CP77.CR2W/Types/cp77/HaveScavengeTargets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HaveScavengeTargets.cs
+++ b/CP77.CR2W/Types/cp77/HaveScavengeTargets.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HeadLookatCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/HeadLookatCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HeadLookatCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/HeadLookatCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HeadlessGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/HeadlessGameEngine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HeadlessGameEngine.cs
+++ b/CP77.CR2W/Types/cp77/HeadlessGameEngine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HealthCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/HealthCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HealthCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/HealthCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HealthConsumable.cs
+++ b/CP77.CR2W/Types/cp77/HealthConsumable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HealthStatListener.cs
+++ b/CP77.CR2W/Types/cp77/HealthStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HealthUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/HealthUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HearStimThreshold.cs
+++ b/CP77.CR2W/Types/cp77/HearStimThreshold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HeartAttackManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/HeartAttackManagerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HeartAttackManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/HeartAttackManagerTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HeatHazeAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/HeatHazeAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HeavyFootstepEvent.cs
+++ b/CP77.CR2W/Types/cp77/HeavyFootstepEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HideIconModuleEvent.cs
+++ b/CP77.CR2W/Types/cp77/HideIconModuleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HideIconModuleEvent.cs
+++ b/CP77.CR2W/Types/cp77/HideIconModuleEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HidePuppetDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/HidePuppetDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HideRecipeRequest.cs
+++ b/CP77.CR2W/Types/cp77/HideRecipeRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HideSingleMappinEvent.cs
+++ b/CP77.CR2W/Types/cp77/HideSingleMappinEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelNPCStatePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HighLevelPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HighLevelPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HighLevelStateMapping.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelStateMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelTransition.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighLevelTransition.cs
+++ b/CP77.CR2W/Types/cp77/HighLevelTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HighestPrioritySignalCondition.cs
+++ b/CP77.CR2W/Types/cp77/HighestPrioritySignalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightConnectionComponentEvent.cs
+++ b/CP77.CR2W/Types/cp77/HighlightConnectionComponentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightConnectionsRequest.cs
+++ b/CP77.CR2W/Types/cp77/HighlightConnectionsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightEditableData.cs
+++ b/CP77.CR2W/Types/cp77/HighlightEditableData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightInstance.cs
+++ b/CP77.CR2W/Types/cp77/HighlightInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightModule.cs
+++ b/CP77.CR2W/Types/cp77/HighlightModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighlightModule.cs
+++ b/CP77.CR2W/Types/cp77/HighlightModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HighlightObjectEffector.cs
+++ b/CP77.CR2W/Types/cp77/HighlightObjectEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HighwaySignSelector.cs
+++ b/CP77.CR2W/Types/cp77/HighwaySignSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitAttackSubtypePrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitAttackSubtypePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitAttackSubtypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitAttackSubtypePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitAttackSubtypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitAttackSubtypePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitCallback.cs
+++ b/CP77.CR2W/Types/cp77/HitCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitConditions.cs
+++ b/CP77.CR2W/Types/cp77/HitConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitConditions.cs
+++ b/CP77.CR2W/Types/cp77/HitConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitDamageOverTimePrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitDamageOverTimePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitDamageOverTimePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitDamageOverTimePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitDamageOverTimePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitDamageOverTimePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitData_Base.cs
+++ b/CP77.CR2W/Types/cp77/HitData_Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitData_Humanoid.cs
+++ b/CP77.CR2W/Types/cp77/HitData_Humanoid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitDistanceCoveredPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitFlagHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/HitFlagHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitFlagPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitFlagPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitFlagPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitFlagPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitFlagPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitFlagPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitHistory.cs
+++ b/CP77.CR2W/Types/cp77/HitHistory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitHistoryItem.cs
+++ b/CP77.CR2W/Types/cp77/HitHistoryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIndicatorWeaponZoomListener.cs
+++ b/CP77.CR2W/Types/cp77/HitIndicatorWeaponZoomListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartHeadPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartLimbPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsBodyPartTorsoPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsHumanPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsHumanPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsHumanPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsHumanPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsHumanPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsHumanPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsInstigatorPlayerPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsMovingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsMovingPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsMovingPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsMovingPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsMovingPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsMovingPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsRarityPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRarityPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsRarityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRarityPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsRarityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRarityPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsRicochetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRicochetPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsRicochetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRicochetPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsRicochetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRicochetPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsRicochetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsRicochetPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsSourceGrenadePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitIsTheSameTargetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitIsTheSameTargetPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitIsTheSameTargetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitIsTheSameTargetPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/HitOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitOperations.cs
+++ b/CP77.CR2W/Types/cp77/HitOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/HitOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionBehaviorData.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionBehaviorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionComponent.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionCumulativeDamageUpdate.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionCumulativeDamageUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionMechComponent.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionMechComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionMechComponent.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionMechComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitReactionRequest.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionStopMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionStopMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReactionStopMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/HitReactionStopMotionExtraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitReceivedCallback.cs
+++ b/CP77.CR2W/Types/cp77/HitReceivedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReceivedCallback.cs
+++ b/CP77.CR2W/Types/cp77/HitReceivedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitReceivedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitReceivedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitReceivedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitReceivedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitShapeUserDataBase.cs
+++ b/CP77.CR2W/Types/cp77/HitShapeUserDataBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitShieldEvent.cs
+++ b/CP77.CR2W/Types/cp77/HitShieldEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitShieldEvent.cs
+++ b/CP77.CR2W/Types/cp77/HitShieldEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolComparisonPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitStatPoolPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatPoolPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/HitStatusEffectPresentPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitTriggeredCallback.cs
+++ b/CP77.CR2W/Types/cp77/HitTriggeredCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitTriggeredCallback.cs
+++ b/CP77.CR2W/Types/cp77/HitTriggeredCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HitTriggeredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitTriggeredPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HitTriggeredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/HitTriggeredPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HmgLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HmgLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HmgLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/HmgLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoldPositionCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/HoldPositionCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloDevice.cs
+++ b/CP77.CR2W/Types/cp77/HoloDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/HoloDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/HoloDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoloDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/HoloDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloFeeder.cs
+++ b/CP77.CR2W/Types/cp77/HoloFeeder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloFeederController.cs
+++ b/CP77.CR2W/Types/cp77/HoloFeederController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloFeederController.cs
+++ b/CP77.CR2W/Types/cp77/HoloFeederController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoloFeederControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/HoloFeederControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloFeederControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/HoloFeederControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoloTable.cs
+++ b/CP77.CR2W/Types/cp77/HoloTable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloTableController.cs
+++ b/CP77.CR2W/Types/cp77/HoloTableController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloTableController.cs
+++ b/CP77.CR2W/Types/cp77/HoloTableController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoloTableControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/HoloTableControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoloTableControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/HoloTableControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Hotkey.cs
+++ b/CP77.CR2W/Types/cp77/Hotkey.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeyAssignmentRequest.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyAssignmentRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeyItemController.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeyManager.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeyManager.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HotkeyRefreshRequest.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyRefreshRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeyRefreshRequest.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyRefreshRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HotkeyWidgetStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/HotkeyWidgetStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HotkeysWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/HotkeysWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoverEvent.cs
+++ b/CP77.CR2W/Types/cp77/HoverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoverJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HoverJumpDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoverJumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/HoverJumpDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HoverJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/HoverJumpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HoverJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/HoverJumpEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HubExperienceBarController.cs
+++ b/CP77.CR2W/Types/cp77/HubExperienceBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HubMenuInitData.cs
+++ b/CP77.CR2W/Types/cp77/HubMenuInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HubMenuLabelContentContainer.cs
+++ b/CP77.CR2W/Types/cp77/HubMenuLabelContentContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HubMenuLabelController.cs
+++ b/CP77.CR2W/Types/cp77/HubMenuLabelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HubMenuUtils.cs
+++ b/CP77.CR2W/Types/cp77/HubMenuUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HubMenuUtils.cs
+++ b/CP77.CR2W/Types/cp77/HubMenuUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HubTimeSkipController.cs
+++ b/CP77.CR2W/Types/cp77/HubTimeSkipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HudMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/HudMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HudMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/HudMeshComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/HudPhoneAvatarController.cs
+++ b/CP77.CR2W/Types/cp77/HudPhoneAvatarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HudPhoneGameController.cs
+++ b/CP77.CR2W/Types/cp77/HudPhoneGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/HudPhoneMessageController.cs
+++ b/CP77.CR2W/Types/cp77/HudPhoneMessageController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/IAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IBackendData.cs
+++ b/CP77.CR2W/Types/cp77/IBackendData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IBackendData.cs
+++ b/CP77.CR2W/Types/cp77/IBackendData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ICameraStorageCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ICameraStorageCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ICameraStorageCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ICameraStorageCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IDebugConsole.cs
+++ b/CP77.CR2W/Types/cp77/IDebugConsole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IDebugConsole.cs
+++ b/CP77.CR2W/Types/cp77/IDebugConsole.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/IDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/IDisplayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IDynamicTextureGenerator.cs
+++ b/CP77.CR2W/Types/cp77/IDynamicTextureGenerator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IDynamicTextureGenerator.cs
+++ b/CP77.CR2W/Types/cp77/IDynamicTextureGenerator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IEvaluatorColor.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluatorColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IEvaluatorColor.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluatorColor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IEvaluatorFloat.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluatorFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IEvaluatorFloat.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluatorFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IEvaluatorVector.cs
+++ b/CP77.CR2W/Types/cp77/IEvaluatorVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IMaterial.cs
+++ b/CP77.CR2W/Types/cp77/IMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IMaterial.cs
+++ b/CP77.CR2W/Types/cp77/IMaterial.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IMaterialDefinition.cs
+++ b/CP77.CR2W/Types/cp77/IMaterialDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IParticleDrawer.cs
+++ b/CP77.CR2W/Types/cp77/IParticleDrawer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IParticleEvent.cs
+++ b/CP77.CR2W/Types/cp77/IParticleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IParticleInitializer.cs
+++ b/CP77.CR2W/Types/cp77/IParticleInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IParticleModificator.cs
+++ b/CP77.CR2W/Types/cp77/IParticleModificator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IParticleModificator.cs
+++ b/CP77.CR2W/Types/cp77/IParticleModificator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IParticleModule.cs
+++ b/CP77.CR2W/Types/cp77/IParticleModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IRenderProxyCustomData.cs
+++ b/CP77.CR2W/Types/cp77/IRenderProxyCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IRenderProxyCustomData.cs
+++ b/CP77.CR2W/Types/cp77/IRenderProxyCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IRenderResourceBlob.cs
+++ b/CP77.CR2W/Types/cp77/IRenderResourceBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IRenderResourceBlob.cs
+++ b/CP77.CR2W/Types/cp77/IRenderResourceBlob.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ISceneStorageCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ISceneStorageCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ISceneStorageCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ISceneStorageCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IScriptable.cs
+++ b/CP77.CR2W/Types/cp77/IScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IScriptable.cs
+++ b/CP77.CR2W/Types/cp77/IScriptable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ISerializable.cs
+++ b/CP77.CR2W/Types/cp77/ISerializable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ISerializable.cs
+++ b/CP77.CR2W/Types/cp77/ISerializable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ITexture.cs
+++ b/CP77.CR2W/Types/cp77/ITexture.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ITexture.cs
+++ b/CP77.CR2W/Types/cp77/ITexture.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ITonemappingMode.cs
+++ b/CP77.CR2W/Types/cp77/ITonemappingMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IUpdatableSystem.cs
+++ b/CP77.CR2W/Types/cp77/IUpdatableSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IUpdatableSystem.cs
+++ b/CP77.CR2W/Types/cp77/IUpdatableSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IVehicleModuleController.cs
+++ b/CP77.CR2W/Types/cp77/IVehicleModuleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IVehicleModuleController.cs
+++ b/CP77.CR2W/Types/cp77/IVehicleModuleController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IWorldWidgetComponent.cs
+++ b/CP77.CR2W/Types/cp77/IWorldWidgetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IceMachine.cs
+++ b/CP77.CR2W/Types/cp77/IceMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IceMachine.cs
+++ b/CP77.CR2W/Types/cp77/IceMachine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IceMachineController.cs
+++ b/CP77.CR2W/Types/cp77/IceMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IceMachineController.cs
+++ b/CP77.CR2W/Types/cp77/IceMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IceMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/IceMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IceMachineInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/IceMachineInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IceMachineSFX.cs
+++ b/CP77.CR2W/Types/cp77/IceMachineSFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IconsInstance.cs
+++ b/CP77.CR2W/Types/cp77/IconsInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IconsModule.cs
+++ b/CP77.CR2W/Types/cp77/IconsModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IconsModule.cs
+++ b/CP77.CR2W/Types/cp77/IconsModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdentifiedWrappedTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/IdentifiedWrappedTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleActions.cs
+++ b/CP77.CR2W/Types/cp77/IdleActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleActions.cs
+++ b/CP77.CR2W/Types/cp77/IdleActions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleActionsCondition.cs
+++ b/CP77.CR2W/Types/cp77/IdleActionsCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleActionsCondition.cs
+++ b/CP77.CR2W/Types/cp77/IdleActionsCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/IdleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/IdleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleTier3Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier3Events.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleTier3Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier3Events.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleTier4Decisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier4Decisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleTier4Decisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier4Decisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleTier4Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier4Events.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleTier4Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier4Events.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleTier5Decisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier5Decisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleTier5Decisions.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier5Decisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IdleTier5Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier5Events.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IdleTier5Events.cs
+++ b/CP77.CR2W/Types/cp77/IdleTier5Events.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IgnoreAlreadyAffectedEntities.cs
+++ b/CP77.CR2W/Types/cp77/IgnoreAlreadyAffectedEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IgnoreAlreadyAffectedEntities.cs
+++ b/CP77.CR2W/Types/cp77/IgnoreAlreadyAffectedEntities.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IgnoreFriendlyTargets.cs
+++ b/CP77.CR2W/Types/cp77/IgnoreFriendlyTargets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IgnoreFriendlyTargets.cs
+++ b/CP77.CR2W/Types/cp77/IgnoreFriendlyTargets.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IgnoreListEvent.cs
+++ b/CP77.CR2W/Types/cp77/IgnoreListEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IgnorePlayerIfMountedToVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IgnorePlayerIfMountedToVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IgnorePlayerIfMountedToVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IgnorePlayerIfMountedToVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IgnorePlayerMountedVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IgnorePlayerMountedVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IgnorePlayerMountedVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IgnorePlayerMountedVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IllegalActionTypes.cs
+++ b/CP77.CR2W/Types/cp77/IllegalActionTypes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageActionButtonLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ImageActionButtonLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageBasedFlareAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ImageBasedFlareAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageButtonCustomData.cs
+++ b/CP77.CR2W/Types/cp77/ImageButtonCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageSwappingController.cs
+++ b/CP77.CR2W/Types/cp77/ImageSwappingController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageTextureGenerator.cs
+++ b/CP77.CR2W/Types/cp77/ImageTextureGenerator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImageTextureGenerator.cs
+++ b/CP77.CR2W/Types/cp77/ImageTextureGenerator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ImmediateExitWithForceEvents.cs
+++ b/CP77.CR2W/Types/cp77/ImmediateExitWithForceEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ImpactReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/ImpactReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InAlertedHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InAlertedHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InAlertedHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InAlertedHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InAttackUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InAttackUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InAttackUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InAttackUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/InCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/InCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InCombatHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InCombatHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InCombatHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InCombatHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InCoverStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InCoverStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InCoverStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InCoverStanceState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InCrouchStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InCrouchStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InCrouchStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InCrouchStanceState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InDeadHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InDeadHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InDeadHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InDeadHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InDefendUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InDefendUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InDefendUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InDefendUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InNormalUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InNormalUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InNormalUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InNormalUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InParryUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InParryUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InParryUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InParryUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InRelaxedHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InRelaxedHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InRelaxedHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InRelaxedHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InReloadUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InReloadUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InReloadUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InReloadUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InShootUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InShootUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InShootUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InShootUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InStandStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InStandStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InStandStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InStandStanceState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InStealthHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InStealthHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InStealthHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InStealthHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InSwimStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InSwimStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InSwimStanceState.cs
+++ b/CP77.CR2W/Types/cp77/InSwimStanceState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InTauntUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InTauntUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InTauntUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/InTauntUpperBodyState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InUnconsciousHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InUnconsciousHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InUnconsciousHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/InUnconsciousHighLevelState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InVehicleCombatDecorator.cs
+++ b/CP77.CR2W/Types/cp77/InVehicleCombatDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InVehicleDecorator.cs
+++ b/CP77.CR2W/Types/cp77/InVehicleDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InVehicleDecorator.cs
+++ b/CP77.CR2W/Types/cp77/InVehicleDecorator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InactiveCoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InactiveCoverDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InactiveCoverDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InactiveCoverDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InactiveCoverEvents.cs
+++ b/CP77.CR2W/Types/cp77/InactiveCoverEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InactiveCoverEvents.cs
+++ b/CP77.CR2W/Types/cp77/InactiveCoverEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IncomingCallGameController.cs
+++ b/CP77.CR2W/Types/cp77/IncomingCallGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IncreaseTraitLevel.cs
+++ b/CP77.CR2W/Types/cp77/IncreaseTraitLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IncrimentStealthStimThreshold.cs
+++ b/CP77.CR2W/Types/cp77/IncrimentStealthStimThreshold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IncrimentStimThreshold.cs
+++ b/CP77.CR2W/Types/cp77/IncrimentStimThreshold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IndustrialArmDamageEvent.cs
+++ b/CP77.CR2W/Types/cp77/IndustrialArmDamageEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IndustrialArmDamageEvent.cs
+++ b/CP77.CR2W/Types/cp77/IndustrialArmDamageEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IngredientData.cs
+++ b/CP77.CR2W/Types/cp77/IngredientData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IngredientListItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/IngredientListItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitCombatAfterHit.cs
+++ b/CP77.CR2W/Types/cp77/InitCombatAfterHit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitialDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InitialDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitialDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InitialDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InitialStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InitialStateDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitialStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InitialStateDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InitialiseNPC.cs
+++ b/CP77.CR2W/Types/cp77/InitialiseNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitialiseNPC.cs
+++ b/CP77.CR2W/Types/cp77/InitialiseNPC.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InitializationSoundController.cs
+++ b/CP77.CR2W/Types/cp77/InitializationSoundController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitializeCLSEvent.cs
+++ b/CP77.CR2W/Types/cp77/InitializeCLSEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitializeCLSEvent.cs
+++ b/CP77.CR2W/Types/cp77/InitializeCLSEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InitializeFocusCluesEvent.cs
+++ b/CP77.CR2W/Types/cp77/InitializeFocusCluesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitializeUserScreenGameController.cs
+++ b/CP77.CR2W/Types/cp77/InitializeUserScreenGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitiateScanner.cs
+++ b/CP77.CR2W/Types/cp77/InitiateScanner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitiateTrafficLightChange.cs
+++ b/CP77.CR2W/Types/cp77/InitiateTrafficLightChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InitiateTrafficLightChange.cs
+++ b/CP77.CR2W/Types/cp77/InitiateTrafficLightChange.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InjectAttackInstigatorAsThreat.cs
+++ b/CP77.CR2W/Types/cp77/InjectAttackInstigatorAsThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InjectAttackInstigatorAsThreat.cs
+++ b/CP77.CR2W/Types/cp77/InjectAttackInstigatorAsThreat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InjectCombatTargetCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/InjectCombatTargetCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InjectCombatThreatCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/InjectCombatThreatCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InjectLookatTargetCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/InjectLookatTargetCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InkAnimHelper.cs
+++ b/CP77.CR2W/Types/cp77/InkAnimHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InkAnimHelper.cs
+++ b/CP77.CR2W/Types/cp77/InkAnimHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InkImageUtils.cs
+++ b/CP77.CR2W/Types/cp77/InkImageUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InkImageUtils.cs
+++ b/CP77.CR2W/Types/cp77/InkImageUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InputContextSystem.cs
+++ b/CP77.CR2W/Types/cp77/InputContextSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputContextTransitionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InputContextTransitionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputContextTransitionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InputContextTransitionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InputContextTransitionEvents.cs
+++ b/CP77.CR2W/Types/cp77/InputContextTransitionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputContextTransitionEvents.cs
+++ b/CP77.CR2W/Types/cp77/InputContextTransitionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InputDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/InputDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputProgressView.cs
+++ b/CP77.CR2W/Types/cp77/InputProgressView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputReceiver.cs
+++ b/CP77.CR2W/Types/cp77/InputReceiver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InputReceiver.cs
+++ b/CP77.CR2W/Types/cp77/InputReceiver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InspectDummy.cs
+++ b/CP77.CR2W/Types/cp77/InspectDummy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectItemInspectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/InspectItemInspectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectableItemObject.cs
+++ b/CP77.CR2W/Types/cp77/InspectableItemObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectableObjectComponent.cs
+++ b/CP77.CR2W/Types/cp77/InspectableObjectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectableObjectComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/InspectableObjectComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionComponent.cs
+++ b/CP77.CR2W/Types/cp77/InspectionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InspectionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/InspectionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InspectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/InspectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionEvents.cs
+++ b/CP77.CR2W/Types/cp77/InspectionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionEvents.cs
+++ b/CP77.CR2W/Types/cp77/InspectionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InspectionObject.cs
+++ b/CP77.CR2W/Types/cp77/InspectionObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InspectionTriggerEvent.cs
+++ b/CP77.CR2W/Types/cp77/InspectionTriggerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstallCyberwareRequest.cs
+++ b/CP77.CR2W/Types/cp77/InstallCyberwareRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstallCyberwareRequest.cs
+++ b/CP77.CR2W/Types/cp77/InstallCyberwareRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InstallItemPart.cs
+++ b/CP77.CR2W/Types/cp77/InstallItemPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstallKeylogger.cs
+++ b/CP77.CR2W/Types/cp77/InstallKeylogger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstallKeylogger.cs
+++ b/CP77.CR2W/Types/cp77/InstallKeylogger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InstallModConfirmationData.cs
+++ b/CP77.CR2W/Types/cp77/InstallModConfirmationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstanceDataMappedToReferenceName.cs
+++ b/CP77.CR2W/Types/cp77/InstanceDataMappedToReferenceName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InstigatorTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/InstigatorTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntComparator.cs
+++ b/CP77.CR2W/Types/cp77/IntComparator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntComparator.cs
+++ b/CP77.CR2W/Types/cp77/IntComparator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractionAreaOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/InteractionAreaOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionAreaOperations.cs
+++ b/CP77.CR2W/Types/cp77/InteractionAreaOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionAreaOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/InteractionAreaOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionChoiceCaptionQuickhackCostPart.cs
+++ b/CP77.CR2W/Types/cp77/InteractionChoiceCaptionQuickhackCostPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionMappinController.cs
+++ b/CP77.CR2W/Types/cp77/InteractionMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionUIBase.cs
+++ b/CP77.CR2W/Types/cp77/InteractionUIBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionsHubGameController.cs
+++ b/CP77.CR2W/Types/cp77/InteractionsHubGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractionsInputView.cs
+++ b/CP77.CR2W/Types/cp77/InteractionsInputView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveAd.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveAdController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveAdController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractiveAdControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveAdFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveAdFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdFinishedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractiveAdInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveAdInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveMasterDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveMasterDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractiveSign.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSign.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractiveSignControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InteractiveSignCustomData.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignDeviceWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignDeviceWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteractiveSignInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/InteractiveSignInkGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Intercom.cs
+++ b/CP77.CR2W/Types/cp77/Intercom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntercomBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/IntercomBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntercomController.cs
+++ b/CP77.CR2W/Types/cp77/IntercomController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntercomController.cs
+++ b/CP77.CR2W/Types/cp77/IntercomController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IntercomControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/IntercomControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IntercomInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/IntercomInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InterestingFacts.cs
+++ b/CP77.CR2W/Types/cp77/InterestingFacts.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InterestingFactsListenersFunctions.cs
+++ b/CP77.CR2W/Types/cp77/InterestingFactsListenersFunctions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InterestingFactsListenersIds.cs
+++ b/CP77.CR2W/Types/cp77/InterestingFactsListenersIds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteriorMapDataUpdater.cs
+++ b/CP77.CR2W/Types/cp77/InteriorMapDataUpdater.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InteriorMapDataUpdater.cs
+++ b/CP77.CR2W/Types/cp77/InteriorMapDataUpdater.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InterpolatorsShowcaseController.cs
+++ b/CP77.CR2W/Types/cp77/InterpolatorsShowcaseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryComboBoxContentController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryComboBoxContentController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryComboBoxContentController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryComboBoxContentController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryComboBoxData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryComboBoxData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryComboBoxItemsList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryComboBoxItemsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryComboBoxItemsList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryComboBoxItemsList.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryCyberwareDetails.cs
+++ b/CP77.CR2W/Types/cp77/InventoryCyberwareDetails.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryCyberwareDetails.cs
+++ b/CP77.CR2W/Types/cp77/InventoryCyberwareDetails.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryCyberwareDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryCyberwareDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryCyberwareItemChooser.cs
+++ b/CP77.CR2W/Types/cp77/InventoryCyberwareItemChooser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryDataManager.cs
+++ b/CP77.CR2W/Types/cp77/InventoryDataManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryDataManagerV2.cs
+++ b/CP77.CR2W/Types/cp77/InventoryDataManagerV2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryEquipmentSlot.cs
+++ b/CP77.CR2W/Types/cp77/InventoryEquipmentSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryFilterButton.cs
+++ b/CP77.CR2W/Types/cp77/InventoryFilterButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryGPRestrictionHelper.cs
+++ b/CP77.CR2W/Types/cp77/InventoryGPRestrictionHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryGPRestrictionHelper.cs
+++ b/CP77.CR2W/Types/cp77/InventoryGPRestrictionHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryGenericItemChooser.cs
+++ b/CP77.CR2W/Types/cp77/InventoryGenericItemChooser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemAttachmentDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemAttachmentDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemAttachments.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemAttachments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemAttachmentsList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemAttachmentsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemDataComparator.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDataComparator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemDataComparator.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDataComparator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryItemDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemDisplayCategoryArea.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDisplayCategoryArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemDisplayEquipmentArea.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemDisplayEquipmentArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemModSlotDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemModSlotDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemModeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemModeLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemPartDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemPartDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemPreviewData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemPreviewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemPreviewPopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemPreviewPopupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemStatItem.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemStatItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemStatList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemStatList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryItemsList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryItemsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryQuickSlotsDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryQuickSlotsDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryQuickSlotsDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryQuickSlotsDisplay.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryRipperdocDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryRipperdocDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventorySlotTooltip.cs
+++ b/CP77.CR2W/Types/cp77/InventorySlotTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventorySlotWrapperTooltip.cs
+++ b/CP77.CR2W/Types/cp77/InventorySlotWrapperTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatItem.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatItemV2.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatItemV2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatsController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatsDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatsDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatsEntryController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatsEntryController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatsList.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/InventoryStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryTooltiData_GrenadeDamageData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryTooltiData_GrenadeDamageData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryTooltiData_GrenadeData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryTooltiData_GrenadeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryTooltipData_QuickhackData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryTooltipData_QuickhackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryTooltipData_StatData.cs
+++ b/CP77.CR2W/Types/cp77/InventoryTooltipData_StatData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryUtils.cs
+++ b/CP77.CR2W/Types/cp77/InventoryUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryUtils.cs
+++ b/CP77.CR2W/Types/cp77/InventoryUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InventoryWeaponDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/InventoryWeaponDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryWeaponItemChooser.cs
+++ b/CP77.CR2W/Types/cp77/InventoryWeaponItemChooser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryWeaponSlot.cs
+++ b/CP77.CR2W/Types/cp77/InventoryWeaponSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InventoryWideItemDisplay.cs
+++ b/CP77.CR2W/Types/cp77/InventoryWideItemDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvestedPerksPrereq.cs
+++ b/CP77.CR2W/Types/cp77/InvestedPerksPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvestedPerksPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/InvestedPerksPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvestedPerksPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/InvestedPerksPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InvestigateController.cs
+++ b/CP77.CR2W/Types/cp77/InvestigateController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvestigationReactionFilter.cs
+++ b/CP77.CR2W/Types/cp77/InvestigationReactionFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvestigationReactionFilter.cs
+++ b/CP77.CR2W/Types/cp77/InvestigationReactionFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InvincibilityCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/InvincibilityCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvincibilityCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/InvincibilityCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InvisibleSceneStash.cs
+++ b/CP77.CR2W/Types/cp77/InvisibleSceneStash.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvisibleSceneStashController.cs
+++ b/CP77.CR2W/Types/cp77/InvisibleSceneStashController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/InvisibleSceneStashController.cs
+++ b/CP77.CR2W/Types/cp77/InvisibleSceneStashController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/InvisibleSceneStashControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/InvisibleSceneStashControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IronsightDetail.cs
+++ b/CP77.CR2W/Types/cp77/IronsightDetail.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IronsightDetail.cs
+++ b/CP77.CR2W/Types/cp77/IronsightDetail.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IronsightGameController.cs
+++ b/CP77.CR2W/Types/cp77/IronsightGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IronsightTargetHealthChangeListener.cs
+++ b/CP77.CR2W/Types/cp77/IronsightTargetHealthChangeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IronsightTargetHealthUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/IronsightTargetHealthUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IronsightTargetHealthUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/IronsightTargetHealthUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsAccessPointFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsAccessPointFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsAccessPointFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsAccessPointFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsAggressive.cs
+++ b/CP77.CR2W/Types/cp77/IsAggressive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsAggressive.cs
+++ b/CP77.CR2W/Types/cp77/IsAggressive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsAnyThreatClose.cs
+++ b/CP77.CR2W/Types/cp77/IsAnyThreatClose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsBoss.cs
+++ b/CP77.CR2W/Types/cp77/IsBoss.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsBoss.cs
+++ b/CP77.CR2W/Types/cp77/IsBoss.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsCombatModuleEquipped.cs
+++ b/CP77.CR2W/Types/cp77/IsCombatModuleEquipped.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsCombatModuleEquipped.cs
+++ b/CP77.CR2W/Types/cp77/IsCombatModuleEquipped.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsConnectedToSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/IsConnectedToSecuritySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsConnectedToSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/IsConnectedToSecuritySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsCoverDevice.cs
+++ b/CP77.CR2W/Types/cp77/IsCoverDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsCoverDevice.cs
+++ b/CP77.CR2W/Types/cp77/IsCoverDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsDead.cs
+++ b/CP77.CR2W/Types/cp77/IsDead.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsDead.cs
+++ b/CP77.CR2W/Types/cp77/IsDead.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsDeviceFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsDeviceFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsDeviceFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsDeviceFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsDriverActive.cs
+++ b/CP77.CR2W/Types/cp77/IsDriverActive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsDriverActive.cs
+++ b/CP77.CR2W/Types/cp77/IsDriverActive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsFacingTowardsSource.cs
+++ b/CP77.CR2W/Types/cp77/IsFacingTowardsSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsFollowTargetInCombat.cs
+++ b/CP77.CR2W/Types/cp77/IsFollowTargetInCombat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsFollowTargetInCombat.cs
+++ b/CP77.CR2W/Types/cp77/IsFollowTargetInCombat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsFriendlyToPlayer.cs
+++ b/CP77.CR2W/Types/cp77/IsFriendlyToPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsFriendlyToPlayer.cs
+++ b/CP77.CR2W/Types/cp77/IsFriendlyToPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsHumanPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsHumanPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsHumanPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsHumanPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsHumanPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsHumanPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsInTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/IsInTrafficLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsInTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/IsInTrafficLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IsInVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IsInVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsInWorkspotPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsLootContainer.cs
+++ b/CP77.CR2W/Types/cp77/IsLootContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsMultiplayerGamePrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsMultiplayerGamePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsMultiplayerGamePrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsMultiplayerGamePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsNPCAloneInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IsNPCAloneInVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNPCAloneInVehicle.cs
+++ b/CP77.CR2W/Types/cp77/IsNPCAloneInVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsNPCDriver.cs
+++ b/CP77.CR2W/Types/cp77/IsNPCDriver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNPCDriver.cs
+++ b/CP77.CR2W/Types/cp77/IsNPCDriver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsNotInstigatorWeakspotFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsNotInstigatorWeakspotFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNotInstigatorWeakspotFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsNotInstigatorWeakspotFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsNotWeakspotFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsNotWeakspotFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNotWeakspotFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsNotWeakspotFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsNpcMountedInSlotPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsNpcMountedInSlotPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNpcMountedInSlotPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsNpcMountedInSlotPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNpcPlayingMountingAnimationPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsNpcPlayingMountingAnimationPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsNpcPlayingMountingAnimationPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsNpcPlayingMountingAnimationPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerAKiller.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerAKiller.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerAKiller.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerAKiller.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerCompanion.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerCompanion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerCompanion.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerCompanion.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerFilter.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerMovingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerMovingPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerMovingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerMovingPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerMovingPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerMovingPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerNotInteractingWithDevice.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerNotInteractingWithDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerNotInteractingWithDevice.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerNotInteractingWithDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPlayerReachablePrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerReachablePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerReachablePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerReachablePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPlayerReachablePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPlayerReachablePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsPuppetActivePrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPuppetActivePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPuppetActivePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPuppetActivePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPuppetBreachedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/IsPuppetBreachedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsPuppetBreachedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/IsPuppetBreachedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsRagdolling.cs
+++ b/CP77.CR2W/Types/cp77/IsRagdolling.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsRagdolling.cs
+++ b/CP77.CR2W/Types/cp77/IsRagdolling.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsReprimandOngoing.cs
+++ b/CP77.CR2W/Types/cp77/IsReprimandOngoing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsReprimandOngoing.cs
+++ b/CP77.CR2W/Types/cp77/IsReprimandOngoing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsScannerTarget.cs
+++ b/CP77.CR2W/Types/cp77/IsScannerTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsScannerTarget.cs
+++ b/CP77.CR2W/Types/cp77/IsScannerTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsStimSourceInRestrictMovementArea.cs
+++ b/CP77.CR2W/Types/cp77/IsStimSourceInRestrictMovementArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsStimSourceInRestrictMovementArea.cs
+++ b/CP77.CR2W/Types/cp77/IsStimSourceInRestrictMovementArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsTargetObjectPlayer.cs
+++ b/CP77.CR2W/Types/cp77/IsTargetObjectPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsUnarmedCondition.cs
+++ b/CP77.CR2W/Types/cp77/IsUnarmedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsUnarmedCondition.cs
+++ b/CP77.CR2W/Types/cp77/IsUnarmedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsValidCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/IsValidCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsValidCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/IsValidCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/IsVehicleDoorLocked.cs
+++ b/CP77.CR2W/Types/cp77/IsVehicleDoorLocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsVehicleDoorLockedState.cs
+++ b/CP77.CR2W/Types/cp77/IsVehicleDoorLockedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsVehicleDoorQuestLocked.cs
+++ b/CP77.CR2W/Types/cp77/IsVehicleDoorQuestLocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsVehicleDoorQuestLockedState.cs
+++ b/CP77.CR2W/Types/cp77/IsVehicleDoorQuestLockedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsWorkspotReaction.cs
+++ b/CP77.CR2W/Types/cp77/IsWorkspotReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IsWorkspotReaction.cs
+++ b/CP77.CR2W/Types/cp77/IsWorkspotReaction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemActionsHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemActionsHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemActionsHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemActionsHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemAddedInventoryCallback.cs
+++ b/CP77.CR2W/Types/cp77/ItemAddedInventoryCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemAddedNotification.cs
+++ b/CP77.CR2W/Types/cp77/ItemAddedNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemAttachments.cs
+++ b/CP77.CR2W/Types/cp77/ItemAttachments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCategoryFliter.cs
+++ b/CP77.CR2W/Types/cp77/ItemCategoryFliter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCategoryFliter.cs
+++ b/CP77.CR2W/Types/cp77/ItemCategoryFliter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemCategoryFliterManager.cs
+++ b/CP77.CR2W/Types/cp77/ItemCategoryFliterManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemChooserItemChanged.cs
+++ b/CP77.CR2W/Types/cp77/ItemChooserItemChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemChooserItemHoverOut.cs
+++ b/CP77.CR2W/Types/cp77/ItemChooserItemHoverOut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemChooserItemHoverOver.cs
+++ b/CP77.CR2W/Types/cp77/ItemChooserItemHoverOver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemChooserUnequipItem.cs
+++ b/CP77.CR2W/Types/cp77/ItemChooserUnequipItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemChooserUnequipMod.cs
+++ b/CP77.CR2W/Types/cp77/ItemChooserUnequipMod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemComparableTypesCache.cs
+++ b/CP77.CR2W/Types/cp77/ItemComparableTypesCache.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCompareBuilder.cs
+++ b/CP77.CR2W/Types/cp77/ItemCompareBuilder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCraftedDataTrackingRequest.cs
+++ b/CP77.CR2W/Types/cp77/ItemCraftedDataTrackingRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCraftingData.cs
+++ b/CP77.CR2W/Types/cp77/ItemCraftingData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCraftingPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/ItemCraftingPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemCraftingPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/ItemCraftingPreviewGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemCreationPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ItemCreationPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayClickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayClickEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayHoldEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayHoldEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayHoverOutEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayHoverOutEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemDisplayHoverOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayHoverOverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayInventoryMiniGrid.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayInventoryMiniGrid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemDisplayUtils.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemDisplayUtils.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemDisplayVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/ItemDisplayVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemFilterCategories.cs
+++ b/CP77.CR2W/Types/cp77/ItemFilterCategories.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemFilterCategories.cs
+++ b/CP77.CR2W/Types/cp77/ItemFilterCategories.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemFilterToggleController.cs
+++ b/CP77.CR2W/Types/cp77/ItemFilterToggleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemFilters.cs
+++ b/CP77.CR2W/Types/cp77/ItemFilters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemFilters.cs
+++ b/CP77.CR2W/Types/cp77/ItemFilters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemIdWrapper.cs
+++ b/CP77.CR2W/Types/cp77/ItemIdWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemInPaperdollSlotCallback.cs
+++ b/CP77.CR2W/Types/cp77/ItemInPaperdollSlotCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemInSlotCallback.cs
+++ b/CP77.CR2W/Types/cp77/ItemInSlotCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemInSlotPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ItemInSlotPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemInSlotPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/ItemInSlotPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemInventoryMiniGrid.cs
+++ b/CP77.CR2W/Types/cp77/ItemInventoryMiniGrid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLabelContainerController.cs
+++ b/CP77.CR2W/Types/cp77/ItemLabelContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLabelController.cs
+++ b/CP77.CR2W/Types/cp77/ItemLabelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLog.cs
+++ b/CP77.CR2W/Types/cp77/ItemLog.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLogPopupLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ItemLogPopupLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLogUserData.cs
+++ b/CP77.CR2W/Types/cp77/ItemLogUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLootedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemLootedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemLootedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ItemLootedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemModeGridClassifier.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeGridClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemModeGridClassifier.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeGridClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemModeGridContainer.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeGridContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemModeGridView.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeGridView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemModeInventoryListenerCallback.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeInventoryListenerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemModeItemChanged.cs
+++ b/CP77.CR2W/Types/cp77/ItemModeItemChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemModificationSystem.cs
+++ b/CP77.CR2W/Types/cp77/ItemModificationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/ItemNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/ItemPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/ItemPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemPreferredAreaItems.cs
+++ b/CP77.CR2W/Types/cp77/ItemPreferredAreaItems.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPreferredComparisonResolver.cs
+++ b/CP77.CR2W/Types/cp77/ItemPreferredComparisonResolver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/ItemPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPreviewHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemPreviewHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemPreviewHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemPreviewHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemQuantityPickerController.cs
+++ b/CP77.CR2W/Types/cp77/ItemQuantityPickerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemRandomizedStatsController.cs
+++ b/CP77.CR2W/Types/cp77/ItemRandomizedStatsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemRecipe.cs
+++ b/CP77.CR2W/Types/cp77/ItemRecipe.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipBottomModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipBottomModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipClothingInfoModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipClothingInfoModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipCommonController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipCommonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipCraftedModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipCraftedModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipCraftedModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipCraftedModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemTooltipDetailsModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipDetailsModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipEquippedModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipEquippedModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipEquippedModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipEquippedModule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemTooltipEvolutionModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipEvolutionModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipGrenadeInfoModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipGrenadeInfoModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipHeaderController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipHeaderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipIconModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipIconModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipModController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipModController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipModEntryController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipModEntryController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipModuleController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipModuleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipModuleSpawnedCallbackData.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipModuleSpawnedCallbackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipRecipeDataModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipRecipeDataModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipRequirementsModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipRequirementsModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipStatController.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipStatController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemTooltipWeaponInfoModule.cs
+++ b/CP77.CR2W/Types/cp77/ItemTooltipWeaponInfoModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemsDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ItemsDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemsLocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemsLocalizationHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemsLocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/ItemsLocalizationHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ItemsNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/ItemsNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemsPoolCachedData.cs
+++ b/CP77.CR2W/Types/cp77/ItemsPoolCachedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ItemsPoolItemSpawnData.cs
+++ b/CP77.CR2W/Types/cp77/ItemsPoolItemSpawnData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/IterateModulesRequest.cs
+++ b/CP77.CR2W/Types/cp77/IterateModulesRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JamWeaponE3HackEvent.cs
+++ b/CP77.CR2W/Types/cp77/JamWeaponE3HackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JamWeaponE3HackEvent.cs
+++ b/CP77.CR2W/Types/cp77/JamWeaponE3HackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JournalEntriesListController.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntriesListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalEntriesListController.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntriesListController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JournalEntryListItemController.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntryListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalEntryListItemController.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntryListItemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JournalEntryListItemData.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntryListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalEntryNotificationRemoveRequestData.cs
+++ b/CP77.CR2W/Types/cp77/JournalEntryNotificationRemoveRequestData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalNotification.cs
+++ b/CP77.CR2W/Types/cp77/JournalNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/JournalNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/JournalNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalRepresentationData.cs
+++ b/CP77.CR2W/Types/cp77/JournalRepresentationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JournalWrapper.cs
+++ b/CP77.CR2W/Types/cp77/JournalWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JsonResource.cs
+++ b/CP77.CR2W/Types/cp77/JsonResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Jukebox.cs
+++ b/CP77.CR2W/Types/cp77/Jukebox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxBigGameController.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxBigGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxController.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxController.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JukeboxControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JukeboxSetup.cs
+++ b/CP77.CR2W/Types/cp77/JukeboxSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/JumpDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JumpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/JumpDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/JumpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/JumpEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JumpLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/JumpLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JumpLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/JumpLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JumpLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/JumpLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JumpLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/JumpLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/JumpPod.cs
+++ b/CP77.CR2W/Types/cp77/JumpPod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/JunkItemRecord.cs
+++ b/CP77.CR2W/Types/cp77/JunkItemRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Katana.cs
+++ b/CP77.CR2W/Types/cp77/Katana.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KatanaLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KatanaLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KatanaLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KatanaLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KatanaLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/KatanaLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KatanaLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/KatanaLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KatanaMagFieldHitDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/KatanaMagFieldHitDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KatanaMagFieldHitDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/KatanaMagFieldHitDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KatanaStimuli.cs
+++ b/CP77.CR2W/Types/cp77/KatanaStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KatanaStimuli.cs
+++ b/CP77.CR2W/Types/cp77/KatanaStimuli.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KerenzikovDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KerenzikovDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KerenzikovDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KerenzikovDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KerenzikovEvents.cs
+++ b/CP77.CR2W/Types/cp77/KerenzikovEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KeyBindings.cs
+++ b/CP77.CR2W/Types/cp77/KeyBindings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KeyboardHintItemController.cs
+++ b/CP77.CR2W/Types/cp77/KeyboardHintItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KeyboardHoldIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/KeyboardHoldIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KeypadDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/KeypadDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KillEntity.cs
+++ b/CP77.CR2W/Types/cp77/KillEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KillEntity.cs
+++ b/CP77.CR2W/Types/cp77/KillEntity.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KillMarkerGameController.cs
+++ b/CP77.CR2W/Types/cp77/KillMarkerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KillTaggedTargetEvent.cs
+++ b/CP77.CR2W/Types/cp77/KillTaggedTargetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Knife.cs
+++ b/CP77.CR2W/Types/cp77/Knife.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnifeCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/KnifeCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnifeCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/KnifeCollisionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KnifeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KnifeLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnifeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KnifeLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KnifeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/KnifeLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnifeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/KnifeLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KnockOverBikeEvent.cs
+++ b/CP77.CR2W/Types/cp77/KnockOverBikeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnockdownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KnockdownDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnockdownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/KnockdownDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/KnockdownEvents.cs
+++ b/CP77.CR2W/Types/cp77/KnockdownEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/KnockdownReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/KnockdownReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LCDScreenSelector.cs
+++ b/CP77.CR2W/Types/cp77/LCDScreenSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LabelInputDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/LabelInputDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LabeledCursorData.cs
+++ b/CP77.CR2W/Types/cp77/LabeledCursorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ladder.cs
+++ b/CP77.CR2W/Types/cp77/Ladder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ladder.cs
+++ b/CP77.CR2W/Types/cp77/Ladder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderClimbContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderClimbContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderClimbContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderClimbContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderClimbContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderClimbContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderClimbContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderClimbContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderController.cs
+++ b/CP77.CR2W/Types/cp77/LadderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderController.cs
+++ b/CP77.CR2W/Types/cp77/LadderController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LadderControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LadderControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderEnterClimbContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterClimbContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderEnterClimbContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterClimbContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderEnterClimbContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterClimbContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderEnterClimbContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterClimbContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderEnterContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderEnterContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderEnterContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderEnterContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderEnterContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderJumpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderJumpEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderJumpEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderSlideDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderSlideDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderSlideDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderSlideDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderSlideEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderSlideEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderSlideEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderSlideEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderSprintDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderSprintDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderSprintDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LadderSprintDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LadderSprintEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderSprintEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LadderSprintEvents.cs
+++ b/CP77.CR2W/Types/cp77/LadderSprintEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LaserDetector.cs
+++ b/CP77.CR2W/Types/cp77/LaserDetector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LaserDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/LaserDetectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LaserDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/LaserDetectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LaserDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LaserDetectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LaserDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LaserDetectorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LaserSight.cs
+++ b/CP77.CR2W/Types/cp77/LaserSight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LastHitDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/LastHitDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LateInit.cs
+++ b/CP77.CR2W/Types/cp77/LateInit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LateInit.cs
+++ b/CP77.CR2W/Types/cp77/LateInit.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LcdScreen.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenBlackBoardDef.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenBlackBoardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenController.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenController.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LcdScreenControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenILogicController.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenILogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LcdScreenSignInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/LcdScreenSignInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LearnAction.cs
+++ b/CP77.CR2W/Types/cp77/LearnAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LearnAction.cs
+++ b/CP77.CR2W/Types/cp77/LearnAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeaveCoverImmediately.cs
+++ b/CP77.CR2W/Types/cp77/LeaveCoverImmediately.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LedColors.cs
+++ b/CP77.CR2W/Types/cp77/LedColors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LedColors_SensorDevice.cs
+++ b/CP77.CR2W/Types/cp77/LedColors_SensorDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareActionAbstractEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchActionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareCatchEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeActionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareChargeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareDataDef.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquippedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEquippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEquippedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareLoopEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareQuickActionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareSafeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareTransition.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareTransition.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequippedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareUnequippedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/LeftHandCyberwareWaitForUnequipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LevelBarsController.cs
+++ b/CP77.CR2W/Types/cp77/LevelBarsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelRewardDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/LevelRewardDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelUpGameController.cs
+++ b/CP77.CR2W/Types/cp77/LevelUpGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelUpNotification.cs
+++ b/CP77.CR2W/Types/cp77/LevelUpNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelUpNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/LevelUpNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelUpUserData.cs
+++ b/CP77.CR2W/Types/cp77/LevelUpUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LevelUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/LevelUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeCMetanodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeCMetanodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeCMetanodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeCMetanodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LibTreeCMetanodeIfDefinition.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeCMetanodeIfDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeCTreeReference.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeCTreeReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeCTreeResource.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeCTreeResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefBool.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefCName.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefEnum.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefEnum.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefFloat.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefISerializable.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefISerializable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefInt32.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefInt32.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefNodeRef.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefNodeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTree.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeList.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariable.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBool.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBoolBase.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBoolBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBoolBase.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableBoolBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableCName.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableEnum.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableEnum.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableFloat.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableISerializable.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableISerializable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableInt32.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableInt32.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableNodeRef.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableNodeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableTreeRef.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableTreeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableTreeRefList.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableTreeRefList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableVector.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariableVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefTreeVariablesList.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefTreeVariablesList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeDefVector.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeDefVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeGenericData.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeGenericData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeGenericData.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeGenericData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LibTreeINodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeINodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeINodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeINodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LibTreeParameter.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeParameterList.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeParameterList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeParametersForwarder.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeParametersForwarder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeSharedVarReferenceName.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeSharedVarReferenceName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LibTreeSharedVarRegistrationName.cs
+++ b/CP77.CR2W/Types/cp77/LibTreeSharedVarRegistrationName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LifePathBluelinePart.cs
+++ b/CP77.CR2W/Types/cp77/LifePathBluelinePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LifePath_ScriptConditionType.cs
+++ b/CP77.CR2W/Types/cp77/LifePath_ScriptConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftArrivedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftArrivedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftController.cs
+++ b/CP77.CR2W/Types/cp77/LiftController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftController.cs
+++ b/CP77.CR2W/Types/cp77/LiftController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LiftControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/LiftControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftDepartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftDepartedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftDevice.cs
+++ b/CP77.CR2W/Types/cp77/LiftDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftFloorSyncDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftFloorSyncDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftMovementLoadEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftMovementLoadEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftMovementLoadEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftMovementLoadEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LiftSetMovementStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftSetMovementStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftSetup.cs
+++ b/CP77.CR2W/Types/cp77/LiftSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftStartDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/LiftStartDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftStatus.cs
+++ b/CP77.CR2W/Types/cp77/LiftStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LiftWidgetCustomData.cs
+++ b/CP77.CR2W/Types/cp77/LiftWidgetCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LightAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/LightAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LightColorSettings.cs
+++ b/CP77.CR2W/Types/cp77/LightColorSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LightDirectionSettings.cs
+++ b/CP77.CR2W/Types/cp77/LightDirectionSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LightGroupsAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/LightGroupsAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LightSwitchRequest.cs
+++ b/CP77.CR2W/Types/cp77/LightSwitchRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LineSpawnData.cs
+++ b/CP77.CR2W/Types/cp77/LineSpawnData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LinkClickedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LinkClickedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LinkClickedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LinkClickedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LinkController.cs
+++ b/CP77.CR2W/Types/cp77/LinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LinkedFocusClueData.cs
+++ b/CP77.CR2W/Types/cp77/LinkedFocusClueData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LinkedStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/LinkedStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LinkedStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/LinkedStatusEffectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ListItemData.cs
+++ b/CP77.CR2W/Types/cp77/ListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ListItemStateMapper.cs
+++ b/CP77.CR2W/Types/cp77/ListItemStateMapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ListItemsGroupController.cs
+++ b/CP77.CR2W/Types/cp77/ListItemsGroupController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LmgLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LmgLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/LmgLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/LmgLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LoadEquipmentSetRequest.cs
+++ b/CP77.CR2W/Types/cp77/LoadEquipmentSetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoadGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/LoadGameMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoadListItem.cs
+++ b/CP77.CR2W/Types/cp77/LoadListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoadingScreenProgressBarController.cs
+++ b/CP77.CR2W/Types/cp77/LoadingScreenProgressBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocalPlayerDef.cs
+++ b/CP77.CR2W/Types/cp77/LocalPlayerDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LockDeviceChainCreation.cs
+++ b/CP77.CR2W/Types/cp77/LockDeviceChainCreation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LockPerkArea.cs
+++ b/CP77.CR2W/Types/cp77/LockPerkArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LockQHackInput.cs
+++ b/CP77.CR2W/Types/cp77/LockQHackInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LockTakeControlAction.cs
+++ b/CP77.CR2W/Types/cp77/LockTakeControlAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionAirDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionAirDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionAirEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionAirLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionAirLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionAirLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionAirLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionAirLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionBraindance.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionBraindance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionBraindance.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionBraindance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionBraindanceEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionBraindanceEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionBraindanceEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionBraindanceEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionGroundDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionGroundDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionGroundDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionGroundDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionGroundEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionGroundEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionGroundEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionGroundEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionSceneInitData.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionSceneInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionSwimming.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionSwimming.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionSwimming.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionSwimming.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionSwimmingEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionSwimmingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionSwimmingEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionSwimmingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTakedownDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTakedownDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LocomotionTakedownEvents.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTakedownEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionTakedownInitData.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTakedownInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionTransition.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LocomotionTransition.cs
+++ b/CP77.CR2W/Types/cp77/LocomotionTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LogEntryLogicController.cs
+++ b/CP77.CR2W/Types/cp77/LogEntryLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LogicalCondition.cs
+++ b/CP77.CR2W/Types/cp77/LogicalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LongBladeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LongBladeLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LongBladeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LongBladeLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LongBladeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/LongBladeLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LongBladeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/LongBladeLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookAtData.cs
+++ b/CP77.CR2W/Types/cp77/LookAtData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtPresetBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtPresetBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookAtPresetBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/LookAtPresetMeleeBaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookAtTargetExecutor.cs
+++ b/CP77.CR2W/Types/cp77/LookAtTargetExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookAtTargetExecutor.cs
+++ b/CP77.CR2W/Types/cp77/LookAtTargetExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookatCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/LookatCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookatCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/LookatCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookatCombatTarget_WithoutArms.cs
+++ b/CP77.CR2W/Types/cp77/LookatCombatTarget_WithoutArms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookatCombatTarget_WithoutArms.cs
+++ b/CP77.CR2W/Types/cp77/LookatCombatTarget_WithoutArms.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookatCompanion.cs
+++ b/CP77.CR2W/Types/cp77/LookatCompanion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LookatCompanion.cs
+++ b/CP77.CR2W/Types/cp77/LookatCompanion.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LookedAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/LookedAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoopAnimationLogicController.cs
+++ b/CP77.CR2W/Types/cp77/LoopAnimationLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoopEndedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LoopEndedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoopEndedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LoopEndedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LoopStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LoopStartedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LoopStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/LoopStartedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransform.cs
+++ b/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransformPS.cs
+++ b/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransformPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransformPS.cs
+++ b/CP77.CR2W/Types/cp77/LootContainerObjectAnimatedByTransformPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LootItemInspectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/LootItemInspectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootPickupDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/LootPickupDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingController.cs
+++ b/CP77.CR2W/Types/cp77/LootingController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingGameController.cs
+++ b/CP77.CR2W/Types/cp77/LootingGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingInventoryItemDataComparator.cs
+++ b/CP77.CR2W/Types/cp77/LootingInventoryItemDataComparator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingInventoryItemDataComparator.cs
+++ b/CP77.CR2W/Types/cp77/LootingInventoryItemDataComparator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/LootingItemController.cs
+++ b/CP77.CR2W/Types/cp77/LootingItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingListItemController.cs
+++ b/CP77.CR2W/Types/cp77/LootingListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LootingScrollBlockController.cs
+++ b/CP77.CR2W/Types/cp77/LootingScrollBlockController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LostTargetDelayFalsePositivesDelay.cs
+++ b/CP77.CR2W/Types/cp77/LostTargetDelayFalsePositivesDelay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LowFPSSelectCoverMode.cs
+++ b/CP77.CR2W/Types/cp77/LowFPSSelectCoverMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/LowFPSSelectCoverMode.cs
+++ b/CP77.CR2W/Types/cp77/LowFPSSelectCoverMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MadnessDebuff.cs
+++ b/CP77.CR2W/Types/cp77/MadnessDebuff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MadnessEffector.cs
+++ b/CP77.CR2W/Types/cp77/MadnessEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MagFieldHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/MagFieldHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MagFieldHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/MagFieldHitEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Mainframe.cs
+++ b/CP77.CR2W/Types/cp77/Mainframe.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Mainframe.cs
+++ b/CP77.CR2W/Types/cp77/Mainframe.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MainframeController.cs
+++ b/CP77.CR2W/Types/cp77/MainframeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MainframeController.cs
+++ b/CP77.CR2W/Types/cp77/MainframeController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MainframeControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MainframeControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaintenancePanel.cs
+++ b/CP77.CR2W/Types/cp77/MaintenancePanel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaintenancePanelController.cs
+++ b/CP77.CR2W/Types/cp77/MaintenancePanelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaintenancePanelController.cs
+++ b/CP77.CR2W/Types/cp77/MaintenancePanelController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MaintenancePanelControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MaintenancePanelControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManageAreaComponent.cs
+++ b/CP77.CR2W/Types/cp77/ManageAreaComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManagePersonalLinkChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/ManagePersonalLinkChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ManualLeanEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ManualLeanLeftDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanLeftDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanLeftDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanLeftDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ManualLeanLeftEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanLeftEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanLeftEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanLeftEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ManualLeanRightDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanRightDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanRightDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanRightDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ManualLeanRightEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanRightEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ManualLeanRightEvents.cs
+++ b/CP77.CR2W/Types/cp77/ManualLeanRightEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MapMenuUserData.cs
+++ b/CP77.CR2W/Types/cp77/MapMenuUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MapNavigationDelay.cs
+++ b/CP77.CR2W/Types/cp77/MapNavigationDelay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MapNavigationDelay.cs
+++ b/CP77.CR2W/Types/cp77/MapNavigationDelay.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MapPinUtility.cs
+++ b/CP77.CR2W/Types/cp77/MapPinUtility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MapPinUtility.cs
+++ b/CP77.CR2W/Types/cp77/MapPinUtility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MappingTimeout.cs
+++ b/CP77.CR2W/Types/cp77/MappingTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MarkBackdoorAsRevealedRequest.cs
+++ b/CP77.CR2W/Types/cp77/MarkBackdoorAsRevealedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MarketSystem.cs
+++ b/CP77.CR2W/Types/cp77/MarketSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MarketSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/MarketSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MarkingBubble.cs
+++ b/CP77.CR2W/Types/cp77/MarkingBubble.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterController.cs
+++ b/CP77.CR2W/Types/cp77/MasterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterController.cs
+++ b/CP77.CR2W/Types/cp77/MasterController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MasterControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MasterControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterDeviceBaseBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/MasterDeviceBaseBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterDeviceDestroyed.cs
+++ b/CP77.CR2W/Types/cp77/MasterDeviceDestroyed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterDeviceDestroyed.cs
+++ b/CP77.CR2W/Types/cp77/MasterDeviceDestroyed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MasterDeviceInkGameControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/MasterDeviceInkGameControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/MasterViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MasterViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/MasterViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Master_Test.cs
+++ b/CP77.CR2W/Types/cp77/Master_Test.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialLayerDef.cs
+++ b/CP77.CR2W/Types/cp77/MaterialLayerDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialParameterInstance.cs
+++ b/CP77.CR2W/Types/cp77/MaterialParameterInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialPass.cs
+++ b/CP77.CR2W/Types/cp77/MaterialPass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialTechnique.cs
+++ b/CP77.CR2W/Types/cp77/MaterialTechnique.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialTooltip.cs
+++ b/CP77.CR2W/Types/cp77/MaterialTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/MaterialTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MaterialUsedParameter.cs
+++ b/CP77.CR2W/Types/cp77/MaterialUsedParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MathHelper.cs
+++ b/CP77.CR2W/Types/cp77/MathHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MathHelper.cs
+++ b/CP77.CR2W/Types/cp77/MathHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Matrix.cs
+++ b/CP77.CR2W/Types/cp77/Matrix.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeasurementUtils.cs
+++ b/CP77.CR2W/Types/cp77/MeasurementUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeasurementUtils.cs
+++ b/CP77.CR2W/Types/cp77/MeasurementUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MediaDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MediaDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaDeviceStatus.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaDeviceStatus.cs
+++ b/CP77.CR2W/Types/cp77/MediaDeviceStatus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MediaResaveData.cs
+++ b/CP77.CR2W/Types/cp77/MediaResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/MediaSystemUIPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MediaSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/MediaSystemUIPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeAttackCommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackCommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeAttackCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeAttackCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeAttackData.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeAttackGenericDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackGenericDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeAttackGenericDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackGenericDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeAttackGenericEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeAttackGenericEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeBlockAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeBlockAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeBlockAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeBlockAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeBlockDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeBlockDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeBlockEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeBlockEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeChargedHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeChargedHoldDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeChargedHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeChargedHoldDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeChargedHoldEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeChargedHoldEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeChargedHoldEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeChargedHoldEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeComboAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeComboAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeComboAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeComboAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeComboAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeComboAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeComboAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeComboAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeCrouchAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeCrouchAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeCrouchAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeCrouchAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeCrouchAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeCrouchAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeCrouchAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeCrouchAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeDashDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDashDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeDashDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDashDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeDashEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDashEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeDashEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDashEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeDeflectAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeDeflectAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeDeflectAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeDeflectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeDeflectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeDeflectEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeDeflectEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeEquipAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEquipAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeEquipAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEquipAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeEquipAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEquipAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeEquipAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEquipAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/MeleeEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeFinalAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeFinalAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeFinalAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeFinalAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeFinalAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeFinalAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeFinalAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeFinalAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeHitAnimEventExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitAnimEventExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHitAnimEventExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitAnimEventExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHitSlowMoEvent.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitSlowMoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHitTerminateGameEffectExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitTerminateGameEffectExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHitTerminateGameEffectExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHitTerminateGameEffectExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHoldDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHoldDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeHoldEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHoldEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeHoldEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeHoldEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeIdleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeIdleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeIdleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeIdleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeJumpAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeJumpAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeJumpAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeJumpAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeJumpAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeJumpAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeJumpAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeJumpAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeLeapDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLeapDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeLeapDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLeapDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeLeapEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLeapEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeNotReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeNotReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeNotReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeNotReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeNotReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeNotReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeNotReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeNotReadyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleePSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/MeleePSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleePSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/MeleePSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleePSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/MeleePSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleePSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/MeleePSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeParriedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeParriedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeParriedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeParriedDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeParriedEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeParriedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeParriedEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeParriedEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleePreAttackExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleePreAttackExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleePreAttackExecutor.cs
+++ b/CP77.CR2W/Types/cp77/MeleePreAttackExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleePublicSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleePublicSafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleePublicSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleePublicSafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleePublicSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleePublicSafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleePublicSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleePublicSafeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeRecoveryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeRecoveryDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeRecoveryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeRecoveryDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeRecoveryEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeRecoveryEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeRecoveryEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeRecoveryEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeResourcePoolListener.cs
+++ b/CP77.CR2W/Types/cp77/MeleeResourcePoolListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSafeAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSafeAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeSafeAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSafeAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSafeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeSprintAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSprintAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSprintAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSprintAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeSprintAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSprintAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeSprintAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeSprintAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeStrongAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeStrongAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeStrongAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeStrongAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeStrongAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeStrongAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeStrongAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeStrongAttackEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeTargetingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTargetingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeTargetingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTargetingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeTargetingEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTargetingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeTargetingEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTargetingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeThrowAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeThrowAttackDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeThrowAttackDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MeleeThrowAttackDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeThrowAttackEvents.cs
+++ b/CP77.CR2W/Types/cp77/MeleeThrowAttackEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeTransition.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeTransition.cs
+++ b/CP77.CR2W/Types/cp77/MeleeTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/MeleeWeaponPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MemoryListener.cs
+++ b/CP77.CR2W/Types/cp77/MemoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuCursorUserData.cs
+++ b/CP77.CR2W/Types/cp77/MenuCursorUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuData.cs
+++ b/CP77.CR2W/Types/cp77/MenuData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuDataBuilder.cs
+++ b/CP77.CR2W/Types/cp77/MenuDataBuilder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuEventBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/MenuEventBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuHubGameController.cs
+++ b/CP77.CR2W/Types/cp77/MenuHubGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuHubLogicController.cs
+++ b/CP77.CR2W/Types/cp77/MenuHubLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuItemController.cs
+++ b/CP77.CR2W/Types/cp77/MenuItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuItemData.cs
+++ b/CP77.CR2W/Types/cp77/MenuItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuItemDelayedUpdate.cs
+++ b/CP77.CR2W/Types/cp77/MenuItemDelayedUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuItemDelayedUpdate.cs
+++ b/CP77.CR2W/Types/cp77/MenuItemDelayedUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuItemDimRequest.cs
+++ b/CP77.CR2W/Types/cp77/MenuItemDimRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_BaseMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_BaseMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_BodyTypeSelection.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_BodyTypeSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_BodyTypeSelection.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_BodyTypeSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_BoothMode.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_BoothMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_BoothMode.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_BoothMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_CharacterCustomization.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_CharacterCustomization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_CharacterCustomization.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_CharacterCustomization.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_ClippedMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_ClippedMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_ClippedMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_ClippedMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_Credits.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Credits.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Credits.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Credits.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_DeathMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_DeathMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_DeathMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_DeathMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_Difficulty.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Difficulty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Difficulty.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Difficulty.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_E3EndMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_E3EndMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_E3EndMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_E3EndMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_FastTravel.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FastTravel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_FastTravel.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FastTravel.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_FinalBoards.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FinalBoards.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_FinalBoards.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FinalBoards.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_FindServers.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FindServers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_FindServers.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_FindServers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_HubMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_HubMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Idle.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Idle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Idle.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Idle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_LifePathSelection.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_LifePathSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_LifePathSelection.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_LifePathSelection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_LoadGame.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_LoadGame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_LoadGame.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_LoadGame.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_MultiplayerMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_MultiplayerMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_MultiplayerMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_MultiplayerMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_NetworkBreach.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_NetworkBreach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_NetworkBreach.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_NetworkBreach.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_NewGame.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_NewGame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_NewGame.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_NewGame.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_PauseMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_PauseMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_PauseMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_PauseMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_PlayRecordedSession.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_PlayRecordedSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_PlayRecordedSession.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_PlayRecordedSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_PreGameSubMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_PreGameSubMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Settings.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Settings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Settings.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Settings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_SingleplayerMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_SingleplayerMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_SingleplayerMenu.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_SingleplayerMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_StatsAdjustment.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_StatsAdjustment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_StatsAdjustment.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_StatsAdjustment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_Storage.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Storage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Storage.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Storage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_Summary.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Summary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Summary.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Summary.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MenuScenario_Vendor.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Vendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MenuScenario_Vendor.cs
+++ b/CP77.CR2W/Types/cp77/MenuScenario_Vendor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MergedMesh.cs
+++ b/CP77.CR2W/Types/cp77/MergedMesh.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MergedMesh.cs
+++ b/CP77.CR2W/Types/cp77/MergedMesh.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MeshAppearanceDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/MeshAppearanceDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MeshParam_Weakspot.cs
+++ b/CP77.CR2W/Types/cp77/MeshParam_Weakspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageCounterController.cs
+++ b/CP77.CR2W/Types/cp77/MessageCounterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageDescTooltip.cs
+++ b/CP77.CR2W/Types/cp77/MessageDescTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageMenuAttachmentData.cs
+++ b/CP77.CR2W/Types/cp77/MessageMenuAttachmentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessagePopupDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/MessagePopupDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageThreadReadEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessageThreadReadEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageTooltip.cs
+++ b/CP77.CR2W/Types/cp77/MessageTooltip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessageTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/MessageTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessangerItemRenderer.cs
+++ b/CP77.CR2W/Types/cp77/MessangerItemRenderer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessangerReplyItemRenderer.cs
+++ b/CP77.CR2W/Types/cp77/MessangerReplyItemRenderer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactDataView.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactDataView.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactDataView.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MessengerContactItemVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactItemVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactSelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactSelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactSyncBackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactSyncBackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MessengerContactSyncData.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactSyncData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerContactsVirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/MessengerContactsVirtualNestedListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerDialogViewController.cs
+++ b/CP77.CR2W/Types/cp77/MessengerDialogViewController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerForceSelectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessengerForceSelectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerGameController.cs
+++ b/CP77.CR2W/Types/cp77/MessengerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerNotification.cs
+++ b/CP77.CR2W/Types/cp77/MessengerNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerThreadSelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/MessengerThreadSelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerUtils.cs
+++ b/CP77.CR2W/Types/cp77/MessengerUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MessengerUtils.cs
+++ b/CP77.CR2W/Types/cp77/MessengerUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MetaQuestLogicController.cs
+++ b/CP77.CR2W/Types/cp77/MetaQuestLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MetaQuestStatus.cs
+++ b/CP77.CR2W/Types/cp77/MetaQuestStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MetroSignSelector.cs
+++ b/CP77.CR2W/Types/cp77/MetroSignSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MicroblendDef.cs
+++ b/CP77.CR2W/Types/cp77/MicroblendDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MiddleFive.cs
+++ b/CP77.CR2W/Types/cp77/MiddleFive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MiddleFive.cs
+++ b/CP77.CR2W/Types/cp77/MiddleFive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MiddleFour.cs
+++ b/CP77.CR2W/Types/cp77/MiddleFour.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MiddleFour.cs
+++ b/CP77.CR2W/Types/cp77/MiddleFour.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MiddleOne.cs
+++ b/CP77.CR2W/Types/cp77/MiddleOne.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MiddleOne.cs
+++ b/CP77.CR2W/Types/cp77/MiddleOne.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MiddleThree.cs
+++ b/CP77.CR2W/Types/cp77/MiddleThree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MiddleThree.cs
+++ b/CP77.CR2W/Types/cp77/MiddleThree.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineArmEvent.cs
+++ b/CP77.CR2W/Types/cp77/MineArmEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineArmEvent.cs
+++ b/CP77.CR2W/Types/cp77/MineArmEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDespawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/MineDespawnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDespawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/MineDespawnEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenser.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenser.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenser.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserCycleItemDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserCycleItemDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserCycleItemDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserCycleItemDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserCycleItemEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserCycleItemEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserCycleItemEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserCycleItemEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserIdleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserIdleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserIdleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserIdleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserIdleEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserIdleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserPlaceDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserPlaceDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserPlaceEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserPlaceEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserTransition.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserTransition.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MineDispenserUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MineDispenserUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/MineDispenserUnequipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinesDataDef.cs
+++ b/CP77.CR2W/Types/cp77/MinesDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MinigameDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameDecisions.cs
+++ b/CP77.CR2W/Types/cp77/MinigameDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameEvents.cs
+++ b/CP77.CR2W/Types/cp77/MinigameEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameEvents.cs
+++ b/CP77.CR2W/Types/cp77/MinigameEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameFailEvent.cs
+++ b/CP77.CR2W/Types/cp77/MinigameFailEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameFailEvent.cs
+++ b/CP77.CR2W/Types/cp77/MinigameFailEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRuleOverridePrograms.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRuleOverridePrograms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRuleOverridePrograms.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRuleOverridePrograms.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoard.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoard.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoard.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoardWithTraps.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoardWithTraps.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoardWithTraps.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRulePredefinedBoardWithTraps.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRuleScalingPrograms.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRuleScalingPrograms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRule_Test.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRule_Test.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameGenerationRule_Test.cs
+++ b/CP77.CR2W/Types/cp77/MinigameGenerationRule_Test.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameTooltipHideRequest.cs
+++ b/CP77.CR2W/Types/cp77/MinigameTooltipHideRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinigameTooltipHideRequest.cs
+++ b/CP77.CR2W/Types/cp77/MinigameTooltipHideRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinigameTooltipShowRequest.cs
+++ b/CP77.CR2W/Types/cp77/MinigameTooltipShowRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipDataRequirements.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipDataRequirements.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipModAttachmentData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipModAttachmentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipModData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipModData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipModData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipModData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipModRecordData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipModRecordData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipRecipeData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipRecipeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalItemTooltipStatData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalItemTooltipStatData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimalLootingListItemData.cs
+++ b/CP77.CR2W/Types/cp77/MinimalLootingListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimapDataNode.cs
+++ b/CP77.CR2W/Types/cp77/MinimapDataNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimapDataNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/MinimapDataNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinimapDataNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/MinimapDataNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MinimapPOIMappinController.cs
+++ b/CP77.CR2W/Types/cp77/MinimapPOIMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinotaurMechComponent.cs
+++ b/CP77.CR2W/Types/cp77/MinotaurMechComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinotaurOnStatusEffectAppliedListener.cs
+++ b/CP77.CR2W/Types/cp77/MinotaurOnStatusEffectAppliedListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinutePassedEvent.cs
+++ b/CP77.CR2W/Types/cp77/MinutePassedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MinutePassedEvent.cs
+++ b/CP77.CR2W/Types/cp77/MinutePassedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MipMapGenParams.cs
+++ b/CP77.CR2W/Types/cp77/MipMapGenParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MissingWorkspotComponentFailsafeEvent.cs
+++ b/CP77.CR2W/Types/cp77/MissingWorkspotComponentFailsafeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyAttackCritChanceEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyAttackCritChanceEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyAttackEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyAttackEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ModifyDamageEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyDamageEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyDamageWithDistance.cs
+++ b/CP77.CR2W/Types/cp77/ModifyDamageWithDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyDamageWithStatPoolEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyDamageWithStatPoolEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyDamageWithVelocity.cs
+++ b/CP77.CR2W/Types/cp77/ModifyDamageWithVelocity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyNPCTelemetryVariable.cs
+++ b/CP77.CR2W/Types/cp77/ModifyNPCTelemetryVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyOverlappedSecurityAreas.cs
+++ b/CP77.CR2W/Types/cp77/ModifyOverlappedSecurityAreas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifySkillCheckPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ModifySkillCheckPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyStatCheckPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ModifyStatCheckPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyStatPoolModifierEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyStatPoolModifierEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyStatPoolValueEffector.cs
+++ b/CP77.CR2W/Types/cp77/ModifyStatPoolValueEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModifyTelemetryVariable.cs
+++ b/CP77.CR2W/Types/cp77/ModifyTelemetryVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ModuleInstance.cs
+++ b/CP77.CR2W/Types/cp77/ModuleInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MonitorMeleeCombo.cs
+++ b/CP77.CR2W/Types/cp77/MonitorMeleeCombo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MonitorStatusEffectBehavior.cs
+++ b/CP77.CR2W/Types/cp77/MonitorStatusEffectBehavior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MonoDisc.cs
+++ b/CP77.CR2W/Types/cp77/MonoDisc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorningPreset.cs
+++ b/CP77.CR2W/Types/cp77/MorningPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorningPreset.cs
+++ b/CP77.CR2W/Types/cp77/MorningPreset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MorphData.cs
+++ b/CP77.CR2W/Types/cp77/MorphData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorphMenuUserData.cs
+++ b/CP77.CR2W/Types/cp77/MorphMenuUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorphTargetMeshEntry.cs
+++ b/CP77.CR2W/Types/cp77/MorphTargetMeshEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorphTargetMesh_.cs
+++ b/CP77.CR2W/Types/cp77/MorphTargetMesh_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MorphTargetsTextureBlendInfo.cs
+++ b/CP77.CR2W/Types/cp77/MorphTargetsTextureBlendInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MotionBlurAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/MotionBlurAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MotorcycleComponent.cs
+++ b/CP77.CR2W/Types/cp77/MotorcycleComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MotorcycleComponent.cs
+++ b/CP77.CR2W/Types/cp77/MotorcycleComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MountAssigendVehicle.cs
+++ b/CP77.CR2W/Types/cp77/MountAssigendVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MountCommandHandlerTask.cs
+++ b/CP77.CR2W/Types/cp77/MountCommandHandlerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MountRequestCondition.cs
+++ b/CP77.CR2W/Types/cp77/MountRequestCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MountRequestPassiveCondition.cs
+++ b/CP77.CR2W/Types/cp77/MountRequestPassiveCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableDevice.cs
+++ b/CP77.CR2W/Types/cp77/MovableDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/MovableDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/MovableDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MovableDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MovableDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableDeviceSetup.cs
+++ b/CP77.CR2W/Types/cp77/MovableDeviceSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableQuestTrigger.cs
+++ b/CP77.CR2W/Types/cp77/MovableQuestTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableWallScreen.cs
+++ b/CP77.CR2W/Types/cp77/MovableWallScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableWallScreenController.cs
+++ b/CP77.CR2W/Types/cp77/MovableWallScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableWallScreenController.cs
+++ b/CP77.CR2W/Types/cp77/MovableWallScreenController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MovableWallScreenControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MovableWallScreenControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MovableWallScreenControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/MovableWallScreenControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MoveObstacle.cs
+++ b/CP77.CR2W/Types/cp77/MoveObstacle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MoveObstacle.cs
+++ b/CP77.CR2W/Types/cp77/MoveObstacle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MoveToCoverCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/MoveToCoverCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MoveToCoverCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/MoveToCoverCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MoveToScavengeTarget.cs
+++ b/CP77.CR2W/Types/cp77/MoveToScavengeTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_Layer.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_Layer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerOverrideSelection.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerOverrideSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerTemplate.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverrides.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesColor.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesLevels.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesLevels.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesNormalStrength.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_LayerTemplateOverridesNormalStrength.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_Mask.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_Mask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Multilayer_Setup.cs
+++ b/CP77.CR2W/Types/cp77/Multilayer_Setup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MultiplayerMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/MultiplayerMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MultiplayerMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/MultiplayerMenuGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/MusicSettings.cs
+++ b/CP77.CR2W/Types/cp77/MusicSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MuteArm.cs
+++ b/CP77.CR2W/Types/cp77/MuteArm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/MuteArmDurationModifier.cs
+++ b/CP77.CR2W/Types/cp77/MuteArmDurationModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NCPDJobDoneEvent.cs
+++ b/CP77.CR2W/Types/cp77/NCPDJobDoneEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NCPDJobDoneNotification.cs
+++ b/CP77.CR2W/Types/cp77/NCPDJobDoneNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCAbility.cs
+++ b/CP77.CR2W/Types/cp77/NPCAbility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCAfterDeathOrDefeatEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCAfterDeathOrDefeatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCAfterDeathOrDefeatEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCAfterDeathOrDefeatEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCAttitudeTowardsPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCAttitudeTowardsPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCAttitudeTowardsPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCAttitudeTowardsPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCBreachEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCBreachEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCDeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCDeadPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCDeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCDeadPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCDeathListener.cs
+++ b/CP77.CR2W/Types/cp77/NPCDeathListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/NPCDebugInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCDetectingPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCDetectingPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCDetectingPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCDetectingPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCGodModeListener.cs
+++ b/CP77.CR2W/Types/cp77/NPCGodModeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCGrappledByPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCGrappledByPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCGrappledByPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCGrappledByPlayerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCHitReactionTypePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCHitReactionTypePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCHitReactionTypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCHitReactionTypePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCHitSourcePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCHitSourcePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCHitSourcePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCHitSourcePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCInScenePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCInScenePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCInScenePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCInScenePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIncapacitatedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIncapacitatedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIncapacitatedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIncapacitatedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCInitTask.cs
+++ b/CP77.CR2W/Types/cp77/NPCInitTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsAggressivePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsAggressivePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsAggressiveState.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsAggressiveState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsAggressiveState.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsAggressiveState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCIsChildPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsChildPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsCrowdPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsCrowdPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsHumanoidPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsHumanoidPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCIsHumanoidPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCIsHumanoidPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCItemToEquip.cs
+++ b/CP77.CR2W/Types/cp77/NPCItemToEquip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCKillDataTrackingRequest.cs
+++ b/CP77.CR2W/Types/cp77/NPCKillDataTrackingRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCKillDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCKillDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCLocomotionTypePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCLocomotionTypePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCLocomotionTypePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCLocomotionTypePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCManager.cs
+++ b/CP77.CR2W/Types/cp77/NPCManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCNotMountedToVehiclePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCNotMountedToVehiclePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCNotMountedToVehiclePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCNotMountedToVehiclePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCPuppet.cs
+++ b/CP77.CR2W/Types/cp77/NPCPuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRarityPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCRarityPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRarityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCRarityPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRarityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCRarityPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCReactionPresetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCReactionPresetPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCReactionPresetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCReactionPresetPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCReactionPresetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCReactionPresetPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCRecordHasVisualTag.cs
+++ b/CP77.CR2W/Types/cp77/NPCRecordHasVisualTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRecordHasVisualTagState.cs
+++ b/CP77.CR2W/Types/cp77/NPCRecordHasVisualTagState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRecordHasVisualTagState.cs
+++ b/CP77.CR2W/Types/cp77/NPCRecordHasVisualTagState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCReference.cs
+++ b/CP77.CR2W/Types/cp77/NPCReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRevealedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCRevealedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRevealedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCRevealedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCRevealedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCRevealedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCRoleChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCRoleChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCScanningDescription.cs
+++ b/CP77.CR2W/Types/cp77/NPCScanningDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStartingDetectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCStartingDetectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStartingDetectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCStartingDetectionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCStateChangeSignal.cs
+++ b/CP77.CR2W/Types/cp77/NPCStateChangeSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCStatePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStatesComponent.cs
+++ b/CP77.CR2W/Types/cp77/NPCStatesComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStoppingDetectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCStoppingDetectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCStoppingDetectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCStoppingDetectionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NPCThrowingGrenadeEvent.cs
+++ b/CP77.CR2W/Types/cp77/NPCThrowingGrenadeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCTrackingPlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCTrackingPlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCTrackingPlayerPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/NPCTrackingPlayerPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCTypePrereq.cs
+++ b/CP77.CR2W/Types/cp77/NPCTypePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NPCstubData.cs
+++ b/CP77.CR2W/Types/cp77/NPCstubData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NamedTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/NamedTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NameplateBarLogicController.cs
+++ b/CP77.CR2W/Types/cp77/NameplateBarLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NameplateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/NameplateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NameplateVisibleEvent.cs
+++ b/CP77.CR2W/Types/cp77/NameplateVisibleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NameplateVisualsLogicController.cs
+++ b/CP77.CR2W/Types/cp77/NameplateVisualsLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NanoWireProjectile.cs
+++ b/CP77.CR2W/Types/cp77/NanoWireProjectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NanoWireProjectileCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/NanoWireProjectileCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NanoWireProjectileCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/NanoWireProjectileCollisionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NarrationJournalGameController.cs
+++ b/CP77.CR2W/Types/cp77/NarrationJournalGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NarrativePlateGameController.cs
+++ b/CP77.CR2W/Types/cp77/NarrativePlateGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NarrativePlateLogicController.cs
+++ b/CP77.CR2W/Types/cp77/NarrativePlateLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NavGenNavigationSetting.cs
+++ b/CP77.CR2W/Types/cp77/NavGenNavigationSetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NavigationFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/NavigationFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NavigationFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/NavigationFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NcartTimeTableCounterUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimeTableCounterUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimeTableCounterUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimeTableCounterUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NcartTimetable.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimetableBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimetableController.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimetableController.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NcartTimetableControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimetableInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NcartTimetableSetup.cs
+++ b/CP77.CR2W/Types/cp77/NcartTimetableSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NemaplateChangedRequest.cs
+++ b/CP77.CR2W/Types/cp77/NemaplateChangedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetRunnerChargesGameController.cs
+++ b/CP77.CR2W/Types/cp77/NetRunnerChargesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetRunnerListItem.cs
+++ b/CP77.CR2W/Types/cp77/NetRunnerListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerChair.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerChair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerChair.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerChair.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetrunnerChairController.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerChairController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerChairController.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerChairController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetrunnerChairControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerChairControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerControlPanel.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerControlPanel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerControlPanel.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerControlPanel.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetrunnerControlPanelController.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerControlPanelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetrunnerControlPanelController.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerControlPanelController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetrunnerControlPanelControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/NetrunnerControlPanelControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkArea.cs
+++ b/CP77.CR2W/Types/cp77/NetworkArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkAreaActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/NetworkAreaActivationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkAreaController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkAreaController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkAreaController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkAreaController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetworkAreaControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/NetworkAreaControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/NetworkBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkBreachedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NetworkBreachedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkLinkQuickhackEvent.cs
+++ b/CP77.CR2W/Types/cp77/NetworkLinkQuickhackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameAnimatedElementController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameAnimatedElementController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallManager.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallManager.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallbacksTransmitter.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallbacksTransmitter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallbacksTransmitter.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameAnimationCallbacksTransmitter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetworkMinigameBasicProgramController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameBasicProgramController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameBasicProgramController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameBasicProgramController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NetworkMinigameBufferController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameBufferController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameData.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameElementController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameElementController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameEndScreenController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameEndScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameGridCellController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameGridCellController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameGridController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameGridController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameProgramController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameProgramController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameProgramListController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameProgramListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkMinigameVisualController.cs
+++ b/CP77.CR2W/Types/cp77/NetworkMinigameVisualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NetworkSystem.cs
+++ b/CP77.CR2W/Types/cp77/NetworkSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewAreaDiscoveredUserData.cs
+++ b/CP77.CR2W/Types/cp77/NewAreaDiscoveredUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewAreaGameController.cs
+++ b/CP77.CR2W/Types/cp77/NewAreaGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewBackdoorDeviceRequest.cs
+++ b/CP77.CR2W/Types/cp77/NewBackdoorDeviceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewCodexEntryGameController.cs
+++ b/CP77.CR2W/Types/cp77/NewCodexEntryGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewCodexEntryUserData.cs
+++ b/CP77.CR2W/Types/cp77/NewCodexEntryUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewCycleEvent.cs
+++ b/CP77.CR2W/Types/cp77/NewCycleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/NewGameMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewHitDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/NewHitDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewLocationNotification.cs
+++ b/CP77.CR2W/Types/cp77/NewLocationNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewTurnMinigameData.cs
+++ b/CP77.CR2W/Types/cp77/NewTurnMinigameData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NewsFeedMenuWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/NewsFeedMenuWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NextFrameEvent.cs
+++ b/CP77.CR2W/Types/cp77/NextFrameEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NextFrameEvent.cs
+++ b/CP77.CR2W/Types/cp77/NextFrameEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NextPreviousActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/NextPreviousActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NextStation.cs
+++ b/CP77.CR2W/Types/cp77/NextStation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NextStation.cs
+++ b/CP77.CR2W/Types/cp77/NextStation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NightPreset.cs
+++ b/CP77.CR2W/Types/cp77/NightPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NightPreset.cs
+++ b/CP77.CR2W/Types/cp77/NightPreset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NitroCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/NitroCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NitroCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/NitroCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NoAmmoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/NoAmmoDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NoAmmoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/NoAmmoDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NoAmmoEvents.cs
+++ b/CP77.CR2W/Types/cp77/NoAmmoEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NoAmmoEvents.cs
+++ b/CP77.CR2W/Types/cp77/NoAmmoEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NoReactionPerformedRequest.cs
+++ b/CP77.CR2W/Types/cp77/NoReactionPerformedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NoReactionPerformedRequest.cs
+++ b/CP77.CR2W/Types/cp77/NoReactionPerformedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NoWeaponCombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/NoWeaponCombatConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NoWeaponCombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/NoWeaponCombatConditions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NonStealthQuickHackVictimEvent.cs
+++ b/CP77.CR2W/Types/cp77/NonStealthQuickHackVictimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NonlethalTakedownAndDisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/NonlethalTakedownAndDisposeBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NonlethalTakedownAndDisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/NonlethalTakedownAndDisposeBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NormalDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/NormalDeathTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NormalDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/NormalDeathTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotInDefeated.cs
+++ b/CP77.CR2W/Types/cp77/NotInDefeated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotInDefeated.cs
+++ b/CP77.CR2W/Types/cp77/NotInDefeated.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotJohnnyReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotJohnnyReplacerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotJohnnyReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotJohnnyReplacerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/NotReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/NotReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/NotReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/NotReadyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotReplacerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotReplacerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotVRReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotVRReplacerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotVRReplacerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/NotVRReplacerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotifiedSecSysAboutCombat.cs
+++ b/CP77.CR2W/Types/cp77/NotifiedSecSysAboutCombat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotifiedSecSysAboutCombat.cs
+++ b/CP77.CR2W/Types/cp77/NotifiedSecSysAboutCombat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotifyHighlightedDevice.cs
+++ b/CP77.CR2W/Types/cp77/NotifyHighlightedDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotifyParentsEvent.cs
+++ b/CP77.CR2W/Types/cp77/NotifyParentsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotifyParentsEvent.cs
+++ b/CP77.CR2W/Types/cp77/NotifyParentsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotifyRecipientsRequest.cs
+++ b/CP77.CR2W/Types/cp77/NotifyRecipientsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotifySecuritySystemCombatEvent.cs
+++ b/CP77.CR2W/Types/cp77/NotifySecuritySystemCombatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NotifySecuritySystemCombatEvent.cs
+++ b/CP77.CR2W/Types/cp77/NotifySecuritySystemCombatEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/NotifyShardRead.cs
+++ b/CP77.CR2W/Types/cp77/NotifyShardRead.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NpcNameplateVisualData.cs
+++ b/CP77.CR2W/Types/cp77/NpcNameplateVisualData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/NumberPlateSelector.cs
+++ b/CP77.CR2W/Types/cp77/NumberPlateSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectInspectEvent.cs
+++ b/CP77.CR2W/Types/cp77/ObjectInspectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectMoverComponent.cs
+++ b/CP77.CR2W/Types/cp77/ObjectMoverComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectMoverComponent.cs
+++ b/CP77.CR2W/Types/cp77/ObjectMoverComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ObjectMoverComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/ObjectMoverComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectMoverComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/ObjectMoverComponentPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ObjectMoverStatus.cs
+++ b/CP77.CR2W/Types/cp77/ObjectMoverStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectScanningDescription.cs
+++ b/CP77.CR2W/Types/cp77/ObjectScanningDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectScanningDescription.cs
+++ b/CP77.CR2W/Types/cp77/ObjectScanningDescription.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ObjectiveController.cs
+++ b/CP77.CR2W/Types/cp77/ObjectiveController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObjectiveEntryLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ObjectiveEntryLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ObstacleCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/ObstacleCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OccluderEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/OccluderEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OccluderEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/OccluderEnableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OdaCementBag.cs
+++ b/CP77.CR2W/Types/cp77/OdaCementBag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OdaCementBagController.cs
+++ b/CP77.CR2W/Types/cp77/OdaCementBagController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OdaCementBagController.cs
+++ b/CP77.CR2W/Types/cp77/OdaCementBagController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OdaCementBagControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/OdaCementBagControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OdaComponent.cs
+++ b/CP77.CR2W/Types/cp77/OdaComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OdaEmergencyListener.cs
+++ b/CP77.CR2W/Types/cp77/OdaEmergencyListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OldUpperBodyEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/OldUpperBodyEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OldUpperBodyEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/OldUpperBodyEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OldUpperBodyTransition.cs
+++ b/CP77.CR2W/Types/cp77/OldUpperBodyTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OldUpperBodyTransition.cs
+++ b/CP77.CR2W/Types/cp77/OldUpperBodyTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnAttachedEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnAttachedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnAttachedEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnAttachedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnAxis.cs
+++ b/CP77.CR2W/Types/cp77/OnAxis.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnAxis.cs
+++ b/CP77.CR2W/Types/cp77/OnAxis.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnBeingNoticed.cs
+++ b/CP77.CR2W/Types/cp77/OnBeingNoticed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnBeingTarget.cs
+++ b/CP77.CR2W/Types/cp77/OnBeingTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnDisableAreaData.cs
+++ b/CP77.CR2W/Types/cp77/OnDisableAreaData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnDoubleClick.cs
+++ b/CP77.CR2W/Types/cp77/OnDoubleClick.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnDoubleClick.cs
+++ b/CP77.CR2W/Types/cp77/OnDoubleClick.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnEnter.cs
+++ b/CP77.CR2W/Types/cp77/OnEnter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnEnter.cs
+++ b/CP77.CR2W/Types/cp77/OnEnter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnFocusLost.cs
+++ b/CP77.CR2W/Types/cp77/OnFocusLost.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnFocusLost.cs
+++ b/CP77.CR2W/Types/cp77/OnFocusLost.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnFocusReceived.cs
+++ b/CP77.CR2W/Types/cp77/OnFocusReceived.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnFocusReceived.cs
+++ b/CP77.CR2W/Types/cp77/OnFocusReceived.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnHold.cs
+++ b/CP77.CR2W/Types/cp77/OnHold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnHold.cs
+++ b/CP77.CR2W/Types/cp77/OnHold.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnHoverOut.cs
+++ b/CP77.CR2W/Types/cp77/OnHoverOut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnHoverOut.cs
+++ b/CP77.CR2W/Types/cp77/OnHoverOut.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnHoverOver.cs
+++ b/CP77.CR2W/Types/cp77/OnHoverOver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnHoverOver.cs
+++ b/CP77.CR2W/Types/cp77/OnHoverOver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnLeave.cs
+++ b/CP77.CR2W/Types/cp77/OnLeave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnLeave.cs
+++ b/CP77.CR2W/Types/cp77/OnLeave.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnOffPrereq.cs
+++ b/CP77.CR2W/Types/cp77/OnOffPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnOffPrereq.cs
+++ b/CP77.CR2W/Types/cp77/OnOffPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnOffPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/OnOffPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnOffPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/OnOffPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnOpenCodexAtEntryEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnOpenCodexAtEntryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnPress.cs
+++ b/CP77.CR2W/Types/cp77/OnPress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnPress.cs
+++ b/CP77.CR2W/Types/cp77/OnPress.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnProgressBarAnimFinish.cs
+++ b/CP77.CR2W/Types/cp77/OnProgressBarAnimFinish.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnRelative.cs
+++ b/CP77.CR2W/Types/cp77/OnRelative.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnRelative.cs
+++ b/CP77.CR2W/Types/cp77/OnRelative.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnRelease.cs
+++ b/CP77.CR2W/Types/cp77/OnRelease.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnRelease.cs
+++ b/CP77.CR2W/Types/cp77/OnRelease.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnReleaseWorkspotEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnReleaseWorkspotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnReleaseWorkspotEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnReleaseWorkspotEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnRepeat.cs
+++ b/CP77.CR2W/Types/cp77/OnRepeat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnRepeat.cs
+++ b/CP77.CR2W/Types/cp77/OnRepeat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnReserveWorkspotEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnReserveWorkspotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnSquadmateDied.cs
+++ b/CP77.CR2W/Types/cp77/OnSquadmateDied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnUnstoppableStateSignal.cs
+++ b/CP77.CR2W/Types/cp77/OnUnstoppableStateSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnUnstoppableStateSignal.cs
+++ b/CP77.CR2W/Types/cp77/OnUnstoppableStateSignal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnVisitedJournalEntryEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnVisitedJournalEntryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnWorkspotAvailabilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/OnWorkspotAvailabilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OneHandedClubLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OneHandedClubLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OneHandedClubLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OneHandedClubLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OneHandedClubLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/OneHandedClubLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OneHandedClubLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/OneHandedClubLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OneTimeCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/OneTimeCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OneTimeCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/OneTimeCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnlySingleStatusEffectFromInstigator.cs
+++ b/CP77.CR2W/Types/cp77/OnlySingleStatusEffectFromInstigator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnlySingleStatusEffectFromInstigator.cs
+++ b/CP77.CR2W/Types/cp77/OnlySingleStatusEffectFromInstigator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnlyVehicleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OnlyVehicleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnlyVehicleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OnlyVehicleDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnlyVehicleEvents.cs
+++ b/CP77.CR2W/Types/cp77/OnlyVehicleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnlyVehicleEvents.cs
+++ b/CP77.CR2W/Types/cp77/OnlyVehicleEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OnscreenDisplayManager.cs
+++ b/CP77.CR2W/Types/cp77/OnscreenDisplayManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OnscreenMessageGameController.cs
+++ b/CP77.CR2W/Types/cp77/OnscreenMessageGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenCodexPopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/OpenCodexPopupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenDocumentEvent.cs
+++ b/CP77.CR2W/Types/cp77/OpenDocumentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenFullscreenUI.cs
+++ b/CP77.CR2W/Types/cp77/OpenFullscreenUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenFullscreenUI.cs
+++ b/CP77.CR2W/Types/cp77/OpenFullscreenUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OpenInteriorManager.cs
+++ b/CP77.CR2W/Types/cp77/OpenInteriorManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenInteriorManager.cs
+++ b/CP77.CR2W/Types/cp77/OpenInteriorManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OpenInventoryQuantityPickerRequest.cs
+++ b/CP77.CR2W/Types/cp77/OpenInventoryQuantityPickerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenMenuRequest.cs
+++ b/CP77.CR2W/Types/cp77/OpenMenuRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenMessengerNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenMessengerNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenPerksNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenPerksNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenShardNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenShardNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenStash.cs
+++ b/CP77.CR2W/Types/cp77/OpenStash.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenStash.cs
+++ b/CP77.CR2W/Types/cp77/OpenStash.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OpenTarotCollectionNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenTarotCollectionNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenVendorUI.cs
+++ b/CP77.CR2W/Types/cp77/OpenVendorUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenVendorUI.cs
+++ b/CP77.CR2W/Types/cp77/OpenVendorUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OpenWorldMapDeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenWorldMapDeviceAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OpenWorldMapNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/OpenWorldMapNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OperationExecutionData.cs
+++ b/CP77.CR2W/Types/cp77/OperationExecutionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OrderTakedownEvent.cs
+++ b/CP77.CR2W/Types/cp77/OrderTakedownEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OrientedBox.cs
+++ b/CP77.CR2W/Types/cp77/OrientedBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutOfCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OutOfCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutOfCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OutOfCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OutOfCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/OutOfCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutOfCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/OutOfCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OutlineData.cs
+++ b/CP77.CR2W/Types/cp77/OutlineData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutlineItemRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/OutlineItemRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutlineRequest.cs
+++ b/CP77.CR2W/Types/cp77/OutlineRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutlineRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/OutlineRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutlineRequestManager.cs
+++ b/CP77.CR2W/Types/cp77/OutlineRequestManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutputPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/OutputPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OutputValidationDataStruct.cs
+++ b/CP77.CR2W/Types/cp77/OutputValidationDataStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OverchargeDevice.cs
+++ b/CP77.CR2W/Types/cp77/OverchargeDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OverchargeDevice.cs
+++ b/CP77.CR2W/Types/cp77/OverchargeDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OverheatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OverheatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OverheatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/OverheatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OverheatEvents.cs
+++ b/CP77.CR2W/Types/cp77/OverheatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OverheatEvents.cs
+++ b/CP77.CR2W/Types/cp77/OverheatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/OverheatStatListener.cs
+++ b/CP77.CR2W/Types/cp77/OverheatStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Overlap.cs
+++ b/CP77.CR2W/Types/cp77/Overlap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OverloadDevice.cs
+++ b/CP77.CR2W/Types/cp77/OverloadDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OwnerWeaponChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/OwnerWeaponChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OxygenListener.cs
+++ b/CP77.CR2W/Types/cp77/OxygenListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OxygenStatListener.cs
+++ b/CP77.CR2W/Types/cp77/OxygenStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/OxygenbarWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/OxygenbarWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSD_Detector.cs
+++ b/CP77.CR2W/Types/cp77/PSD_Detector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSD_Detector.cs
+++ b/CP77.CR2W/Types/cp77/PSD_Detector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PSD_DetectorPS.cs
+++ b/CP77.CR2W/Types/cp77/PSD_DetectorPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSD_Master.cs
+++ b/CP77.CR2W/Types/cp77/PSD_Master.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSD_Master.cs
+++ b/CP77.CR2W/Types/cp77/PSD_Master.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PSD_MasterPS.cs
+++ b/CP77.CR2W/Types/cp77/PSD_MasterPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSD_MasterPS.cs
+++ b/CP77.CR2W/Types/cp77/PSD_MasterPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PSD_Trigger.cs
+++ b/CP77.CR2W/Types/cp77/PSD_Trigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescBlendModeDesc.cs
+++ b/CP77.CR2W/Types/cp77/PSODescBlendModeDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescDepthStencilModeDesc.cs
+++ b/CP77.CR2W/Types/cp77/PSODescDepthStencilModeDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescRasterizerModeDesc.cs
+++ b/CP77.CR2W/Types/cp77/PSODescRasterizerModeDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescRenderTarget.cs
+++ b/CP77.CR2W/Types/cp77/PSODescRenderTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescRenderTargetSetup.cs
+++ b/CP77.CR2W/Types/cp77/PSODescRenderTargetSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSODescStencilFuncDesc.cs
+++ b/CP77.CR2W/Types/cp77/PSODescStencilFuncDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSOwnerData.cs
+++ b/CP77.CR2W/Types/cp77/PSOwnerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/PSRefreshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PSRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/PSRefreshEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PUPPET_ACtor.cs
+++ b/CP77.CR2W/Types/cp77/PUPPET_ACtor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PUPPET_ACtor.cs
+++ b/CP77.CR2W/Types/cp77/PUPPET_ACtor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PachinkoMachine.cs
+++ b/CP77.CR2W/Types/cp77/PachinkoMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PachinkoMachineController.cs
+++ b/CP77.CR2W/Types/cp77/PachinkoMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PachinkoMachineController.cs
+++ b/CP77.CR2W/Types/cp77/PachinkoMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PachinkoMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/PachinkoMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PachinkoMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/PachinkoMachineControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PainReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/PainReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PanzerSmartWeaponTargetController.cs
+++ b/CP77.CR2W/Types/cp77/PanzerSmartWeaponTargetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaperDollSlotController.cs
+++ b/CP77.CR2W/Types/cp77/PaperDollSlotController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaperdollGlitchController.cs
+++ b/CP77.CR2W/Types/cp77/PaperdollGlitchController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ParryReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/ParryReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ParryReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/ParryReactionTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PartInstallRequest.cs
+++ b/CP77.CR2W/Types/cp77/PartInstallRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PartUninstallRequest.cs
+++ b/CP77.CR2W/Types/cp77/PartUninstallRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ParticleBurst.cs
+++ b/CP77.CR2W/Types/cp77/ParticleBurst.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ParticleDamage.cs
+++ b/CP77.CR2W/Types/cp77/ParticleDamage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassengerDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PassengerDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassengerDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PassengerDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PassengerEvents.cs
+++ b/CP77.CR2W/Types/cp77/PassengerEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassengerEvents.cs
+++ b/CP77.CR2W/Types/cp77/PassengerEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PassiveAlertedConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassiveAlertedConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveAutonomousCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveAutonomousCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveAutonomousCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveAutonomousCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PassiveCannotMoveConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassiveCannotMoveConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveCombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassiveCombatConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveCommandCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveCommandCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveCoverSelectionConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassiveCoverSelectionConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveGlobalDeathCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveGlobalDeathCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveIsPlayerCompanionCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveIsPlayerCompanionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveNoWeaponCombatConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassiveNoWeaponCombatConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassivePatrolConditions.cs
+++ b/CP77.CR2W/Types/cp77/PassivePatrolConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PassiveRoleCondition.cs
+++ b/CP77.CR2W/Types/cp77/PassiveRoleCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolAction.cs
+++ b/CP77.CR2W/Types/cp77/PatrolAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolAction.cs
+++ b/CP77.CR2W/Types/cp77/PatrolAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PatrolAlertedCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/PatrolAlertedCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolAlertedControllerTask.cs
+++ b/CP77.CR2W/Types/cp77/PatrolAlertedControllerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolAlertedControllerTask.cs
+++ b/CP77.CR2W/Types/cp77/PatrolAlertedControllerTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PatrolCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/PatrolCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolControllerTask.cs
+++ b/CP77.CR2W/Types/cp77/PatrolControllerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolControllerTask.cs
+++ b/CP77.CR2W/Types/cp77/PatrolControllerTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PatrolRoleCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/PatrolRoleCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolRoleHandler.cs
+++ b/CP77.CR2W/Types/cp77/PatrolRoleHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PatrolRoleHandler.cs
+++ b/CP77.CR2W/Types/cp77/PatrolRoleHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PatrolSpotAction.cs
+++ b/CP77.CR2W/Types/cp77/PatrolSpotAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseBraindance.cs
+++ b/CP77.CR2W/Types/cp77/PauseBraindance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseBraindance.cs
+++ b/CP77.CR2W/Types/cp77/PauseBraindance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PauseMenuBackgroundGameController.cs
+++ b/CP77.CR2W/Types/cp77/PauseMenuBackgroundGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseMenuBackgroundGameController.cs
+++ b/CP77.CR2W/Types/cp77/PauseMenuBackgroundGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PauseMenuButtonItem.cs
+++ b/CP77.CR2W/Types/cp77/PauseMenuButtonItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/PauseMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseMenuListItemData.cs
+++ b/CP77.CR2W/Types/cp77/PauseMenuListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PauseResumePhoneCallEvent.cs
+++ b/CP77.CR2W/Types/cp77/PauseResumePhoneCallEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Pay.cs
+++ b/CP77.CR2W/Types/cp77/Pay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Pay.cs
+++ b/CP77.CR2W/Types/cp77/Pay.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PayActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/PayActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaymentBalanced_ScriptConditionType.cs
+++ b/CP77.CR2W/Types/cp77/PaymentBalanced_ScriptConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaymentBluelinePart.cs
+++ b/CP77.CR2W/Types/cp77/PaymentBluelinePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaymentConditionTypeBase.cs
+++ b/CP77.CR2W/Types/cp77/PaymentConditionTypeBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PaymentFixedAmount_ScriptConditionType.cs
+++ b/CP77.CR2W/Types/cp77/PaymentFixedAmount_ScriptConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PendingSecuritySystemDisable.cs
+++ b/CP77.CR2W/Types/cp77/PendingSecuritySystemDisable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerformFastTravelRequest.cs
+++ b/CP77.CR2W/Types/cp77/PerformFastTravelRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerformedAction.cs
+++ b/CP77.CR2W/Types/cp77/PerformedAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkBoughtEvent.cs
+++ b/CP77.CR2W/Types/cp77/PerkBoughtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkDisplayContainerController.cs
+++ b/CP77.CR2W/Types/cp77/PerkDisplayContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkDisplayContainerCreatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/PerkDisplayContainerCreatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/PerkDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/PerkDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkDisplayTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/PerkDisplayTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/PerkHoverOutEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkHoverOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/PerkHoverOverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkMenuTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/PerkMenuTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PerkPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/PerkPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/PerkPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PerkScreenController.cs
+++ b/CP77.CR2W/Types/cp77/PerkScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerkTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/PerkTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksItemHoldStart.cs
+++ b/CP77.CR2W/Types/cp77/PerksItemHoldStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksLevelBarController.cs
+++ b/CP77.CR2W/Types/cp77/PerksLevelBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/PerksMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemClicked.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemClicked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemController.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemCreated.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemCreated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoldStart.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoldStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoverOut.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoverOut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoverOver.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuAttributeItemHoverOver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksMenuProficiencyItemClicked.cs
+++ b/CP77.CR2W/Types/cp77/PerksMenuProficiencyItemClicked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksPointsDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/PerksPointsDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksScreenStaticData.cs
+++ b/CP77.CR2W/Types/cp77/PerksScreenStaticData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksScreenStaticData.cs
+++ b/CP77.CR2W/Types/cp77/PerksScreenStaticData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PerksSkillLabelContentContainer.cs
+++ b/CP77.CR2W/Types/cp77/PerksSkillLabelContentContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksSkillLabelController.cs
+++ b/CP77.CR2W/Types/cp77/PerksSkillLabelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksSkillLabelController.cs
+++ b/CP77.CR2W/Types/cp77/PerksSkillLabelController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PerksSkillsLevelDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/PerksSkillsLevelDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PerksSkillsLevelsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/PerksSkillsLevelsContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PersonnelSystem.cs
+++ b/CP77.CR2W/Types/cp77/PersonnelSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PersonnelSystemController.cs
+++ b/CP77.CR2W/Types/cp77/PersonnelSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PersonnelSystemController.cs
+++ b/CP77.CR2W/Types/cp77/PersonnelSystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PersonnelSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/PersonnelSystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PersonnelSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/PersonnelSystemControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneCallUploadDurationListener.cs
+++ b/CP77.CR2W/Types/cp77/PhoneCallUploadDurationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneContactItemVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/PhoneContactItemVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneDialerDelayedInit.cs
+++ b/CP77.CR2W/Types/cp77/PhoneDialerDelayedInit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneDialerDelayedInit.cs
+++ b/CP77.CR2W/Types/cp77/PhoneDialerDelayedInit.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneDialerGameController.cs
+++ b/CP77.CR2W/Types/cp77/PhoneDialerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneHotkeyController.cs
+++ b/CP77.CR2W/Types/cp77/PhoneHotkeyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneMessageHidePopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/PhoneMessageHidePopupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneMessageHidePopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/PhoneMessageHidePopupEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneMessageNotificationsGameController.cs
+++ b/CP77.CR2W/Types/cp77/PhoneMessageNotificationsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneMessagePopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/PhoneMessagePopupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneMessagePopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/PhoneMessagePopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneOffDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOffDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneOffDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOffDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneOffEvents.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOffEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneOffEvents.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOffEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneOnDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOnDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneOnDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOnDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneOnEvents.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOnEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneOnEvents.cs
+++ b/CP77.CR2W/Types/cp77/PhoneOnEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhoneSystem.cs
+++ b/CP77.CR2W/Types/cp77/PhoneSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneTimeoutRequest.cs
+++ b/CP77.CR2W/Types/cp77/PhoneTimeoutRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhoneTimeoutRequest.cs
+++ b/CP77.CR2W/Types/cp77/PhoneTimeoutRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhotoModeCameraLocation.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeCameraLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeDef.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeFrame.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeFrame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeListController.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeMenuListItem.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeMenuListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeMenuListItemData.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeMenuListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModePlayerEntityComponent.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModePlayerEntityComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeQuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeQuestPrefabStateListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeQuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeQuestPrefabStateListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhotoModeSticker.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeSticker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeToggle.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeToggle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhotoModeTopBarController.cs
+++ b/CP77.CR2W/Types/cp77/PhotoModeTopBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhysicalHackingEvent.cs
+++ b/CP77.CR2W/Types/cp77/PhysicalHackingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhysicsFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/PhysicsFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhysicsFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/PhysicsFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PhysicsParticleInitializer.cs
+++ b/CP77.CR2W/Types/cp77/PhysicsParticleInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PhysicsParticleInitializer.cs
+++ b/CP77.CR2W/Types/cp77/PhysicsParticleInitializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownEvents.cs
+++ b/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownEvents.cs
+++ b/CP77.CR2W/Types/cp77/PickUpBodyAfterTakedownEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PickUpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PickUpDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PickUpDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PickUpDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PickUpEvents.cs
+++ b/CP77.CR2W/Types/cp77/PickUpEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PickupPhoneRequest.cs
+++ b/CP77.CR2W/Types/cp77/PickupPhoneRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingCachedData.cs
+++ b/CP77.CR2W/Types/cp77/PingCachedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingDevice.cs
+++ b/CP77.CR2W/Types/cp77/PingDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingNetworkGridEvent.cs
+++ b/CP77.CR2W/Types/cp77/PingNetworkGridEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingSquad.cs
+++ b/CP77.CR2W/Types/cp77/PingSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingSquadEffector.cs
+++ b/CP77.CR2W/Types/cp77/PingSquadEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingSystemMappinController.cs
+++ b/CP77.CR2W/Types/cp77/PingSystemMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PingSystemMappinController.cs
+++ b/CP77.CR2W/Types/cp77/PingSystemMappinController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PipelineProcessedCallback.cs
+++ b/CP77.CR2W/Types/cp77/PipelineProcessedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PipelineProcessedCallback.cs
+++ b/CP77.CR2W/Types/cp77/PipelineProcessedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlaceMineEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlaceMineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Plane.cs
+++ b/CP77.CR2W/Types/cp77/Plane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayBinkDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/PlayBinkDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayBinkEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayBinkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayBreathingAnimationEffector.cs
+++ b/CP77.CR2W/Types/cp77/PlayBreathingAnimationEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayDeafeningMusic.cs
+++ b/CP77.CR2W/Types/cp77/PlayDeafeningMusic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayDeafeningMusic.cs
+++ b/CP77.CR2W/Types/cp77/PlayDeafeningMusic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayEffectDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/PlayEffectDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayInitFearAnimation.cs
+++ b/CP77.CR2W/Types/cp77/PlayInitFearAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayInitFearAnimation.cs
+++ b/CP77.CR2W/Types/cp77/PlayInitFearAnimation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayLibraryAnimationButtonView.cs
+++ b/CP77.CR2W/Types/cp77/PlayLibraryAnimationButtonView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayPauseActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/PlayPauseActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayRadio.cs
+++ b/CP77.CR2W/Types/cp77/PlayRadio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayRecordedSessionMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/PlayRecordedSessionMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlaySFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/PlaySFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlaySoundDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/PlaySoundDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlaySoundEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlaySoundEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayTransformAnimationDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/PlayTransformAnimationDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayVFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/PlayVFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlaybackOptionsUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/PlaybackOptionsUpdateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCanGiveCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCanGiveCPOMissionDataPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCanGiveCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCanGiveCPOMissionDataPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerCanTakeCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCanTakeCPOMissionDataPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCanTakeCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCanTakeCPOMissionDataPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerCombatStateTimePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCombatStateTimePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCombatStateTimePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCombatStateTimePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCompanionCacheDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCompanionCacheDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerControlDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/PlayerControlDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerControlsDevicePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerControlsDevicePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCoverHelper.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCoverHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerCoverHelper.cs
+++ b/CP77.CR2W/Types/cp77/PlayerCoverHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerDamageFromDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDamageFromDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerDamageFromDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDamageFromDataEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerDeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDeadPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerDeadPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDeadPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerDevUpdateDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDevUpdateDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerDevUpdateDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDevUpdateDataEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerDevelopmentData.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDevelopmentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerDevelopmentDataManager.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDevelopmentDataManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerDevelopmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/PlayerDevelopmentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerEnteredNewDistrictEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerEnteredNewDistrictEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/PlayerFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/PlayerFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerGameplayRestrictions.cs
+++ b/CP77.CR2W/Types/cp77/PlayerGameplayRestrictions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerGameplayRestrictions.cs
+++ b/CP77.CR2W/Types/cp77/PlayerGameplayRestrictions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerHandicapSystem.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHandicapSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHasCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasCPOMissionDataPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHasCPOMissionDataPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasCPOMissionDataPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerHasMantisBladesEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasMantisBladesEquippedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHasMantisBladesEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasMantisBladesEquippedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerHasNanoWiresEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasNanoWiresEquippedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHasNanoWiresEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasNanoWiresEquippedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerHasTakedownWeaponEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasTakedownWeaponEquippedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHasTakedownWeaponEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHasTakedownWeaponEquippedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerHostileThreatDetected.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHostileThreatDetected.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerHostileThreatDetected.cs
+++ b/CP77.CR2W/Types/cp77/PlayerHostileThreatDetected.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerIgnoreFriendlyAndAlive.cs
+++ b/CP77.CR2W/Types/cp77/PlayerIgnoreFriendlyAndAlive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerIgnoreFriendlyAndAlive.cs
+++ b/CP77.CR2W/Types/cp77/PlayerIgnoreFriendlyAndAlive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerListEntryData.cs
+++ b/CP77.CR2W/Types/cp77/PlayerListEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerListEntryLogicController.cs
+++ b/CP77.CR2W/Types/cp77/PlayerListEntryLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerMuntedToMyVehicle.cs
+++ b/CP77.CR2W/Types/cp77/PlayerMuntedToMyVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerNotCarryingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotCarryingPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerNotCarryingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotCarryingPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerNotGrapplingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotGrapplingPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerNotGrapplingPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotGrapplingPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerNotInBraindancePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotInBraindancePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerNotInBraindancePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerNotInBraindancePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerPerkDataDef.cs
+++ b/CP77.CR2W/Types/cp77/PlayerPerkDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerPhone.cs
+++ b/CP77.CR2W/Types/cp77/PlayerPhone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerPhone.cs
+++ b/CP77.CR2W/Types/cp77/PlayerPhone.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerPuppet.cs
+++ b/CP77.CR2W/Types/cp77/PlayerPuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerPuppetPS.cs
+++ b/CP77.CR2W/Types/cp77/PlayerPuppetPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerQuickhackData.cs
+++ b/CP77.CR2W/Types/cp77/PlayerQuickhackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerSecureAreaDef.cs
+++ b/CP77.CR2W/Types/cp77/PlayerSecureAreaDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerSpotted.cs
+++ b/CP77.CR2W/Types/cp77/PlayerSpotted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerSquadInterface.cs
+++ b/CP77.CR2W/Types/cp77/PlayerSquadInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerSquadInterface.cs
+++ b/CP77.CR2W/Types/cp77/PlayerSquadInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerStaminaHelpers.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStaminaHelpers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStaminaHelpers.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStaminaHelpers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerStateMachineDef.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachineDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachinePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachinePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachinePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachinePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachineTestFiveInput.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachineTestFiveInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachineTestFourInput.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachineTestFourInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachineTestFourOutput.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachineTestFourOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStateMachineTestThreeOutput.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStateMachineTestThreeOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/PlayerStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerTargetChangedRequest.cs
+++ b/CP77.CR2W/Types/cp77/PlayerTargetChangedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerTotalDamageAgainstHealth.cs
+++ b/CP77.CR2W/Types/cp77/PlayerTotalDamageAgainstHealth.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerUnauthorized.cs
+++ b/CP77.CR2W/Types/cp77/PlayerUnauthorized.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVehicleStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVehicleStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVehicleStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVehicleStatePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeController.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerActiveFlags.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerActiveFlags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBIds.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBIds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBListeners.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBListeners.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBValuesIds.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBBValuesIds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBlackboardListenersFunctions.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerBlackboardListenersFunctions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputActionsNames.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputActionsNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputActiveFlags.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputActiveFlags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputListeners.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInputListeners.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInvalidateEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerInvalidateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerOtherVars.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerOtherVars.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerVisionModeControllerRefreshPolicy.cs
+++ b/CP77.CR2W/Types/cp77/PlayerVisionModeControllerRefreshPolicy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerWeaponSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerWeaponSetupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PlayerWeaponSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/PlayerWeaponSetupEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PlayerWokrspotDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/PlayerWokrspotDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Point.cs
+++ b/CP77.CR2W/Types/cp77/Point.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Point3D.cs
+++ b/CP77.CR2W/Types/cp77/Point3D.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PointerController.cs
+++ b/CP77.CR2W/Types/cp77/PointerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PointerSlot.cs
+++ b/CP77.CR2W/Types/cp77/PointerSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PointerSlot.cs
+++ b/CP77.CR2W/Types/cp77/PointerSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PopupStateUtils.cs
+++ b/CP77.CR2W/Types/cp77/PopupStateUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PopupStateUtils.cs
+++ b/CP77.CR2W/Types/cp77/PopupStateUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PositionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/PositionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PositionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/PositionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PostponedCursorContext.cs
+++ b/CP77.CR2W/Types/cp77/PostponedCursorContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreCrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PreCrouchLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreCrouchLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PreCrouchLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreCrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/PreCrouchLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreCrouchLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/PreCrouchLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreGameSubMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/PreGameSubMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PrecisionRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PrecisionRifleLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PrecisionRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PrecisionRifleLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PrecisionRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/PrecisionRifleLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PrecisionRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/PrecisionRifleLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreloadAnimationsEvent.cs
+++ b/CP77.CR2W/Types/cp77/PreloadAnimationsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PresetAction.cs
+++ b/CP77.CR2W/Types/cp77/PresetAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PresetTimetableEvent.cs
+++ b/CP77.CR2W/Types/cp77/PresetTimetableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionAgents.cs
+++ b/CP77.CR2W/Types/cp77/PreventionAgents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionBountyViewData.cs
+++ b/CP77.CR2W/Types/cp77/PreventionBountyViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionCombatStartedRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionCombatStartedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionConditionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/PreventionConditionAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionConditionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/PreventionConditionAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreventionConsoleInstructionRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionConsoleInstructionRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionCrimeWitnessRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionCrimeWitnessRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDamageRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDamageRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDelayed100SpawnPoliceRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayed100SpawnPoliceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDelayed100SpawnPoliceRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayed100SpawnPoliceRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreventionDelayedSpawnRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayedSpawnRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDelayedSpawnUnitRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayedSpawnUnitRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDelayedZeroRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayedZeroRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionDelayedZeroRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionDelayedZeroRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreventionForceSpawnPoliceRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionForceSpawnPoliceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionForceSpawnPoliceRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionForceSpawnPoliceRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreventionNotification.cs
+++ b/CP77.CR2W/Types/cp77/PreventionNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionPoliceSecuritySystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionPoliceSecuritySystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionRegisterRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionRegisterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionSecurityAreaRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionSecurityAreaRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionSystem.cs
+++ b/CP77.CR2W/Types/cp77/PreventionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionSystemConfig.cs
+++ b/CP77.CR2W/Types/cp77/PreventionSystemConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionTickRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionTickRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionTickRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionTickRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PreventionVehicleStolenRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionVehicleStolenRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreventionVisibilityRequest.cs
+++ b/CP77.CR2W/Types/cp77/PreventionVisibilityRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreviousFearPhaseCheck.cs
+++ b/CP77.CR2W/Types/cp77/PreviousFearPhaseCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreviousMenuData.cs
+++ b/CP77.CR2W/Types/cp77/PreviousMenuData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreviousStation.cs
+++ b/CP77.CR2W/Types/cp77/PreviousStation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PreviousStation.cs
+++ b/CP77.CR2W/Types/cp77/PreviousStation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PrimaryWeaponTypeCondition.cs
+++ b/CP77.CR2W/Types/cp77/PrimaryWeaponTypeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PriorityCheckEventCondition.cs
+++ b/CP77.CR2W/Types/cp77/PriorityCheckEventCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PriorityCheckEventCondition.cs
+++ b/CP77.CR2W/Types/cp77/PriorityCheckEventCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProcessQueuedCombatExperience.cs
+++ b/CP77.CR2W/Types/cp77/ProcessQueuedCombatExperience.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProcessVendettaAchievementEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProcessVendettaAchievementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProcessVisualTags.cs
+++ b/CP77.CR2W/Types/cp77/ProcessVisualTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProficiencyButtonController.cs
+++ b/CP77.CR2W/Types/cp77/ProficiencyButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProficiencyDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/ProficiencyDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProficiencyProgressEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProficiencyProgressEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProficiencyTabButtonController.cs
+++ b/CP77.CR2W/Types/cp77/ProficiencyTabButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramAction.cs
+++ b/CP77.CR2W/Types/cp77/ProgramAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramAction.cs
+++ b/CP77.CR2W/Types/cp77/ProgramAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProgramData.cs
+++ b/CP77.CR2W/Types/cp77/ProgramData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramProgressData.cs
+++ b/CP77.CR2W/Types/cp77/ProgramProgressData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramSetDeviceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/ProgramSetDeviceAttitude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramSetDeviceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/ProgramSetDeviceAttitude.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProgramSetDeviceOff.cs
+++ b/CP77.CR2W/Types/cp77/ProgramSetDeviceOff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramSetDeviceOff.cs
+++ b/CP77.CR2W/Types/cp77/ProgramSetDeviceOff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProgramTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/ProgramTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramTooltipEffectController.cs
+++ b/CP77.CR2W/Types/cp77/ProgramTooltipEffectController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgramTooltipEffectController.cs
+++ b/CP77.CR2W/Types/cp77/ProgramTooltipEffectController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProgramTooltipStatController.cs
+++ b/CP77.CR2W/Types/cp77/ProgramTooltipStatController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressBarAnimationChunkController.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarAnimationChunkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressBarButton.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressBarFinishedProccess.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarFinishedProccess.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressBarFinishedProccess.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarFinishedProccess.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProgressBarSimpleWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarSimpleWidgetLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressBarsController.cs
+++ b/CP77.CR2W/Types/cp77/ProgressBarsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressionNotification.cs
+++ b/CP77.CR2W/Types/cp77/ProgressionNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProgressionWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/ProgressionWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileBreachEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileBreachEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileBreachEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileBreachEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileGameEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileGameEffectHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileGameEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileGameEffectHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileHitHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileHitHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileHitHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileHitHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileLaunchHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLaunchHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLaunchHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLaunchHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRound.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundBreachEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundBreachEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundBreachEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundBreachEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDetonationDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDetonationDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDetonationDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundDetonationDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundTickEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileLauncherRoundTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileLauncherRoundTickEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileTargetingHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileTargetingHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileTargetingHelper.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileTargetingHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProjectileTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileTickEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProjectileTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProjectileTickEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProtectedEntities.cs
+++ b/CP77.CR2W/Types/cp77/ProtectedEntities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProximityDetector.cs
+++ b/CP77.CR2W/Types/cp77/ProximityDetector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProximityDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/ProximityDetectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProximityDetectorController.cs
+++ b/CP77.CR2W/Types/cp77/ProximityDetectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProximityDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ProximityDetectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProximityDetectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ProximityDetectorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ProximityLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProximityLookatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ProximityLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/ProximityLookatEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PublicSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PublicSafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PublicSafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PublicSafeToReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeToReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PublicSafeToReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeToReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PublicSafeToReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeToReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PublicSafeToReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/PublicSafeToReadyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PullSquadSyncRequest.cs
+++ b/CP77.CR2W/Types/cp77/PullSquadSyncRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PulseFinishedRequest.cs
+++ b/CP77.CR2W/Types/cp77/PulseFinishedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PulseFinishedRequest.cs
+++ b/CP77.CR2W/Types/cp77/PulseFinishedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PuppetAction.cs
+++ b/CP77.CR2W/Types/cp77/PuppetAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetAction.cs
+++ b/CP77.CR2W/Types/cp77/PuppetAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PuppetActionContext.cs
+++ b/CP77.CR2W/Types/cp77/PuppetActionContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetDef.cs
+++ b/CP77.CR2W/Types/cp77/PuppetDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetDeviceLinkPS.cs
+++ b/CP77.CR2W/Types/cp77/PuppetDeviceLinkPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetForceVisionAppearanceData.cs
+++ b/CP77.CR2W/Types/cp77/PuppetForceVisionAppearanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetIncapacitatedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PuppetIncapacitatedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetIncapacitatedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PuppetIncapacitatedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PuppetListener.cs
+++ b/CP77.CR2W/Types/cp77/PuppetListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetMortalPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PuppetMortalPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetNotBossPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PuppetNotBossPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetNotBossPrereq.cs
+++ b/CP77.CR2W/Types/cp77/PuppetNotBossPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/PuppetReactionDef.cs
+++ b/CP77.CR2W/Types/cp77/PuppetReactionDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetSquadInterface.cs
+++ b/CP77.CR2W/Types/cp77/PuppetSquadInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/PuppetStateDef.cs
+++ b/CP77.CR2W/Types/cp77/PuppetStateDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QHackWheelItemChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/QHackWheelItemChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QhackExecuted.cs
+++ b/CP77.CR2W/Types/cp77/QhackExecuted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QhackExecuted.cs
+++ b/CP77.CR2W/Types/cp77/QhackExecuted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QsTransform.cs
+++ b/CP77.CR2W/Types/cp77/QsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Quad.cs
+++ b/CP77.CR2W/Types/cp77/Quad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuadRacerBonusCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/QuadRacerBonusCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuadRacerGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuadRacerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuadRacerObstacleCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/QuadRacerObstacleCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuadRacerObstacleCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/QuadRacerObstacleCollisionLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuantityPickerPopupCloseData.cs
+++ b/CP77.CR2W/Types/cp77/QuantityPickerPopupCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuantityPickerPopupData.cs
+++ b/CP77.CR2W/Types/cp77/QuantityPickerPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Quaternion.cs
+++ b/CP77.CR2W/Types/cp77/Quaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestAddTransition.cs
+++ b/CP77.CR2W/Types/cp77/QuestAddTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestAnimationMappinController.cs
+++ b/CP77.CR2W/Types/cp77/QuestAnimationMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestBreachAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/QuestBreachAccessPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestBreachAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/QuestBreachAccessPoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestChangeSecuritySystemAttitudeGroup.cs
+++ b/CP77.CR2W/Types/cp77/QuestChangeSecuritySystemAttitudeGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCloseAllDoors.cs
+++ b/CP77.CR2W/Types/cp77/QuestCloseAllDoors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCloseAllDoors.cs
+++ b/CP77.CR2W/Types/cp77/QuestCloseAllDoors.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestCodexLinkController.cs
+++ b/CP77.CR2W/Types/cp77/QuestCodexLinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCombatActionAreaNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestCombatActionAreaNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCombatActionNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestCombatActionNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCombatActionNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestCombatActionNotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestContactLinkController.cs
+++ b/CP77.CR2W/Types/cp77/QuestContactLinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCustomAction.cs
+++ b/CP77.CR2W/Types/cp77/QuestCustomAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestCustomAction.cs
+++ b/CP77.CR2W/Types/cp77/QuestCustomAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestDataWrapper.cs
+++ b/CP77.CR2W/Types/cp77/QuestDataWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDetailsObjectiveController.cs
+++ b/CP77.CR2W/Types/cp77/QuestDetailsObjectiveController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDetailsPanelController.cs
+++ b/CP77.CR2W/Types/cp77/QuestDetailsPanelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDisableFixing.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableFixing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDisableFixing.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableFixing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestDisableInteraction.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableInteraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDisableInteraction.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableInteraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestDisableLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableLiftTravelTimeOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDisableLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableLiftTravelTimeOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestDisableRadio.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableRadio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestDisableRadio.cs
+++ b/CP77.CR2W/Types/cp77/QuestDisableRadio.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestEnableFixing.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableFixing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestEnableFixing.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableFixing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestEnableInteraction.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableInteraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestEnableInteraction.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableInteraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestEnableLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableLiftTravelTimeOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestEnableLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestEnableLiftTravelTimeOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestExecuteTransition.cs
+++ b/CP77.CR2W/Types/cp77/QuestExecuteTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestFollowTarget.cs
+++ b/CP77.CR2W/Types/cp77/QuestFollowTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceActivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceActivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAttitude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAttitude.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceAuthorizationDisabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAuthorizationDisabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceAuthorizationDisabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAuthorizationDisabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceAuthorizationEnabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAuthorizationEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceAuthorizationEnabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceAuthorizationEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceCameraZoom.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceCameraZoom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceClearGlass.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceClearGlass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceClearGlass.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceClearGlass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceClose.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceClose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceClose.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceClose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceCloseImmediate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceCloseImmediate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceCloseImmediate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceCloseImmediate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceCloseScene.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceCloseScene.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceCloseScene.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceCloseScene.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDeactivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDeactivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceDestructible.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDestructible.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceDestructible.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDestructible.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceDetonate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDetonate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceDetonate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDetonate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceDisabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDisabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceDisabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDisabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceDisconnectPersonalLink.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDisconnectPersonalLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceDisconnectPersonalLink.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceDisconnectPersonalLink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceEnabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceEnabled.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceFakeElevatorArrows.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceFakeElevatorArrows.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceFakeElevatorArrows.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceFakeElevatorArrows.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceGlitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceGlitch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceGoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceGoToFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceGoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceGoToFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceIndestructible.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceIndestructible.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceIndestructible.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceIndestructible.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceInvulnerable.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceInvulnerable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceInvulnerable.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceInvulnerable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapArmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapArmed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapArmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapArmed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapDeactivated.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapDeactivated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapDeactivated.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceJuryrigTrapDeactivated.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceLock.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceLock.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceLock.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceOFF.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOFF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceOFF.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOFF.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceON.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceON.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceON.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceOpen.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceOpen.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOpen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceOpenScene.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOpenScene.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceOpenScene.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOpenScene.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceOverheat.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOverheat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceOverheat.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceOverheat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForcePersonalLinkUnderStrictQuestControl.cs
+++ b/CP77.CR2W/Types/cp77/QuestForcePersonalLinkUnderStrictQuestControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForcePersonalLinkUnderStrictQuestControl.cs
+++ b/CP77.CR2W/Types/cp77/QuestForcePersonalLinkUnderStrictQuestControl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForcePower.cs
+++ b/CP77.CR2W/Types/cp77/QuestForcePower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForcePower.cs
+++ b/CP77.CR2W/Types/cp77/QuestForcePower.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceReload.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceReload.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceReload.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceReload.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceReplaceStreamWithVideo.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceReplaceStreamWithVideo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceReplaceStreamWithVideo.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceReplaceStreamWithVideo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeActivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeActivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeDeactivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceRoadBlockadeDeactivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceScanEffect.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceScanEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceScanEffect.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceScanEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceScanEffectStop.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceScanEffectStop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceScanEffectStop.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceScanEffectStop.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceSeal.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSeal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceSeal.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSeal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemAlarmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemAlarmed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemAlarmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemAlarmed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemArmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemArmed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemArmed.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemArmed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemSafe.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemSafe.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceSecuritySystemSafe.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceSecuritySystemSafe.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceStopReplacingStream.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceStopReplacingStream.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceStopReplacingStream.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceStopReplacingStream.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceStopTakeControlOverCamera.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceStopTakeControlOverCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceStopTakeControlOverCamera.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceStopTakeControlOverCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCamera.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCamera.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCameraWithChain.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCameraWithChain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCameraWithChain.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTakeControlOverCameraWithChain.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceTeleportToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTeleportToFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceTeleportToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTeleportToFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceTintGlass.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTintGlass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceTintGlass.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceTintGlass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceUnlock.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceUnlock.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnlock.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceUnpower.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnpower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceUnpower.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnpower.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestForceUnseal.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnseal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestForceUnseal.cs
+++ b/CP77.CR2W/Types/cp77/QuestForceUnseal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestGoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestGoToFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestGoToFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestGoToFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestHangUpCall.cs
+++ b/CP77.CR2W/Types/cp77/QuestHangUpCall.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestHangUpCall.cs
+++ b/CP77.CR2W/Types/cp77/QuestHangUpCall.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestHideFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestHideFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestHideFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestHideFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestIllegalActionAreaNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestIllegalActionAreaNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestIllegalActionNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestIllegalActionNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestIllegalActionNotification.cs
+++ b/CP77.CR2W/Types/cp77/QuestIllegalActionNotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestItemController.cs
+++ b/CP77.CR2W/Types/cp77/QuestItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListDistanceData.cs
+++ b/CP77.CR2W/Types/cp77/QuestListDistanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListHeaderClicked.cs
+++ b/CP77.CR2W/Types/cp77/QuestListHeaderClicked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListHeaderController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListHeaderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListHeaderData.cs
+++ b/CP77.CR2W/Types/cp77/QuestListHeaderData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListHeaderLogicController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListHeaderLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListItemController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListItemData.cs
+++ b/CP77.CR2W/Types/cp77/QuestListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListItemHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestListItemHoverOutEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListItemHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestListItemHoverOutEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestListItemHoverOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestListItemHoverOverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListVirtualNestedDataView.cs
+++ b/CP77.CR2W/Types/cp77/QuestListVirtualNestedDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListVirtualNestedDataView.cs
+++ b/CP77.CR2W/Types/cp77/QuestListVirtualNestedDataView.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestListVirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListVirtualNestedListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestListVirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/QuestListVirtualNestedListController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestLogUtils.cs
+++ b/CP77.CR2W/Types/cp77/QuestLogUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestLogUtils.cs
+++ b/CP77.CR2W/Types/cp77/QuestLogUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestLookAtTarget.cs
+++ b/CP77.CR2W/Types/cp77/QuestLookAtTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMappinController.cs
+++ b/CP77.CR2W/Types/cp77/QuestMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMappinHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestMappinHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMappinLinkController.cs
+++ b/CP77.CR2W/Types/cp77/QuestMappinLinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMessageSelector.cs
+++ b/CP77.CR2W/Types/cp77/QuestMessageSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestModifyFilters.cs
+++ b/CP77.CR2W/Types/cp77/QuestModifyFilters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMuteSounds.cs
+++ b/CP77.CR2W/Types/cp77/QuestMuteSounds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestMuteSounds.cs
+++ b/CP77.CR2W/Types/cp77/QuestMuteSounds.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestObjectiveHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestObjectiveHoverOutEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestObjectiveHoverOutEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestObjectiveHoverOutEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestObjectiveHoverOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestObjectiveHoverOverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestObjectiveHoverOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestObjectiveHoverOverEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestObjectiveWrapper.cs
+++ b/CP77.CR2W/Types/cp77/QuestObjectiveWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestPickUpCall.cs
+++ b/CP77.CR2W/Types/cp77/QuestPickUpCall.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestPickUpCall.cs
+++ b/CP77.CR2W/Types/cp77/QuestPickUpCall.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/QuestPrefabStateListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/QuestPrefabStateListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestRemoveQuickHacks.cs
+++ b/CP77.CR2W/Types/cp77/QuestRemoveQuickHacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestRemoveQuickHacks.cs
+++ b/CP77.CR2W/Types/cp77/QuestRemoveQuickHacks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestRemoveTransition.cs
+++ b/CP77.CR2W/Types/cp77/QuestRemoveTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestRemoveWeapon.cs
+++ b/CP77.CR2W/Types/cp77/QuestRemoveWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestRemoveWeapon.cs
+++ b/CP77.CR2W/Types/cp77/QuestRemoveWeapon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestResetDeviceToInitialState.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetDeviceToInitialState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestResetDeviceToInitialState.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetDeviceToInitialState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestResetFakeElevatorArrows.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetFakeElevatorArrows.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestResetFakeElevatorArrows.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetFakeElevatorArrows.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestResetPerfomedActionsStorage.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetPerfomedActionsStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestResetPerfomedActionsStorage.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetPerfomedActionsStorage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestResetPerformedActionsStorage.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetPerformedActionsStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestResetPerformedActionsStorage.cs
+++ b/CP77.CR2W/Types/cp77/QuestResetPerformedActionsStorage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestResumeElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuestResumeElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestResumeElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuestResumeElevator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSecuritySystemInput.cs
+++ b/CP77.CR2W/Types/cp77/QuestSecuritySystemInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetChannel.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetChannel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetChannel.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetChannel.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetDetectionToFalse.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetDetectionToFalse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetDetectionToFalse.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetDetectionToFalse.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetDetectionToTrue.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetDetectionToTrue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetDetectionToTrue.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetDetectionToTrue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetFloorActive.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetFloorActive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetFloorActive.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetFloorActive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetFloorInactive.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetFloorInactive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetFloorInactive.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetFloorInactive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetIndustrialArmAnimationOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetIndustrialArmAnimationOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetIndustrialArmAnimationOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetIndustrialArmAnimationOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetLiftSpeed.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetLiftSpeed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetLiftSpeed.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetLiftSpeed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetLiftTravelTimeOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetLiftTravelTimeOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetLiftTravelTimeOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetPlayerSafePass.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetPlayerSafePass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetPlayerSafePass.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetPlayerSafePass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSetRadioStation.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetRadioStation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSetRadioStation.cs
+++ b/CP77.CR2W/Types/cp77/QuestSetRadioStation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestShowFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestShowFloor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestShowFloor.cs
+++ b/CP77.CR2W/Types/cp77/QuestShowFloor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSpotTargetReference.cs
+++ b/CP77.CR2W/Types/cp77/QuestSpotTargetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStartGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestStartGlitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStartGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestStartGlitch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestStopElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStopElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopElevator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestStopFollowingTarget.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopFollowingTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStopGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopGlitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStopGlitch.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopGlitch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestStopLookAtTarget.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopLookAtTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestStopLookAtTarget.cs
+++ b/CP77.CR2W/Types/cp77/QuestStopLookAtTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestSubObjectiveWrapper.cs
+++ b/CP77.CR2W/Types/cp77/QuestSubObjectiveWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestSubObjectiveWrapper.cs
+++ b/CP77.CR2W/Types/cp77/QuestSubObjectiveWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestToggleAds.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleAds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestToggleAds.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleAds.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestToggleAutomaticAttack.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleAutomaticAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestToggleAutomaticAttack.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleAutomaticAttack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestToggleCustomAction.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleCustomAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestToggleCustomAction.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleCustomAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestToggleInteractivity.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleInteractivity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestToggleInteractivity.cs
+++ b/CP77.CR2W/Types/cp77/QuestToggleInteractivity.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestTrackerGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuestTrackerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestTrackerObjectiveLogicController.cs
+++ b/CP77.CR2W/Types/cp77/QuestTrackerObjectiveLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestTrackingEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuestTrackingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestUIUtils.cs
+++ b/CP77.CR2W/Types/cp77/QuestUIUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestUIUtils.cs
+++ b/CP77.CR2W/Types/cp77/QuestUIUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuestUpdateGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuestUpdateGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestUpdateUserData.cs
+++ b/CP77.CR2W/Types/cp77/QuestUpdateUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuestlListItemClicked.cs
+++ b/CP77.CR2W/Types/cp77/QuestlListItemClicked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QueueCombatExperience.cs
+++ b/CP77.CR2W/Types/cp77/QueueCombatExperience.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickActionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackAuthorization.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackAuthorization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackAuthorization.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackAuthorization.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackCallElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCallElevator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackCallElevator.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCallElevator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackCrosshairStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCrosshairStateDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackCrosshairStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCrosshairStateDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCrosshairStateEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackCrosshairStateEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackDescriptionGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDescriptionGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackDistractExplosive.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDistractExplosive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackDistractExplosive.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDistractExplosive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackDistraction.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDistraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackDistraction.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDistraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackDurationListener.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDurationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackDurationListener.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackDurationListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackExplodeExplosive.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackExplodeExplosive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackExplodeExplosive.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackExplodeExplosive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackLockHacks.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackLockHacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackMappinController.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackPanelStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackPanelStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackScreenOpen.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackScreenOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackSetDescriptionVisibilityRequest.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackSetDescriptionVisibilityRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackTimeDilationOverride.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackTimeDilationOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackToggleActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleActivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackToggleActivate.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleActivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackToggleBlockade.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleBlockade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackToggleBlockade.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleBlockade.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackToggleON.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackToggleON.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleON.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackToggleOpen.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackToggleOpen.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackToggleOpen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickHackUploadListener.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackUploadListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickHackUploadListener.cs
+++ b/CP77.CR2W/Types/cp77/QuickHackUploadListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickMeleeAttackData.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeAttackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickMeleeDataDef.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickMeleeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickMeleeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickMeleeEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickMeleeHitExecutor.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeHitExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickMeleeHitExecutor.cs
+++ b/CP77.CR2W/Types/cp77/QuickMeleeHitExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotButtonHoldEndEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotButtonHoldEndEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotButtonHoldStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotButtonHoldStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotButtonTap.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotButtonTap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotCommand.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotCommandUsed.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotCommandUsed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotKeyboardTap.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotKeyboardTap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotUIStructure.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotUIStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsBusyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsBusyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsBusyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsBusyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsBusyEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsBusyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsBusyEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsBusyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsDisabledDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDisabledDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsDisabledDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDisabledDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsDisabledEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDisabledEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsDisabledEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsDisabledEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsHoldDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsHoldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsHoldDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsHoldEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsHoldEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsManager.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsManagerPS.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsManagerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsTapDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTapDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsTapDecisions.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTapDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsTapEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTapEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsTapEvents.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTapEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickSlotsTransition.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickSlotsTransition.cs
+++ b/CP77.CR2W/Types/cp77/QuickSlotsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickWheelEndUIStructure.cs
+++ b/CP77.CR2W/Types/cp77/QuickWheelEndUIStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickWheelStartUIStructure.cs
+++ b/CP77.CR2W/Types/cp77/QuickWheelStartUIStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhackBarController.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhackData.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhackDescriptionUpdate.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackDescriptionUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhackDescriptionUpdate.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackDescriptionUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuickhackInstance.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhackModule.cs
+++ b/CP77.CR2W/Types/cp77/QuickhackModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhacksListGameController.cs
+++ b/CP77.CR2W/Types/cp77/QuickhacksListGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhacksListItemController.cs
+++ b/CP77.CR2W/Types/cp77/QuickhacksListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuickhacksVulnerabilityLogicController.cs
+++ b/CP77.CR2W/Types/cp77/QuickhacksVulnerabilityLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuicksortInt.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuicksortInt.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortInt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuicksortInventoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortInventoryItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuicksortInventoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortInventoryItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/QuicksortTemplate.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/QuicksortTemplate.cs
+++ b/CP77.CR2W/Types/cp77/QuicksortTemplate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RTAOAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/RTAOAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RaceCheckpointSelector.cs
+++ b/CP77.CR2W/Types/cp77/RaceCheckpointSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialAnimData.cs
+++ b/CP77.CR2W/Types/cp77/RadialAnimData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/RadialMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialMenuHelper.cs
+++ b/CP77.CR2W/Types/cp77/RadialMenuHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialMenuHelper.cs
+++ b/CP77.CR2W/Types/cp77/RadialMenuHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RadialMenuItem.cs
+++ b/CP77.CR2W/Types/cp77/RadialMenuItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialMenuItem.cs
+++ b/CP77.CR2W/Types/cp77/RadialMenuItem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RadialPointerController.cs
+++ b/CP77.CR2W/Types/cp77/RadialPointerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialSlot.cs
+++ b/CP77.CR2W/Types/cp77/RadialSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialStatusEffectController.cs
+++ b/CP77.CR2W/Types/cp77/RadialStatusEffectController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadialWheelController.cs
+++ b/CP77.CR2W/Types/cp77/RadialWheelController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Radio.cs
+++ b/CP77.CR2W/Types/cp77/Radio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioController.cs
+++ b/CP77.CR2W/Types/cp77/RadioController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioController.cs
+++ b/CP77.CR2W/Types/cp77/RadioController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RadioControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/RadioControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/RadioInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioListItemData.cs
+++ b/CP77.CR2W/Types/cp77/RadioListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioLogicController.cs
+++ b/CP77.CR2W/Types/cp77/RadioLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioResaveData.cs
+++ b/CP77.CR2W/Types/cp77/RadioResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioSetup.cs
+++ b/CP77.CR2W/Types/cp77/RadioSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioStationListItemController.cs
+++ b/CP77.CR2W/Types/cp77/RadioStationListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioStationsDataView.cs
+++ b/CP77.CR2W/Types/cp77/RadioStationsDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioStationsDataView.cs
+++ b/CP77.CR2W/Types/cp77/RadioStationsDataView.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RadioStationsMap.cs
+++ b/CP77.CR2W/Types/cp77/RadioStationsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/RadioViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RadioViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/RadioViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RagdollDamagePollData.cs
+++ b/CP77.CR2W/Types/cp77/RagdollDamagePollData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RagdollTask.cs
+++ b/CP77.CR2W/Types/cp77/RagdollTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RagdollTask.cs
+++ b/CP77.CR2W/Types/cp77/RagdollTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RagdollToggleDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/RagdollToggleDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RainAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/RainAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RainMissileProjectile.cs
+++ b/CP77.CR2W/Types/cp77/RainMissileProjectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RandomChancePrereq.cs
+++ b/CP77.CR2W/Types/cp77/RandomChancePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RandomChancePrereq.cs
+++ b/CP77.CR2W/Types/cp77/RandomChancePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RandomChancePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/RandomChancePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RandomChancePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/RandomChancePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/RangedWeaponPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RayTracingCustomData.cs
+++ b/CP77.CR2W/Types/cp77/RayTracingCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RayTracingCustomData.cs
+++ b/CP77.CR2W/Types/cp77/RayTracingCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RayTracingRenderDebugCustomData.cs
+++ b/CP77.CR2W/Types/cp77/RayTracingRenderDebugCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RayTracingRenderDebugCustomData.cs
+++ b/CP77.CR2W/Types/cp77/RayTracingRenderDebugCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReactionBehaviorStatus.cs
+++ b/CP77.CR2W/Types/cp77/ReactionBehaviorStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactionManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/ReactionManagerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactionManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/ReactionManagerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactionOutput.cs
+++ b/CP77.CR2W/Types/cp77/ReactionOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactionTransition.cs
+++ b/CP77.CR2W/Types/cp77/ReactionTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactionTransition.cs
+++ b/CP77.CR2W/Types/cp77/ReactionTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReactiveEventSender.cs
+++ b/CP77.CR2W/Types/cp77/ReactiveEventSender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReactoToPreventionSystem.cs
+++ b/CP77.CR2W/Types/cp77/ReactoToPreventionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReadAction.cs
+++ b/CP77.CR2W/Types/cp77/ReadAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReadAction.cs
+++ b/CP77.CR2W/Types/cp77/ReadAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ReadyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReadyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ReadyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReadyEvents.cs
+++ b/CP77.CR2W/Types/cp77/ReadyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RealTimeUpdateRequest.cs
+++ b/CP77.CR2W/Types/cp77/RealTimeUpdateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RecipeData.cs
+++ b/CP77.CR2W/Types/cp77/RecipeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RecipientData.cs
+++ b/CP77.CR2W/Types/cp77/RecipientData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Record1DamageInHistoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/Record1DamageInHistoryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Rect.cs
+++ b/CP77.CR2W/Types/cp77/Rect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RectF.cs
+++ b/CP77.CR2W/Types/cp77/RectF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RecurrentStimuliEvent.cs
+++ b/CP77.CR2W/Types/cp77/RecurrentStimuliEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReenableColliderEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReenableColliderEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReenableColliderEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReenableColliderEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReevaluateDetectionOverwriteEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluateDetectionOverwriteEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReevaluateOxygenEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluateOxygenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReevaluateOxygenEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluateOxygenEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReevaluatePresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluatePresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReevaluatePresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluatePresetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReevaluateTargetsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluateTargetsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReevaluateTargetsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReevaluateTargetsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractFinalClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractFinalClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractFinalClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_AbstractFinalClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_FinalClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_FinalClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_FinalClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_FinalClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_NonTrivialClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_NonTrivialClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_PrivateClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_PrivateClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_PrivateClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_PrivateClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_ProtectedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_ProtectedClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_ProtectedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_ProtectedClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_PublicClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_PublicClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_PublicClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_PublicClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClassExplicitExtends.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClassExplicitExtends.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClassExplicitExtends.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_1_TrivialClassExplicitExtends.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_1_BaseStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_1_BaseStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_1_BottomDerivedStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_1_BottomDerivedStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_1_DerivedStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_1_DerivedStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_2_BaseStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_2_BaseStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_2_DerivedStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_2_DerivedStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_DerivedStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_DerivedStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_FinalStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_FinalStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_FinalStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_FinalStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_NonTrivialStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_NonTrivialStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_TrivialStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_TrivialStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_3_2_TrivialStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_3_2_TrivialStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_4_1_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_4_1_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_4_1_Struct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_4_1_Struct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_4_2_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_4_2_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_1_4_2_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_4_2_Class.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_1_4_2_HandlesOwner.cs
+++ b/CP77.CR2W/Types/cp77/Ref_1_4_2_HandlesOwner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_1_BaseClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_1_BaseClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_1_DerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_1_DerivedClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_1_DerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_1_DerivedClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_2_2_6_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_2_6_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_2_7_Struct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_2_7_Struct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_3_2_Base.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_2_Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_3_2_Base.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_2_Base.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_2_3_2_Derived.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_2_Derived.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_3_2_Derived.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_2_Derived.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_2_3_4_AnotherStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_4_AnotherStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_2_3_4_Struct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_2_3_4_Struct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_1_1_MyStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_1_1_MyStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_1_1_MyStruct.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_1_1_MyStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_1_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_1_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_1_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_1_Class.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_2_1_OptionalParameters.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_2_1_OptionalParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_2_1_OptionalParameters.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_2_1_OptionalParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_2_2_OutputParameters.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_2_2_OutputParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_2_2_OutputParameters.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_2_2_OutputParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_3_Overloading.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_3_Overloading.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_3_Overloading.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_3_Overloading.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_4_BaseClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_BaseClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_4_BaseClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_BaseClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_4_BottomDerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_BottomDerivedClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_4_BottomDerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_BottomDerivedClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_3_4_DerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_DerivedClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_3_4_DerivedClass.cs
+++ b/CP77.CR2W/Types/cp77/Ref_3_4_DerivedClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_4_1_2_ClassVariables.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_1_2_ClassVariables.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_1_2_StructureVariables.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_1_2_StructureVariables.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_2_1_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_1_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_2_2_Base.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_2_Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_2_2_Base.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_2_Base.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_4_2_2_ConstantHandles.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_2_ConstantHandles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_2_2_Derived.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_2_Derived.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_2_2_Derived.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_2_2_Derived.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_4_3_Defaults.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_3_Defaults.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_3_DerivedStruct_Defaults.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_3_DerivedStruct_Defaults.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_3_DerivedStruct_Defaults.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_3_DerivedStruct_Defaults.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_4_4_Hints.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_4_Hints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_5_Attributes.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_5_Attributes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_5_Browsable.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_5_Browsable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_4_5_Browsable.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_5_Browsable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Ref_4_5_Browsable_Base.cs
+++ b/CP77.CR2W/Types/cp77/Ref_4_5_Browsable_Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables.cs
+++ b/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables_Class.cs
+++ b/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables_SubStructure.cs
+++ b/CP77.CR2W/Types/cp77/Ref_6_ReplicatedVariables_SubStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Reflector.cs
+++ b/CP77.CR2W/Types/cp77/Reflector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Reflector.cs
+++ b/CP77.CR2W/Types/cp77/Reflector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReflectorController.cs
+++ b/CP77.CR2W/Types/cp77/ReflectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReflectorController.cs
+++ b/CP77.CR2W/Types/cp77/ReflectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReflectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ReflectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReflectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ReflectorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReflectorSFX.cs
+++ b/CP77.CR2W/Types/cp77/ReflectorSFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshActorRequest.cs
+++ b/CP77.CR2W/Types/cp77/RefreshActorRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshBuyQueueEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshBuyQueueEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshBuyQueueEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshBuyQueueEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshCLSOnSlavesEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshCLSOnSlavesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshClueScanningDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshClueScanningDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshClueScanningDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshClueScanningDataEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshCrosshairEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshCrosshairEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshDistrictRequest.cs
+++ b/CP77.CR2W/Types/cp77/RefreshDistrictRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshFloorAuthorizationDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshFloorAuthorizationDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshFloorDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshFloorDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshPerkAreas.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPerkAreas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshPerkAreas.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPerkAreas.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshPingEffector.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPingEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshPlayerAuthorizationEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPlayerAuthorizationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshPlayerAuthorizationEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPlayerAuthorizationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshPowerOnSlavesEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPowerOnSlavesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshPowerOnSlavesEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshPowerOnSlavesEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshSellQueueEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshSellQueueEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshSellQueueEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshSellQueueEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshSlavesEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshSlavesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshSlavesState.cs
+++ b/CP77.CR2W/Types/cp77/RefreshSlavesState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RefreshSlavesState.cs
+++ b/CP77.CR2W/Types/cp77/RefreshSlavesState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RefreshTooltipEvent.cs
+++ b/CP77.CR2W/Types/cp77/RefreshTooltipEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterActiveClueOwnerkRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterActiveClueOwnerkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterCommunityRunner.cs
+++ b/CP77.CR2W/Types/cp77/RegisterCommunityRunner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterCommunityRunner.cs
+++ b/CP77.CR2W/Types/cp77/RegisterCommunityRunner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegisterDebuggerCanditateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RegisterDebuggerCanditateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterDropPointMappinRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterDropPointMappinRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterFastTravelPointRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterFastTravelPointRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterFastTravelPointsEvent.cs
+++ b/CP77.CR2W/Types/cp77/RegisterFastTravelPointsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterFastTravelPointsRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterFastTravelPointsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterFleeingNPC.cs
+++ b/CP77.CR2W/Types/cp77/RegisterFleeingNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterGameplayObjectiveRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterGameplayObjectiveRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterInputListenerRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterInputListenerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterItemUsedRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterItemUsedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterLinkedCluekRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterLinkedCluekRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterNetworkLinkRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterNetworkLinkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterPingNetworkLinkRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterPingNetworkLinkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterPoliceCaller.cs
+++ b/CP77.CR2W/Types/cp77/RegisterPoliceCaller.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterPostionEvent.cs
+++ b/CP77.CR2W/Types/cp77/RegisterPostionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterTimeListeners.cs
+++ b/CP77.CR2W/Types/cp77/RegisterTimeListeners.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterTimeListeners.cs
+++ b/CP77.CR2W/Types/cp77/RegisterTimeListeners.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegisterTimetableRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterTimetableRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterToListListener.cs
+++ b/CP77.CR2W/Types/cp77/RegisterToListListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterTrafficRunner.cs
+++ b/CP77.CR2W/Types/cp77/RegisterTrafficRunner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterTrafficRunner.cs
+++ b/CP77.CR2W/Types/cp77/RegisterTrafficRunner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegisterUnitRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterUnitRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegisterVehicleRequest.cs
+++ b/CP77.CR2W/Types/cp77/RegisterVehicleRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegularLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegularLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegularLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegularLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegularLandLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegularLandLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RegularLandLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RegularLandLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/RegularLandLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RelaxedState.cs
+++ b/CP77.CR2W/Types/cp77/RelaxedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RelaxedState.cs
+++ b/CP77.CR2W/Types/cp77/RelaxedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReleaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/ReleaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReleaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/ReleaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReleaseSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReleaseSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReleaseWorkSpotTask.cs
+++ b/CP77.CR2W/Types/cp77/ReleaseWorkSpotTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReloadDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ReloadDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReloadDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ReloadDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReloadEvents.cs
+++ b/CP77.CR2W/Types/cp77/ReloadEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReloadWeaponEffector.cs
+++ b/CP77.CR2W/Types/cp77/ReloadWeaponEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoteBreach.cs
+++ b/CP77.CR2W/Types/cp77/RemoteBreach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoteBreach.cs
+++ b/CP77.CR2W/Types/cp77/RemoteBreach.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemotePlayerMappinController.cs
+++ b/CP77.CR2W/Types/cp77/RemotePlayerMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemotelyConnectToAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/RemotelyConnectToAccessPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemotelyConnectToAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/RemotelyConnectToAccessPoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveActiveContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveActiveContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveAllPerks.cs
+++ b/CP77.CR2W/Types/cp77/RemoveAllPerks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveAllPerks.cs
+++ b/CP77.CR2W/Types/cp77/RemoveAllPerks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveAllStatusEffectOfTypeEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveAllStatusEffectOfTypeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveAllStatusEffectsEffector.cs
+++ b/CP77.CR2W/Types/cp77/RemoveAllStatusEffectsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveAllStatusEffectsEffector.cs
+++ b/CP77.CR2W/Types/cp77/RemoveAllStatusEffectsEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveCachedStatusEffectFXEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveCachedStatusEffectFXEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveCachedStatusEffectFXEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveCachedStatusEffectFXEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveCommand.cs
+++ b/CP77.CR2W/Types/cp77/RemoveCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveConsumableDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveConsumableDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveCooldownRequest.cs
+++ b/CP77.CR2W/Types/cp77/RemoveCooldownRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveDOTStatusEffectsEffector.cs
+++ b/CP77.CR2W/Types/cp77/RemoveDOTStatusEffectsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveFromBlacklistEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveFromBlacklistEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveFromChainRequest.cs
+++ b/CP77.CR2W/Types/cp77/RemoveFromChainRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveHitFlagFromAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/RemoveHitFlagFromAttackEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveItemPart.cs
+++ b/CP77.CR2W/Types/cp77/RemoveItemPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveLinkEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveLinkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveLinkEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveLinkEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveLinkedStatusEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveLinkedStatusEffectsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveLinkedStatusEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveLinkedStatusEffectsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemovePerk.cs
+++ b/CP77.CR2W/Types/cp77/RemovePerk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveSecondaryDiodeLightPresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveSecondaryDiodeLightPresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveSecondaryDiodeLightPresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveSecondaryDiodeLightPresetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectListenerEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectListenerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectOnOwner.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectOnOwner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectsEffector.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectsOnStoryTier.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectsOnStoryTier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveStatusEffectsOnStoryTier.cs
+++ b/CP77.CR2W/Types/cp77/RemoveStatusEffectsOnStoryTier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RemoveSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/RemoveSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RemoveTargetFromHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/RemoveTargetFromHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_ClusteredProxyDisabledInstances.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_ClusteredProxyDisabledInstances.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_ClusteredProxyDisabledInstances.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_ClusteredProxyDisabledInstances.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Garment.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Garment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Garment.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Garment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_MaterialParams.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_MaterialParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_MaterialParams.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_MaterialParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Mirror.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Mirror.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Mirror.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Mirror.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_MiscMeshParams.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_MiscMeshParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_MiscMeshParams.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_MiscMeshParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_OriginalLodGroups.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_OriginalLodGroups.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_OriginalLodGroups.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_OriginalLodGroups.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Skinning.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Skinning.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderProxyCustomData_Skinning.cs
+++ b/CP77.CR2W/Types/cp77/RenderProxyCustomData_Skinning.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderTexturePreviewData.cs
+++ b/CP77.CR2W/Types/cp77/RenderTexturePreviewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderTexturePreviewData.cs
+++ b/CP77.CR2W/Types/cp77/RenderTexturePreviewData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RenderingFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/RenderingFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RenderingFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/RenderingFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RepeatLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/RepeatLookatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RepeatPersonalLinkAnimFeaturesHACK.cs
+++ b/CP77.CR2W/Types/cp77/RepeatPersonalLinkAnimFeaturesHACK.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Reprimand.cs
+++ b/CP77.CR2W/Types/cp77/Reprimand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandAgentDisconnectEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandAgentDisconnectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandData.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandDeescalateAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandDeescalateAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandDeescalateAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandDeescalateAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandDeescalation.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandDeescalation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandDeescalation.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandDeescalation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandEscalateAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandEscalateAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandEscalateAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandEscalateAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandEscalation.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandEscalation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandEscalation.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandEscalation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandEscalationEvent.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandEscalationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandResetAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandResetAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandResetAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandResetAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandStartAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandStartAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandStartAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandStartAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandToAlertedAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandToAlertedAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandToAlertedAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandToAlertedAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandToCombatAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandToCombatAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReprimandToCombatAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandToCombatAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ReprimandUpdate.cs
+++ b/CP77.CR2W/Types/cp77/ReprimandUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestActionWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestActionWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestActionWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestActionWidgetsUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestBannerWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestBannerWidgetUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestBannerWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestBannerWidgetUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestBreadCrumbBarUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestBreadCrumbBarUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestBuyAttribute.cs
+++ b/CP77.CR2W/Types/cp77/RequestBuyAttribute.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestChangeTrackedObjective.cs
+++ b/CP77.CR2W/Types/cp77/RequestChangeTrackedObjective.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestComputerMainMenuWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestComputerMainMenuWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestComputerMainMenuWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestComputerMainMenuWidgetsUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestComputerMenuWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestComputerMenuWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestComputerMenuWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestComputerMenuWidgetsUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestDeviceWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDeviceWidgetUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestDeviceWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDeviceWidgetUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestDeviceWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDeviceWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestDismembermentEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDismembermentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestDocumentThumbnailWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDocumentThumbnailWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestDocumentWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestDocumentWidgetUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestEquipHeavyWeapon.cs
+++ b/CP77.CR2W/Types/cp77/RequestEquipHeavyWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestQuestTakeControlInputLock.cs
+++ b/CP77.CR2W/Types/cp77/RequestQuestTakeControlInputLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestReleaseControl.cs
+++ b/CP77.CR2W/Types/cp77/RequestReleaseControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestReleaseControl.cs
+++ b/CP77.CR2W/Types/cp77/RequestReleaseControl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestStatsBB.cs
+++ b/CP77.CR2W/Types/cp77/RequestStatsBB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestStatsBB.cs
+++ b/CP77.CR2W/Types/cp77/RequestStatsBB.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestTakeControl.cs
+++ b/CP77.CR2W/Types/cp77/RequestTakeControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestThumbnailWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestThumbnailWidgetsUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestThumbnailWidgetsUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestThumbnailWidgetsUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RequestUIRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestUIRefreshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RequestWidgetUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RequestWidgetUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReserveItemToThisDropPoint.cs
+++ b/CP77.CR2W/Types/cp77/ReserveItemToThisDropPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ReserveWorkSpotTask.cs
+++ b/CP77.CR2W/Types/cp77/ReserveWorkSpotTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetAllFearWrappers.cs
+++ b/CP77.CR2W/Types/cp77/ResetAllFearWrappers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetAllFearWrappers.cs
+++ b/CP77.CR2W/Types/cp77/ResetAllFearWrappers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetAttackDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetAttackDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetBlockAttackHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetBlockAttackHitsReceivedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetBlockAttackHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetBlockAttackHitsReceivedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetBlockedHitsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetBlockedHitsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetBlockedHitsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetBlockedHitsRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetDeflectedHitsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetDeflectedHitsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetDeflectedHitsRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetDeflectedHitsRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetDevelopmentPointsEffector.cs
+++ b/CP77.CR2W/Types/cp77/ResetDevelopmentPointsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetDevelopmentPointsEffector.cs
+++ b/CP77.CR2W/Types/cp77/ResetDevelopmentPointsEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetDoorState.cs
+++ b/CP77.CR2W/Types/cp77/ResetDoorState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetDoorState.cs
+++ b/CP77.CR2W/Types/cp77/ResetDoorState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetFacialEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetFacialEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetFacialEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetFacialEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetFinalComboHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetFinalComboHitsReceivedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetFinalComboHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetFinalComboHitsReceivedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetFrameDamage.cs
+++ b/CP77.CR2W/Types/cp77/ResetFrameDamage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetFrameDamage.cs
+++ b/CP77.CR2W/Types/cp77/ResetFrameDamage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetGuardBreakRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetGuardBreakRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetGuardBreakRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetGuardBreakRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetItemAppearanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetItemAppearanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetLightHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetLightHitsReceivedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetLightHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetLightHitsReceivedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetLookatReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetLookatReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetLookatReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetLookatReactionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetMagFieldHitsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetMagFieldHitsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetMagFieldHitsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetMagFieldHitsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetMeleeAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetMeleeAttackDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetMeleeAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetMeleeAttackDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNPCDefeatedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCDefeatedDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNPCDefeatedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCDefeatedDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNPCDownedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCDownedDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNPCDownedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCDownedDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNPCFinishedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCFinishedDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNPCFinishedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCFinishedDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNPCIncapacitatedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCIncapacitatedDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNPCIncapacitatedDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCIncapacitatedDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNPCKilledDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCKilledDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNPCKilledDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetNPCKilledDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetNetworkBreachState.cs
+++ b/CP77.CR2W/Types/cp77/ResetNetworkBreachState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetNetworkBreachState.cs
+++ b/CP77.CR2W/Types/cp77/ResetNetworkBreachState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetRangedAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetRangedAttackDelayedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetRangedAttackDelayedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetRangedAttackDelayedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetReprimandEscalation.cs
+++ b/CP77.CR2W/Types/cp77/ResetReprimandEscalation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetReprimandEscalation.cs
+++ b/CP77.CR2W/Types/cp77/ResetReprimandEscalation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetSignal.cs
+++ b/CP77.CR2W/Types/cp77/ResetSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetStrongHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetStrongHitsReceivedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetStrongHitsReceivedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResetStrongHitsReceivedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResetTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetTickEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResetTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResetTickEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResloveFocusClueDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResloveFocusClueDescriptionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResloveFocusClueDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResloveFocusClueDescriptionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResolveActionData.cs
+++ b/CP77.CR2W/Types/cp77/ResolveActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveAllSkillchecksEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResolveAllSkillchecksEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveAllSkillchecksEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResolveAllSkillchecksEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResolveQualityRangeInteractionLayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResolveQualityRangeInteractionLayerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveQuickHackRadialRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResolveQuickHackRadialRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveQuickHackRadialRequest.cs
+++ b/CP77.CR2W/Types/cp77/ResolveQuickHackRadialRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResolveSensorDeviceBehaviour.cs
+++ b/CP77.CR2W/Types/cp77/ResolveSensorDeviceBehaviour.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveSkillchecksEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResolveSkillchecksEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResolveSkillchecksEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResolveSkillchecksEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResourceLibraryComponent.cs
+++ b/CP77.CR2W/Types/cp77/ResourceLibraryComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RespawnHealthConsumable.cs
+++ b/CP77.CR2W/Types/cp77/RespawnHealthConsumable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RespawnHealthConsumable.cs
+++ b/CP77.CR2W/Types/cp77/RespawnHealthConsumable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResponseEvent.cs
+++ b/CP77.CR2W/Types/cp77/ResponseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RestedEvents.cs
+++ b/CP77.CR2W/Types/cp77/RestedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RestedEvents.cs
+++ b/CP77.CR2W/Types/cp77/RestedEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RestoreRevealStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RestoreRevealStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RestoreRevealStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/RestoreRevealStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RestoreStatPoolEffector.cs
+++ b/CP77.CR2W/Types/cp77/RestoreStatPoolEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RestrictedMovementAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/RestrictedMovementAreaCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RestrictedMovementAreaCondition.cs
+++ b/CP77.CR2W/Types/cp77/RestrictedMovementAreaCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResurrectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ResurrectDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResurrectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ResurrectDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ResurrectEvents.cs
+++ b/CP77.CR2W/Types/cp77/ResurrectEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ResurrectEvents.cs
+++ b/CP77.CR2W/Types/cp77/ResurrectEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RetractableAd.cs
+++ b/CP77.CR2W/Types/cp77/RetractableAd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RetractableAdController.cs
+++ b/CP77.CR2W/Types/cp77/RetractableAdController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RetractableAdController.cs
+++ b/CP77.CR2W/Types/cp77/RetractableAdController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RetractableAdControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/RetractableAdControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealAccessPointPrereq.cs
+++ b/CP77.CR2W/Types/cp77/RevealAccessPointPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealAccessPointPrereq.cs
+++ b/CP77.CR2W/Types/cp77/RevealAccessPointPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealAccessPointPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/RevealAccessPointPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealDeviceRequest.cs
+++ b/CP77.CR2W/Types/cp77/RevealDeviceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealDevicesGridEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealDevicesGridEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealDevicesGridOnEntityEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealDevicesGridOnEntityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealEnemies.cs
+++ b/CP77.CR2W/Types/cp77/RevealEnemies.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealEnemies.cs
+++ b/CP77.CR2W/Types/cp77/RevealEnemies.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealEnemiesProgram.cs
+++ b/CP77.CR2W/Types/cp77/RevealEnemiesProgram.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealEnemiesProgram.cs
+++ b/CP77.CR2W/Types/cp77/RevealEnemiesProgram.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealInteractionWheel.cs
+++ b/CP77.CR2W/Types/cp77/RevealInteractionWheel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealNetworkGridEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealNetworkGridEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealNetworkGridNetworkRequest.cs
+++ b/CP77.CR2W/Types/cp77/RevealNetworkGridNetworkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealNetworkGridNetworkRequest.cs
+++ b/CP77.CR2W/Types/cp77/RevealNetworkGridNetworkRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealNetworkGridOnPulse.cs
+++ b/CP77.CR2W/Types/cp77/RevealNetworkGridOnPulse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealNetworkRequestRequest.cs
+++ b/CP77.CR2W/Types/cp77/RevealNetworkRequestRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealObjectExecutor.cs
+++ b/CP77.CR2W/Types/cp77/RevealObjectExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealObjectExecutor.cs
+++ b/CP77.CR2W/Types/cp77/RevealObjectExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealPlayerPositionEffector.cs
+++ b/CP77.CR2W/Types/cp77/RevealPlayerPositionEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealPlayerPositionEffector.cs
+++ b/CP77.CR2W/Types/cp77/RevealPlayerPositionEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevealPlayerSettings.cs
+++ b/CP77.CR2W/Types/cp77/RevealPlayerSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealQuestTargetEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealQuestTargetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealQuickhackMenu.cs
+++ b/CP77.CR2W/Types/cp77/RevealQuickhackMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealRequestsStorage.cs
+++ b/CP77.CR2W/Types/cp77/RevealRequestsStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/RevealStateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevealStatusNotification.cs
+++ b/CP77.CR2W/Types/cp77/RevealStatusNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevokeAuthorization.cs
+++ b/CP77.CR2W/Types/cp77/RevokeAuthorization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevokeQuickHackAccess.cs
+++ b/CP77.CR2W/Types/cp77/RevokeQuickHackAccess.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevokeQuickHackAccess.cs
+++ b/CP77.CR2W/Types/cp77/RevokeQuickHackAccess.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevolverLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RevolverLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevolverLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RevolverLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RevolverLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/RevolverLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RevolverLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/RevolverLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RewireComponent.cs
+++ b/CP77.CR2W/Types/cp77/RewireComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RewireEvent.cs
+++ b/CP77.CR2W/Types/cp77/RewireEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RifleLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/RifleLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/RifleLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/RifleLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RipOff.cs
+++ b/CP77.CR2W/Types/cp77/RipOff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RipOff.cs
+++ b/CP77.CR2W/Types/cp77/RipOff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RipperDocGameController.cs
+++ b/CP77.CR2W/Types/cp77/RipperDocGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RipperDocItemBoughtCallback.cs
+++ b/CP77.CR2W/Types/cp77/RipperDocItemBoughtCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RipperdocFilterToggleController.cs
+++ b/CP77.CR2W/Types/cp77/RipperdocFilterToggleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RipperdocFilterToggleController.cs
+++ b/CP77.CR2W/Types/cp77/RipperdocFilterToggleController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RipperdocIdPanel.cs
+++ b/CP77.CR2W/Types/cp77/RipperdocIdPanel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoachRaceGameController.cs
+++ b/CP77.CR2W/Types/cp77/RoachRaceGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlock.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockController.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockController.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RoadBlockControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockTrap.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockTrap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockTrapController.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockTrapController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockTrapController.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockTrapController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RoadBlockTrapControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockTrapControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoadBlockTrapControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/RoadBlockTrapControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/RootMotionCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/RootMotionCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoyceComponent.cs
+++ b/CP77.CR2W/Types/cp77/RoyceComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoyceHealthChangeListener.cs
+++ b/CP77.CR2W/Types/cp77/RoyceHealthChangeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/RoyceLaserSight.cs
+++ b/CP77.CR2W/Types/cp77/RoyceLaserSight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SActionTypeForward.cs
+++ b/CP77.CR2W/Types/cp77/SActionTypeForward.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SActionWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SActionWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SAreaEffectData.cs
+++ b/CP77.CR2W/Types/cp77/SAreaEffectData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SAreaEffectTargetData.cs
+++ b/CP77.CR2W/Types/cp77/SAreaEffectTargetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SAttribute.cs
+++ b/CP77.CR2W/Types/cp77/SAttribute.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBannerWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SBannerWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBaseActionOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SBaseActionOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBaseDeviceOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SBaseDeviceOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBaseStateOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SBaseStateOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBinkperationData.cs
+++ b/CP77.CR2W/Types/cp77/SBinkperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBokehDofParams.cs
+++ b/CP77.CR2W/Types/cp77/SBokehDofParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBraindanceInputMask.cs
+++ b/CP77.CR2W/Types/cp77/SBraindanceInputMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBreadCrumbUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/SBreadCrumbUpdateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SBreadcrumbElementData.cs
+++ b/CP77.CR2W/Types/cp77/SBreadcrumbElementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCachedStat.cs
+++ b/CP77.CR2W/Types/cp77/SCachedStat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SChannelEnumData.cs
+++ b/CP77.CR2W/Types/cp77/SChannelEnumData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCodexRecord.cs
+++ b/CP77.CR2W/Types/cp77/SCodexRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCodexRecordPart.cs
+++ b/CP77.CR2W/Types/cp77/SCodexRecordPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SColor.cs
+++ b/CP77.CR2W/Types/cp77/SColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SColor.cs
+++ b/CP77.CR2W/Types/cp77/SColor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SComponentOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SComponentOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SComputerMenuButtonWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SComputerMenuButtonWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCooldown.cs
+++ b/CP77.CR2W/Types/cp77/SCooldown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCustomActionOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SCustomActionOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCustomDeviceActionsData.cs
+++ b/CP77.CR2W/Types/cp77/SCustomDeviceActionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SCyberware.cs
+++ b/CP77.CR2W/Types/cp77/SCyberware.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDamageDealt.cs
+++ b/CP77.CR2W/Types/cp77/SDamageDealt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDamageOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SDamageOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDebugChoice.cs
+++ b/CP77.CR2W/Types/cp77/SDebugChoice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDevelopmentPoints.cs
+++ b/CP77.CR2W/Types/cp77/SDevelopmentPoints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceActionBoolData.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceActionBoolData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceActionCustomData.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceActionCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceActionData.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceMappinData.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceTimetableEntry.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceTimetableEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDeviceWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SDeviceWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDocumentAdress.cs
+++ b/CP77.CR2W/Types/cp77/SDocumentAdress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDocumentThumbnailWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SDocumentThumbnailWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDocumentWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SDocumentWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SDoorStateOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SDoorStateOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SExperiencePoints.cs
+++ b/CP77.CR2W/Types/cp77/SExperiencePoints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SFactOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SFactOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SFactToChange.cs
+++ b/CP77.CR2W/Types/cp77/SFactToChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SFakeFeatureChoice.cs
+++ b/CP77.CR2W/Types/cp77/SFakeFeatureChoice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SFocusModeOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SFocusModeOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SGenericDeviceActionsData.cs
+++ b/CP77.CR2W/Types/cp77/SGenericDeviceActionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SGenericDevicePersistentData.cs
+++ b/CP77.CR2W/Types/cp77/SGenericDevicePersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SHighlightTarget.cs
+++ b/CP77.CR2W/Types/cp77/SHighlightTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SHitFlag.cs
+++ b/CP77.CR2W/Types/cp77/SHitFlag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SHitNPC.cs
+++ b/CP77.CR2W/Types/cp77/SHitNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SHitOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SHitOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SHitStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/SHitStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SInspectableClue.cs
+++ b/CP77.CR2W/Types/cp77/SInspectableClue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SInteractionAreaOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SInteractionAreaOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SInternetData.cs
+++ b/CP77.CR2W/Types/cp77/SInternetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SInventoryOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SInventoryOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SItemTransaction.cs
+++ b/CP77.CR2W/Types/cp77/SItemTransaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SMeshChunkPacked.cs
+++ b/CP77.CR2W/Types/cp77/SMeshChunkPacked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SMeshStream.cs
+++ b/CP77.CR2W/Types/cp77/SMeshStream.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SMeshTopology.cs
+++ b/CP77.CR2W/Types/cp77/SMeshTopology.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SMovementPattern.cs
+++ b/CP77.CR2W/Types/cp77/SMovementPattern.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SNameplateRangesData.cs
+++ b/CP77.CR2W/Types/cp77/SNameplateRangesData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SNetworkLinkData.cs
+++ b/CP77.CR2W/Types/cp77/SNetworkLinkData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SNewsFeedData.cs
+++ b/CP77.CR2W/Types/cp77/SNewsFeedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SNewsFeedElementData.cs
+++ b/CP77.CR2W/Types/cp77/SNewsFeedElementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SOMState.cs
+++ b/CP77.CR2W/Types/cp77/SOMState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPaperdollEquipData.cs
+++ b/CP77.CR2W/Types/cp77/SPaperdollEquipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SParticleEmitterLODLevel.cs
+++ b/CP77.CR2W/Types/cp77/SParticleEmitterLODLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPerformedActions.cs
+++ b/CP77.CR2W/Types/cp77/SPerformedActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPerk.cs
+++ b/CP77.CR2W/Types/cp77/SPerk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPerkArea.cs
+++ b/CP77.CR2W/Types/cp77/SPerkArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPlayerCooldown.cs
+++ b/CP77.CR2W/Types/cp77/SPlayerCooldown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPresetTimetableEntry.cs
+++ b/CP77.CR2W/Types/cp77/SPresetTimetableEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SPreventionAgentData.cs
+++ b/CP77.CR2W/Types/cp77/SPreventionAgentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SProficiency.cs
+++ b/CP77.CR2W/Types/cp77/SProficiency.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSAOAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/SSAOAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSFXOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SSFXOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSRCustomData.cs
+++ b/CP77.CR2W/Types/cp77/SSRCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSRCustomData.cs
+++ b/CP77.CR2W/Types/cp77/SSRCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SSensesOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SSensesOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSimpleGameTime.cs
+++ b/CP77.CR2W/Types/cp77/SSimpleGameTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSoundData.cs
+++ b/CP77.CR2W/Types/cp77/SSoundData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SStatPoolValue.cs
+++ b/CP77.CR2W/Types/cp77/SStatPoolValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SStatusEffectOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SStatusEffectOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SStimOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SStimOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SSubCharacter.cs
+++ b/CP77.CR2W/Types/cp77/SSubCharacter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STeleportOperationData.cs
+++ b/CP77.CR2W/Types/cp77/STeleportOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STextureGroupSetup.cs
+++ b/CP77.CR2W/Types/cp77/STextureGroupSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SThumbnailWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SThumbnailWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SToggleDeviceOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SToggleDeviceOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SToggleOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SToggleOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STonemappingACESParams.cs
+++ b/CP77.CR2W/Types/cp77/STonemappingACESParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STonemappingACESParamsHDR.cs
+++ b/CP77.CR2W/Types/cp77/STonemappingACESParamsHDR.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STonemappingACESParamsHDR.cs
+++ b/CP77.CR2W/Types/cp77/STonemappingACESParamsHDR.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/STonemappingACESParamsSDR.cs
+++ b/CP77.CR2W/Types/cp77/STonemappingACESParamsSDR.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STonemappingACESParamsSDR.cs
+++ b/CP77.CR2W/Types/cp77/STonemappingACESParamsSDR.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/STrait.cs
+++ b/CP77.CR2W/Types/cp77/STrait.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STransformAnimationData.cs
+++ b/CP77.CR2W/Types/cp77/STransformAnimationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STransformAnimationPlayEventData.cs
+++ b/CP77.CR2W/Types/cp77/STransformAnimationPlayEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STransformAnimationSkipEventData.cs
+++ b/CP77.CR2W/Types/cp77/STransformAnimationSkipEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STriggerVolumeOperationData.cs
+++ b/CP77.CR2W/Types/cp77/STriggerVolumeOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/STvChannel.cs
+++ b/CP77.CR2W/Types/cp77/STvChannel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SUIScreenDefinition.cs
+++ b/CP77.CR2W/Types/cp77/SUIScreenDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SVFXOperationData.cs
+++ b/CP77.CR2W/Types/cp77/SVFXOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SVfxInstanceData.cs
+++ b/CP77.CR2W/Types/cp77/SVfxInstanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWeakPoints.cs
+++ b/CP77.CR2W/Types/cp77/SWeakPoints.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWeaponPlaneParams.cs
+++ b/CP77.CR2W/Types/cp77/SWeaponPlaneParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWidgetAnimationData.cs
+++ b/CP77.CR2W/Types/cp77/SWidgetAnimationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWidgetPackage.cs
+++ b/CP77.CR2W/Types/cp77/SWidgetPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWidgetPackageBase.cs
+++ b/CP77.CR2W/Types/cp77/SWidgetPackageBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SWorkspotData.cs
+++ b/CP77.CR2W/Types/cp77/SWorkspotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SafeCrosshairStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SafeCrosshairStateDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SafeCrosshairStateDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SafeCrosshairStateDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SafeCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/SafeCrosshairStateEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SafeCrosshairStateEvents.cs
+++ b/CP77.CR2W/Types/cp77/SafeCrosshairStateEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SafeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SafeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SafeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/SafeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SafeEvents.cs
+++ b/CP77.CR2W/Types/cp77/SafeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SameTargetHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/SameTargetHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleBumpEvent.cs
+++ b/CP77.CR2W/Types/cp77/SampleBumpEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleComponentWithCounter.cs
+++ b/CP77.CR2W/Types/cp77/SampleComponentWithCounter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleComponentWithCounter.cs
+++ b/CP77.CR2W/Types/cp77/SampleComponentWithCounter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SampleComponentWithCounterPS.cs
+++ b/CP77.CR2W/Types/cp77/SampleComponentWithCounterPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleCounterDisplayComponent.cs
+++ b/CP77.CR2W/Types/cp77/SampleCounterDisplayComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleDeviceClass.cs
+++ b/CP77.CR2W/Types/cp77/SampleDeviceClass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleDeviceClass.cs
+++ b/CP77.CR2W/Types/cp77/SampleDeviceClass.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SampleDeviceClassPS.cs
+++ b/CP77.CR2W/Types/cp77/SampleDeviceClassPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleEntityWithCounter.cs
+++ b/CP77.CR2W/Types/cp77/SampleEntityWithCounter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleEntityWithCounter.cs
+++ b/CP77.CR2W/Types/cp77/SampleEntityWithCounter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SampleEntityWithCounterPS.cs
+++ b/CP77.CR2W/Types/cp77/SampleEntityWithCounterPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleInteractiveEntityThatBumpsTheCounter.cs
+++ b/CP77.CR2W/Types/cp77/SampleInteractiveEntityThatBumpsTheCounter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/SampleMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleUIButtons.cs
+++ b/CP77.CR2W/Types/cp77/SampleUIButtons.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleUIMeasurementController.cs
+++ b/CP77.CR2W/Types/cp77/SampleUIMeasurementController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SampleUITextSystemController.cs
+++ b/CP77.CR2W/Types/cp77/SampleUITextSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Abstract_Class_1_9.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Abstract_Class_1_9.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Abstract_Class_1_9.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Abstract_Class_1_9.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_All_Supported_Replicated_Types.cs
+++ b/CP77.CR2W/Types/cp77/Sample_All_Supported_Replicated_Types.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Basic_Replicated_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Basic_Replicated_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_14.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_14.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_14.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_14.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_15.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_15.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_15.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_15.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_16.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_16.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_16.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_16.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_2_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_2_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_2_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_2_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_2_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_2_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_2_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_2_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_3_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_3_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_3_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_3_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_3_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_3_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_3_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_3_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_7_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_7_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_7_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_7_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_7_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_7_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_1_7_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_1_7_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_10.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_10.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_11.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_11.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_12_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_12_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_12_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_12_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_12_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_12_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_13.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_13.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_14.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_14.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_15.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_15.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_16_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_16_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_16_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_16_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_16_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_16_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_2.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_3.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_3.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_4_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_4_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_4_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_4_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_4_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_4_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_5.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_5.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_6.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_6.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_7.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_7.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_8.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_8.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_2_9.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_2_9.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_2.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_2.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_2.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_3.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_3.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_3.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_3.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_4.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_3_4.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_3_4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_10.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_10.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_10.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_10.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_11.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_11.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_11.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_11.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_15_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_15_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_15_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_15_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_2.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_2.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_2.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_6.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_6.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_6.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_6.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_7.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_7.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_6_7.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_6_7.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Class_Without_Default_Object_1_11.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_Without_Default_Object_1_11.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Class_Without_Default_Object_1_11.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Class_Without_Default_Object_1_11.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Customized_Replicated_Root_Object.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Customized_Replicated_Root_Object.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_10Sample_Abstract_Class_1_10.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_10Sample_Abstract_Class_1_10.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_10Sample_Abstract_Class_1_10.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_10Sample_Abstract_Class_1_10.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_12Sample_Class_Without_Default_Object_1_12.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_12Sample_Class_Without_Default_Object_1_12.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_12Sample_Class_Without_Default_Object_1_12.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_12Sample_Class_Without_Default_Object_1_12.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_13_0Sample_Namespace_1_13_1Sample_Namespace_1_13_2Sample_Class_1_13.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_13_0Sample_Namespace_1_13_1Sample_Namespace_1_13_2Sample_Class_1_13.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_13_0Sample_Namespace_1_13_1Sample_Namespace_1_13_2Sample_Class_1_13.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_13_0Sample_Namespace_1_13_1Sample_Namespace_1_13_2Sample_Class_1_13.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_4Sample_Class_1_4.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_4Sample_Class_1_4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_4Sample_Class_1_4.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_4Sample_Class_1_4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_5Sample_Class_1_5_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_0Sample_Class_1_6_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_0Sample_Class_1_6_0.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_0Sample_Class_1_6_0.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_0Sample_Class_1_6_0.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_1Sample_Class_1_6_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_1Sample_Class_1_6_1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_1Sample_Class_1_6_1.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Namespace_1_6_1Sample_Class_1_6_1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Non_Copyable_Class_1_8.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Non_Copyable_Class_1_8.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Non_Copyable_Class_1_8.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Non_Copyable_Class_1_8.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_RPC_Class.cs
+++ b/CP77.CR2W/Types/cp77/Sample_RPC_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_RPC_Class.cs
+++ b/CP77.CR2W/Types/cp77/Sample_RPC_Class.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Double_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Double_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Dynamic_Array_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Dynamic_Array_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Dynamic_Map_Array_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Dynamic_Map_Array_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Float_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Float_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Int_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Int_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Pointed_Class.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Pointed_Class.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Root_Object.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Root_Object.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Serializable.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Serializable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_String_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_String_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Struct.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Struct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_THandle_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_THandle_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Unique_Pointer_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Unique_Pointer_Property.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sample_Replicated_Unique_Pointer_Property.cs
+++ b/CP77.CR2W/Types/cp77/Sample_Replicated_Unique_Pointer_Property.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SamplerStateInfo.cs
+++ b/CP77.CR2W/Types/cp77/SamplerStateInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SandevistanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SandevistanDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SandevistanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SandevistanDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SandevistanEvents.cs
+++ b/CP77.CR2W/Types/cp77/SandevistanEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SandevistanEvents.cs
+++ b/CP77.CR2W/Types/cp77/SandevistanEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SasquatchComponent.cs
+++ b/CP77.CR2W/Types/cp77/SasquatchComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SaveEquipmentSetRequest.cs
+++ b/CP77.CR2W/Types/cp77/SaveEquipmentSetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SaveGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/SaveGameMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScanEvent.cs
+++ b/CP77.CR2W/Types/cp77/ScanEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScanInstance.cs
+++ b/CP77.CR2W/Types/cp77/ScanInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScanPlayerDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ScanPlayerDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScanPlayerDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/ScanPlayerDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScannerAbilities.cs
+++ b/CP77.CR2W/Types/cp77/ScannerAbilities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerAbilitiesGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerAbilitiesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerAbilityItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerAbilityItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerArchetype.cs
+++ b/CP77.CR2W/Types/cp77/ScannerArchetype.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerAttitude.cs
+++ b/CP77.CR2W/Types/cp77/ScannerAttitude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerAuthorization.cs
+++ b/CP77.CR2W/Types/cp77/ScannerAuthorization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerBountySystem.cs
+++ b/CP77.CR2W/Types/cp77/ScannerBountySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerBountySystemGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerBountySystemGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerChunk.cs
+++ b/CP77.CR2W/Types/cp77/ScannerChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerChunk.cs
+++ b/CP77.CR2W/Types/cp77/ScannerChunk.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScannerConnections.cs
+++ b/CP77.CR2W/Types/cp77/ScannerConnections.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerControlComponent.cs
+++ b/CP77.CR2W/Types/cp77/ScannerControlComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerCrosshairLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerCrosshairLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerDescription.cs
+++ b/CP77.CR2W/Types/cp77/ScannerDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerDescriptionGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerDescriptionGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerDeviceBodyGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerDeviceBodyGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerDeviceHeaderGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerDeviceHeaderGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerDeviceStatus.cs
+++ b/CP77.CR2W/Types/cp77/ScannerDeviceStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerFaction.cs
+++ b/CP77.CR2W/Types/cp77/ScannerFaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerHealth.cs
+++ b/CP77.CR2W/Types/cp77/ScannerHealth.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerHintInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerHintInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerLevel.cs
+++ b/CP77.CR2W/Types/cp77/ScannerLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerModule.cs
+++ b/CP77.CR2W/Types/cp77/ScannerModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerNPCBodyGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerNPCBodyGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerNPCHeaderGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerNPCHeaderGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerName.cs
+++ b/CP77.CR2W/Types/cp77/ScannerName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerNetworkLevel.cs
+++ b/CP77.CR2W/Types/cp77/ScannerNetworkLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerNetworkStatus.cs
+++ b/CP77.CR2W/Types/cp77/ScannerNetworkStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerQuestClue.cs
+++ b/CP77.CR2W/Types/cp77/ScannerQuestClue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerQuestCluesGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerQuestCluesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerQuickHackDescription.cs
+++ b/CP77.CR2W/Types/cp77/ScannerQuickHackDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerRarity.cs
+++ b/CP77.CR2W/Types/cp77/ScannerRarity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerRequirementItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerRequirementItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerRequirementsGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerRequirementsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerResistances.cs
+++ b/CP77.CR2W/Types/cp77/ScannerResistances.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerResistancesGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerResistancesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSkillCheckConditionDataItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSkillCheckConditionDataItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSkillCheckConditionDescriptionLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSkillCheckConditionDescriptionLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSkillCheckItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSkillCheckItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSkillCheckLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSkillCheckLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSkillchecks.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSkillchecks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerSquadInfo.cs
+++ b/CP77.CR2W/Types/cp77/ScannerSquadInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerStatDetails.cs
+++ b/CP77.CR2W/Types/cp77/ScannerStatDetails.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerTargetChangedRequest.cs
+++ b/CP77.CR2W/Types/cp77/ScannerTargetChangedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleDriveLayout.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleDriveLayout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleHorsepower.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleHorsepower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleInfo.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleManufacturer.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleManufacturer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleMass.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleMass.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleName.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleProdYears.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleProdYears.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVehicleState.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVehicleState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVulnerabilities.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVulnerabilities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVulnerabilitiesGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVulnerabilitiesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerVulnerabilityItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScannerVulnerabilityItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerWeakspot.cs
+++ b/CP77.CR2W/Types/cp77/ScannerWeakspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerWeakspot.cs
+++ b/CP77.CR2W/Types/cp77/ScannerWeakspot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScannerWeaponBasic.cs
+++ b/CP77.CR2W/Types/cp77/ScannerWeaponBasic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannerWeaponDetailed.cs
+++ b/CP77.CR2W/Types/cp77/ScannerWeaponDetailed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScannervehicleGameController.cs
+++ b/CP77.CR2W/Types/cp77/ScannervehicleGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScavengeComponent.cs
+++ b/CP77.CR2W/Types/cp77/ScavengeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScavengeTarget.cs
+++ b/CP77.CR2W/Types/cp77/ScavengeTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScavengeTarget.cs
+++ b/CP77.CR2W/Types/cp77/ScavengeTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScavengeTargetConfirmEvent.cs
+++ b/CP77.CR2W/Types/cp77/ScavengeTargetConfirmEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ColorFadeParams.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ColorFadeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ColorFadeParams.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ColorFadeParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadows.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadows.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadows.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadows.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadowsCommon.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadowsCommon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadowsCommon.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_DistantShadowsCommon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_RainMap.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_RainMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_RainMap.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_RainMap.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ReflectionAtlas.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ReflectionAtlas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ReflectionAtlas.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ReflectionAtlas.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_Selection.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_Selection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_Selection.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_Selection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ShadowManager.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ShadowManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneCustomData_ShadowManager.cs
+++ b/CP77.CR2W/Types/cp77/SceneCustomData_ShadowManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneExitingCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingCombatDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneExitingCombatDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingCombatDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneExitingCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingCombatEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneExitingCombatEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingCombatEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneExitingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneExitingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneExitingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneForceWeaponAim.cs
+++ b/CP77.CR2W/Types/cp77/SceneForceWeaponAim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneForceWeaponAim.cs
+++ b/CP77.CR2W/Types/cp77/SceneForceWeaponAim.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneForceWeaponSafe.cs
+++ b/CP77.CR2W/Types/cp77/SceneForceWeaponSafe.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneGameplayOverridesDef.cs
+++ b/CP77.CR2W/Types/cp77/SceneGameplayOverridesDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneScreen.cs
+++ b/CP77.CR2W/Types/cp77/SceneScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneScreenGameController.cs
+++ b/CP77.CR2W/Types/cp77/SceneScreenGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneScreenUIAnimationsData.cs
+++ b/CP77.CR2W/Types/cp77/SceneScreenUIAnimationsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierAbstract.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierAbstract.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstractDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierAbstractDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstractDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierAbstractEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstractEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierAbstractEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierAbstractEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierIIDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIIDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierIIEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIIIDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIIDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIIIDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIIDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierIIIEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIIEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIIIEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIIIEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierIVDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIVDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIVDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIVDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierIVEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIVEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierIVEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierIVEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierVDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierVDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierVDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierVDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SceneTierVEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierVEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SceneTierVEvents.cs
+++ b/CP77.CR2W/Types/cp77/SceneTierVEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScenesFastForwardTransition.cs
+++ b/CP77.CR2W/Types/cp77/ScenesFastForwardTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScenesFastForwardTransition.cs
+++ b/CP77.CR2W/Types/cp77/ScenesFastForwardTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScoreboardEntityLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScoreboardEntityLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScoreboardLogicController.cs
+++ b/CP77.CR2W/Types/cp77/ScoreboardLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScoreboardPlayer.cs
+++ b/CP77.CR2W/Types/cp77/ScoreboardPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScreenDefinitionPackage.cs
+++ b/CP77.CR2W/Types/cp77/ScreenDefinitionPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScreenMessageData.cs
+++ b/CP77.CR2W/Types/cp77/ScreenMessageData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScreenMessageSelector.cs
+++ b/CP77.CR2W/Types/cp77/ScreenMessageSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptConditionTypeBase.cs
+++ b/CP77.CR2W/Types/cp77/ScriptConditionTypeBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptConditionTypeBase.cs
+++ b/CP77.CR2W/Types/cp77/ScriptConditionTypeBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScriptGameInstance.cs
+++ b/CP77.CR2W/Types/cp77/ScriptGameInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptGameInstance.cs
+++ b/CP77.CR2W/Types/cp77/ScriptGameInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScriptHitData.cs
+++ b/CP77.CR2W/Types/cp77/ScriptHitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptLightSettings.cs
+++ b/CP77.CR2W/Types/cp77/ScriptLightSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptReentrantRWLock.cs
+++ b/CP77.CR2W/Types/cp77/ScriptReentrantRWLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptReentrantRWLock.cs
+++ b/CP77.CR2W/Types/cp77/ScriptReentrantRWLock.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScriptableDC.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableDC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptableDC.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableDC.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScriptableDeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableDeviceAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptableDeviceComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableDeviceComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptableVirtualCameraViewComponent.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableVirtualCameraViewComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptableVirtualCameraViewComponent.cs
+++ b/CP77.CR2W/Types/cp77/ScriptableVirtualCameraViewComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ScriptedPuppet.cs
+++ b/CP77.CR2W/Types/cp77/ScriptedPuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptedPuppetPS.cs
+++ b/CP77.CR2W/Types/cp77/ScriptedPuppetPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptedReactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/ScriptedReactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScriptedWeakspotObject.cs
+++ b/CP77.CR2W/Types/cp77/ScriptedWeakspotObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ScrollingText.cs
+++ b/CP77.CR2W/Types/cp77/ScrollingText.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SearchInFrontPatternLookat.cs
+++ b/CP77.CR2W/Types/cp77/SearchInFrontPatternLookat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SearchInFrontPatternLookat.cs
+++ b/CP77.CR2W/Types/cp77/SearchInFrontPatternLookat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SearchPatternMappingLookat.cs
+++ b/CP77.CR2W/Types/cp77/SearchPatternMappingLookat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecSystemDebugger.cs
+++ b/CP77.CR2W/Types/cp77/SecSystemDebugger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecondHeartStatListener.cs
+++ b/CP77.CR2W/Types/cp77/SecondHeartStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecretOpenAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecretOpenAnimationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecretOpenAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecretOpenAnimationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityAccessLevelEntry.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAccessLevelEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAccessLevelEntryClient.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAccessLevelEntryClient.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAgentSpawnedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAgentSpawnedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarm.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarmBreachResponse.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmBreachResponse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarmController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarmController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityAlarmControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarmEscalate.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmEscalate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAlarmEscalate.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmEscalate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityAlarmSetup.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAlarmSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityArea.cs
+++ b/CP77.CR2W/Types/cp77/SecurityArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityAreaControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaCrossingPerimeter.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaCrossingPerimeter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaData.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaResetRequest.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaResetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityAreaResetRequest.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaResetRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityAreaTypeChangedNotification.cs
+++ b/CP77.CR2W/Types/cp77/SecurityAreaTypeChangedNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityBreachPuppetNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecurityBreachPuppetNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityBreachPuppetNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/SecurityBreachPuppetNotificationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityGate.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityGateControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateDetectionProperties.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateDetectionProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateForceUnlock.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateForceUnlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateLock.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateLockController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateLockController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateLockController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateLockController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityGateLockControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateLockControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateResponse.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateResponse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityGateResponseProperties.cs
+++ b/CP77.CR2W/Types/cp77/SecurityGateResponseProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLocker.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLocker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLockerController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLockerController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityLockerControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLockerProperties.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLockerUserEntry.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerUserEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityLockerUserEntry.cs
+++ b/CP77.CR2W/Types/cp77/SecurityLockerUserEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecuritySupportListener.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySupportListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemClearanceEntry.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemClearanceEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemController.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemController.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecuritySystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemData.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemDisabled.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemDisabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemDisabled.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemDisabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecuritySystemEnabled.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemEnabled.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemEnabled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecuritySystemForceAttitudeChange.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemForceAttitudeChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemInput.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemMorphData.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemMorphData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemOutput.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemOutputData.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemOutputData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemStatus.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemStatus.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemStatus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecuritySystemSupport.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemSupport.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemUIPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecuritySystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/SecuritySystemUIPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityTurret.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurret.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretController.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityTurretControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretOffline.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretOffline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretOffline.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretOffline.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SecurityTurretReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretStatus.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SecurityTurretStatus.cs
+++ b/CP77.CR2W/Types/cp77/SecurityTurretStatus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Segment.cs
+++ b/CP77.CR2W/Types/cp77/Segment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectClosestPlayerThreat.cs
+++ b/CP77.CR2W/Types/cp77/SelectClosestPlayerThreat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectClosestPlayerThreat.cs
+++ b/CP77.CR2W/Types/cp77/SelectClosestPlayerThreat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SelectMenuRequest.cs
+++ b/CP77.CR2W/Types/cp77/SelectMenuRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectedForMultiplayerChoiceDialog.cs
+++ b/CP77.CR2W/Types/cp77/SelectedForMultiplayerChoiceDialog.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectedForMultiplayerChoiceDialog.cs
+++ b/CP77.CR2W/Types/cp77/SelectedForMultiplayerChoiceDialog.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SelectorRevalutionBreak.cs
+++ b/CP77.CR2W/Types/cp77/SelectorRevalutionBreak.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectorTimeout.cs
+++ b/CP77.CR2W/Types/cp77/SelectorTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SelectorTimeout.cs
+++ b/CP77.CR2W/Types/cp77/SelectorTimeout.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SellItemToVendor.cs
+++ b/CP77.CR2W/Types/cp77/SellItemToVendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SellRequest.cs
+++ b/CP77.CR2W/Types/cp77/SellRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SellRequest.cs
+++ b/CP77.CR2W/Types/cp77/SellRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SemiAutoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SemiAutoDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SemiAutoDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SemiAutoDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SemiAutoEvents.cs
+++ b/CP77.CR2W/Types/cp77/SemiAutoEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SemiAutoEvents.cs
+++ b/CP77.CR2W/Types/cp77/SemiAutoEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SendAIBheaviorReactionStim.cs
+++ b/CP77.CR2W/Types/cp77/SendAIBheaviorReactionStim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendEquipWeaponCommand.cs
+++ b/CP77.CR2W/Types/cp77/SendEquipWeaponCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendInstructionRequest.cs
+++ b/CP77.CR2W/Types/cp77/SendInstructionRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendPatrolEndSignal.cs
+++ b/CP77.CR2W/Types/cp77/SendPatrolEndSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendPatrolEndSignal.cs
+++ b/CP77.CR2W/Types/cp77/SendPatrolEndSignal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SendPauseBraindanceRequest.cs
+++ b/CP77.CR2W/Types/cp77/SendPauseBraindanceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendPauseBraindanceRequest.cs
+++ b/CP77.CR2W/Types/cp77/SendPauseBraindanceRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SendScoreRequest.cs
+++ b/CP77.CR2W/Types/cp77/SendScoreRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendScoreRequestAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/SendScoreRequestAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendSpiderbotToOverloadDevice.cs
+++ b/CP77.CR2W/Types/cp77/SendSpiderbotToOverloadDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendSpiderbotToOverloadDevice.cs
+++ b/CP77.CR2W/Types/cp77/SendSpiderbotToOverloadDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SendSpiderbotToPerformActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/SendSpiderbotToPerformActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendSpiderbotToTogglePower.cs
+++ b/CP77.CR2W/Types/cp77/SendSpiderbotToTogglePower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SendSpiderbotToTogglePower.cs
+++ b/CP77.CR2W/Types/cp77/SendSpiderbotToTogglePower.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SensePresetChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/SensePresetChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SenseSwitchEffector.cs
+++ b/CP77.CR2W/Types/cp77/SenseSwitchEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SenseSwitchEffector.cs
+++ b/CP77.CR2W/Types/cp77/SenseSwitchEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SensesOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/SensesOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensesOperations.cs
+++ b/CP77.CR2W/Types/cp77/SensesOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensesOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/SensesOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensorDevice.cs
+++ b/CP77.CR2W/Types/cp77/SensorDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensorDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/SensorDeviceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensorDeviceController.cs
+++ b/CP77.CR2W/Types/cp77/SensorDeviceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SensorDeviceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SensorDeviceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SensorJammed.cs
+++ b/CP77.CR2W/Types/cp77/SensorJammed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SequenceCallback.cs
+++ b/CP77.CR2W/Types/cp77/SequenceCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SequenceVideo.cs
+++ b/CP77.CR2W/Types/cp77/SequenceVideo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SequencerLock.cs
+++ b/CP77.CR2W/Types/cp77/SequencerLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ServerInfoController.cs
+++ b/CP77.CR2W/Types/cp77/ServerInfoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAchievementProgressRequest.cs
+++ b/CP77.CR2W/Types/cp77/SetAchievementProgressRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetActiveItemInEquipmentArea.cs
+++ b/CP77.CR2W/Types/cp77/SetActiveItemInEquipmentArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAnimWrappersFromMountData.cs
+++ b/CP77.CR2W/Types/cp77/SetAnimWrappersFromMountData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAnyTargetIsLocked.cs
+++ b/CP77.CR2W/Types/cp77/SetAnyTargetIsLocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAppearance.cs
+++ b/CP77.CR2W/Types/cp77/SetAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArgumentBoolean.cs
+++ b/CP77.CR2W/Types/cp77/SetArgumentBoolean.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArgumentFloat.cs
+++ b/CP77.CR2W/Types/cp77/SetArgumentFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArgumentInt.cs
+++ b/CP77.CR2W/Types/cp77/SetArgumentInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArgumentName.cs
+++ b/CP77.CR2W/Types/cp77/SetArgumentName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArgumentVector.cs
+++ b/CP77.CR2W/Types/cp77/SetArgumentVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetArguments.cs
+++ b/CP77.CR2W/Types/cp77/SetArguments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAttribute.cs
+++ b/CP77.CR2W/Types/cp77/SetAttribute.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAuthorizationModuleOFF.cs
+++ b/CP77.CR2W/Types/cp77/SetAuthorizationModuleOFF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAuthorizationModuleOFF.cs
+++ b/CP77.CR2W/Types/cp77/SetAuthorizationModuleOFF.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetAuthorizationModuleON.cs
+++ b/CP77.CR2W/Types/cp77/SetAuthorizationModuleON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAuthorizationModuleON.cs
+++ b/CP77.CR2W/Types/cp77/SetAuthorizationModuleON.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetAvoidThreatDestination.cs
+++ b/CP77.CR2W/Types/cp77/SetAvoidThreatDestination.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetAvoidThreatDestination.cs
+++ b/CP77.CR2W/Types/cp77/SetAvoidThreatDestination.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetBackOffAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/SetBackOffAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBackOffAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/SetBackOffAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetBloodPuddleSettingsEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBloodPuddleSettingsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBodyPositionEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBodyPositionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBooleanArgumentWhenActive.cs
+++ b/CP77.CR2W/Types/cp77/SetBooleanArgumentWhenActive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBountyEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBountyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBountyObjectEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBountyObjectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBraindanceState.cs
+++ b/CP77.CR2W/Types/cp77/SetBraindanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBusyEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBusyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetBusyEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetBusyEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetChancePrereq.cs
+++ b/CP77.CR2W/Types/cp77/SetChancePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetChancePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SetChancePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetChancePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SetChancePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetCloseItself.cs
+++ b/CP77.CR2W/Types/cp77/SetCloseItself.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetClosed.cs
+++ b/CP77.CR2W/Types/cp77/SetClosed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetClosed.cs
+++ b/CP77.CR2W/Types/cp77/SetClosed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetContainerStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetContainerStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetControllerStimSource.cs
+++ b/CP77.CR2W/Types/cp77/SetControllerStimSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetCurrentGameplayRoleEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetCurrentGameplayRoleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetCustomObjectDescriptionEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetCustomObjectDescriptionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetCustomPersonalLinkReason.cs
+++ b/CP77.CR2W/Types/cp77/SetCustomPersonalLinkReason.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetCustomShootPosition.cs
+++ b/CP77.CR2W/Types/cp77/SetCustomShootPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDebugSceneThrehsold.cs
+++ b/CP77.CR2W/Types/cp77/SetDebugSceneThrehsold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDefaultHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetDefaultHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDesiredReaction.cs
+++ b/CP77.CR2W/Types/cp77/SetDesiredReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDestinationWaypoint.cs
+++ b/CP77.CR2W/Types/cp77/SetDestinationWaypoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDetectionMultiplier.cs
+++ b/CP77.CR2W/Types/cp77/SetDetectionMultiplier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceAttitude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceAttitude.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceAttitude.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDeviceControllerInvestigationData.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceControllerInvestigationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceInvestigationData.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceInvestigationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceOFF.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceOFF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceOFF.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceOFF.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDeviceON.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceON.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceON.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDevicePowered.cs
+++ b/CP77.CR2W/Types/cp77/SetDevicePowered.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDevicePowered.cs
+++ b/CP77.CR2W/Types/cp77/SetDevicePowered.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDeviceTagKillMode.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceTagKillMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceTagKillMode.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceTagKillMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDeviceUnpowered.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceUnpowered.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDeviceUnpowered.cs
+++ b/CP77.CR2W/Types/cp77/SetDeviceUnpowered.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetDocumentStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetDocumentStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDoorType.cs
+++ b/CP77.CR2W/Types/cp77/SetDoorType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDroppedThreatLastKnowPosition.cs
+++ b/CP77.CR2W/Types/cp77/SetDroppedThreatLastKnowPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetDroppedThreatLastKnowPosition.cs
+++ b/CP77.CR2W/Types/cp77/SetDroppedThreatLastKnowPosition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetExplosionInstigatorPositionAsStimSource.cs
+++ b/CP77.CR2W/Types/cp77/SetExplosionInstigatorPositionAsStimSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetExplosionInstigatorPositionAsStimSource.cs
+++ b/CP77.CR2W/Types/cp77/SetExplosionInstigatorPositionAsStimSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetExposeQuickHacks.cs
+++ b/CP77.CR2W/Types/cp77/SetExposeQuickHacks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetFactEffector.cs
+++ b/CP77.CR2W/Types/cp77/SetFactEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetFriendlyEffector.cs
+++ b/CP77.CR2W/Types/cp77/SetFriendlyEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetGameplayObjectiveStateRequest.cs
+++ b/CP77.CR2W/Types/cp77/SetGameplayObjectiveStateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetGameplayRoleEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetGameplayRoleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetGlitchOnUIEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetGlitchOnUIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetGlobalTvChannel.cs
+++ b/CP77.CR2W/Types/cp77/SetGlobalTvChannel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetGlobalTvOnly.cs
+++ b/CP77.CR2W/Types/cp77/SetGlobalTvOnly.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetIgnoreAutoDoorCloseEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetIgnoreAutoDoorCloseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetInspectStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetInspectStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetIsInBraindance.cs
+++ b/CP77.CR2W/Types/cp77/SetIsInBraindance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetIsPlayerInsideLiftEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetIsPlayerInsideLiftEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetIsSpiderbotInteractionOrderedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetIsSpiderbotInteractionOrderedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetJammedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetJammedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetLogicReadyEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetLogicReadyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetManouverPosition.cs
+++ b/CP77.CR2W/Types/cp77/SetManouverPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetMessageRecordEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetMessageRecordEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetOpened.cs
+++ b/CP77.CR2W/Types/cp77/SetOpened.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetOpened.cs
+++ b/CP77.CR2W/Types/cp77/SetOpened.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetPanicOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/SetPanicOnTrafficLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetPanicOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/SetPanicOnTrafficLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetPendingReactionBB.cs
+++ b/CP77.CR2W/Types/cp77/SetPendingReactionBB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetPendingReactionBB.cs
+++ b/CP77.CR2W/Types/cp77/SetPendingReactionBB.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetPersistentForcedHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetPersistentForcedHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetPhaseState.cs
+++ b/CP77.CR2W/Types/cp77/SetPhaseState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetPlayerAsKiller.cs
+++ b/CP77.CR2W/Types/cp77/SetPlayerAsKiller.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetPlayerAsKiller.cs
+++ b/CP77.CR2W/Types/cp77/SetPlayerAsKiller.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetProficiencyLevel.cs
+++ b/CP77.CR2W/Types/cp77/SetProficiencyLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetProgressionBuild.cs
+++ b/CP77.CR2W/Types/cp77/SetProgressionBuild.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetQuestTargetWasSeen.cs
+++ b/CP77.CR2W/Types/cp77/SetQuestTargetWasSeen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetQuickHackAttemptEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetQuickHackAttemptEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetQuickHackEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetQuickHackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetRagdollComponentStateEffector.cs
+++ b/CP77.CR2W/Types/cp77/SetRagdollComponentStateEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetRandomIntArgument.cs
+++ b/CP77.CR2W/Types/cp77/SetRandomIntArgument.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetRevealedInNetwork.cs
+++ b/CP77.CR2W/Types/cp77/SetRevealedInNetwork.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetScriptExecutionContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetScriptExecutionContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetSearchInfluenceTask.cs
+++ b/CP77.CR2W/Types/cp77/SetSearchInfluenceTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetSearchInfluenceTask.cs
+++ b/CP77.CR2W/Types/cp77/SetSearchInfluenceTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetSecuritySystemState.cs
+++ b/CP77.CR2W/Types/cp77/SetSecuritySystemState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetSkillcheckEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetSkillcheckEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetSkipDeathAnimationTask.cs
+++ b/CP77.CR2W/Types/cp77/SetSkipDeathAnimationTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetStressOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/SetStressOnTrafficLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetStressOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/SetStressOnTrafficLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetTargetHealthEffector.cs
+++ b/CP77.CR2W/Types/cp77/SetTargetHealthEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTemporaryIndividualTimeDilation.cs
+++ b/CP77.CR2W/Types/cp77/SetTemporaryIndividualTimeDilation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTemporaryIndividualTimeDilation.cs
+++ b/CP77.CR2W/Types/cp77/SetTemporaryIndividualTimeDilation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetThreatsPersistenceRequest.cs
+++ b/CP77.CR2W/Types/cp77/SetThreatsPersistenceRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTimeDilationEffector.cs
+++ b/CP77.CR2W/Types/cp77/SetTimeDilationEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTimestampToBehaviorAgrument.cs
+++ b/CP77.CR2W/Types/cp77/SetTimestampToBehaviorAgrument.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTopThreatToCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/SetTopThreatToCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetTrafficLaneMovementParams.cs
+++ b/CP77.CR2W/Types/cp77/SetTrafficLaneMovementParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetUICameraZoomEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetUICameraZoomEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetVendorPriceMultiplierRequest.cs
+++ b/CP77.CR2W/Types/cp77/SetVendorPriceMultiplierRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetWeaponOwnerEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetWeaponOwnerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SetWeaponOwnerEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetWeaponOwnerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SetZoomLevelEvent.cs
+++ b/CP77.CR2W/Types/cp77/SetZoomLevelEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingControllerScheme.cs
+++ b/CP77.CR2W/Types/cp77/SettingControllerScheme.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsCategory.cs
+++ b/CP77.CR2W/Types/cp77/SettingsCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsCategoryController.cs
+++ b/CP77.CR2W/Types/cp77/SettingsCategoryController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsCategoryItem.cs
+++ b/CP77.CR2W/Types/cp77/SettingsCategoryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsCategoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/SettingsCategoryItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsCategoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/SettingsCategoryItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SettingsListItem.cs
+++ b/CP77.CR2W/Types/cp77/SettingsListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/SettingsMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsNotificationListener.cs
+++ b/CP77.CR2W/Types/cp77/SettingsNotificationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerBool.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerFloat.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerInt.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerLanguagesList.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerLanguagesList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerList.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListFloat.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListFloat.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListInt.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListInt.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListInt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListName.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListString.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListString.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerListString.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerListString.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SettingsSelectorControllerRange.cs
+++ b/CP77.CR2W/Types/cp77/SettingsSelectorControllerRange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SettingsVarListener.cs
+++ b/CP77.CR2W/Types/cp77/SettingsVarListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShaderDefine.cs
+++ b/CP77.CR2W/Types/cp77/ShaderDefine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShadowCascadeConfig.cs
+++ b/CP77.CR2W/Types/cp77/ShadowCascadeConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShaftsAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/ShaftsAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCaseAnimationEnded.cs
+++ b/CP77.CR2W/Types/cp77/ShardCaseAnimationEnded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCaseContainer.cs
+++ b/CP77.CR2W/Types/cp77/ShardCaseContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCaseContainerPS.cs
+++ b/CP77.CR2W/Types/cp77/ShardCaseContainerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCaseContainerPS.cs
+++ b/CP77.CR2W/Types/cp77/ShardCaseContainerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShardCollectedInventoryCallback.cs
+++ b/CP77.CR2W/Types/cp77/ShardCollectedInventoryCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCollectedNotification.cs
+++ b/CP77.CR2W/Types/cp77/ShardCollectedNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardCollectedNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/ShardCollectedNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardEntryData.cs
+++ b/CP77.CR2W/Types/cp77/ShardEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardEntrySelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShardEntrySelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardForceSelectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShardForceSelectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardItemVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/ShardItemVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardNotificationController.cs
+++ b/CP77.CR2W/Types/cp77/ShardNotificationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardReadPopupData.cs
+++ b/CP77.CR2W/Types/cp77/ShardReadPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardSelectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShardSelectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShardSyncBackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardSyncBackEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShardSyncBackEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShardsMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/ShardsMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardsNestedListDataView.cs
+++ b/CP77.CR2W/Types/cp77/ShardsNestedListDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShardsNestedListDataView.cs
+++ b/CP77.CR2W/Types/cp77/ShardsNestedListDataView.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShardsVirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/ShardsVirtualNestedListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SharedGameplayPS.cs
+++ b/CP77.CR2W/Types/cp77/SharedGameplayPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SharpeningAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/SharpeningAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootCommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/ShootCommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/ShootCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/ShootCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShootDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShootEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShootEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShootEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShoppingCartListItem.cs
+++ b/CP77.CR2W/Types/cp77/ShoppingCartListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShortBladeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShortBladeLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShortBladeLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShortBladeLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShortBladeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShortBladeLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShortBladeLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShortBladeLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShotgunDualLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunDualLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShotgunDualLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunDualLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShotgunDualLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunDualLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShotgunDualLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunDualLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShotgunLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShotgunLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShotgunLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShotgunLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/ShotgunLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShouldExitVehicle.cs
+++ b/CP77.CR2W/Types/cp77/ShouldExitVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShouldExitVehicle.cs
+++ b/CP77.CR2W/Types/cp77/ShouldExitVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShouldNPCContinueInAlerted.cs
+++ b/CP77.CR2W/Types/cp77/ShouldNPCContinueInAlerted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShouldNPCContinueInAlerted.cs
+++ b/CP77.CR2W/Types/cp77/ShouldNPCContinueInAlerted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShouldPoliceReactionBeAggressive.cs
+++ b/CP77.CR2W/Types/cp77/ShouldPoliceReactionBeAggressive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShouldPoliceReactionBeAggressive.cs
+++ b/CP77.CR2W/Types/cp77/ShouldPoliceReactionBeAggressive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShowRecipeRequest.cs
+++ b/CP77.CR2W/Types/cp77/ShowRecipeRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShowSingleMappinEvent.cs
+++ b/CP77.CR2W/Types/cp77/ShowSingleMappinEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShowUIWarningEffector.cs
+++ b/CP77.CR2W/Types/cp77/ShowUIWarningEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShowVendor.cs
+++ b/CP77.CR2W/Types/cp77/ShowVendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ShowVendor.cs
+++ b/CP77.CR2W/Types/cp77/ShowVendor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ShutdownModule.cs
+++ b/CP77.CR2W/Types/cp77/ShutdownModule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SideScrollerMiniGameScoreSystem.cs
+++ b/CP77.CR2W/Types/cp77/SideScrollerMiniGameScoreSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SideScrollerMiniGameScoreSystemAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/SideScrollerMiniGameScoreSystemAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleBinkGameController.cs
+++ b/CP77.CR2W/Types/cp77/SimpleBinkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleCombatConditon.cs
+++ b/CP77.CR2W/Types/cp77/SimpleCombatConditon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleSwitch.cs
+++ b/CP77.CR2W/Types/cp77/SimpleSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleSwitchController.cs
+++ b/CP77.CR2W/Types/cp77/SimpleSwitchController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleSwitchController.cs
+++ b/CP77.CR2W/Types/cp77/SimpleSwitchController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SimpleSwitchControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SimpleSwitchControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleTargetManager.cs
+++ b/CP77.CR2W/Types/cp77/SimpleTargetManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleTargetManager.cs
+++ b/CP77.CR2W/Types/cp77/SimpleTargetManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SimpleTemporalCustomData.cs
+++ b/CP77.CR2W/Types/cp77/SimpleTemporalCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SimpleTemporalCustomData.cs
+++ b/CP77.CR2W/Types/cp77/SimpleTemporalCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SimpleTriggerAttackEffect.cs
+++ b/CP77.CR2W/Types/cp77/SimpleTriggerAttackEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SingleCooldownManager.cs
+++ b/CP77.CR2W/Types/cp77/SingleCooldownManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SinglePlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/SinglePlayerPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SinglePlayerPrereq.cs
+++ b/CP77.CR2W/Types/cp77/SinglePlayerPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SingleWieldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SingleWieldDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SingleWieldDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SingleWieldDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SingleWieldEvents.cs
+++ b/CP77.CR2W/Types/cp77/SingleWieldEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SingleplayerMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/SingleplayerMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SkillCheckBase.cs
+++ b/CP77.CR2W/Types/cp77/SkillCheckBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SkillCheckPrereq.cs
+++ b/CP77.CR2W/Types/cp77/SkillCheckPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SkillCheckPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SkillCheckPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SkillCheckPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SkillCheckPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SkillTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/SkillTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Slave_Test.cs
+++ b/CP77.CR2W/Types/cp77/Slave_Test.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlideEvents.cs
+++ b/CP77.CR2W/Types/cp77/SlideEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideFallDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideFallDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlideFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/SlideFallEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/SlideFallEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlideLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SlideLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlideLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SlideLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlideLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SlideLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlidingLadder.cs
+++ b/CP77.CR2W/Types/cp77/SlidingLadder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlidingLadderController.cs
+++ b/CP77.CR2W/Types/cp77/SlidingLadderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlidingLadderController.cs
+++ b/CP77.CR2W/Types/cp77/SlidingLadderController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlidingLadderControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SlidingLadderControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlotAnimationInProgress.cs
+++ b/CP77.CR2W/Types/cp77/SlotAnimationInProgress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlotAnimationInProgress.cs
+++ b/CP77.CR2W/Types/cp77/SlotAnimationInProgress.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SlotMachineController.cs
+++ b/CP77.CR2W/Types/cp77/SlotMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlotMachineSlot.cs
+++ b/CP77.CR2W/Types/cp77/SlotMachineSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlotReservationDecorator.cs
+++ b/CP77.CR2W/Types/cp77/SlotReservationDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SlotUserData.cs
+++ b/CP77.CR2W/Types/cp77/SlotUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartBulletDeflectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SmartBulletDeflectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartDespawnRequest.cs
+++ b/CP77.CR2W/Types/cp77/SmartDespawnRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartDespawnRequest.cs
+++ b/CP77.CR2W/Types/cp77/SmartDespawnRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartHouse.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartHouseConfiguration.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouseConfiguration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartHouseController.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartHouseController.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouseController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartHouseControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouseControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartHouseDeviceWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/SmartHouseDeviceWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartHousePreset.cs
+++ b/CP77.CR2W/Types/cp77/SmartHousePreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindow.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindow.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindow.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartWindowController.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindowController.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartWindowControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindowControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartWindowInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindowInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowInkGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmartWindowMainLayoutWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowMainLayoutWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindowViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmartWindowViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/SmartWindowViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SmgLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmgLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SmgLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/SmgLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmgLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/SmgLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmokeMachine.cs
+++ b/CP77.CR2W/Types/cp77/SmokeMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmokeMachineController.cs
+++ b/CP77.CR2W/Types/cp77/SmokeMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmokeMachineController.cs
+++ b/CP77.CR2W/Types/cp77/SmokeMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SmokeMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SmokeMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SmokeMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SmokeMachineControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SnapToTargetExecutor.cs
+++ b/CP77.CR2W/Types/cp77/SnapToTargetExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SnapToTargetExecutor.cs
+++ b/CP77.CR2W/Types/cp77/SnapToTargetExecutor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SniperRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SniperRifleLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SniperRifleLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SniperRifleLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SniperRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/SniperRifleLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SniperRifleLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/SniperRifleLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SocialPanelContactInfo.cs
+++ b/CP77.CR2W/Types/cp77/SocialPanelContactInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SocialPanelContactsDetails.cs
+++ b/CP77.CR2W/Types/cp77/SocialPanelContactsDetails.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SocialPanelContactsList.cs
+++ b/CP77.CR2W/Types/cp77/SocialPanelContactsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SocialPanelContactsListItem.cs
+++ b/CP77.CR2W/Types/cp77/SocialPanelContactsListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SocialPanelGameController.cs
+++ b/CP77.CR2W/Types/cp77/SocialPanelGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SoldItem.cs
+++ b/CP77.CR2W/Types/cp77/SoldItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SoldItemsCache.cs
+++ b/CP77.CR2W/Types/cp77/SoldItemsCache.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SortComparatorTemplate.cs
+++ b/CP77.CR2W/Types/cp77/SortComparatorTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SortComparatorTemplate.cs
+++ b/CP77.CR2W/Types/cp77/SortComparatorTemplate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SortingDropdownData.cs
+++ b/CP77.CR2W/Types/cp77/SortingDropdownData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SortingDropdownData.cs
+++ b/CP77.CR2W/Types/cp77/SortingDropdownData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SoundSystem.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SoundSystem.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SoundSystemController.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SoundSystemController.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SoundSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SoundSystemSettings.cs
+++ b/CP77.CR2W/Types/cp77/SoundSystemSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SourceTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/SourceTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/SpaceShuttleInteriorContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpatialQueriesHelper.cs
+++ b/CP77.CR2W/Types/cp77/SpatialQueriesHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpatialQueriesHelper.cs
+++ b/CP77.CR2W/Types/cp77/SpatialQueriesHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpawnBoxEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/SpawnBoxEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnBoxEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/SpawnBoxEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpawnLaserAttackEvent.cs
+++ b/CP77.CR2W/Types/cp77/SpawnLaserAttackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnLibraryItemController.cs
+++ b/CP77.CR2W/Types/cp77/SpawnLibraryItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnSphereEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/SpawnSphereEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnSphereEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/SpawnSphereEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpawnSubCharacterEffector.cs
+++ b/CP77.CR2W/Types/cp77/SpawnSubCharacterEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/SpawnSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/SpawnSubCharacterRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpawnUniquePursuitSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/SpawnUniquePursuitSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnUniqueSubCharacterRequest.cs
+++ b/CP77.CR2W/Types/cp77/SpawnUniqueSubCharacterRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpawnerData.cs
+++ b/CP77.CR2W/Types/cp77/SpawnerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Speaker.cs
+++ b/CP77.CR2W/Types/cp77/Speaker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpeakerController.cs
+++ b/CP77.CR2W/Types/cp77/SpeakerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpeakerController.cs
+++ b/CP77.CR2W/Types/cp77/SpeakerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpeakerControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SpeakerControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpeakerSetup.cs
+++ b/CP77.CR2W/Types/cp77/SpeakerSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpecialProperties.cs
+++ b/CP77.CR2W/Types/cp77/SpecialProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpeedIndicatorIconsManager.cs
+++ b/CP77.CR2W/Types/cp77/SpeedIndicatorIconsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Sphere.cs
+++ b/CP77.CR2W/Types/cp77/Sphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotActivateActivator.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotActivateActivator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotActivateActivator.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotActivateActivator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotBoolAction.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotBoolAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevicePerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDisarmExplosiveDevicePerformed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractDevicePerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractDevicePerformed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevicePerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractExplosiveDevicePerformed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistraction.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistraction.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractionPerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractionPerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotDistractionPerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotDistractionPerformed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotEnableAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotEnableAccessPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotEnableAccessPoint.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotEnableAccessPoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevice.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevicePerformed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevicePerformed.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotExplodeExplosiveDevicePerformed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotHeavyProjectile.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotHeavyProjectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotOrderCompletedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotOrderCompletedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotOrderCompletedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotOrderCompletedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SpiderbotOrderDeviceEvent.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotOrderDeviceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpiderbotScavengeOptions.cs
+++ b/CP77.CR2W/Types/cp77/SpiderbotScavengeOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Spline.cs
+++ b/CP77.CR2W/Types/cp77/Spline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SplinePoint.cs
+++ b/CP77.CR2W/Types/cp77/SplinePoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpreadEffector.cs
+++ b/CP77.CR2W/Types/cp77/SpreadEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpreadFearEvent.cs
+++ b/CP77.CR2W/Types/cp77/SpreadFearEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpreadInitEffector.cs
+++ b/CP77.CR2W/Types/cp77/SpreadInitEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SpreadMapItem.cs
+++ b/CP77.CR2W/Types/cp77/SpreadMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintJumpLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintJumpLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintJumpLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintJumpLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintJumpLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintJumpLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintJumpLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintJumpLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintWindupLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintWindupLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintWindupLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SprintWindupLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SprintWindupLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintWindupLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SprintWindupLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/SprintWindupLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SquadActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/SquadActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SquadActionSignal.cs
+++ b/CP77.CR2W/Types/cp77/SquadActionSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SquadAlertedSync.cs
+++ b/CP77.CR2W/Types/cp77/SquadAlertedSync.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SquadAlertedSync.cs
+++ b/CP77.CR2W/Types/cp77/SquadAlertedSync.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SquadMemberBaseComponent.cs
+++ b/CP77.CR2W/Types/cp77/SquadMemberBaseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SquadTask.cs
+++ b/CP77.CR2W/Types/cp77/SquadTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SquadTask.cs
+++ b/CP77.CR2W/Types/cp77/SquadTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SquadTicketReceipt.cs
+++ b/CP77.CR2W/Types/cp77/SquadTicketReceipt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SsimpleBanerData.cs
+++ b/CP77.CR2W/Types/cp77/SsimpleBanerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StackAlertedState.cs
+++ b/CP77.CR2W/Types/cp77/StackAlertedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StackAlertedState.cs
+++ b/CP77.CR2W/Types/cp77/StackAlertedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StackChangeHighLevelStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/StackChangeHighLevelStateAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StackChangeHighLevelStateAbstract.cs
+++ b/CP77.CR2W/Types/cp77/StackChangeHighLevelStateAbstract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StackClearCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/StackClearCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StackClearCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/StackClearCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StackRelaxedState.cs
+++ b/CP77.CR2W/Types/cp77/StackRelaxedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StackRelaxedState.cs
+++ b/CP77.CR2W/Types/cp77/StackRelaxedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Stagger.cs
+++ b/CP77.CR2W/Types/cp77/Stagger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StaggerDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StaggerDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StaggerReactionTask.cs
+++ b/CP77.CR2W/Types/cp77/StaggerReactionTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StalkEvent.cs
+++ b/CP77.CR2W/Types/cp77/StalkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StalkEvent.cs
+++ b/CP77.CR2W/Types/cp77/StalkEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StaminaEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/StaminaEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StaminaEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/StaminaEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StaminaPoolListener.cs
+++ b/CP77.CR2W/Types/cp77/StaminaPoolListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StaminaTransition.cs
+++ b/CP77.CR2W/Types/cp77/StaminaTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StaminabarWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/StaminabarWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StanceNPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/StanceNPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StanceNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StanceNPCStatePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StanceNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StanceNPCStatePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StanceStateChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/StanceStateChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StandEvents.cs
+++ b/CP77.CR2W/Types/cp77/StandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StandLowGravityDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandLowGravityDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StandLowGravityDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StandLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/StandLowGravityEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandLowGravityEvents.cs
+++ b/CP77.CR2W/Types/cp77/StandLowGravityEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StandState.cs
+++ b/CP77.CR2W/Types/cp77/StandState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StandState.cs
+++ b/CP77.CR2W/Types/cp77/StandState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StarController.cs
+++ b/CP77.CR2W/Types/cp77/StarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartCall.cs
+++ b/CP77.CR2W/Types/cp77/StartCall.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartCall.cs
+++ b/CP77.CR2W/Types/cp77/StartCall.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StartEndPhoneCallEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartEndPhoneCallEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartGlitchingText.cs
+++ b/CP77.CR2W/Types/cp77/StartGlitchingText.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartGlitchingText.cs
+++ b/CP77.CR2W/Types/cp77/StartGlitchingText.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StartGrenadeThrowQueryEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartGrenadeThrowQueryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartHubMenuEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartHubMenuEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartOverheatEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartOverheatEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartOverheatEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartOverheatEffectEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StartPingingNetworkRequest.cs
+++ b/CP77.CR2W/Types/cp77/StartPingingNetworkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartRagdollDamageEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartRagdollDamageEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StartRagdollDamageEvent.cs
+++ b/CP77.CR2W/Types/cp77/StartRagdollDamageEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Stash.cs
+++ b/CP77.CR2W/Types/cp77/Stash.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StashController.cs
+++ b/CP77.CR2W/Types/cp77/StashController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StashController.cs
+++ b/CP77.CR2W/Types/cp77/StashController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StashControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/StashControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StashControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/StashControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatCheckPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatCheckPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatCheckPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatCheckPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatCheckPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatCheckPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatPoolComparisonHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolComparisonHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolEffector.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolEffector.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatPoolHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolSpentPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolSpentPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolSpentPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolSpentPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolSpentPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolSpentPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolsManager.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPoolsManager.cs
+++ b/CP77.CR2W/Types/cp77/StatPoolsManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/StatPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatProvider.cs
+++ b/CP77.CR2W/Types/cp77/StatProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/State.cs
+++ b/CP77.CR2W/Types/cp77/State.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatisticDifferenceBarController.cs
+++ b/CP77.CR2W/Types/cp77/StatisticDifferenceBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsDetailListController.cs
+++ b/CP77.CR2W/Types/cp77/StatsDetailListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsDetailViewController.cs
+++ b/CP77.CR2W/Types/cp77/StatsDetailViewController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/StatsMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsManager.cs
+++ b/CP77.CR2W/Types/cp77/StatsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsPlayTimeController.cs
+++ b/CP77.CR2W/Types/cp77/StatsPlayTimeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsProgressController.cs
+++ b/CP77.CR2W/Types/cp77/StatsProgressController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsStreetCredReward.cs
+++ b/CP77.CR2W/Types/cp77/StatsStreetCredReward.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsStreetCredRewardItem.cs
+++ b/CP77.CR2W/Types/cp77/StatsStreetCredRewardItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/StatsSystemHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatsSystemHelper.cs
+++ b/CP77.CR2W/Types/cp77/StatsSystemHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatsViewController.cs
+++ b/CP77.CR2W/Types/cp77/StatsViewController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectAbsentPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectActions.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectActions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectActions.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectActions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectEvents.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectManagerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectPresentHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectPresentHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectRemovedPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectSignalEvent.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectSignalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectSlot.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectSlot.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectTasks.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectTasks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StatusEffectTasks.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectTasks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StatusEffectTriggerListener.cs
+++ b/CP77.CR2W/Types/cp77/StatusEffectTriggerListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StealthDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthDecisions.cs
+++ b/CP77.CR2W/Types/cp77/StealthDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StealthEvents.cs
+++ b/CP77.CR2W/Types/cp77/StealthEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthMappinGameController.cs
+++ b/CP77.CR2W/Types/cp77/StealthMappinGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthState.cs
+++ b/CP77.CR2W/Types/cp77/StealthState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthState.cs
+++ b/CP77.CR2W/Types/cp77/StealthState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StealthStimThreshold.cs
+++ b/CP77.CR2W/Types/cp77/StealthStimThreshold.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthStimThresholdEvent.cs
+++ b/CP77.CR2W/Types/cp77/StealthStimThresholdEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthZonesGameController.cs
+++ b/CP77.CR2W/Types/cp77/StealthZonesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StealthZonesGameController.cs
+++ b/CP77.CR2W/Types/cp77/StealthZonesGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SteetCredDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/SteetCredDataHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SteetCredDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/SteetCredDataHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Stillage.cs
+++ b/CP77.CR2W/Types/cp77/Stillage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StillageController.cs
+++ b/CP77.CR2W/Types/cp77/StillageController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StillageController.cs
+++ b/CP77.CR2W/Types/cp77/StillageController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StillageControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/StillageControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimBroadcasterComponent.cs
+++ b/CP77.CR2W/Types/cp77/StimBroadcasterComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/StimDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimEventData.cs
+++ b/CP77.CR2W/Types/cp77/StimEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimParams.cs
+++ b/CP77.CR2W/Types/cp77/StimParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimRequest.cs
+++ b/CP77.CR2W/Types/cp77/StimRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimRequestID.cs
+++ b/CP77.CR2W/Types/cp77/StimRequestID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimTargetData.cs
+++ b/CP77.CR2W/Types/cp77/StimTargetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimTargetsEvent.cs
+++ b/CP77.CR2W/Types/cp77/StimTargetsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimThresholdEvent.cs
+++ b/CP77.CR2W/Types/cp77/StimThresholdEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimuliEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/StimuliEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StimuliSquadActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/StimuliSquadActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopAndPlaySFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/StopAndPlaySFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopAndPlayVFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/StopAndPlayVFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopCallReinforcements.cs
+++ b/CP77.CR2W/Types/cp77/StopCallReinforcements.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopPingingNetworkRequest.cs
+++ b/CP77.CR2W/Types/cp77/StopPingingNetworkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopSFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/StopSFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopShortGlitchEvent.cs
+++ b/CP77.CR2W/Types/cp77/StopShortGlitchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StopShortGlitchEvent.cs
+++ b/CP77.CR2W/Types/cp77/StopShortGlitchEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StopVFXEffector.cs
+++ b/CP77.CR2W/Types/cp77/StopVFXEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StorageBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/StorageBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StorageUserData.cs
+++ b/CP77.CR2W/Types/cp77/StorageUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StoreMiniGameProgramEvent.cs
+++ b/CP77.CR2W/Types/cp77/StoreMiniGameProgramEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StreetNameSelector.cs
+++ b/CP77.CR2W/Types/cp77/StreetNameSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StreetSignSelector.cs
+++ b/CP77.CR2W/Types/cp77/StreetSignSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StreetSignSelector.cs
+++ b/CP77.CR2W/Types/cp77/StreetSignSelector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StreetSignWidgetComponent.cs
+++ b/CP77.CR2W/Types/cp77/StreetSignWidgetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeDuration_Debug.cs
+++ b/CP77.CR2W/Types/cp77/StrikeDuration_Debug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeDuration_Debug.cs
+++ b/CP77.CR2W/Types/cp77/StrikeDuration_Debug.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeDuration_Debug_VDB.cs
+++ b/CP77.CR2W/Types/cp77/StrikeDuration_Debug_VDB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ApplyStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ApplyStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ApplyStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ApplyStatusEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ModifyStatPool.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ModifyStatPool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ModifyStatPool.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_ModifyStatPool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStat.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStat.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStats.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStats.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_PrintStats.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_VDB.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_VDB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_VDB.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Debug_VDB.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Heal.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Heal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Kill.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Kill.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_Kill.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_Kill.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_ModifyStat.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_ModifyStat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/StrikeExecutor_ModifyStat.cs
+++ b/CP77.CR2W/Types/cp77/StrikeExecutor_ModifyStat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/StrikeFilterSingle_NPC.cs
+++ b/CP77.CR2W/Types/cp77/StrikeFilterSingle_NPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubCharEquipRequest.cs
+++ b/CP77.CR2W/Types/cp77/SubCharEquipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubCharUnequipRequest.cs
+++ b/CP77.CR2W/Types/cp77/SubCharUnequipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubCharacterSystem.cs
+++ b/CP77.CR2W/Types/cp77/SubCharacterSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubMenuPanelLogicController.cs
+++ b/CP77.CR2W/Types/cp77/SubMenuPanelLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubmenuDataBuilder.cs
+++ b/CP77.CR2W/Types/cp77/SubmenuDataBuilder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubtitleLineLogicController.cs
+++ b/CP77.CR2W/Types/cp77/SubtitleLineLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubtitlesGameController.cs
+++ b/CP77.CR2W/Types/cp77/SubtitlesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SubtitlesSettingsListener.cs
+++ b/CP77.CR2W/Types/cp77/SubtitlesSettingsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroFallDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroFallDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuperheroFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroFallEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroFallEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuperheroLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuperheroLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuperheroLandRecoveryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandRecoveryDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroLandRecoveryDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandRecoveryDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuperheroLandRecoveryEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandRecoveryEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuperheroLandRecoveryEvents.cs
+++ b/CP77.CR2W/Types/cp77/SuperheroLandRecoveryEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SuppressNPCInSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/SuppressNPCInSecuritySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuppressOutlineEvent.cs
+++ b/CP77.CR2W/Types/cp77/SuppressOutlineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuppressSecuritySystemReaction.cs
+++ b/CP77.CR2W/Types/cp77/SuppressSecuritySystemReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SuppressSecuritySystemStateChange.cs
+++ b/CP77.CR2W/Types/cp77/SuppressSecuritySystemStateChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCamera.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraController.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraController.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraResaveData.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraStatus.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraStatus.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraStatus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceCameraViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceCameraViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SurveillanceSystem.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceSystem.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SurveillanceSystemController.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceSystemController.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystemController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SurveillanceSystemControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystemControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystemUIPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SurveillanceSystemUIPS.cs
+++ b/CP77.CR2W/Types/cp77/SurveillanceSystemUIPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SvgResource.cs
+++ b/CP77.CR2W/Types/cp77/SvgResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwapItemPart.cs
+++ b/CP77.CR2W/Types/cp77/SwapItemPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwapMeshDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SwapMeshDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwapMeshDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/SwapMeshDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwapPresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/SwapPresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingClimbDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingClimbDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingClimbDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingClimbDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingClimbEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingClimbEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingClimbEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingClimbEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingDivingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingDivingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingDivingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingDivingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingDivingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingDivingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingFastDivingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingFastDivingDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingFastDivingDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingFastDivingDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingFastDivingEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingFastDivingEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingForceFreezeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingForceFreezeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingForceFreezeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingForceFreezeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingForceFreezeEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingForceFreezeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingForceFreezeEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingForceFreezeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingLadderDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingLadderDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingLadderDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingLadderDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingLadderEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingLadderEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingLadderEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingLadderEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceFastDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceFastDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceFastDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceFastDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingSurfaceFastEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingSurfaceFastEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingTransitionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingTransitionDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingTransitionDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingTransitionDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwimmingTransitionEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingTransitionEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwimmingTransitionEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwimmingTransitionEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwitchSeatsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwitchSeatsDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SwitchSeatsDecisions.cs
+++ b/CP77.CR2W/Types/cp77/SwitchSeatsDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SwitchSeatsEvents.cs
+++ b/CP77.CR2W/Types/cp77/SwitchSeatsEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SyncAnimDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/SyncAnimDeathTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SyncAnimDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/SyncAnimDeathTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SysDebuggerEvent.cs
+++ b/CP77.CR2W/Types/cp77/SysDebuggerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/SysDebuggerEvent.cs
+++ b/CP77.CR2W/Types/cp77/SysDebuggerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/SystemDeviceWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/SystemDeviceWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSInputCameraZoom.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputCameraZoom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSInputCameraZoom.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputCameraZoom.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TCSInputDeviceAttack.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputDeviceAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSInputXAxisEvent.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputXAxisEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSInputXYAxisEvent.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputXYAxisEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSInputYAxisEvent.cs
+++ b/CP77.CR2W/Types/cp77/TCSInputYAxisEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSTakeOverControlActivate.cs
+++ b/CP77.CR2W/Types/cp77/TCSTakeOverControlActivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSTakeOverControlActivate.cs
+++ b/CP77.CR2W/Types/cp77/TCSTakeOverControlActivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TCSTakeOverControlDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/TCSTakeOverControlDeactivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSTakeOverControlDeactivate.cs
+++ b/CP77.CR2W/Types/cp77/TCSTakeOverControlDeactivate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TCSUpdate.cs
+++ b/CP77.CR2W/Types/cp77/TCSUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TCSUpdate.cs
+++ b/CP77.CR2W/Types/cp77/TCSUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TDB.cs
+++ b/CP77.CR2W/Types/cp77/TDB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TDB.cs
+++ b/CP77.CR2W/Types/cp77/TDB.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TEMP_ScanningEvent.cs
+++ b/CP77.CR2W/Types/cp77/TEMP_ScanningEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TV.cs
+++ b/CP77.CR2W/Types/cp77/TV.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVController.cs
+++ b/CP77.CR2W/Types/cp77/TVController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVController.cs
+++ b/CP77.CR2W/Types/cp77/TVController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TVControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TVControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/TVDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVResaveData.cs
+++ b/CP77.CR2W/Types/cp77/TVResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVSetup.cs
+++ b/CP77.CR2W/Types/cp77/TVSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/TVViabilityInterpreter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TVViabilityInterpreter.cs
+++ b/CP77.CR2W/Types/cp77/TVViabilityInterpreter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TXAACustomData.cs
+++ b/CP77.CR2W/Types/cp77/TXAACustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TXAACustomData.cs
+++ b/CP77.CR2W/Types/cp77/TXAACustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TabButtonController.cs
+++ b/CP77.CR2W/Types/cp77/TabButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TabRadioGroup.cs
+++ b/CP77.CR2W/Types/cp77/TabRadioGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TagLinkedCluekRequest.cs
+++ b/CP77.CR2W/Types/cp77/TagLinkedCluekRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TagObjectEvent.cs
+++ b/CP77.CR2W/Types/cp77/TagObjectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TagStatusNotification.cs
+++ b/CP77.CR2W/Types/cp77/TagStatusNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TaggedObjectsListDef.cs
+++ b/CP77.CR2W/Types/cp77/TaggedObjectsListDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakeOverControlSystem.cs
+++ b/CP77.CR2W/Types/cp77/TakeOverControlSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakeOverSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/TakeOverSecuritySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakeOverSecuritySystem.cs
+++ b/CP77.CR2W/Types/cp77/TakeOverSecuritySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownActionDataTrackingRequest.cs
+++ b/CP77.CR2W/Types/cp77/TakedownActionDataTrackingRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownAndDisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/TakedownAndDisposeBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownAndDisposeBody.cs
+++ b/CP77.CR2W/Types/cp77/TakedownAndDisposeBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownBeginDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownBeginDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownBeginDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownBeginDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownBeginEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownBeginEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownBeginEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownBeginEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownEndDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownEndDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownEndDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownEndDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownEndEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownEndEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownEndEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownEndEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownAndDisposeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownExecuteTakedownEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownExecuteTakedownEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownGameEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGameEffectHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownGameEffectHelper.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGameEffectHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownGrappleFailedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrappleFailedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownGrappleFailedEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrappleFailedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownGrappleFailedEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrappleFailedEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownGrapplePreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrapplePreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownGrapplePreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrapplePreyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownGrapplePreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownGrapplePreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownLeapToPreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownLeapToPreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownLeapToPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownLeapToPreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownLeapToPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownLeapToPreyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TakedownPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TakedownPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TakedownPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TakedownPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownReleasePreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownReleasePreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownReleasePreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownReleasePreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownReleasePreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownReleasePreyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownSlideToPreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownSlideToPreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownSlideToPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownSlideToPreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownSlideToPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownSlideToPreyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownUnmountPreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUnmountPreyDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownUnmountPreyDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUnmountPreyDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownUnmountPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUnmountPreyEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownUnmountPreyEvents.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUnmountPreyEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TakedownUtils.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TakedownUtils.cs
+++ b/CP77.CR2W/Types/cp77/TakedownUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TalkingTriggerRequest.cs
+++ b/CP77.CR2W/Types/cp77/TalkingTriggerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TankTurret.cs
+++ b/CP77.CR2W/Types/cp77/TankTurret.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TankTurret.cs
+++ b/CP77.CR2W/Types/cp77/TankTurret.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TankTurretComponent.cs
+++ b/CP77.CR2W/Types/cp77/TankTurretComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Target.cs
+++ b/CP77.CR2W/Types/cp77/Target.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetAcquiredEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetAcquiredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetAssessmentRequest.cs
+++ b/CP77.CR2W/Types/cp77/TargetAssessmentRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetAttitudeAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/TargetAttitudeAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetHitIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/TargetHitIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetHitIndicatorLogicController.cs
+++ b/CP77.CR2W/Types/cp77/TargetHitIndicatorLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetIndicatorEntry.cs
+++ b/CP77.CR2W/Types/cp77/TargetIndicatorEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetKilledHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/TargetKilledHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetKilledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TargetKilledPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetKilledPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TargetKilledPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TargetKilledPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TargetKilledPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetKilledPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TargetKilledPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TargetLockedEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetLockedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetLockedEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetLockedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TargetLostEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetLostEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetNPCRarityHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/TargetNPCRarityHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetNPCTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/TargetNPCTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetNeutraliziedEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetNeutraliziedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetScavengedEvent.cs
+++ b/CP77.CR2W/Types/cp77/TargetScavengedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetTrackingExtension.cs
+++ b/CP77.CR2W/Types/cp77/TargetTrackingExtension.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/TargetTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetedObjectDeathListener.cs
+++ b/CP77.CR2W/Types/cp77/TargetedObjectDeathListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TargetingBehaviour.cs
+++ b/CP77.CR2W/Types/cp77/TargetingBehaviour.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotCardAdded.cs
+++ b/CP77.CR2W/Types/cp77/TarotCardAdded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotCardAddedNotification.cs
+++ b/CP77.CR2W/Types/cp77/TarotCardAddedNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotCardData.cs
+++ b/CP77.CR2W/Types/cp77/TarotCardData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotCardPreviewData.cs
+++ b/CP77.CR2W/Types/cp77/TarotCardPreviewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotCardPreviewPopupEvent.cs
+++ b/CP77.CR2W/Types/cp77/TarotCardPreviewPopupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/TarotMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TarotPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/TarotPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TechQA_ImageSwappingButtonController.cs
+++ b/CP77.CR2W/Types/cp77/TechQA_ImageSwappingButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TeleportCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/TeleportCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TeleportDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/TeleportDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TeleportFailsafeHelper.cs
+++ b/CP77.CR2W/Types/cp77/TeleportFailsafeHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TeleportFailsafeHelper.cs
+++ b/CP77.CR2W/Types/cp77/TeleportFailsafeHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TempClearForcedCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/TempClearForcedCombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TempClearForcedCombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/TempClearForcedCombatTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TemporalPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TemporalPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TemporalPrereqDelayCallback.cs
+++ b/CP77.CR2W/Types/cp77/TemporalPrereqDelayCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TemporalPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TemporalPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TemporaryDoorState.cs
+++ b/CP77.CR2W/Types/cp77/TemporaryDoorState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TemporaryUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TemporaryUnequipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TemporaryUnequipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TemporaryUnequipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TemporaryUnequipEvents.cs
+++ b/CP77.CR2W/Types/cp77/TemporaryUnequipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Terminal.cs
+++ b/CP77.CR2W/Types/cp77/Terminal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalController.cs
+++ b/CP77.CR2W/Types/cp77/TerminalController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalController.cs
+++ b/CP77.CR2W/Types/cp77/TerminalController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TerminalControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TerminalControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalInkGameControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/TerminalInkGameControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalMainLayoutWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/TerminalMainLayoutWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalSetState.cs
+++ b/CP77.CR2W/Types/cp77/TerminalSetState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalSetup.cs
+++ b/CP77.CR2W/Types/cp77/TerminalSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminalSystemCustomData.cs
+++ b/CP77.CR2W/Types/cp77/TerminalSystemCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminateReactionLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/TerminateReactionLookatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TerminateReactionLookatEvent.cs
+++ b/CP77.CR2W/Types/cp77/TerminateReactionLookatEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestBehaviorDelegate.cs
+++ b/CP77.CR2W/Types/cp77/TestBehaviorDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestBehaviorDelegateTask.cs
+++ b/CP77.CR2W/Types/cp77/TestBehaviorDelegateTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestConditon.cs
+++ b/CP77.CR2W/Types/cp77/TestConditon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestConditon.cs
+++ b/CP77.CR2W/Types/cp77/TestConditon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestEffector.cs
+++ b/CP77.CR2W/Types/cp77/TestEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestEffector.cs
+++ b/CP77.CR2W/Types/cp77/TestEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestFalseConditon.cs
+++ b/CP77.CR2W/Types/cp77/TestFalseConditon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestFalseConditon.cs
+++ b/CP77.CR2W/Types/cp77/TestFalseConditon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestMappinScriptData.cs
+++ b/CP77.CR2W/Types/cp77/TestMappinScriptData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestNPCOutsideNavmeshEvent.cs
+++ b/CP77.CR2W/Types/cp77/TestNPCOutsideNavmeshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/TestRandomizationSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestScriptableComponent.cs
+++ b/CP77.CR2W/Types/cp77/TestScriptableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestScriptableComponent.cs
+++ b/CP77.CR2W/Types/cp77/TestScriptableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestStackPassiveExpression.cs
+++ b/CP77.CR2W/Types/cp77/TestStackPassiveExpression.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestStackScript.cs
+++ b/CP77.CR2W/Types/cp77/TestStackScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TestStackScript.cs
+++ b/CP77.CR2W/Types/cp77/TestStackScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TestStackScriptData.cs
+++ b/CP77.CR2W/Types/cp77/TestStackScriptData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Tetrahedron.cs
+++ b/CP77.CR2W/Types/cp77/Tetrahedron.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TextAnimOnTextChange.cs
+++ b/CP77.CR2W/Types/cp77/TextAnimOnTextChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TextSectionLogicController.cs
+++ b/CP77.CR2W/Types/cp77/TextSectionLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TextSpawnerController.cs
+++ b/CP77.CR2W/Types/cp77/TextSpawnerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThreatPersistanceMemory.cs
+++ b/CP77.CR2W/Types/cp77/ThreatPersistanceMemory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowEquipmentRequest.cs
+++ b/CP77.CR2W/Types/cp77/ThrowEquipmentRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowGrenadeCommandCleanup.cs
+++ b/CP77.CR2W/Types/cp77/ThrowGrenadeCommandCleanup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowGrenadeCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/ThrowGrenadeCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowGrenadeCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/ThrowGrenadeCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowStuff.cs
+++ b/CP77.CR2W/Types/cp77/ThrowStuff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThrowStuff.cs
+++ b/CP77.CR2W/Types/cp77/ThrowStuff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ThrowableWeaponObject.cs
+++ b/CP77.CR2W/Types/cp77/ThrowableWeaponObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ThumbnailUI.cs
+++ b/CP77.CR2W/Types/cp77/ThumbnailUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TierIIIContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TierIIIContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TierIIIContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TierIIIContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TierIIIContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/TierIIIContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TierIIIContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/TierIIIContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TierIVContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TierIVContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TierIVContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TierIVContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TierIVContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/TierIVContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TierIVContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/TierIVContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Time.cs
+++ b/CP77.CR2W/Types/cp77/Time.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeBetweenHitsParameters.cs
+++ b/CP77.CR2W/Types/cp77/TimeBetweenHitsParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationEventsTransitions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationEventsTransitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationEventsTransitions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationEventsTransitions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationFocusModeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationFocusModeDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationFocusModeDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationFocusModeDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationFocusModeEvents.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationFocusModeEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationFocusModeEvents.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationFocusModeEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationHelper.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationHelper.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationParameters.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputEvents.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationProgressWithInputEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationTransitions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationTransitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeDilationTransitions.cs
+++ b/CP77.CR2W/Types/cp77/TimeDilationTransitions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/TimeMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeOfDayVisibilityResource.cs
+++ b/CP77.CR2W/Types/cp77/TimeOfDayVisibilityResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeOfDayVisibilityResource.cs
+++ b/CP77.CR2W/Types/cp77/TimeOfDayVisibilityResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeSkipPopupCloseData.cs
+++ b/CP77.CR2W/Types/cp77/TimeSkipPopupCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeSkipPopupData.cs
+++ b/CP77.CR2W/Types/cp77/TimeSkipPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimeSkipPopupData.cs
+++ b/CP77.CR2W/Types/cp77/TimeSkipPopupData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimeTableCallbackRequest.cs
+++ b/CP77.CR2W/Types/cp77/TimeTableCallbackRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimerEvent.cs
+++ b/CP77.CR2W/Types/cp77/TimerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimerEvent.cs
+++ b/CP77.CR2W/Types/cp77/TimerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TimerGameController.cs
+++ b/CP77.CR2W/Types/cp77/TimerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TimetableCallbackData.cs
+++ b/CP77.CR2W/Types/cp77/TimetableCallbackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleAOEEffect.cs
+++ b/CP77.CR2W/Types/cp77/ToggleAOEEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleAOEEffect.cs
+++ b/CP77.CR2W/Types/cp77/ToggleAOEEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleActivate.cs
+++ b/CP77.CR2W/Types/cp77/ToggleActivate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleActivation.cs
+++ b/CP77.CR2W/Types/cp77/ToggleActivation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleActivation.cs
+++ b/CP77.CR2W/Types/cp77/ToggleActivation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ToggleAlarm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleAlarm.cs
+++ b/CP77.CR2W/Types/cp77/ToggleAlarm.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleBlockade.cs
+++ b/CP77.CR2W/Types/cp77/ToggleBlockade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleBulletBendingEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleBulletBendingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleChargeHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleChargeHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleClueConclusionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleClueConclusionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleComponentsDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ToggleComponentsDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleComponentsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleComponentsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleContainerLockEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleContainerLockEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleController.cs
+++ b/CP77.CR2W/Types/cp77/ToggleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleCustomActionDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ToggleCustomActionDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleCustomActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleCustomActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleDoorInteractionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleDoorInteractionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleDoorInteractionEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleDoorInteractionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleDropPointSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/ToggleDropPointSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleEffect.cs
+++ b/CP77.CR2W/Types/cp77/ToggleEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleEffect.cs
+++ b/CP77.CR2W/Types/cp77/ToggleEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleFactEffector.cs
+++ b/CP77.CR2W/Types/cp77/ToggleFactEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleFastTravelAvailabilityOnMapRequest.cs
+++ b/CP77.CR2W/Types/cp77/ToggleFastTravelAvailabilityOnMapRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleFocusClueEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleFocusClueEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleForcedHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleForcedHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleGameplayMappinVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleGameplayMappinVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleGlassTint.cs
+++ b/CP77.CR2W/Types/cp77/ToggleGlassTint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleGlassTintHack.cs
+++ b/CP77.CR2W/Types/cp77/ToggleGlassTintHack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleGlassTintHack.cs
+++ b/CP77.CR2W/Types/cp77/ToggleGlassTintHack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleJuryrigTrap.cs
+++ b/CP77.CR2W/Types/cp77/ToggleJuryrigTrap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleJuryrigTrap.cs
+++ b/CP77.CR2W/Types/cp77/ToggleJuryrigTrap.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleLight.cs
+++ b/CP77.CR2W/Types/cp77/ToggleLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleLight.cs
+++ b/CP77.CR2W/Types/cp77/ToggleLight.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleLightByNameEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleLightByNameEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleLightEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleLightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleLock.cs
+++ b/CP77.CR2W/Types/cp77/ToggleLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleMappinsOnLookAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleMappinsOnLookAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleMaterialOverlayEffector.cs
+++ b/CP77.CR2W/Types/cp77/ToggleMaterialOverlayEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleNetrunnerDive.cs
+++ b/CP77.CR2W/Types/cp77/ToggleNetrunnerDive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleON.cs
+++ b/CP77.CR2W/Types/cp77/ToggleON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOffMeshConnections.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOffMeshConnections.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOffMeshConnectionsDeviceOperation.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOffMeshConnectionsDeviceOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOpen.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOpen.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleOpenComputer.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpenComputer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOpenComputer.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpenComputer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleOpenFridge.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpenFridge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleOpenFridge.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOpenFridge.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleOperationEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleOperationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePersonalLink.cs
+++ b/CP77.CR2W/Types/cp77/TogglePersonalLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePlay.cs
+++ b/CP77.CR2W/Types/cp77/TogglePlay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePlay.cs
+++ b/CP77.CR2W/Types/cp77/TogglePlay.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEffector.cs
+++ b/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEffector.cs
+++ b/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/TogglePlayerFlashlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePower.cs
+++ b/CP77.CR2W/Types/cp77/TogglePower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TogglePreventionSystem.cs
+++ b/CP77.CR2W/Types/cp77/TogglePreventionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleSeal.cs
+++ b/CP77.CR2W/Types/cp77/ToggleSeal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleSeal.cs
+++ b/CP77.CR2W/Types/cp77/ToggleSeal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleShow.cs
+++ b/CP77.CR2W/Types/cp77/ToggleShow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleShow.cs
+++ b/CP77.CR2W/Types/cp77/ToggleShow.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleStreamFeed.cs
+++ b/CP77.CR2W/Types/cp77/ToggleStreamFeed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleTakeOverControl.cs
+++ b/CP77.CR2W/Types/cp77/ToggleTakeOverControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleTargetingComponentsEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleTargetingComponentsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleTiltBlinders.cs
+++ b/CP77.CR2W/Types/cp77/ToggleTiltBlinders.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleTiltBlinders.cs
+++ b/CP77.CR2W/Types/cp77/ToggleTiltBlinders.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleUIInteractivity.cs
+++ b/CP77.CR2W/Types/cp77/ToggleUIInteractivity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleVehicle.cs
+++ b/CP77.CR2W/Types/cp77/ToggleVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleVehicle.cs
+++ b/CP77.CR2W/Types/cp77/ToggleVehicle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToggleVisibilityInAnimSystemEvent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleVisibilityInAnimSystemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleVisibilityInAnimSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/ToggleVisibilityInAnimSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleVisibleObjectComponent.cs
+++ b/CP77.CR2W/Types/cp77/ToggleVisibleObjectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleZoomInteraction.cs
+++ b/CP77.CR2W/Types/cp77/ToggleZoomInteraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToggleZoomInteraction.cs
+++ b/CP77.CR2W/Types/cp77/ToggleZoomInteraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Toilet.cs
+++ b/CP77.CR2W/Types/cp77/Toilet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Toilet.cs
+++ b/CP77.CR2W/Types/cp77/Toilet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToiletController.cs
+++ b/CP77.CR2W/Types/cp77/ToiletController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ToiletController.cs
+++ b/CP77.CR2W/Types/cp77/ToiletController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ToiletControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/ToiletControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingModeACES.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeACES.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingModeACESApprox.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeACESApprox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingModeACESApprox.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeACESApprox.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TonemappingModeLinear.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeLinear.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingModeLinear.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeLinear.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TonemappingModeLottes.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeLottes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TonemappingModeLottesACES.cs
+++ b/CP77.CR2W/Types/cp77/TonemappingModeLottesACES.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/TooltipAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipCycleDotController.cs
+++ b/CP77.CR2W/Types/cp77/TooltipCycleDotController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipLootingCachedData.cs
+++ b/CP77.CR2W/Types/cp77/TooltipLootingCachedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipProgessBarController.cs
+++ b/CP77.CR2W/Types/cp77/TooltipProgessBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipProvider.cs
+++ b/CP77.CR2W/Types/cp77/TooltipProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipSpecialAbilityDisplay.cs
+++ b/CP77.CR2W/Types/cp77/TooltipSpecialAbilityDisplay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipSpecialAbilityList.cs
+++ b/CP77.CR2W/Types/cp77/TooltipSpecialAbilityList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/TooltipWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TooltipWidgetStyledReference.cs
+++ b/CP77.CR2W/Types/cp77/TooltipWidgetStyledReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrackQuestNotificationAction.cs
+++ b/CP77.CR2W/Types/cp77/TrackQuestNotificationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrackedQuestPhaseUpdateRequest.cs
+++ b/CP77.CR2W/Types/cp77/TrackedQuestPhaseUpdateRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrackedQuestPhaseUpdateRequest.cs
+++ b/CP77.CR2W/Types/cp77/TrackedQuestPhaseUpdateRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficGenDynamicTrafficSetting.cs
+++ b/CP77.CR2W/Types/cp77/TrafficGenDynamicTrafficSetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficGenTrafficSetting.cs
+++ b/CP77.CR2W/Types/cp77/TrafficGenTrafficSetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficIntersectionManagerController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficIntersectionManagerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficIntersectionManagerController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficIntersectionManagerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficIntersectionManagerControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TrafficIntersectionManagerControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLight.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLightController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLightController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLightControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficLightGreen.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightGreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLightGreen.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightGreen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficLightRed.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightRed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficLightRed.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightRed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficLightResaveData.cs
+++ b/CP77.CR2W/Types/cp77/TrafficLightResaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/TrafficPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficZebra.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebra.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficZebra.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebra.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficZebraController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebraController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficZebraController.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebraController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrafficZebraControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebraControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrafficZebraControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/TrafficZebraControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TraitBoughtEvent.cs
+++ b/CP77.CR2W/Types/cp77/TraitBoughtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TraitDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/TraitDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TraitTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/TraitTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TransactionRequest.cs
+++ b/CP77.CR2W/Types/cp77/TransactionRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TransactionRequestData.cs
+++ b/CP77.CR2W/Types/cp77/TransactionRequestData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Transform.cs
+++ b/CP77.CR2W/Types/cp77/Transform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Transition.cs
+++ b/CP77.CR2W/Types/cp77/Transition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TransparencyAnimationButtonView.cs
+++ b/CP77.CR2W/Types/cp77/TransparencyAnimationButtonView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TransparencyAnimationToggleView.cs
+++ b/CP77.CR2W/Types/cp77/TransparencyAnimationToggleView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrapComponent.cs
+++ b/CP77.CR2W/Types/cp77/TrapComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrapComponent.cs
+++ b/CP77.CR2W/Types/cp77/TrapComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrapPhysicsActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/TrapPhysicsActivationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TrapPhysicsActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/TrapPhysicsActivationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TrespasserEntry.cs
+++ b/CP77.CR2W/Types/cp77/TrespasserEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerAttackByChanceEffector.cs
+++ b/CP77.CR2W/Types/cp77/TriggerAttackByChanceEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerAttackEffectorWithDelay.cs
+++ b/CP77.CR2W/Types/cp77/TriggerAttackEffectorWithDelay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerAttackOnOwnerEffect.cs
+++ b/CP77.CR2W/Types/cp77/TriggerAttackOnOwnerEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerAttackOnTargetEffect.cs
+++ b/CP77.CR2W/Types/cp77/TriggerAttackOnTargetEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerCombatAgainstStimTarget.cs
+++ b/CP77.CR2W/Types/cp77/TriggerCombatAgainstStimTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerCombatAgainstStimTarget.cs
+++ b/CP77.CR2W/Types/cp77/TriggerCombatAgainstStimTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerCombatReaction.cs
+++ b/CP77.CR2W/Types/cp77/TriggerCombatReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerCombatReaction.cs
+++ b/CP77.CR2W/Types/cp77/TriggerCombatReaction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerContinuousAttackEffector.cs
+++ b/CP77.CR2W/Types/cp77/TriggerContinuousAttackEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerDelayedReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/TriggerDelayedReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerFearRunningVO.cs
+++ b/CP77.CR2W/Types/cp77/TriggerFearRunningVO.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerFearRunningVO.cs
+++ b/CP77.CR2W/Types/cp77/TriggerFearRunningVO.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerHackingMinigameEffector.cs
+++ b/CP77.CR2W/Types/cp77/TriggerHackingMinigameEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerModeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/TriggerModeLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerModeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/TriggerModeLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWire.cs
+++ b/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWire.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWireInstance.cs
+++ b/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWireInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWireInstance.cs
+++ b/CP77.CR2W/Types/cp77/TriggerNotifier_BarbedWireInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerPlayerAreaCheck.cs
+++ b/CP77.CR2W/Types/cp77/TriggerPlayerAreaCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerPlayerAreaCheck.cs
+++ b/CP77.CR2W/Types/cp77/TriggerPlayerAreaCheck.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TriggerVolumeOperationTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/TriggerVolumeOperationTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerVolumeOperations.cs
+++ b/CP77.CR2W/Types/cp77/TriggerVolumeOperations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TriggerVolumeOperationsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/TriggerVolumeOperationsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TryStopMovingOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/TryStopMovingOnTrafficLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TryStopMovingOnTrafficLane.cs
+++ b/CP77.CR2W/Types/cp77/TryStopMovingOnTrafficLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurnOnVisibilitySenseComponent.cs
+++ b/CP77.CR2W/Types/cp77/TurnOnVisibilitySenseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurnOnVisibilitySenseComponent.cs
+++ b/CP77.CR2W/Types/cp77/TurnOnVisibilitySenseComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretBeginDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretBeginDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretBeginDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretBeginDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretBeginEvents.cs
+++ b/CP77.CR2W/Types/cp77/TurretBeginEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretBurstShootingDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/TurretBurstShootingDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretBurstShootingDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/TurretBurstShootingDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretEndDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretEndDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretEndDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretEndDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretEndEvents.cs
+++ b/CP77.CR2W/Types/cp77/TurretEndEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretEndEvents.cs
+++ b/CP77.CR2W/Types/cp77/TurretEndEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretInitData.cs
+++ b/CP77.CR2W/Types/cp77/TurretInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretRipOffDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretRipOffDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretRipOffDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TurretRipOffDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretRipOffEvents.cs
+++ b/CP77.CR2W/Types/cp77/TurretRipOffEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretShootingIntervalEvent.cs
+++ b/CP77.CR2W/Types/cp77/TurretShootingIntervalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretShootingIntervalEvent.cs
+++ b/CP77.CR2W/Types/cp77/TurretShootingIntervalEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TurretTransition.cs
+++ b/CP77.CR2W/Types/cp77/TurretTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TurretTransition.cs
+++ b/CP77.CR2W/Types/cp77/TurretTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TutorialMainController.cs
+++ b/CP77.CR2W/Types/cp77/TutorialMainController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TutorialPopupData.cs
+++ b/CP77.CR2W/Types/cp77/TutorialPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TutorialPopupDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/TutorialPopupDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TutorialStep.cs
+++ b/CP77.CR2W/Types/cp77/TutorialStep.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TvChannelSpawnData.cs
+++ b/CP77.CR2W/Types/cp77/TvChannelSpawnData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TvDeviceWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/TvDeviceWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TvDeviceWidgetCustomData.cs
+++ b/CP77.CR2W/Types/cp77/TvDeviceWidgetCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TvInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/TvInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIAction.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionCondition.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionConditionAbstract.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionConditionAbstract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionRecord.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionRecord.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionRecord.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TweakAIActionSelector.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionSequence.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAIActionSmartComposite.cs
+++ b/CP77.CR2W/Types/cp77/TweakAIActionSmartComposite.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAISubAction.cs
+++ b/CP77.CR2W/Types/cp77/TweakAISubAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakAISubAction.cs
+++ b/CP77.CR2W/Types/cp77/TweakAISubAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TweakDBResource.cs
+++ b/CP77.CR2W/Types/cp77/TweakDBResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TweakDBResource.cs
+++ b/CP77.CR2W/Types/cp77/TweakDBResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TwoHandedClubLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TwoHandedClubLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TwoHandedClubLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/TwoHandedClubLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TwoHandedClubLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/TwoHandedClubLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/TwoHandedClubLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/TwoHandedClubLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/TypeComparableItemsCache.cs
+++ b/CP77.CR2W/Types/cp77/TypeComparableItemsCache.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIBuffInfo.cs
+++ b/CP77.CR2W/Types/cp77/UIBuffInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/UIFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/UIFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIGameDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UIGameDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIGenderHelper.cs
+++ b/CP77.CR2W/Types/cp77/UIGenderHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIGenderHelper.cs
+++ b/CP77.CR2W/Types/cp77/UIGenderHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIInGameNotification.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInGameNotification.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationRemoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationRemoveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationRemoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationRemoveEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInGameNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/UIInGameNotificationViewData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIInteractionSkillCheck.cs
+++ b/CP77.CR2W/Types/cp77/UIInteractionSkillCheck.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIInteractionsDef.cs
+++ b/CP77.CR2W/Types/cp77/UIInteractionsDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UILocRecord.cs
+++ b/CP77.CR2W/Types/cp77/UILocRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UILocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/UILocalizationHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UILocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/UILocalizationHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UILocalizationKeys.cs
+++ b/CP77.CR2W/Types/cp77/UILocalizationKeys.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UILocalizationKeys.cs
+++ b/CP77.CR2W/Types/cp77/UILocalizationKeys.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UILocalizationMap.cs
+++ b/CP77.CR2W/Types/cp77/UILocalizationMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIMenuNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIMenuNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIMenuNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/UIMenuNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIMenuNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/UIMenuNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UINotification.cs
+++ b/CP77.CR2W/Types/cp77/UINotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UINotification.cs
+++ b/CP77.CR2W/Types/cp77/UINotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIObjectiveEntryData.cs
+++ b/CP77.CR2W/Types/cp77/UIObjectiveEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/UIObjectsLoaderSystemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/UIObjectsLoaderSystemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIRefreshedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIRefreshedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIRefreshedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIRefreshedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIScriptableInventoryListenerCallback.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableInventoryListenerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystem.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryAddItem.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryAddItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryInspectItem.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryInspectItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryRemoveItem.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemInventoryRemoveItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemSetBackpackFilter.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemSetBackpackFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemSetBackpackSorting.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemSetBackpackSorting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemSetVendorPanelPlayerSorting.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemSetVendorPanelPlayerSorting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIScriptableSystemSetVendorPanelVendorSorting.cs
+++ b/CP77.CR2W/Types/cp77/UIScriptableSystemSetVendorPanelVendorSorting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIUnstreamedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIUnstreamedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIUnstreamedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIUnstreamedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UIVendorItemsBoughtEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIVendorItemsBoughtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIVendorItemsSoldEvent.cs
+++ b/CP77.CR2W/Types/cp77/UIVendorItemsSoldEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UIWorldBoundariesDef.cs
+++ b/CP77.CR2W/Types/cp77/UIWorldBoundariesDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ActiveVehicleDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ActiveVehicleDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ActiveWeaponDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ActiveWeaponDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ActivityLogDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ActivityLogDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_BriefingDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_BriefingDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ChatBoxDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ChatBoxDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CodexSystemDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CodexSystemDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ComDeviceDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ComDeviceDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CompanionDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CompanionDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CompassInfoDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CompassInfoDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CpoCharacterSelectionDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CpoCharacterSelectionDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CraftingDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CraftingDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CrosshairDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CrosshairDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_CustomQuestNotificationDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_CustomQuestNotificationDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_DamageInfoDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_DamageInfoDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_EquipmentDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_EquipmentDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_EquipmentDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_EquipmentDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_FastForwardDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_FastForwardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HUDButtonHintDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HUDButtonHintDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HUDNarrationLogDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HUDNarrationLogDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HUDProgressBarDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HUDProgressBarDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HUDSignalProgressBarDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HUDSignalProgressBarDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HackingDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HackingDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HotkeysDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HotkeysDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HudButtonHelpDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HudButtonHelpDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_HudTooltipDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_HudTooltipDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ItemLogDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ItemLogDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ItemModSystemDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ItemModSystemDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_LevelUpDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_LevelUpDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_MapDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_MapDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_NPCNextToTheCrosshairDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_NPCNextToTheCrosshairDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_NameplateDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_NameplateDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_NarrativePlateDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_NarrativePlateDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_NotificationsDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_NotificationsDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_PlayerBioMonitorDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_PlayerBioMonitorDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_PlayerStatsDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_PlayerStatsDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_QuickSlotsDataDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_QuickSlotsDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ScannerDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ScannerDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_ScannerModulesDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_ScannerModulesDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_SceneScreenDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_SceneScreenDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_StealthDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_StealthDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_SystemDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_SystemDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_TargetingInfoDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_TargetingInfoDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_TopbarHubMenuDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_TopbarHubMenuDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_VendorDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_VendorDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_VisionModeDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_VisionModeDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UI_WantedBarDef.cs
+++ b/CP77.CR2W/Types/cp77/UI_WantedBarDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UiPhoneContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiPhoneContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiPhoneContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiPhoneContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UiQuickHackPanelContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiQuickHackPanelContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiQuickHackPanelContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiQuickHackPanelContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UiQuickHackPanelContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/UiQuickHackPanelContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiQuickHackPanelContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/UiQuickHackPanelContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UiRadialContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiRadialContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiRadialContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiRadialContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UiRadialContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/UiRadialContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiVendorContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiVendorContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UiVendorContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UiVendorContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnRegisterInputListenerRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnRegisterInputListenerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnTagAllObjectRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnTagAllObjectRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnTagAllObjectRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnTagAllObjectRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnarmedLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnarmedLookAtDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnarmedLookAtDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnarmedLookAtDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnarmedLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnarmedLookAtEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnarmedLookAtEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnarmedLookAtEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnblockAmmoDrop.cs
+++ b/CP77.CR2W/Types/cp77/UnblockAmmoDrop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnblockAmmoDrop.cs
+++ b/CP77.CR2W/Types/cp77/UnblockAmmoDrop.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnblockHealingConsumableDrop.cs
+++ b/CP77.CR2W/Types/cp77/UnblockHealingConsumableDrop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnblockHealingConsumableDrop.cs
+++ b/CP77.CR2W/Types/cp77/UnblockHealingConsumableDrop.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnconsciousManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/UnconsciousManagerTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnconsciousManagerTask.cs
+++ b/CP77.CR2W/Types/cp77/UnconsciousManagerTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnconsciousState.cs
+++ b/CP77.CR2W/Types/cp77/UnconsciousState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnconsciousState.cs
+++ b/CP77.CR2W/Types/cp77/UnconsciousState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UncontrolledMovementEffector.cs
+++ b/CP77.CR2W/Types/cp77/UncontrolledMovementEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UndelectAllItemsDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UndelectAllItemsDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UndelectAllItemsDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/UndelectAllItemsDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UndressPlayer.cs
+++ b/CP77.CR2W/Types/cp77/UndressPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequipCycleDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnequipCycleDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequipCycleEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnequipCycleEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequipItemsRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnequipItemsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequipRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnequipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequippedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnequippedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnequippedEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnequippedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UninstallCyberwareRequest.cs
+++ b/CP77.CR2W/Types/cp77/UninstallCyberwareRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UninstallCyberwareRequest.cs
+++ b/CP77.CR2W/Types/cp77/UninstallCyberwareRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnitsLocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/UnitsLocalizationHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnitsLocalizationHelper.cs
+++ b/CP77.CR2W/Types/cp77/UnitsLocalizationHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnlimitedUnlocked.cs
+++ b/CP77.CR2W/Types/cp77/UnlimitedUnlocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnlimitedUnlocked.cs
+++ b/CP77.CR2W/Types/cp77/UnlimitedUnlocked.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnlockAllAchievementsRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnlockAllAchievementsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnlockAllAchievementsRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnlockAllAchievementsRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnlockCodexPartRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnlockCodexPartRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnlockMinigameProgramEffector.cs
+++ b/CP77.CR2W/Types/cp77/UnlockMinigameProgramEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnlockPerkArea.cs
+++ b/CP77.CR2W/Types/cp77/UnlockPerkArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterAllMappinsEvent.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterAllMappinsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterAllMappinsEvent.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterAllMappinsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnregisterAllNetworkLinksRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterAllNetworkLinksRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterAllNetworkLinksRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterAllNetworkLinksRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnregisterCommunityRunner.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterCommunityRunner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterDropPointMappinRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterDropPointMappinRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterFastTravelPointRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterFastTravelPointRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterFleeingNPC.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterFleeingNPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterFromZoomBlackboardEvent.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterFromZoomBlackboardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterFromZoomBlackboardEvent.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterFromZoomBlackboardEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnregisterLinkedCluekRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterLinkedCluekRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterListenerOnTargetHPEvent.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterListenerOnTargetHPEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterNetworkLinkBetweenTwoEntitiesRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterNetworkLinkBetweenTwoEntitiesRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterNetworkLinkRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterNetworkLinkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterNetworkLinksByIDRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterNetworkLinksByIDRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterNetworkLinksByIdAndTypeRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterNetworkLinksByIdAndTypeRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterPoliceCaller.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterPoliceCaller.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterPoliceCaller.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterPoliceCaller.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnregisterReactionAction.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterReactionAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterTimetableRequest.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterTimetableRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnregisterTrafficRunner.cs
+++ b/CP77.CR2W/Types/cp77/UnregisterTrafficRunner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnsecureFootingFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnsecureFootingFallDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnsecureFootingFallDecisions.cs
+++ b/CP77.CR2W/Types/cp77/UnsecureFootingFallDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnsecureFootingFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnsecureFootingFallEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnsecureFootingFallEvents.cs
+++ b/CP77.CR2W/Types/cp77/UnsecureFootingFallEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UnstablePlatform.cs
+++ b/CP77.CR2W/Types/cp77/UnstablePlatform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UnstablePlatform.cs
+++ b/CP77.CR2W/Types/cp77/UnstablePlatform.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateAutoRevealStatEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateAutoRevealStatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateComponent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateComponent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateDamageChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDamageChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateDamageChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDamageChangeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateDebuggerRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDebuggerRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateDropPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDropPointEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateDyingStimSource.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDyingStimSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateDyingStimSource.cs
+++ b/CP77.CR2W/Types/cp77/UpdateDyingStimSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateGatePosition.cs
+++ b/CP77.CR2W/Types/cp77/UpdateGatePosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateGatePosition.cs
+++ b/CP77.CR2W/Types/cp77/UpdateGatePosition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateLinkedClueskRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpdateLinkedClueskRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateMeleeTrailEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateMeleeTrailEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateMiniGameProgramsEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateMiniGameProgramsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateNetworkVisualisationRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpdateNetworkVisualisationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateNetworkVisualisationRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpdateNetworkVisualisationRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateOpenedQuestEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateOpenedQuestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateOverheatEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateOverheatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdatePlayerDevelopment.cs
+++ b/CP77.CR2W/Types/cp77/UpdatePlayerDevelopment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdatePlayerDevelopment.cs
+++ b/CP77.CR2W/Types/cp77/UpdatePlayerDevelopment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateShardFailedDropsRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpdateShardFailedDropsRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateStimSource.cs
+++ b/CP77.CR2W/Types/cp77/UpdateStimSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateStimSource.cs
+++ b/CP77.CR2W/Types/cp77/UpdateStimSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateTrackedObjectiveEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateTrackedObjectiveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateVisibilityModifierEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateVisibilityModifierEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateVisibilityModifierEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateVisibilityModifierEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateWeaponChargeEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateWeaponChargeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateWeaponStatsEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateWeaponStatsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpdateWeaponStatsEvent.cs
+++ b/CP77.CR2W/Types/cp77/UpdateWeaponStatsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpdateWillingInvestigators.cs
+++ b/CP77.CR2W/Types/cp77/UpdateWillingInvestigators.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpgradeItemRequest.cs
+++ b/CP77.CR2W/Types/cp77/UpgradeItemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UploadFromNPCToNPCListener.cs
+++ b/CP77.CR2W/Types/cp77/UploadFromNPCToNPCListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UploadFromNPCToPlayerListener.cs
+++ b/CP77.CR2W/Types/cp77/UploadFromNPCToPlayerListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UploadProgramProgressEvent.cs
+++ b/CP77.CR2W/Types/cp77/UploadProgramProgressEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereq.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyNPCStatePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpperBodyPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpperBodyPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UpperBodyTransition.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UpperBodyTransition.cs
+++ b/CP77.CR2W/Types/cp77/UpperBodyTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UseAction.cs
+++ b/CP77.CR2W/Types/cp77/UseAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UseAction.cs
+++ b/CP77.CR2W/Types/cp77/UseAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UseCoverCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/UseCoverCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UseCoverCommandTask.cs
+++ b/CP77.CR2W/Types/cp77/UseCoverCommandTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UsePhoneRequest.cs
+++ b/CP77.CR2W/Types/cp77/UsePhoneRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UsePhoneRequest.cs
+++ b/CP77.CR2W/Types/cp77/UsePhoneRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UseSecurityLocker.cs
+++ b/CP77.CR2W/Types/cp77/UseSecurityLocker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UseSecurityLocker.cs
+++ b/CP77.CR2W/Types/cp77/UseSecurityLocker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UseWorkspotCommandDelegate.cs
+++ b/CP77.CR2W/Types/cp77/UseWorkspotCommandDelegate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UseWorkspotCommandHandler.cs
+++ b/CP77.CR2W/Types/cp77/UseWorkspotCommandHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UsingCoverPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/UsingCoverPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/UsingCoverPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/UsingCoverPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/UsingCoverPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/UsingCoverPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VEHICLE_Actor.cs
+++ b/CP77.CR2W/Types/cp77/VEHICLE_Actor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VEHICLE_Actor.cs
+++ b/CP77.CR2W/Types/cp77/VEHICLE_Actor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VRoomFeed.cs
+++ b/CP77.CR2W/Types/cp77/VRoomFeed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Validate.cs
+++ b/CP77.CR2W/Types/cp77/Validate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Validate.cs
+++ b/CP77.CR2W/Types/cp77/Validate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VaultDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VaultDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VaultEvents.cs
+++ b/CP77.CR2W/Types/cp77/VaultEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VaultEvents.cs
+++ b/CP77.CR2W/Types/cp77/VaultEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/Vector2.cs
+++ b/CP77.CR2W/Types/cp77/Vector2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Vector3.cs
+++ b/CP77.CR2W/Types/cp77/Vector3.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Vector4.cs
+++ b/CP77.CR2W/Types/cp77/Vector4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehEntityPlayerStateData.cs
+++ b/CP77.CR2W/Types/cp77/VehEntityPlayerStateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleActionsContext.cs
+++ b/CP77.CR2W/Types/cp77/VehicleActionsContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleAlertNotification.cs
+++ b/CP77.CR2W/Types/cp77/VehicleAlertNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleAlertNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/VehicleAlertNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleBlockInputContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBlockInputContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleBlockInputContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBlockInputContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleBlockInputContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBlockInputContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleBlockInputContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBlockInputContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleBodyDisposalPerformedEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBodyDisposalPerformedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleBodyDisposalPerformedEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleBodyDisposalPerformedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCloseHood.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCloseHood.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCloseHood.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCloseHood.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCloseTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCloseTrunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCloseTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCloseTrunk.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCombatContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCombatContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCombatContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCombatContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCombatContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCombatContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleComponent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/VehicleComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeMeshVisibilityDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeMeshVisibilityDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeMeshVisibilityDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeMeshVisibilityDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeOffDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeOffDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeOffDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeOffDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeOnDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeOnDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCrystalDomeOnDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCrystalDomeOnDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleCycleLightsEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCycleLightsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleCycleLightsEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleCycleLightsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDamageStageTurnOffEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDamageStageTurnOffEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDamageStageTurnOffEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDamageStageTurnOffEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDeathTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDef.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDeviceLinkPS.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDeviceLinkPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDeviceLinkPS.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDeviceLinkPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDoorClose.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDoorClose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDoorDetached.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDoorDetached.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDoorInteraction.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDoorInteraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDoorInteractionStateChange.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDoorInteractionStateChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDoorOpen.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDoorOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDriverCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverCombatContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDriverCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverCombatContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDriverCombatContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverCombatContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDriverCombatContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverCombatContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDriverContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDriverContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDriverContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDriverContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDriverContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDumpBody.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDumpBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleDumpBody.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDumpBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleDumpBodyDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleDumpBodyDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/VehicleEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleExternalDoorRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleExternalDoorRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleExternalWindowRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleExternalWindowRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleForceOccupantOut.cs
+++ b/CP77.CR2W/Types/cp77/VehicleForceOccupantOut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleForwardRaceCheckpointFactEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleForwardRaceCheckpointFactEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleForwardRaceCheckpointFactEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleForwardRaceCheckpointFactEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleForwardRaceClockUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleForwardRaceClockUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleForwardRaceClockUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleForwardRaceClockUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleGameplayContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleGameplayContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleGameplayContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleGameplayContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleHealthStatPoolListener.cs
+++ b/CP77.CR2W/Types/cp77/VehicleHealthStatPoolListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleHornOffDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleHornOffDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleHornOffDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleHornOffDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleInsideWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleInsideWheelDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleInsideWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleInsideWheelDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleInsideWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleInsideWheelEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleInsideWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleInsideWheelEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleLightQuestToggleEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleLightQuestToggleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleLightSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleLightSetupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleLightSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleLightSetupEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleListItemData.cs
+++ b/CP77.CR2W/Types/cp77/VehicleListItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleMappinComponent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleMappinComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleMappinDelayedDiscreteModeCallback.cs
+++ b/CP77.CR2W/Types/cp77/VehicleMappinDelayedDiscreteModeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleMinimapMappinComponent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleMinimapMappinComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveCombatContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveCombatContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveCombatContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleNoDriveContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleNoDriveContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleOpenHood.cs
+++ b/CP77.CR2W/Types/cp77/VehicleOpenHood.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleOpenHood.cs
+++ b/CP77.CR2W/Types/cp77/VehicleOpenHood.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleOpenTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehicleOpenTrunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleOpenTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehicleOpenTrunk.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclePSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclePSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclePanzerBootupUIQuestEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePanzerBootupUIQuestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePassengerContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePassengerContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePassengerContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePassengerContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclePassengerContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePassengerContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePassengerContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePassengerContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclePlayerTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePlayerTrunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclePlayerTrunk.cs
+++ b/CP77.CR2W/Types/cp77/VehiclePlayerTrunk.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleQuestAVThrusterEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestAVThrusterEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestChangeDoorStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestChangeDoorStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestCrystalDomeEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestCrystalDomeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestDoorLocked.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestDoorLocked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestDoorLocked.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestDoorLocked.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleQuestEnableUIEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestEnableUIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestHornEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestHornEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestRestrictedContextEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleQuestSirenEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestSirenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestToggleEngineEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestToggleEngineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestUIEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestUIEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestVisualDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestVisualDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleQuestWindowDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleQuestWindowDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRaceClockUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRaceClockUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRaceClockUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRaceClockUpdateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleRaceQuestEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRaceQuestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRadioEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRadioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRadioLogicController.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRadioLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRadioPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRadioPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleRadioTierEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleRadioTierEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleReadyInteractionDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleReadyInteractionDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleReadyInteractionDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleReadyInteractionDelayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleSeatReservationEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleSeatReservationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleSirenDelayEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleSirenDelayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleStartedUnmountingEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleStartedUnmountingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleState.cs
+++ b/CP77.CR2W/Types/cp77/VehicleState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleState.cs
+++ b/CP77.CR2W/Types/cp77/VehicleState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleSummonDataDef.cs
+++ b/CP77.CR2W/Types/cp77/VehicleSummonDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleSummonWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/VehicleSummonWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleTakeBody.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTakeBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleTakeBody.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTakeBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleTankDriverContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTankDriverContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleTankDriverContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTankDriverContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleTransition.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleTransitionInitData.cs
+++ b/CP77.CR2W/Types/cp77/VehicleTransitionInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleUIactivateEvent.cs
+++ b/CP77.CR2W/Types/cp77/VehicleUIactivateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWheelDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWheelDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWheelEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWheelEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehicleWindowClose.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWindowClose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWindowOpen.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWindowOpen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWindowState.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWindowState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehicleWindowState.cs
+++ b/CP77.CR2W/Types/cp77/VehicleWindowState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclesManagerDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerDataHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclesManagerDataHelper.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerDataHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclesManagerDataView.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclesManagerDataView.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerDataView.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VehiclesManagerListItemController.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VehiclesManagerPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/VehiclesManagerPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VelocityEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocityEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VelocityEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocityEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VelocityInheritEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocityInheritEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VelocityInheritEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocityInheritEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VelocitySpreadEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocitySpreadEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VelocitySpreadEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/VelocitySpreadEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VendingMachine.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineController.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineController.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VendingMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineDeviceBlackboardDef.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineDeviceBlackboardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineSFX.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineSFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingMachineSetup.cs
+++ b/CP77.CR2W/Types/cp77/VendingMachineSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingTerminal.cs
+++ b/CP77.CR2W/Types/cp77/VendingTerminal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingTerminalController.cs
+++ b/CP77.CR2W/Types/cp77/VendingTerminalController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingTerminalController.cs
+++ b/CP77.CR2W/Types/cp77/VendingTerminalController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VendingTerminalControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/VendingTerminalControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendingTerminalSetup.cs
+++ b/CP77.CR2W/Types/cp77/VendingTerminalSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Vendor.cs
+++ b/CP77.CR2W/Types/cp77/Vendor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorBoughtItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/VendorBoughtItemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorComponent.cs
+++ b/CP77.CR2W/Types/cp77/VendorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorConfirmationPopup.cs
+++ b/CP77.CR2W/Types/cp77/VendorConfirmationPopup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorConfirmationPopupCloseData.cs
+++ b/CP77.CR2W/Types/cp77/VendorConfirmationPopupCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorConfirmationPopupData.cs
+++ b/CP77.CR2W/Types/cp77/VendorConfirmationPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorDataManager.cs
+++ b/CP77.CR2W/Types/cp77/VendorDataManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorDataView.cs
+++ b/CP77.CR2W/Types/cp77/VendorDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorGameItemData.cs
+++ b/CP77.CR2W/Types/cp77/VendorGameItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorHubMenuChanged.cs
+++ b/CP77.CR2W/Types/cp77/VendorHubMenuChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorHubMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/VendorHubMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorInventoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/VendorInventoryItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorItemActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/VendorItemActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorItemVirtualController.cs
+++ b/CP77.CR2W/Types/cp77/VendorItemVirtualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorJunkSellItem.cs
+++ b/CP77.CR2W/Types/cp77/VendorJunkSellItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorRegisterBlackBoardDef.cs
+++ b/CP77.CR2W/Types/cp77/VendorRegisterBlackBoardDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorRequirementsNotMetNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/VendorRequirementsNotMetNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorSellJunkPopup.cs
+++ b/CP77.CR2W/Types/cp77/VendorSellJunkPopup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorSellJunkPopupCloseData.cs
+++ b/CP77.CR2W/Types/cp77/VendorSellJunkPopupCloseData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorSellJunkPopupData.cs
+++ b/CP77.CR2W/Types/cp77/VendorSellJunkPopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorShoppingCartItem.cs
+++ b/CP77.CR2W/Types/cp77/VendorShoppingCartItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VendorUserData.cs
+++ b/CP77.CR2W/Types/cp77/VendorUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationArea.cs
+++ b/CP77.CR2W/Types/cp77/VentilationArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationAreaController.cs
+++ b/CP77.CR2W/Types/cp77/VentilationAreaController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationAreaController.cs
+++ b/CP77.CR2W/Types/cp77/VentilationAreaController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VentilationAreaControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/VentilationAreaControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationAreaSetup.cs
+++ b/CP77.CR2W/Types/cp77/VentilationAreaSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationEffector.cs
+++ b/CP77.CR2W/Types/cp77/VentilationEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationEffectorController.cs
+++ b/CP77.CR2W/Types/cp77/VentilationEffectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationEffectorController.cs
+++ b/CP77.CR2W/Types/cp77/VentilationEffectorController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VentilationEffectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/VentilationEffectorControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VentilationEffectorControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/VentilationEffectorControllerPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VeryHardLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VeryHardLandDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VeryHardLandDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VeryHardLandDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VeryHardLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/VeryHardLandEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VeryHardLandEvents.cs
+++ b/CP77.CR2W/Types/cp77/VeryHardLandEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VignetteAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/VignetteAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualComponentBinder.cs
+++ b/CP77.CR2W/Types/cp77/VirtualComponentBinder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualComponentBinder.cs
+++ b/CP77.CR2W/Types/cp77/VirtualComponentBinder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VirtualItem_TEMP.cs
+++ b/CP77.CR2W/Types/cp77/VirtualItem_TEMP.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/VirtualMasterDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualMasterDevice.cs
+++ b/CP77.CR2W/Types/cp77/VirtualMasterDevice.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VirtualMasterDevicePS.cs
+++ b/CP77.CR2W/Types/cp77/VirtualMasterDevicePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualNestedListController.cs
+++ b/CP77.CR2W/Types/cp77/VirtualNestedListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualNestedListDataView.cs
+++ b/CP77.CR2W/Types/cp77/VirtualNestedListDataView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualQuestItemController.cs
+++ b/CP77.CR2W/Types/cp77/VirtualQuestItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualQuestListController.cs
+++ b/CP77.CR2W/Types/cp77/VirtualQuestListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirtualSystemPS.cs
+++ b/CP77.CR2W/Types/cp77/VirtualSystemPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirutalNestedListClassifier.cs
+++ b/CP77.CR2W/Types/cp77/VirutalNestedListClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VirutalNestedListClassifier.cs
+++ b/CP77.CR2W/Types/cp77/VirutalNestedListClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VirutalNestedListData.cs
+++ b/CP77.CR2W/Types/cp77/VirutalNestedListData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VisibilitySimpleControllerBase.cs
+++ b/CP77.CR2W/Types/cp77/VisibilitySimpleControllerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VisibilityStatListener.cs
+++ b/CP77.CR2W/Types/cp77/VisibilityStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VisionContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VisionContextDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VisionContextDecisions.cs
+++ b/CP77.CR2W/Types/cp77/VisionContextDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VisualTagsPrereq.cs
+++ b/CP77.CR2W/Types/cp77/VisualTagsPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VoiceOverQuickHackFeedbackEvent.cs
+++ b/CP77.CR2W/Types/cp77/VoiceOverQuickHackFeedbackEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VolCloudsCustomData.cs
+++ b/CP77.CR2W/Types/cp77/VolCloudsCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VolCloudsCustomData.cs
+++ b/CP77.CR2W/Types/cp77/VolCloudsCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VolFogCustomData.cs
+++ b/CP77.CR2W/Types/cp77/VolFogCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/VolFogCustomData.cs
+++ b/CP77.CR2W/Types/cp77/VolFogCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/VolumetricFogAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/VolumetricFogAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Vulnerability.cs
+++ b/CP77.CR2W/Types/cp77/Vulnerability.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitBeforeExiting.cs
+++ b/CP77.CR2W/Types/cp77/WaitBeforeExiting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitBeforeExiting.cs
+++ b/CP77.CR2W/Types/cp77/WaitBeforeExiting.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WaitForEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WaitForEquipDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitForEquipDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WaitForEquipDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WaitForEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/WaitForEquipEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitForEquipEvents.cs
+++ b/CP77.CR2W/Types/cp77/WaitForEquipEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WaitIfEnteringOrLeavingCover.cs
+++ b/CP77.CR2W/Types/cp77/WaitIfEnteringOrLeavingCover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitIfEnteringOrLeavingCover.cs
+++ b/CP77.CR2W/Types/cp77/WaitIfEnteringOrLeavingCover.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WaitingForSceneDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WaitingForSceneDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitingForSceneDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WaitingForSceneDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WaitingForSceneEvents.cs
+++ b/CP77.CR2W/Types/cp77/WaitingForSceneEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaitingForSceneEvents.cs
+++ b/CP77.CR2W/Types/cp77/WaitingForSceneEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WakeUpFromRestartEvent.cs
+++ b/CP77.CR2W/Types/cp77/WakeUpFromRestartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WakeUpFromRestartEvent.cs
+++ b/CP77.CR2W/Types/cp77/WakeUpFromRestartEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WallCollisionHelpers.cs
+++ b/CP77.CR2W/Types/cp77/WallCollisionHelpers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WallCollisionHelpers.cs
+++ b/CP77.CR2W/Types/cp77/WallCollisionHelpers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WallScreen.cs
+++ b/CP77.CR2W/Types/cp77/WallScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WallScreenController.cs
+++ b/CP77.CR2W/Types/cp77/WallScreenController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WallScreenController.cs
+++ b/CP77.CR2W/Types/cp77/WallScreenController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WallScreenControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/WallScreenControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarEndFlashEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarEndFlashEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarEndFlashEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarEndFlashEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WantedBarFlashAndHideEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarFlashAndHideEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarFlashAndHideEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarFlashAndHideEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WantedBarFlashAndShowEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarFlashAndShowEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarFlashAndShowEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarFlashAndShowEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WantedBarGameController.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarStartFlashEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarStartFlashEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WantedBarStartFlashEvent.cs
+++ b/CP77.CR2W/Types/cp77/WantedBarStartFlashEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WarningMessageGameController.cs
+++ b/CP77.CR2W/Types/cp77/WarningMessageGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WaterAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/WaterAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakFence.cs
+++ b/CP77.CR2W/Types/cp77/WeakFence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakFenceController.cs
+++ b/CP77.CR2W/Types/cp77/WeakFenceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakFenceController.cs
+++ b/CP77.CR2W/Types/cp77/WeakFenceController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeakFenceControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/WeakFenceControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakFenceSetup.cs
+++ b/CP77.CR2W/Types/cp77/WeakFenceSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakspotOnDestroyEffector.cs
+++ b/CP77.CR2W/Types/cp77/WeakspotOnDestroyEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakspotOnDestroyEffector.cs
+++ b/CP77.CR2W/Types/cp77/WeakspotOnDestroyEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeakspotOnDestroyEvent.cs
+++ b/CP77.CR2W/Types/cp77/WeakspotOnDestroyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakspotOnDestroyProperties.cs
+++ b/CP77.CR2W/Types/cp77/WeakspotOnDestroyProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeakspotRecordData.cs
+++ b/CP77.CR2W/Types/cp77/WeakspotRecordData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponChargeStatListener.cs
+++ b/CP77.CR2W/Types/cp77/WeaponChargeStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/WeaponCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/WeaponCollisionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponDataDef.cs
+++ b/CP77.CR2W/Types/cp77/WeaponDataDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponEquipEvent.cs
+++ b/CP77.CR2W/Types/cp77/WeaponEquipEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/WeaponEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/WeaponEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponJammedAction.cs
+++ b/CP77.CR2W/Types/cp77/WeaponJammedAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponMachineInkGameController.cs
+++ b/CP77.CR2W/Types/cp77/WeaponMachineInkGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponMalfunctionHudEffector.cs
+++ b/CP77.CR2W/Types/cp77/WeaponMalfunctionHudEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponPositionComponent.cs
+++ b/CP77.CR2W/Types/cp77/WeaponPositionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponRadialSlot.cs
+++ b/CP77.CR2W/Types/cp77/WeaponRadialSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponStateMachinePrereq.cs
+++ b/CP77.CR2W/Types/cp77/WeaponStateMachinePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponStateMachinePrereq.cs
+++ b/CP77.CR2W/Types/cp77/WeaponStateMachinePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponStateMachinePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/WeaponStateMachinePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponStateMachinePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/WeaponStateMachinePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponTransition.cs
+++ b/CP77.CR2W/Types/cp77/WeaponTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponTransition.cs
+++ b/CP77.CR2W/Types/cp77/WeaponTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponTypeHitPrereqCondition.cs
+++ b/CP77.CR2W/Types/cp77/WeaponTypeHitPrereqCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachine.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachineController.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachineController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachineController.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachineController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachineControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachineControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachineSFX.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachineSFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendingMachineSetup.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendingMachineSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponVendorActionWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/WeaponVendorActionWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WeaponWheelDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponWheelDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WeaponWheelDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/WeaponWheelEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponWheelEvents.cs
+++ b/CP77.CR2W/Types/cp77/WeaponWheelEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/WeaponsUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WeaponsUtils.cs
+++ b/CP77.CR2W/Types/cp77/WeaponsUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WebPage.cs
+++ b/CP77.CR2W/Types/cp77/WebPage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WebsiteLoadingSpinner.cs
+++ b/CP77.CR2W/Types/cp77/WebsiteLoadingSpinner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WebsiteLoadingSpinner.cs
+++ b/CP77.CR2W/Types/cp77/WebsiteLoadingSpinner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WidgetAnimationManager.cs
+++ b/CP77.CR2W/Types/cp77/WidgetAnimationManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetBaseComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetBaseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetBaseComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetBaseComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WidgetCustomData.cs
+++ b/CP77.CR2W/Types/cp77/WidgetCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetCustomData.cs
+++ b/CP77.CR2W/Types/cp77/WidgetCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WidgetHudComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetHudComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetHudComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetHudComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WidgetHudComponentInterface.cs
+++ b/CP77.CR2W/Types/cp77/WidgetHudComponentInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetMenuComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetMenuComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetMenuComponent.cs
+++ b/CP77.CR2W/Types/cp77/WidgetMenuComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WidgetMenuComponentInterface.cs
+++ b/CP77.CR2W/Types/cp77/WidgetMenuComponentInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WidgetsPoolItemSpawnData.cs
+++ b/CP77.CR2W/Types/cp77/WidgetsPoolItemSpawnData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WillDieSoonEvent.cs
+++ b/CP77.CR2W/Types/cp77/WillDieSoonEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WillDieSoonEvent.cs
+++ b/CP77.CR2W/Types/cp77/WillDieSoonEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WindAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/WindAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/Window.cs
+++ b/CP77.CR2W/Types/cp77/Window.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowBlinders.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlinders.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowBlindersController.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlindersController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowBlindersController.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlindersController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WindowBlindersControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlindersControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowBlindersData.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlindersData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowBlindersReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/WindowBlindersReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowController.cs
+++ b/CP77.CR2W/Types/cp77/WindowController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WindowController.cs
+++ b/CP77.CR2W/Types/cp77/WindowController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WindowControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/WindowControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WireRepairable.cs
+++ b/CP77.CR2W/Types/cp77/WireRepairable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WithoutHitDataDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/WithoutHitDataDeathTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WithoutHitDataDeathTask.cs
+++ b/CP77.CR2W/Types/cp77/WithoutHitDataDeathTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorkSpotTask.cs
+++ b/CP77.CR2W/Types/cp77/WorkSpotTask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkSpotTask.cs
+++ b/CP77.CR2W/Types/cp77/WorkSpotTask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorkspotDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkspotDecisions.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorkspotEntryData.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotEntryData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkspotEvents.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkspotEvents.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorkspotFunctionalTestsDebugListener.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotFunctionalTestsDebugListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkspotMapData.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotMapData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorkspotMapperComponent.cs
+++ b/CP77.CR2W/Types/cp77/WorkspotMapperComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/WorldFunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldFunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/WorldFunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorldLightingConfig.cs
+++ b/CP77.CR2W/Types/cp77/WorldLightingConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapDistrictTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapDistrictTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapGangItemController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapGangItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapLegendController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapLegendController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapLegendListItemController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapLegendListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapPoliceTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapPoliceTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapPoliceTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapPoliceTooltipController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorldMapTooltipBaseController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapTooltipBaseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapTooltipContainer.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapTooltipContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapTooltipController.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapTooltipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapTooltipData.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapTooltipData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapUtils.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldMapUtils.cs
+++ b/CP77.CR2W/Types/cp77/WorldMapUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WorldPosition.cs
+++ b/CP77.CR2W/Types/cp77/WorldPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldRenderAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/WorldRenderAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldShadowConfig.cs
+++ b/CP77.CR2W/Types/cp77/WorldShadowConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldTransform.cs
+++ b/CP77.CR2W/Types/cp77/WorldTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WorldWidgetComponent.cs
+++ b/CP77.CR2W/Types/cp77/WorldWidgetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WoundedInstigated.cs
+++ b/CP77.CR2W/Types/cp77/WoundedInstigated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WoundedLookatController.cs
+++ b/CP77.CR2W/Types/cp77/WoundedLookatController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WoundedLookatController.cs
+++ b/CP77.CR2W/Types/cp77/WoundedLookatController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/WoundedTriggeredPrereq.cs
+++ b/CP77.CR2W/Types/cp77/WoundedTriggeredPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WoundedTriggeredPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/WoundedTriggeredPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/WrappedInventoryItemData.cs
+++ b/CP77.CR2W/Types/cp77/WrappedInventoryItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/XmlResource.cs
+++ b/CP77.CR2W/Types/cp77/XmlResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoneAlertNotification.cs
+++ b/CP77.CR2W/Types/cp77/ZoneAlertNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoneAlertNotificationQueue.cs
+++ b/CP77.CR2W/Types/cp77/ZoneAlertNotificationQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoneAlertNotificationRemoveRequestData.cs
+++ b/CP77.CR2W/Types/cp77/ZoneAlertNotificationRemoveRequestData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoneAlertNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/ZoneAlertNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZonesPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ZonesPSMPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZonesPSMPrereq.cs
+++ b/CP77.CR2W/Types/cp77/ZonesPSMPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZonesPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/ZonesPSMPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZonesPSMPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/ZonesPSMPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomBlockedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomBlockedDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomBlockedDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomBlockedDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomBlockedEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomBlockedEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomDecisionsTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomDecisionsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomDecisionsTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomDecisionsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomEventsTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomEventsTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomEventsTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevel3Decisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel3Decisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevel3Decisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel3Decisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevel3Events.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel3Events.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevel3Events.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel3Events.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevel4Decisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel4Decisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevel4Decisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel4Decisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevel4Events.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel4Events.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevel4Events.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevel4Events.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevelAimDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelAimDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelAimDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelAimDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevelAimEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelAimEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevelBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelBaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevelScanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelScanDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelScanDecisions.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelScanDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomLevelScanEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelScanEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomLevelScanEvents.cs
+++ b/CP77.CR2W/Types/cp77/ZoomLevelScanEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomTransition.cs
+++ b/CP77.CR2W/Types/cp77/ZoomTransition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/ZoomTransitionHelper.cs
+++ b/CP77.CR2W/Types/cp77/ZoomTransitionHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/ZoomTransitionHelper.cs
+++ b/CP77.CR2W/Types/cp77/ZoomTransitionHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/activityLogEntryLogicController.cs
+++ b/CP77.CR2W/Types/cp77/activityLogEntryLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/activityLogGameController.cs
+++ b/CP77.CR2W/Types/cp77/activityLogGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarBool.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarFloat.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarInt.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarName.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarPosition.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/aiscriptSharedVarTarget.cs
+++ b/CP77.CR2W/Types/cp77/aiscriptSharedVarTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/analogSpeedometerLogicController.cs
+++ b/CP77.CR2W/Types/cp77/analogSpeedometerLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/analogTachLogicController.cs
+++ b/CP77.CR2W/Types/cp77/analogTachLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animActionAnimDatabase.cs
+++ b/CP77.CR2W/Types/cp77/animActionAnimDatabase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animActionAnimDatabase_AnimationData.cs
+++ b/CP77.CR2W/Types/cp77/animActionAnimDatabase_AnimationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animActionAnimDatabase_DatabaseRow.cs
+++ b/CP77.CR2W/Types/cp77/animActionAnimDatabase_DatabaseRow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAdditionalFloatTrackContainer.cs
+++ b/CP77.CR2W/Types/cp77/animAdditionalFloatTrackContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAdditionalFloatTrackEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAdditionalFloatTrackEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAdditionalTransformContainer.cs
+++ b/CP77.CR2W/Types/cp77/animAdditionalTransformContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAdditionalTransformEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAdditionalTransformEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimBreakpointSimple.cs
+++ b/CP77.CR2W/Types/cp77/animAnimBreakpointSimple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDataAddress.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDataAddress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDataChunk.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDataChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDatabaseCollection.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDatabaseCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDatabaseCollectionEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDatabaseCollectionEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_ActivationChanges.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_ActivationChanges.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_ActivationChanges.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_ActivationChanges.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_BoolOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_BoolOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_BoolOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_BoolOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_FloatOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_FloatOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_FloatOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_FloatOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_GetAvailableHooks.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_GetAvailableHooks.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_GetAvailableHooks.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_GetAvailableHooks.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksRegistered.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksRegistered.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksRegistered.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksRegistered.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksUnregistered.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksUnregistered.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksUnregistered.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_HooksUnregistered.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_IntOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_IntOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_IntOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_IntOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_NormalizedProgressOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_NormalizedProgressOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_NormalizedProgressOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_NormalizedProgressOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_RecordActiveChanged.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_RecordActiveChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_RecordActiveChanged.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_RecordActiveChanged.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_SetDebugHookState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_SetDebugHookState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_SetDebugHookState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_SetDebugHookState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_TransitionOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_TransitionOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_TransitionOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_TransitionOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_VectorOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_VectorOutputApplied.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_VectorOutputApplied.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_VectorOutputApplied.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_WeightChanges.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_WeightChanges.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_WeightChanges.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDebuggerCommand_WeightChanges.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimDurationFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimDurationFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Effect.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Effect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_EffectDuration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_EffectDuration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_FoleyAction.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_FoleyAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_FootIK.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_FootIK.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_FootPhase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_FootPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_FootPlant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_FootPlant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_ForceRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_ForceRagdoll.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_ForceRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_ForceRagdoll.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_GameplayVo.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_GameplayVo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_ItemEffect.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_ItemEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_ItemEffectDuration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_ItemEffectDuration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_KeyPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_KeyPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_KeyPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_KeyPose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Phase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Phase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Phase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Phase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_SafeCut.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_SafeCut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_SafeCut.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_SafeCut.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_SceneItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_SceneItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Simple.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Simple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Simple.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Simple.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_SimpleDuration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_SimpleDuration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_SimpleDuration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_SimpleDuration.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Slide.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Slide.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Slide.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Slide.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Sound.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Sound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_TrajectoryAdjustment.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_TrajectoryAdjustment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_TrajectoryAdjustment.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_TrajectoryAdjustment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_Valued.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_Valued.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotFastExitCutoff.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotFastExitCutoff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotFastExitCutoff.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotFastExitCutoff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotPlayFacialAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimEvent_WorkspotPlayFacialAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFallbackFrameDesc.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFallbackFrameDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeatureEntry_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureEntry_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeatureMarkUnstable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureMarkUnstable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureMarkUnstable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureMarkUnstable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeaturePlaySlotAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeaturePlaySlotAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureUpdateWorkspot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureUpdateWorkspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotExitAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotExitAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotExitAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotExitAnim.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotInertializationAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeatureWorkspotInertializationAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_AIAction.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_AIAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_AIActionAnimation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_AIActionAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Aim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Aim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_BasicAim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_BasicAim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Bump.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Bump.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Climb.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Climb.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_ConsumableAnimation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_ConsumableAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_ContainerBase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_ContainerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Cover.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Cover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_CoverAction.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_CoverAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Crowd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Crowd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_CrowdLocomotion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_CrowdLocomotion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_DangleExternalInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_DangleExternalInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_DeviceCameraControlled.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_DeviceCameraControlled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_DodgeData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_DodgeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_DroneLocomotion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_DroneLocomotion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_EditorOnlyPredictiveLookAt.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_EditorOnlyPredictiveLookAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_EquipUnequipItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_EquipUnequipItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_ExitCover.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_ExitCover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_FPPCamera.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_FPPCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_HitReactions.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_HitReactions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_HitReactionsData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_HitReactionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_IK.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_IK.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Interaction.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Interaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Ladder.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Ladder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_LeftHandItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_LeftHandItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Locomotion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Locomotion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_MeleeData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_MeleeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_MeleeIKData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_MeleeIKData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_MeleeSlotData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_MeleeSlotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_MoveTo.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_MoveTo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Movement.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Movement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_NPCCoverStanceState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_NPCCoverStanceState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_NPCCoverStanceState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_NPCCoverStanceState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeature_NPCExploration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_NPCExploration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_NPCState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_NPCState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerCover.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerCover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerCoverActionState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerCoverActionState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerMovement.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerMovement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerSpatialAwareness.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerSpatialAwareness.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerStateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerStateMachineState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_PlayerStateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_PlayerStateMachineState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimFeature_QuickMelee.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_QuickMelee.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_SmartObject.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_SmartObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Stance.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Stance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_Vault.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_Vault.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_VehiclePassenger.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_VehiclePassenger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_VehiclePassengerAnimSetup.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_VehiclePassengerAnimSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_WallRun.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_WallRun.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimFeature_WeaponUser.cs
+++ b/CP77.CR2W/Types/cp77/animAnimFeature_WeaponUser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimGraphDebugState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimGraphDebugState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimGraphExternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimGraphExternalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimGraph_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimGraph_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimMathExpressionFloatSocket.cs
+++ b/CP77.CR2W/Types/cp77/animAnimMathExpressionFloatSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimMathExpressionQuaternionSocket.cs
+++ b/CP77.CR2W/Types/cp77/animAnimMathExpressionQuaternionSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimMathExpressionVectorSocket.cs
+++ b/CP77.CR2W/Types/cp77/animAnimMathExpressionVectorSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimMultiBoolToFloatEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimMultiBoolToFloatEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeDebugState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeDebugState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQsTransform.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQuat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureQuat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_AnimFeatureVector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_FloatTrack.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_FloatTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_OrientationVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_OrientationVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_ReferenceTransformVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_ReferenceTransformVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQsTransform.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQuat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketQuat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_SocketVector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticQsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticQuat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_StaticVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformQsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformQuat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_TransformVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedQsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedQsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedQuat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedQuat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNodeSourceChannel_WeightedVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AddIkRequest.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AddIkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AddSnapToTerrainIkRequest.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AddSnapToTerrainIkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AdditionalFloatTrack.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AdditionalFloatTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AdditionalTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AdditionalTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint_ObjectRotationUp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint_ObjectRotationUp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint_ObjectUp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AimConstraint_ObjectUp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AnimDatabase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AnimDatabase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AnimSetTagValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AnimSetTagValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_AnimSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_AnimSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ApplyCorrectivePoseRBF.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ApplyCorrectivePoseRBF.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BaseSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BaseSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Base_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Base_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Blend2.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Blend2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendAdditive.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendAdditive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendByMaskDynamic.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendByMaskDynamic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendFromPose_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendFromPose_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendMultiple_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendMultiple_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendOverride.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpace.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpaceCoordinateDescription.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpaceCoordinateDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpacePoint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BlendSpace_InternalsBlendSpacePoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolToFloatConverter.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolToFloatConverter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_BoolVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_BoolVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentBegin_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentBegin_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentEnd_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentEnd_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentEnd_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ConditionalSegmentEnd_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_ConeLimit.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ConeLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Container.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Container.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_CoordinateFromVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_CoordinateFromVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_CriticalSpringDamp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_CriticalSpringDamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_CurveFloatValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_CurveFloatValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_CurvePathSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_CurvePathSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_CurveVectorValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_CurveVectorValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DampFloat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DampFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DampQuaternion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DampQuaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DampVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DampVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Dangle.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Dangle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DirectConnConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DirectConnConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DirectionToEuler.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DirectionToEuler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_DisableSleepMode.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_DisableSleepMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Drag.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Drag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_EnumSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EnumSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Event.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Event.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_EventValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EventValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ExplorationAdjuster.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ExplorationAdjuster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_EyesLookAt.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EyesLookAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_EyesReset.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EyesReset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_EyesReset.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EyesReset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_EyesTracksLookAt.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_EyesTracksLookAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FPPCamera.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FPPCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FPPCamera.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FPPCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_FPPCameraSharedVar.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FPPCameraSharedVar.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FPPCameraSharedVar.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FPPCameraSharedVar.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_FacialMixerSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FacialMixerSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FacialSharedMetaPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FacialSharedMetaPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FacialSharedMetaPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FacialSharedMetaPose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatClamp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatClamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatComparator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatComparator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatCumulative.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatCumulative.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatInput_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatInput_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatInterpolation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatInterpolation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatMathOp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatMathOp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatRandom.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatRandom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatTimeDependentSinus.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatTimeDependentSinus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatToBoolConverter.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatToBoolConverter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatToIntConverter.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatToIntConverter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackDirectConnConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackDirectConnConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackModifier.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackModifierMarkUnstable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatTrackModifierMarkUnstable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatValueDebugProvider.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatValueDebugProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloatVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloatVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloorIk.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloorIk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FloorIkBase.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FloorIkBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FootStepAdjuster.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FootStepAdjuster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_FootStepScaling.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FootStepScaling.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentBegin_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentBegin_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentBegin_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentBegin_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentEnd_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentEnd_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentEnd_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ForegroundSegmentEnd_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_FrozenFrame.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_FrozenFrame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_GenerateIkAnimFeatureData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GenerateIkAnimFeatureData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_GraphSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GraphSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotConditions.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotConditions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GraphSlotInput.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_GraphSlot_Test.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_GraphSlot_Test.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_HumanIk.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_HumanIk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IdentityPoseTerminator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IdentityPoseTerminator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IdentityPoseTerminator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IdentityPoseTerminator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_Ik2.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Ik2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Ik2Constraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Ik2Constraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Inertialization.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Inertialization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_InputSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_InputSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntInput_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntInput_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntToFloatConverter.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntToFloatConverter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_IntVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_IntVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Join.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Join.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LODBegin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LODBegin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LODEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LODEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LocoState.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LocoState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LocomotionAdjuster.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LocomotionAdjuster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LocomotionAdjusterOnEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LocomotionAdjusterOnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LocomotionMachine.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LocomotionMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LocomotionSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LocomotionSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LookAt.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LookAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LookAtApplyVehicleRestrictions.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LookAtApplyVehicleRestrictions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LookAtController_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LookAtController_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LookAtPose360.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LookAtPose360.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_LookAtPose360Direction.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_LookAtPose360Direction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MaskReset.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MaskReset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionFloat_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionFloat_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionPose_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionPose_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionQuaternion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionQuaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionVector_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MathExpressionVector_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MixerSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MixerSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MotionAdjuster.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MotionAdjuster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MotionTableSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MotionTableSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MotionTableSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MotionTableSwitch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_MultiBoolToFloatValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MultiBoolToFloatValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MultipleParentConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MultipleParentConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_MultipleParentConstraint_ParentInfo.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_MultipleParentConstraint_ParentInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_NPCExploration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_NPCExploration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_NPCExploration.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_NPCExploration.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_NameHashConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_NameHashConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_OnePoseInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_OnePoseInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_OrientConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_OrientConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_OrientConstraint_WeightedTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_OrientConstraint_WeightedTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Output.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Output.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ParentConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ParentConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ParentTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ParentTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PointConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PointConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PointConstraint_WeightedTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PointConstraint_WeightedTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Pose360.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Pose360.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseCorrection.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseCorrection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseCorrection.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseCorrection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseLsToMs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseLsToMs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseLsToMs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseLsToMs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseMsToLs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseMsToLs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PoseMsToLs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PoseMsToLs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_PostProcess_Footlock.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PostProcess_Footlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_PostProcess_Footlock.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_PostProcess_Footlock.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionInterpolation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionInterpolation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_QuaternionWsToMs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_QuaternionWsToMs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RagdollControl.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RagdollControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RagdollPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RagdollPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RagdollPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RagdollPose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_ReadIkRequest.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ReadIkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ReferencePoseTerminator_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_Retarget.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Retarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Root.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Root.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RotateBone.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RotateBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RotateBoneByQuaternion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RotateBoneByQuaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RotationLimit.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RotationLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_RuntimeSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_RuntimeSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SelectiveJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SelectiveJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SelectiveJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SelectiveJoin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_Sermo_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Sermo_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Sermo_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Sermo_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetBoneOrientation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetBoneOrientation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetBonePosition.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetBonePosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetBoneTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetBoneTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsISetDrivenKeyEntryProvider.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsISetDrivenKeyEntryProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsISetDrivenKeyEntryProvider.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsISetDrivenKeyEntryProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsSetDrivenKeyEntryProviderInline.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetDrivenKey_InternalsSetDrivenKeyEntryProviderInline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetRequiredDistanceCategory.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetRequiredDistanceCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetRequiredDistanceCategoryByBone.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetRequiredDistanceCategoryByBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SetTrackRange.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SetTrackRange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SharedMetaPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SharedMetaPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SharedMetaPoseAdditive.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SharedMetaPoseAdditive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Signal.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Signal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SimpleBounce.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SimpleBounce.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SimpleSpline.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SimpleSpline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkAnimAdjuster.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkAnimAdjuster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkAnimContinue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkAnimContinue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkAnimDecorator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkAnimDecorator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkAnimSlot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkAnimSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkAnim_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkAnim_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkDurationAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkDurationAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkFrameAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkFrameAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkFrameAnimByTrack.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkFrameAnimByTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkOneShotAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkOneShotAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseSlotWithDurationAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseSlotWithDurationAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseWithDurationAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseWithDurationAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseWithSpeedAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkPhaseWithSpeedAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkSpeedAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkSpeedAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedMasterAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedMasterAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedMasterAnimByTime.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedMasterAnimByTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedSlaveAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkSyncedSlaveAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleBegin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleBegin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleBegin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleBegin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipConsoleEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeBegin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeBegin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeBegin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeBegin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SkipPerformanceModeEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SpringDamp.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SpringDamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StackTracksExtender_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StackTracksExtender_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StackTracksShrinker_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StackTracksShrinker_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StackTransformsExtender_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StackTransformsExtender_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StackTransformsShrinker_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StackTransformsShrinker_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Stage.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Stage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StageFloatEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StageFloatEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StageFloatEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StageFloatEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_StagePoseEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StagePoseEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_State.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_State.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StateFrozen.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StateFrozen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StateFrozen.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StateFrozen.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_StateMachine_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StateMachine_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_StaticSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_StaticSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_SuspensionLimit.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_SuspensionLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Switch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Switch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TagSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TagSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TagValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TagValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Timer.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Timer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_Timer.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_Timer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_TrackSetter.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TrackSetter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TrajectoryFromMetaPose.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TrajectoryFromMetaPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformInterpolation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformInterpolation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformRotator.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformRotator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformToTrack.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformToTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_TransformVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TransformVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TranslateBone.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TranslateBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TranslationLimit.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TranslationLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TriggerBranch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TriggerBranch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_TwistConstraint.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_TwistConstraint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_ValueBySpeed.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_ValueBySpeed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorConstant.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorConstant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorInput.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorInterpolation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorInterpolation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorJoin.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorJoin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorLatch.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorLatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_VectorWsToMs.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_VectorWsToMs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_WorkspotAnim.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_WorkspotAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_WorkspotHub.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_WorkspotHub.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimNode_WrapperValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimNode_WrapperValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfileData_RootItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfileData_RootItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_SectionTimings.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_SectionTimings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_Timings.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_Timings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsDetailed.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsDetailed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsDetailedRoot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsDetailedRoot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsRoot.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_TimingsRoot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimProfilerData_TreeItem.cs
+++ b/CP77.CR2W/Types/cp77/animAnimProfilerData_TreeItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSet.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetCollection.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetEntryAudioData.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetEntryAudioData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetup.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetupEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetupEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimSetupResource.cs
+++ b/CP77.CR2W/Types/cp77/animAnimSetupResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateMachineConditionalEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateMachineConditionalEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnimEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnimEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnyAnimEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnyAnimEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnyAnimEnd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_AnyAnimEnd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolEdgeFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolEdgeFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_BoolVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_CompositeSimultaneous.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_CompositeSimultaneous.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_ExternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_ExternalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FloatFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FloatFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FloatVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FloatVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FootPhaseEvent.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_FootPhaseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_HasAnimation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_HasAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeFromToFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeFromToFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeGreaterFromZeroFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeGreaterFromZeroFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeToFeature.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntEdgeToFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntFeature_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntFeature_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_IntVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_ModifiedFloatVariable.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_ModifiedFloatVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_Timed.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_Timed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_WrapperValue.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionCondition_WrapperValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionDescription.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimStateTransitionInterpolator_Blend_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimStateTransitionInterpolator_Blend_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimTransformMappingEntry.cs
+++ b/CP77.CR2W/Types/cp77/animAnimTransformMappingEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableBool.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableContainer.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableFloat.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableInt.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableQuaternion.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableQuaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableTransform.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariableVector.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariableVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimVariable_.cs
+++ b/CP77.CR2W/Types/cp77/animAnimVariable_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimWrapperVariableDescription.cs
+++ b/CP77.CR2W/Types/cp77/animAnimWrapperVariableDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimation.cs
+++ b/CP77.CR2W/Types/cp77/animAnimation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimationBufferCompressed.cs
+++ b/CP77.CR2W/Types/cp77/animAnimationBufferCompressed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimationBufferSimd.cs
+++ b/CP77.CR2W/Types/cp77/animAnimationBufferSimd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimationImportInfo.cs
+++ b/CP77.CR2W/Types/cp77/animAnimationImportInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimationSetup.cs
+++ b/CP77.CR2W/Types/cp77/animAnimationSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimsetVariableCondition.cs
+++ b/CP77.CR2W/Types/cp77/animAnimsetVariableCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animAnimsetWithOverridesTagCondition.cs
+++ b/CP77.CR2W/Types/cp77/animAnimsetWithOverridesTagCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animBoneCorrection.cs
+++ b/CP77.CR2W/Types/cp77/animBoneCorrection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animBoneTraceCondition.cs
+++ b/CP77.CR2W/Types/cp77/animBoneTraceCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animBoolLink.cs
+++ b/CP77.CR2W/Types/cp77/animBoolLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCAnimationBufferBitwiseCompressed.cs
+++ b/CP77.CR2W/Types/cp77/animCAnimationBufferBitwiseCompressed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCAnimationBufferUncompressed.cs
+++ b/CP77.CR2W/Types/cp77/animCAnimationBufferUncompressed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCollisionRoundedShape_.cs
+++ b/CP77.CR2W/Types/cp77/animCollisionRoundedShape_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCollisionShapesCollection.cs
+++ b/CP77.CR2W/Types/cp77/animCollisionShapesCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCompareBone.cs
+++ b/CP77.CR2W/Types/cp77/animCompareBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animComponentTagCondition.cs
+++ b/CP77.CR2W/Types/cp77/animComponentTagCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animConditionalSegmentCondition.cs
+++ b/CP77.CR2W/Types/cp77/animConditionalSegmentCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCorrectivePoseEntry.cs
+++ b/CP77.CR2W/Types/cp77/animCorrectivePoseEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCurvePathAnimControllerPreset.cs
+++ b/CP77.CR2W/Types/cp77/animCurvePathAnimControllerPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCurvePathBakerAdvancedUserInput.cs
+++ b/CP77.CR2W/Types/cp77/animCurvePathBakerAdvancedUserInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCurvePathBakerUserInput.cs
+++ b/CP77.CR2W/Types/cp77/animCurvePathBakerUserInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCurvePathControllersSetup.cs
+++ b/CP77.CR2W/Types/cp77/animCurvePathControllersSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animCurvePathPartInput.cs
+++ b/CP77.CR2W/Types/cp77/animCurvePathPartInput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationDyng_.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationDyng_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationPendulum.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationPendulum.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationPositionProjection.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationPositionProjection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationSingleBone.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationSingleBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationSpring.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_SimulationSpring.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDangleConstraint_Simulation_.cs
+++ b/CP77.CR2W/Types/cp77/animDangleConstraint_Simulation_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngConstraintCone.cs
+++ b/CP77.CR2W/Types/cp77/animDyngConstraintCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngConstraintEllipsoid_.cs
+++ b/CP77.CR2W/Types/cp77/animDyngConstraintEllipsoid_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngConstraintLink.cs
+++ b/CP77.CR2W/Types/cp77/animDyngConstraintLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngConstraintMulti.cs
+++ b/CP77.CR2W/Types/cp77/animDyngConstraintMulti.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngParticle_.cs
+++ b/CP77.CR2W/Types/cp77/animDyngParticle_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animDyngParticlesContainer.cs
+++ b/CP77.CR2W/Types/cp77/animDyngParticlesContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animEventsContainer.cs
+++ b/CP77.CR2W/Types/cp77/animEventsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialCustomizationSet.cs
+++ b/CP77.CR2W/Types/cp77/animFacialCustomizationSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialCustomizationTargetEntryTemp.cs
+++ b/CP77.CR2W/Types/cp77/animFacialCustomizationTargetEntryTemp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialEmotionTransitionBaked.cs
+++ b/CP77.CR2W/Types/cp77/animFacialEmotionTransitionBaked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialEmotionTransitionEditData.cs
+++ b/CP77.CR2W/Types/cp77/animFacialEmotionTransitionEditData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup_BufferInfo.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup_BufferInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup_OneSermoBufferInfo.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup_OneSermoBufferInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup_OneSermoPoseBufferInfo.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup_OneSermoPoseBufferInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup_PosesBufferInfo.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup_PosesBufferInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFacialSetup_TracksMapping.cs
+++ b/CP77.CR2W/Types/cp77/animFacialSetup_TracksMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFloatClamp.cs
+++ b/CP77.CR2W/Types/cp77/animFloatClamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFloatLink.cs
+++ b/CP77.CR2W/Types/cp77/animFloatLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animFloatTrackInfo.cs
+++ b/CP77.CR2W/Types/cp77/animFloatTrackInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animGenericAnimDatabase.cs
+++ b/CP77.CR2W/Types/cp77/animGenericAnimDatabase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animGenericAnimDatabase_AnimationData.cs
+++ b/CP77.CR2W/Types/cp77/animGenericAnimDatabase_AnimationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animGenericAnimDatabase_DatabaseRow.cs
+++ b/CP77.CR2W/Types/cp77/animGenericAnimDatabase_DatabaseRow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animGraphSlotCondition.cs
+++ b/CP77.CR2W/Types/cp77/animGraphSlotCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animHasAnimationCondition.cs
+++ b/CP77.CR2W/Types/cp77/animHasAnimationCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animHipsIkRequest.cs
+++ b/CP77.CR2W/Types/cp77/animHipsIkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimBreakpoint.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimBreakpoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimDebuggerCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimDebuggerCommand.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimDebuggerCommand.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Float.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Float.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Float.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Float.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_QsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_QsTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_QsTransform.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_QsTransform.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Quat.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Quat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Quat.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Quat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Vector.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Vector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Vector.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNodeSourceChannel_Vector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimNode_PostProcess.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimNode_PostProcess.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimStateTransitionCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimStateTransitionCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimStateTransitionCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimStateTransitionCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimStateTransitionInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimStateTransitionInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimStateTransitionInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimStateTransitionInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIAnimationBuffer.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimationBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIAnimationBuffer.cs
+++ b/CP77.CR2W/Types/cp77/animIAnimationBuffer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIDyngConstraint_.cs
+++ b/CP77.CR2W/Types/cp77/animIDyngConstraint_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIDyngConstraint_.cs
+++ b/CP77.CR2W/Types/cp77/animIDyngConstraint_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIKChainSettings.cs
+++ b/CP77.CR2W/Types/cp77/animIKChainSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Add.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Add.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Add.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Add.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Remove.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Remove.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Remove.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Remove.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Update.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Update.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIKTargetParams_Update.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetParams_Update.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIKTargetRef.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIKTargetRequest.cs
+++ b/CP77.CR2W/Types/cp77/animIKTargetRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animIMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animIMotionExtraction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIMotionTableProvider.cs
+++ b/CP77.CR2W/Types/cp77/animIMotionTableProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIPoseBlendMethod.cs
+++ b/CP77.CR2W/Types/cp77/animIPoseBlendMethod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIPoseBlendMethod.cs
+++ b/CP77.CR2W/Types/cp77/animIPoseBlendMethod.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIRigIkSetup.cs
+++ b/CP77.CR2W/Types/cp77/animIRigIkSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIRuntimeCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIRuntimeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIRuntimeCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIRuntimeCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animIStaticCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIStaticCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIStaticCondition.cs
+++ b/CP77.CR2W/Types/cp77/animIStaticCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animISyncMethod.cs
+++ b/CP77.CR2W/Types/cp77/animISyncMethod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animISyncMethod.cs
+++ b/CP77.CR2W/Types/cp77/animISyncMethod.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animImportFacialCorrectivePoseDataDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialCorrectivePoseDataDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialCorrectivePoseDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialCorrectivePoseDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialInitialControlsDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialInitialControlsDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialInitialPoseEntryDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialInitialPoseEntryDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialInitialPoseWeightDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialInitialPoseWeightDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialMainPoseDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialMainPoseDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialPoseDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialPoseDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialSetupCombinedDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialSetupCombinedDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialSetupDesc.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialSetupDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialTransform.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animImportFacialTransformNoScale.cs
+++ b/CP77.CR2W/Types/cp77/animImportFacialTransformNoScale.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animInertializationFloatClamp.cs
+++ b/CP77.CR2W/Types/cp77/animInertializationFloatClamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animInertializationRotationLimit.cs
+++ b/CP77.CR2W/Types/cp77/animInertializationRotationLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animIntLink.cs
+++ b/CP77.CR2W/Types/cp77/animIntLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLinearCompressedMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animLinearCompressedMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLipsyncMapping.cs
+++ b/CP77.CR2W/Types/cp77/animLipsyncMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLipsyncMappingSceneEntry.cs
+++ b/CP77.CR2W/Types/cp77/animLipsyncMappingSceneEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_BothArms.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_BothArms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_Eyes.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_Eyes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_FullControl.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_FullControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_LeftArm.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_LeftArm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_RightArm.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAdditionalPreset_RightArm.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtAnimationDefinition.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtAnimationDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtLimits.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtLimits.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtParams_Add.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_Add.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtParams_Add.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_Add.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animLookAtParams_Remove.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_Remove.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtParams_Remove.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_Remove.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animLookAtParams_UpdatePositions.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_UpdatePositions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtParams_UpdatePositions.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtParams_UpdatePositions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animLookAtPartInfo_.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPartInfo_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPartRequest.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPartRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPartsDependency_.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPartsDependency_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_Eyes.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_Eyes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHead.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHead.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyAttached.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyAttached.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyFree.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyFree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyFreeForFollower.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithBodyFreeForFollower.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithoutSuppress.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_EyesHeadWithoutSuppress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtPreset_FullControl.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtPreset_FullControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtRef.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtRequestForPart.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtRequestForPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtRequest_.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtRequest_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtStateMachineSettings.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtStateMachineSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtVehicleRestrictionParams.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtVehicleRestrictionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animLookAtVehicleRestrictionParams.cs
+++ b/CP77.CR2W/Types/cp77/animLookAtVehicleRestrictionParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMathExpressionNodeData.cs
+++ b/CP77.CR2W/Types/cp77/animMathExpressionNodeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMixerSlotAddIdleParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotAddIdleParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMixerSlotAddIdleParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotAddIdleParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMixerSlotIdleParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotIdleParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMixerSlotIdleParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotIdleParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMixerSlotParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMixerSlotParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMixerSlotTrajectoryBlendParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotTrajectoryBlendParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMixerSlotTrajectoryBlendParams.cs
+++ b/CP77.CR2W/Types/cp77/animMixerSlotTrajectoryBlendParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_Animation.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_Animation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_Animation.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_Animation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_Default.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_Default.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_Default.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_Default.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_MasterSlaveBlend.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_MasterSlaveBlend.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_MultiBlend.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_MultiBlend.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_MultiBlend.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_MultiBlend.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_StaticSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_StaticSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionTableProvider_StaticSwitch.cs
+++ b/CP77.CR2W/Types/cp77/animMotionTableProvider_StaticSwitch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMotionWrapper.cs
+++ b/CP77.CR2W/Types/cp77/animMotionWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMotionWrapper.cs
+++ b/CP77.CR2W/Types/cp77/animMotionWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animMultipleParentConstraint_JsonEntry.cs
+++ b/CP77.CR2W/Types/cp77/animMultipleParentConstraint_JsonEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animMultipleParentConstraint_JsonProperties.cs
+++ b/CP77.CR2W/Types/cp77/animMultipleParentConstraint_JsonProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animNamedTrackIndex.cs
+++ b/CP77.CR2W/Types/cp77/animNamedTrackIndex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animNodeProfileTimerInfo.cs
+++ b/CP77.CR2W/Types/cp77/animNodeProfileTimerInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animOverrideAnimSetRef.cs
+++ b/CP77.CR2W/Types/cp77/animOverrideAnimSetRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animOverrideBlendBoneInfo.cs
+++ b/CP77.CR2W/Types/cp77/animOverrideBlendBoneInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animOverrideBlendTrackInfo.cs
+++ b/CP77.CR2W/Types/cp77/animOverrideBlendTrackInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPlaneUncompressedMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animPlaneUncompressedMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoleVectorDetails.cs
+++ b/CP77.CR2W/Types/cp77/animPoleVectorDetails.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseBlendMethod_BoneBranch.cs
+++ b/CP77.CR2W/Types/cp77/animPoseBlendMethod_BoneBranch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseBlendMethod_Mask.cs
+++ b/CP77.CR2W/Types/cp77/animPoseBlendMethod_Mask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseCorrection.cs
+++ b/CP77.CR2W/Types/cp77/animPoseCorrection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseCorrectionGroup.cs
+++ b/CP77.CR2W/Types/cp77/animPoseCorrectionGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseCorrectionParams.cs
+++ b/CP77.CR2W/Types/cp77/animPoseCorrectionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseInfoLogger.cs
+++ b/CP77.CR2W/Types/cp77/animPoseInfoLogger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry.cs
+++ b/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry.cs
+++ b/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry_FloatTrack.cs
+++ b/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry_FloatTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry_Transform.cs
+++ b/CP77.CR2W/Types/cp77/animPoseInfoLoggerEntry_Transform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseLimitWeights.cs
+++ b/CP77.CR2W/Types/cp77/animPoseLimitWeights.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPoseLink.cs
+++ b/CP77.CR2W/Types/cp77/animPoseLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPropSetup.cs
+++ b/CP77.CR2W/Types/cp77/animPropSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animPropSetup.cs
+++ b/CP77.CR2W/Types/cp77/animPropSetup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animQuaternionLink.cs
+++ b/CP77.CR2W/Types/cp77/animQuaternionLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigIk2Setup.cs
+++ b/CP77.CR2W/Types/cp77/animRigIk2Setup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigIkLeftFootSetup.cs
+++ b/CP77.CR2W/Types/cp77/animRigIkLeftFootSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigIkLeftFootSetup.cs
+++ b/CP77.CR2W/Types/cp77/animRigIkLeftFootSetup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animRigIkRightFootSetup.cs
+++ b/CP77.CR2W/Types/cp77/animRigIkRightFootSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigIkRightFootSetup.cs
+++ b/CP77.CR2W/Types/cp77/animRigIkRightFootSetup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animRigPart.cs
+++ b/CP77.CR2W/Types/cp77/animRigPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigPartBone.cs
+++ b/CP77.CR2W/Types/cp77/animRigPartBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigPartBoneTree.cs
+++ b/CP77.CR2W/Types/cp77/animRigPartBoneTree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigRetarget.cs
+++ b/CP77.CR2W/Types/cp77/animRigRetarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigSharedData.cs
+++ b/CP77.CR2W/Types/cp77/animRigSharedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRigTagCondition.cs
+++ b/CP77.CR2W/Types/cp77/animRigTagCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animRig_.cs
+++ b/CP77.CR2W/Types/cp77/animRig_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressedBoneTrack.cs
+++ b/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressedBoneTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressedData.cs
+++ b/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressionSettings.cs
+++ b/CP77.CR2W/Types/cp77/animSAnimationBufferBitwiseCompressionSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSApplyRotationIKSolver.cs
+++ b/CP77.CR2W/Types/cp77/animSApplyRotationIKSolver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSApplyRotationIKSolver.cs
+++ b/CP77.CR2W/Types/cp77/animSApplyRotationIKSolver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSApplyRotationIKSolverData.cs
+++ b/CP77.CR2W/Types/cp77/animSApplyRotationIKSolverData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCachedTrace.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCachedTrace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCachedTrace.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCachedTrace.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommon.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommon.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommonData.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKCommonData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKDebugTrace.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKDebugTrace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKDebugTrace.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKDebugTrace.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKFrontBackWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKFrontBackWeightHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKFrontBackWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKFrontBackWeightHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLeg.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLeg.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLeg.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLeg.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegs.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegs.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsData.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsIKWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsIKWeightHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsIKWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKLegsIKWeightHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBone.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBone.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBone.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBoneData.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKMaintainLookBoneData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBone.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBone.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBone.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBoneData.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKVerticalBoneData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKWeightHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKWeightHandler.cs
+++ b/CP77.CR2W/Types/cp77/animSBehaviorConstraintNodeFloorIKWeightHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSTwoBonesIKSolver.cs
+++ b/CP77.CR2W/Types/cp77/animSTwoBonesIKSolver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSTwoBonesIKSolver.cs
+++ b/CP77.CR2W/Types/cp77/animSTwoBonesIKSolver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSTwoBonesIKSolverData.cs
+++ b/CP77.CR2W/Types/cp77/animSTwoBonesIKSolverData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSermoPoseInfo.cs
+++ b/CP77.CR2W/Types/cp77/animSermoPoseInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSermoTestController.cs
+++ b/CP77.CR2W/Types/cp77/animSermoTestController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSetBoneTransformEntry.cs
+++ b/CP77.CR2W/Types/cp77/animSetBoneTransformEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSetBoneTransform_JsonEntry.cs
+++ b/CP77.CR2W/Types/cp77/animSetBoneTransform_JsonEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSetBoneTransform_JsonProperties.cs
+++ b/CP77.CR2W/Types/cp77/animSetBoneTransform_JsonProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSimpleBounceTrackOutput.cs
+++ b/CP77.CR2W/Types/cp77/animSimpleBounceTrackOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSimpleBounceTransformOutput.cs
+++ b/CP77.CR2W/Types/cp77/animSimpleBounceTransformOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSimpleBounceTransformOutput_ChannelEntry.cs
+++ b/CP77.CR2W/Types/cp77/animSimpleBounceTransformOutput_ChannelEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSimpleBounce_JsonProperties.cs
+++ b/CP77.CR2W/Types/cp77/animSimpleBounce_JsonProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSmoothFloatClamp.cs
+++ b/CP77.CR2W/Types/cp77/animSmoothFloatClamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSnapToTerrainIkRequest.cs
+++ b/CP77.CR2W/Types/cp77/animSnapToTerrainIkRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSplineCompressedMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animSplineCompressedMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animStackTracksExtender_JsonEntry.cs
+++ b/CP77.CR2W/Types/cp77/animStackTracksExtender_JsonEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animStackTracksExtender_JsonProperties.cs
+++ b/CP77.CR2W/Types/cp77/animStackTracksExtender_JsonProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animStackTransformsExtender_Entry.cs
+++ b/CP77.CR2W/Types/cp77/animStackTransformsExtender_Entry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animStackTransformsExtender_JsonEntry.cs
+++ b/CP77.CR2W/Types/cp77/animStackTransformsExtender_JsonEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animStackTransformsExtender_JsonProperties.cs
+++ b/CP77.CR2W/Types/cp77/animStackTransformsExtender_JsonProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSyncMethodByEvent.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodByEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSyncMethodByFootPhase.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodByFootPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSyncMethodByFootPhase.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodByFootPhase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSyncMethodByProgress.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodByProgress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animSyncMethodByProgress.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodByProgress.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/animSyncMethodLocomotion.cs
+++ b/CP77.CR2W/Types/cp77/animSyncMethodLocomotion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTEMP_IKTargetsControllerBodyType.cs
+++ b/CP77.CR2W/Types/cp77/animTEMP_IKTargetsControllerBodyType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTransformIndex.cs
+++ b/CP77.CR2W/Types/cp77/animTransformIndex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTransformInfo.cs
+++ b/CP77.CR2W/Types/cp77/animTransformInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTransformLink.cs
+++ b/CP77.CR2W/Types/cp77/animTransformLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTransformMask.cs
+++ b/CP77.CR2W/Types/cp77/animTransformMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animTwistOutput.cs
+++ b/CP77.CR2W/Types/cp77/animTwistOutput.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animUncompressedAllAnglesMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animUncompressedAllAnglesMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animUncompressedMotionExtraction.cs
+++ b/CP77.CR2W/Types/cp77/animUncompressedMotionExtraction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animVectorLink.cs
+++ b/CP77.CR2W/Types/cp77/animVectorLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animVisualTagCondition.cs
+++ b/CP77.CR2W/Types/cp77/animVisualTagCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animationPlayer.cs
+++ b/CP77.CR2W/Types/cp77/animationPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/animfssBodyOfflineParams.cs
+++ b/CP77.CR2W/Types/cp77/animfssBodyOfflineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceAppearanceDefinition.cs
+++ b/CP77.CR2W/Types/cp77/appearanceAppearanceDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceAppearancePart.cs
+++ b/CP77.CR2W/Types/cp77/appearanceAppearancePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceAppearancePartOverrides.cs
+++ b/CP77.CR2W/Types/cp77/appearanceAppearancePartOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceAppearanceResource.cs
+++ b/CP77.CR2W/Types/cp77/appearanceAppearanceResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceCensorshipEntry.cs
+++ b/CP77.CR2W/Types/cp77/appearanceCensorshipEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceChunkMaskSettings.cs
+++ b/CP77.CR2W/Types/cp77/appearanceChunkMaskSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearanceCookedAppearanceData.cs
+++ b/CP77.CR2W/Types/cp77/appearanceCookedAppearanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/appearancePartComponentOverrides.cs
+++ b/CP77.CR2W/Types/cp77/appearancePartComponentOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/artist_test_area_r.cs
+++ b/CP77.CR2W/Types/cp77/artist_test_area_r.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAccumulatedSoundDecoratorMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAccumulatedSoundDecoratorMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAcousticConstantsPreset.cs
+++ b/CP77.CR2W/Types/cp77/audioAcousticConstantsPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAcousticZoneMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAcousticZoneMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAcousticZoneParameterMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAcousticZoneParameterMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAcousticsEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAcousticsEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAdvertMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAdvertMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAdvertPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioAdvertPositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAdvertPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioAdvertPositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAdvertSoundMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAdvertSoundMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaContextActivatedASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaContextActivatedASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaGroupingSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaGroupingSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAmbientAreaSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientAreaSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientPaletteBrush.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientPaletteBrush.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushCategory.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientPaletteBrushDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAmbientPaletteEntry.cs
+++ b/CP77.CR2W/Types/cp77/audioAmbientPaletteEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAnimationOverrideDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioAnimationOverrideDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAnimationOverrideDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAnimationOverrideDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAnimationOverrideMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAnimationOverrideMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAnyStateTransitionEntry.cs
+++ b/CP77.CR2W/Types/cp77/audioAnyStateTransitionEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAppearanceToNPCMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAppearanceToNPCMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAppearanceToPlayerMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAppearanceToPlayerMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAppearancesGroup.cs
+++ b/CP77.CR2W/Types/cp77/audioAppearancesGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioApplySoundPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioApplySoundPositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioApplySoundPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioApplySoundPositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAudBulletTimeModeMap.cs
+++ b/CP77.CR2W/Types/cp77/audioAudBulletTimeModeMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudBulletTimeModeMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAudBulletTimeModeMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/audioAudEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudParameter.cs
+++ b/CP77.CR2W/Types/cp77/audioAudParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudSimpleParameter.cs
+++ b/CP77.CR2W/Types/cp77/audioAudSimpleParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudSwitch.cs
+++ b/CP77.CR2W/Types/cp77/audioAudSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioAttractAreaSounds.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioAttractAreaSounds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioEventArray.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioEventArray.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioEventMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioEventMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioEventMetadataArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioEventMetadataArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioEventPostedASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioEventPostedASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioFoliageMaterial.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioFoliageMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioFoliageMaterialDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioFoliageMaterialDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioFoliageMaterialDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioFoliageMaterialDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioFoliageMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioFoliageMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioMaterialMetadataMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioMaterialMetadataMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAudioMetadataBase.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioMetadataBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneDefaults.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneDefaults.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneSignalOverride.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneSignalOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneStateOverride.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneStateOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneVariableReadActionData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneVariableReadActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSceneVariableWriteActionData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSceneVariableWriteActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioScenesMap.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioScenesMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSquadHandler.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSquadHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioSquadHandler.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioSquadHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAudioStateData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioStateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioStateTransitionConditionData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioStateTransitionConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAudioStateTransitionConditionData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioStateTransitionConditionData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioAudioStateTransitionData.cs
+++ b/CP77.CR2W/Types/cp77/audioAudioStateTransitionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioAuxiliaryMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioAuxiliaryMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBaseAudioSquadHandler.cs
+++ b/CP77.CR2W/Types/cp77/audioBaseAudioSquadHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBaseAudioSquadHandler.cs
+++ b/CP77.CR2W/Types/cp77/audioBaseAudioSquadHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioBaseRadioAnnouncementPlayer.cs
+++ b/CP77.CR2W/Types/cp77/audioBaseRadioAnnouncementPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBaseRadioAnnouncementPlayer.cs
+++ b/CP77.CR2W/Types/cp77/audioBaseRadioAnnouncementPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioBreathingSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioBreathingSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBreathingStateMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioBreathingStateMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBreathingStateTransitionMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioBreathingStateTransitionMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBreathingTemporaryStateMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioBreathingTemporaryStateMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioBulletImpactSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioBulletImpactSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCombatVoManagerSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioCombatVoManagerSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCombatVoSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioCombatVoSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCombatVoTriggerVariationsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioCombatVoTriggerVariationsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCombatVoTriggerVariationsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioCombatVoTriggerVariationsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCommonEntitySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioCommonEntitySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCompoundEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioCompoundEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioContextualAudEventMap.cs
+++ b/CP77.CR2W/Types/cp77/audioContextualAudEventMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioContextualAudEventMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioContextualAudEventMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioContextualVoiceGrunt.cs
+++ b/CP77.CR2W/Types/cp77/audioContextualVoiceGrunt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioContextualVoiceGruntSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioContextualVoiceGruntSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioConversationCharacterCondition.cs
+++ b/CP77.CR2W/Types/cp77/audioConversationCharacterCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioConversationItemMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioConversationItemMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioConversationMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioConversationMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCookedMetadataResource.cs
+++ b/CP77.CR2W/Types/cp77/audioCookedMetadataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCpoConversation.cs
+++ b/CP77.CR2W/Types/cp77/audioCpoConversation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCustomEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioCustomEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioCustomEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioCustomEmitterMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioDefaultMixingSignposts.cs
+++ b/CP77.CR2W/Types/cp77/audioDefaultMixingSignposts.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDeviceSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDeviceSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDeviceStateSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDeviceStateSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDialogLineEventData.cs
+++ b/CP77.CR2W/Types/cp77/audioDialogLineEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDirectorSystemSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDirectorSystemSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDismembermentSoundSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDismembermentSoundSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDistanceSoundDecoratorMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioDistanceSoundDecoratorMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDoorDecoratorMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioDoorDecoratorMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDoorsSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDoorsSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDroneGlobalSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDroneGlobalSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDroneMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioDroneMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDynamicEventsPerVisualTags.cs
+++ b/CP77.CR2W/Types/cp77/audioDynamicEventsPerVisualTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDynamicEventsWithInterval.cs
+++ b/CP77.CR2W/Types/cp77/audioDynamicEventsWithInterval.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioDynamicReverbSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioDynamicReverbSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEditorSelectedData.cs
+++ b/CP77.CR2W/Types/cp77/audioEditorSelectedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEditorSelectedMeleeWeapon.cs
+++ b/CP77.CR2W/Types/cp77/audioEditorSelectedMeleeWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioElevatorSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioElevatorSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioEmitterMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioEnemyStateCountASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioEnemyStateCountASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEntityEmitterSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioEntityEmitterSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEntityMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioEntityMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEntitySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioEntitySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEnvelopeSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioEnvelopeSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEventOverrideDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioEventOverrideDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEventOverrideDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioEventOverrideDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioEventOverrides.cs
+++ b/CP77.CR2W/Types/cp77/audioEventOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFlybySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioFlybySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFoleyAppearanceName.cs
+++ b/CP77.CR2W/Types/cp77/audioFoleyAppearanceName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFoleyGlobalMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFoleyGlobalMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFoleyNPCAppearanceMappingMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFoleyNPCAppearanceMappingMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFoleyNPCMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFoleyNPCMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFoleyPlayerAppearanceMappingMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFoleyPlayerAppearanceMappingMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFootstepDecalMaterialEntry.cs
+++ b/CP77.CR2W/Types/cp77/audioFootstepDecalMaterialEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFootstepDecalMaterialsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioFootstepDecalMaterialsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFootstepsMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFootstepsMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFootwearType.cs
+++ b/CP77.CR2W/Types/cp77/audioFootwearType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioFootwearVsMaterialMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioFootwearVsMaterialMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGameplayTierActivatedASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioGameplayTierActivatedASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGearSweetener.cs
+++ b/CP77.CR2W/Types/cp77/audioGearSweetener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGeneralVoiceGruntSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioGeneralVoiceGruntSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGenericEntitySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericEntitySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGenericEntitySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericEntitySettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioGenericGameplayEventOccurredASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericGameplayEventOccurredASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGenericNameEventDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericNameEventDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGenericNameEventItem.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericNameEventItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGenericNameEventMap.cs
+++ b/CP77.CR2W/Types/cp77/audioGenericNameEventMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGrenadeEntitySettings.cs
+++ b/CP77.CR2W/Types/cp77/audioGrenadeEntitySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGroupingCountableMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioGroupingCountableMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGroupingLimitMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioGroupingLimitMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGroupingShapeClassifierMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioGroupingShapeClassifierMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioGroupingTagMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioGroupingTagMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioIBasicGameInterface.cs
+++ b/CP77.CR2W/Types/cp77/audioIBasicGameInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioIBasicGameInterface.cs
+++ b/CP77.CR2W/Types/cp77/audioIBasicGameInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioIndexedSinglePositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioIndexedSinglePositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioIndexedSinglePositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioIndexedSinglePositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioInlinedAudioMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioInlinedAudioMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioInlinedAudioMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioInlinedAudioMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioKeySoundEventDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioKeySoundEventDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioKeySoundEventPairDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioKeySoundEventPairDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioKeyUiControlDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioKeyUiControlDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioKeyUiControlPairDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioKeyUiControlPairDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioKeyUiSoundDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioKeyUiSoundDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioKeyUiSoundPairDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioKeyUiSoundPairDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLanguage.cs
+++ b/CP77.CR2W/Types/cp77/audioLanguage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLanguageGameConfiguration.cs
+++ b/CP77.CR2W/Types/cp77/audioLanguageGameConfiguration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLanguageMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioLanguageMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionCustomActionEventDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionCustomActionEventDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionCustomActionEventDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionCustomActionEventDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionCustomActionType.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionCustomActionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionEventMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionEventMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionEventMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionEventMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioLocomotionStateEventDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionStateEventDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionStateEventDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionStateEventDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLocomotionStateType.cs
+++ b/CP77.CR2W/Types/cp77/audioLocomotionStateType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLoopedSoundEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioLoopedSoundEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioLoopingSoundController.cs
+++ b/CP77.CR2W/Types/cp77/audioLoopingSoundController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMaterialMeleeSoundDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioMaterialMeleeSoundDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMaterialMeleeSoundDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioMaterialMeleeSoundDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMaterialOverride.cs
+++ b/CP77.CR2W/Types/cp77/audioMaterialOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeAttackSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeAttackSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeEvent.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeHitSoundMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeHitSoundMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeHitTypeMeleeSoundDictionary.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeHitTypeMeleeSoundDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeHitTypeMeleeSoundDictionaryItem.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeHitTypeMeleeSoundDictionaryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeRigMap.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeRigMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeRigMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeRigMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeRigTypeMeleeWeaponConfigurationMap.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeRigTypeMeleeWeaponConfigurationMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeRigTypeMeleeWeaponConfigurationMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeRigTypeMeleeWeaponConfigurationMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeSound.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeSound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponConfiguration.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponConfiguration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponNpcSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponNpcSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponNpcSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponNpcSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponPlayerSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponPlayerSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponPlayerSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponPlayerSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMeleeWeaponVariations.cs
+++ b/CP77.CR2W/Types/cp77/audioMeleeWeaponVariations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMixParamDescription.cs
+++ b/CP77.CR2W/Types/cp77/audioMixParamDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMixSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioMixSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMixingActionData.cs
+++ b/CP77.CR2W/Types/cp77/audioMixingActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMultiplePositionsStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioMultiplePositionsStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioMultiplePositionsStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioMultiplePositionsStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioMusicController.cs
+++ b/CP77.CR2W/Types/cp77/audioMusicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioNpcGunChoirSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioNpcGunChoirSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioNpcGunChoirVoice.cs
+++ b/CP77.CR2W/Types/cp77/audioNpcGunChoirVoice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioNpcWeaponSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioNpcWeaponSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioNullPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioNullPositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioNullPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioNullPositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioPanicModeVirtualizeList.cs
+++ b/CP77.CR2W/Types/cp77/audioPanicModeVirtualizeList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioParamMixerDecoratorMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioParamMixerDecoratorMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPhysicalMaterialSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioPhysicalMaterialSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPhysicalMaterialToAudioMetadataMatrix.cs
+++ b/CP77.CR2W/Types/cp77/audioPhysicalMaterialToAudioMetadataMatrix.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPhysicalObstructionSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioPhysicalObstructionSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPhysicalPropSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioPhysicalPropSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPlayerInVehicleASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioPlayerInVehicleASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPlayerWeaponSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioPlayerWeaponSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPlaylistEmitterMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioPlaylistEmitterMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPlaylistMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioPlaylistMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPlaylistTrackEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/audioPlaylistTrackEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioPoliceDispatcherMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioPoliceDispatcherMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioQuadEmitterSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioQuadEmitterSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioQuadPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioQuadPositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioQuadPositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioQuadPositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioRadioStationJingleMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioStationJingleMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRadioStationMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioStationMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRadioStationMetadataMap.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioStationMetadataMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRadioStationSongEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioStationSongEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRadioTrack.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRadioTracksMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioRadioTracksMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRagdollCollisionMaterial.cs
+++ b/CP77.CR2W/Types/cp77/audioRagdollCollisionMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioReflectionEmitterSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioReflectionEmitterSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioReflectionMaterialSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioReflectionMaterialSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioReverbCrossoverParams.cs
+++ b/CP77.CR2W/Types/cp77/audioReverbCrossoverParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioRigMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioRigMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioScanningSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioScanningSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioScriptableAudioInterface.cs
+++ b/CP77.CR2W/Types/cp77/audioScriptableAudioInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioScriptableAudioInterface.cs
+++ b/CP77.CR2W/Types/cp77/audioScriptableAudioInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioSecurityTurretMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioSecurityTurretMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioShockwaveGlobalSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioShockwaveGlobalSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioShockwaveMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioShockwaveMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioShockwavePropertyMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioShockwavePropertyMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioSoundBankStruct.cs
+++ b/CP77.CR2W/Types/cp77/audioSoundBankStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioSourceBasedReverbBussesMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioSourceBasedReverbBussesMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioSpatialSoundLimitMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioSpatialSoundLimitMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioStandaloneSinglePositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioStandaloneSinglePositionStrategy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioStandaloneSinglePositionStrategy.cs
+++ b/CP77.CR2W/Types/cp77/audioStandaloneSinglePositionStrategy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/audioUiControl.cs
+++ b/CP77.CR2W/Types/cp77/audioUiControl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiControlEventsSettingsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioUiControlEventsSettingsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiControlMap.cs
+++ b/CP77.CR2W/Types/cp77/audioUiControlMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiGenericControlSettingsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioUiGenericControlSettingsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiGenericControlSettingsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioUiGenericControlSettingsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiSound.cs
+++ b/CP77.CR2W/Types/cp77/audioUiSound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiSpecificControlSettingsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioUiSpecificControlSettingsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioUiSpecificControlSettingsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioUiSpecificControlSettingsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleCollisionMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleCollisionMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleCollisionMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleCollisionMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleDestructionGridCell.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleDestructionGridCell.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleDestructionGridLayer.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleDestructionGridLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleDoorsSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleDoorsSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleDoorsSettingsMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleDoorsSettingsMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleEmitterPositionData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleEmitterPositionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleEngageMovingFasterInterpolationData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleEngageMovingFasterInterpolationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleGeneralData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleGeneralData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleGridDestruction.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleGridDestruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleInteriorParameterData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleInteriorParameterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleMechanicalData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleMechanicalData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleNpcOcclusionMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleNpcOcclusionMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehiclePartSettingsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVehiclePartSettingsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehiclePartSettingsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVehiclePartSettingsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleTemperatureSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleTemperatureSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleWheelData.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleWheelData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleWheelMaterialsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleWheelMaterialsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVehicleWheelMaterialsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVehicleWheelMaterialsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVisualTagAppearanceGroup.cs
+++ b/CP77.CR2W/Types/cp77/audioVisualTagAppearanceGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVisualTagAppearanceMapping.cs
+++ b/CP77.CR2W/Types/cp77/audioVisualTagAppearanceMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVisualTagToNPCMetadata.cs
+++ b/CP77.CR2W/Types/cp77/audioVisualTagToNPCMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoLineSignal.cs
+++ b/CP77.CR2W/Types/cp77/audioVoLineSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceContextAnswer.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceContextAnswer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceContextMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceContextMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceContextMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceContextMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceGruntVariations.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceGruntVariations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTagAppearanceGroup.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTagAppearanceGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTagAppearanceMapping.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTagAppearanceMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTagGroup.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTagGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerLimits.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerLimits.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerLimitsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerLimitsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerLimitsMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerLimitsMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerPerSquadOrderMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerPerSquadOrderMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerPerSquadOrderMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerPerSquadOrderMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerRewireMap.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerRewireMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioVoiceTriggerRewireMapItem.cs
+++ b/CP77.CR2W/Types/cp77/audioVoiceTriggerRewireMapItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWaitTimeASTCD.cs
+++ b/CP77.CR2W/Types/cp77/audioWaitTimeASTCD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponAmmoSettingsMap.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponAmmoSettingsMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponFireModeSounds.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponFireModeSounds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponHandlingSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponHandlingSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponSettingsGroup.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponSettingsGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponShellCasingSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponShellCasingSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponTailOverride.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponTailOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponTailOverrides.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponTailOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWeaponTailSettings.cs
+++ b/CP77.CR2W/Types/cp77/audioWeaponTailSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audioWwiseIgnoredNames.cs
+++ b/CP77.CR2W/Types/cp77/audioWwiseIgnoredNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audiouiAudioHandler.cs
+++ b/CP77.CR2W/Types/cp77/audiouiAudioHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/audiouiAudioHandler.cs
+++ b/CP77.CR2W/Types/cp77/audiouiAudioHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/blunderbussWeaponController.cs
+++ b/CP77.CR2W/Types/cp77/blunderbussWeaponController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/buffListGameController.cs
+++ b/CP77.CR2W/Types/cp77/buffListGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/buffListItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/buffListItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/buildsWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/buildsWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphColorOption.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphColorOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphImageThumbnail.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphImageThumbnail.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphMenu.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphOption.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPicker.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPicker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPickerButton.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPickerButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPickerItem.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionColorPickerItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionSelectorButton.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationBodyMorphOptionSelectorButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationGenderBackstoryBtn.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationGenderBackstoryBtn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationLifePathBtn.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationLifePathBtn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationNavigationBtn.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationNavigationBtn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationStatsAttributeBtn.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationStatsAttributeBtn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationSummaryListItem.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationSummaryListItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationSummaryMenu.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationSummaryMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/characterCreationVoiceOverSwitcher.cs
+++ b/CP77.CR2W/Types/cp77/characterCreationVoiceOverSwitcher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityArea.cs
+++ b/CP77.CR2W/Types/cp77/communityArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunityEntryPhaseSpotsData.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunityEntryPhaseSpotsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunityEntryPhaseTimePeriodData.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunityEntryPhaseTimePeriodData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunityEntrySpotsData.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunityEntrySpotsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunitySpawnSetTemplate.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunitySpawnSetTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunitySpawnSetTemplate.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunitySpawnSetTemplate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/communityCommunityTemplate.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunityTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityCommunityTemplateData.cs
+++ b/CP77.CR2W/Types/cp77/communityCommunityTemplateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityPatrolInitializer.cs
+++ b/CP77.CR2W/Types/cp77/communityPatrolInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityPhaseTimePeriod.cs
+++ b/CP77.CR2W/Types/cp77/communityPhaseTimePeriod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityRole.cs
+++ b/CP77.CR2W/Types/cp77/communityRole.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communitySpawnEntry.cs
+++ b/CP77.CR2W/Types/cp77/communitySpawnEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communitySpawnInitializer.cs
+++ b/CP77.CR2W/Types/cp77/communitySpawnInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communitySpawnInitializer.cs
+++ b/CP77.CR2W/Types/cp77/communitySpawnInitializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/communitySpawnPhase.cs
+++ b/CP77.CR2W/Types/cp77/communitySpawnPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communitySquadInitializer.cs
+++ b/CP77.CR2W/Types/cp77/communitySquadInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communitySquadInitializerEntry.cs
+++ b/CP77.CR2W/Types/cp77/communitySquadInitializerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityTimePeriod.cs
+++ b/CP77.CR2W/Types/cp77/communityTimePeriod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/communityVoiceTagInitializer.cs
+++ b/CP77.CR2W/Types/cp77/communityVoiceTagInitializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpAnimFeature_Stairs.cs
+++ b/CP77.CR2W/Types/cp77/cpAnimFeature_Stairs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpBumpEvent.cs
+++ b/CP77.CR2W/Types/cp77/cpBumpEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyor.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyorComponent.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyorComponent.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpConveyorLine.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorLine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyorObject.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyorSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorSetupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpConveyorSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/cpConveyorSetupEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpExplosiveBarrel.cs
+++ b/CP77.CR2W/Types/cp77/cpExplosiveBarrel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpGameplayLightComponent.cs
+++ b/CP77.CR2W/Types/cp77/cpGameplayLightComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpMeatBag.cs
+++ b/CP77.CR2W/Types/cp77/cpMeatBag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayer.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayer.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpPlayerDetector.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayerDetector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayerDetectorPS.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayerDetectorPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayerDetector_PseudoDevice.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayerDetector_PseudoDevice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpPlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/cpPlayerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpSplinePlacementProvider.cs
+++ b/CP77.CR2W/Types/cp77/cpSplinePlacementProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpSplinePlacementProvider.cs
+++ b/CP77.CR2W/Types/cp77/cpSplinePlacementProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpSplinePlacementProvider_Count.cs
+++ b/CP77.CR2W/Types/cp77/cpSplinePlacementProvider_Count.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpSplinePlacementProvider_Distance.cs
+++ b/CP77.CR2W/Types/cp77/cpSplinePlacementProvider_Distance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpStairsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/cpStairsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpStairsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/cpStairsTrigger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpTestComponent.cs
+++ b/CP77.CR2W/Types/cp77/cpTestComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpTestComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/cpTestComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpTestPhysXDynamicMovement.cs
+++ b/CP77.CR2W/Types/cp77/cpTestPhysXDynamicMovement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpTestPhysXDynamicMovement.cs
+++ b/CP77.CR2W/Types/cp77/cpTestPhysXDynamicMovement.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/cpTestPlatformController.cs
+++ b/CP77.CR2W/Types/cp77/cpTestPlatformController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cpTimerTest.cs
+++ b/CP77.CR2W/Types/cp77/cpTimerTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/cursorDeviceGameController.cs
+++ b/CP77.CR2W/Types/cp77/cursorDeviceGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/curveSingleChannelCurve.cs
+++ b/CP77.CR2W/Types/cp77/curveSingleChannelCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/customGameNotificationDataSet.cs
+++ b/CP77.CR2W/Types/cp77/customGameNotificationDataSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/dbgSpawner.cs
+++ b/CP77.CR2W/Types/cp77/dbgSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/debugRuntimeSystemSpeedSplinePreview.cs
+++ b/CP77.CR2W/Types/cp77/debugRuntimeSystemSpeedSplinePreview.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/debugRuntimeSystemSpeedSplinePreview.cs
+++ b/CP77.CR2W/Types/cp77/debugRuntimeSystemSpeedSplinePreview.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/dialogWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/dialogWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/drillMachine.cs
+++ b/CP77.CR2W/Types/cp77/drillMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/drillMachineEvent.cs
+++ b/CP77.CR2W/Types/cp77/drillMachineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectBaseItem.cs
+++ b/CP77.CR2W/Types/cp77/effectBaseItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectBaseItem.cs
+++ b/CP77.CR2W/Types/cp77/effectBaseItem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectBloomPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectBloomPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectBloomPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectBloomPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectBoneEntries.cs
+++ b/CP77.CR2W/Types/cp77/effectBoneEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectBoneEntry.cs
+++ b/CP77.CR2W/Types/cp77/effectBoneEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectCameraComponentSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectCameraComponentSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectCameraComponentSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectCameraComponentSpawner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectCameraComponentTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectCameraComponentTrackItemPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectCameraComponentTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectCameraComponentTrackItemPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectChromaticAberrationPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectChromaticAberrationPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectChromaticAberrationPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectChromaticAberrationPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectColorGradePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectColorGradePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectColorGradePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectColorGradePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectColorGradeV2PlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectColorGradeV2PlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectColorGradeV2PlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectColorGradeV2PlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectDataMoshPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDataMoshPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectDataMoshPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDataMoshPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDecalPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDecalPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectDynamicDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDynamicDecalPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectDynamicDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectDynamicDecalPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectEffectParameterEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/effectEffectParameterEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorColor.cs
+++ b/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorColor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorFloat.cs
+++ b/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorVector.cs
+++ b/CP77.CR2W/Types/cp77/effectEffectParameterEvaluatorVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectEmissivePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectEmissivePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectEmissivePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectEmissivePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectExposureScalePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectExposureScalePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectExposureScalePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectExposureScalePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectFOVPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFOVPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectFOVPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFOVPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectFilmGrainPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFilmGrainPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectFilmGrainPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFilmGrainPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectFogVolumePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFogVolumePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectFogVolumePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectFogVolumePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectForwardDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectForwardDecalPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectForwardDecalPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectForwardDecalPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectGenericTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectGenericTrackItemPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectGenericTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectGenericTrackItemPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectHudParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectHudParameterPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectHudParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectHudParameterPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectIPlacementEntries.cs
+++ b/CP77.CR2W/Types/cp77/effectIPlacementEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectIPlacementEntries.cs
+++ b/CP77.CR2W/Types/cp77/effectIPlacementEntries.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectLightParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectLightParameterPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectLightParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectLightParameterPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectLoopData.cs
+++ b/CP77.CR2W/Types/cp77/effectLoopData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectMaterialParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectMaterialParameterPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectMaterialParameterPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectMaterialParameterPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectMotionBlurScalePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectMotionBlurScalePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectMotionBlurScalePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectMotionBlurScalePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectParticlesPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectParticlesPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectParticlesPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectParticlesPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectPlacedSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectPlacedSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectPlacedTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectPlacedTrackItemPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectPlacedTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectPlacedTrackItemPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectPointLightPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectPointLightPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectPointLightPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectPointLightPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectRootEntries.cs
+++ b/CP77.CR2W/Types/cp77/effectRootEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectRootEntry.cs
+++ b/CP77.CR2W/Types/cp77/effectRootEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectSlotEntries.cs
+++ b/CP77.CR2W/Types/cp77/effectSlotEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectSlotEntry.cs
+++ b/CP77.CR2W/Types/cp77/effectSlotEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectSoundPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectSoundPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectSoundPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectSoundPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectSpawner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTonemappingPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectTonemappingPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTonemappingPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectTonemappingPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTrack.cs
+++ b/CP77.CR2W/Types/cp77/effectTrack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackBase.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackBase.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTrackGroup.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItem.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemBloom.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemBloom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemChromaticAberration.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemChromaticAberration.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemColorGrade.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemColorGrade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemColorGradeV2.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemColorGradeV2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemDataMosh.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemDataMosh.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemDecal.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemDecal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemDynamicDecal.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemDynamicDecal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemEmissive.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemEmissive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemExposureScale.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemExposureScale.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemFOV.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemFOV.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemFilmGrain.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemFilmGrain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemFogVolume.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemFogVolume.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemForwardDecal.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemForwardDecal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemHudParameter.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemHudParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemLightParameter.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemLightParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemLoopMarker.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemLoopMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemLoopMarker.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemLoopMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTrackItemMaterialParameter.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemMaterialParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemMetadata.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemMetadata.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTrackItemMotionBlurScale.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemMotionBlurScale.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemParticles.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemParticles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectTrackItemPointLight.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemPointLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemSound.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemSound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemTonemapping.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemTonemapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemVignette.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemVignette.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectTrackItemWeaponPlaneBlur.cs
+++ b/CP77.CR2W/Types/cp77/effectTrackItemWeaponPlaneBlur.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectVignettePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectVignettePlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectVignettePlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectVignettePlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectVisualComponentSpawner.cs
+++ b/CP77.CR2W/Types/cp77/effectVisualComponentSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectVisualComponentTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectVisualComponentTrackItemPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectVisualComponentTrackItemPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectVisualComponentTrackItemPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/effectWeaponPlaneBlurPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectWeaponPlaneBlurPlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/effectWeaponPlaneBlurPlayData.cs
+++ b/CP77.CR2W/Types/cp77/effectWeaponPlaneBlurPlayData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAllowVehicleCollisionRagdollInSceneEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAllowVehicleCollisionRagdollInSceneEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAmbientSoundEmitterComponent.cs
+++ b/CP77.CR2W/Types/cp77/entAmbientSoundEmitterComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimDataChanged.cs
+++ b/CP77.CR2W/Types/cp77/entAnimDataChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimDataChanged.cs
+++ b/CP77.CR2W/Types/cp77/entAnimDataChanged.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimEntityToEntityAttachmentEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimEntityToEntityAttachmentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimEntityToEntityAttachmentEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimEntityToEntityAttachmentEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimExternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimExternalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimFastForwardEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimFastForwardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimFastForwardEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimFastForwardEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimGraphCustomDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimGraphCustomDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimGraphCustomDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimGraphCustomDataEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimGraphResourceContainer.cs
+++ b/CP77.CR2W/Types/cp77/entAnimGraphResourceContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimGraphResourceContainerEntry.cs
+++ b/CP77.CR2W/Types/cp77/entAnimGraphResourceContainerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetter.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterBool.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterFloat.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterInt.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterQuaternion.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterQuaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterUsesSleepMode.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterUsesSleepMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimInputSetterVector.cs
+++ b/CP77.CR2W/Types/cp77/entAnimInputSetterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimOnStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimOnStateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimOnStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimOnStateChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimParamsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimParamsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimSoundEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimSoundEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimTargetAddEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimTargetAddEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimTrackParameter.cs
+++ b/CP77.CR2W/Types/cp77/entAnimTrackParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimVisibilityChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimVisibilityChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimWrapperWeightSetter.cs
+++ b/CP77.CR2W/Types/cp77/entAnimWrapperWeightSetter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimatedComponent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimatedComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyDisabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyDisabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimatedRagdollNotifyEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimationControlAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControlAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationControlAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControlAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimationControlBinding.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControlBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationControlBinding.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControlBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimationControllerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControllerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationControllerReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationControllerReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationExtensionAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationExtensionAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationExtensionAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationExtensionAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimationFloatTrackAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationFloatTrackAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAnimationFloatTrackAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationFloatTrackAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAnimationSetupExtensionComponent.cs
+++ b/CP77.CR2W/Types/cp77/entAnimationSetupExtensionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAppearanceChangeFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceChangeFinishEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAppearanceChangeFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceChangeFinishEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAppearanceDissolveFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceDissolveFinishEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAppearanceDissolveFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceDissolveFinishEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAppearanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAppearanceMeshLoadedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceMeshLoadedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAppearanceMeshLoadedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceMeshLoadedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAppearanceStatusEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAppearanceStatusEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAreaEnteredEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAreaEnteredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAreaEnteredEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAreaEnteredEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAreaExitedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAreaExitedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAreaExitedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAreaExitedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAttachEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAttachEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAttachEffectToComponentEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectToComponentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAttachEffectToComponentEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectToComponentEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAttachEffectToSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectToSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAttachEffectToSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachEffectToSlotEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAttachGraphToSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachGraphToSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entAttachGraphToSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAttachGraphToSlotEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/entAudioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entBakedDestructionComponent.cs
+++ b/CP77.CR2W/Types/cp77/entBakedDestructionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entBaseCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/entBaseCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entBreakEffectLoopEvent.cs
+++ b/CP77.CR2W/Types/cp77/entBreakEffectLoopEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCameraData.cs
+++ b/CP77.CR2W/Types/cp77/entCameraData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entChangeVoicesetStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/entChangeVoicesetStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCharacterCustomizationSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entCharacterCustomizationSkinnedMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entClothComponent.cs
+++ b/CP77.CR2W/Types/cp77/entClothComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponent.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponentBox.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponentBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponentCapsule.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponentCapsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponentConvex.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponentConvex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponentShape.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponentShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entColliderComponentSphere.cs
+++ b/CP77.CR2W/Types/cp77/entColliderComponentSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCollisionPredictionPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entCollisionPredictionPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCollisionPredictionPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entCollisionPredictionPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entComponentsStorage.cs
+++ b/CP77.CR2W/Types/cp77/entComponentsStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entContextualLookAtAddEvent.cs
+++ b/CP77.CR2W/Types/cp77/entContextualLookAtAddEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entContextualLookAtRemoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/entContextualLookAtRemoveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCorpseComponent.cs
+++ b/CP77.CR2W/Types/cp77/entCorpseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entCorpseParameter.cs
+++ b/CP77.CR2W/Types/cp77/entCorpseParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDebugPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entDebugPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDebugPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entDebugPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entDebug_ShapeComponent.cs
+++ b/CP77.CR2W/Types/cp77/entDebug_ShapeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDecalComponent.cs
+++ b/CP77.CR2W/Types/cp77/entDecalComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDestructionAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDestructionAudioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDestructionAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDestructionAudioEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entDetachGraphFromSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDetachGraphFromSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDetachGraphFromSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDetachGraphFromSlotEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entDismemberedBodyPartEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDismemberedBodyPartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDismembermentAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/entDismembermentAudioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDistanceLODsPresets.cs
+++ b/CP77.CR2W/Types/cp77/entDistanceLODsPresets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entDynamicActorRepellingComponent.cs
+++ b/CP77.CR2W/Types/cp77/entDynamicActorRepellingComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entE3_Hack_VFXPassEvent.cs
+++ b/CP77.CR2W/Types/cp77/entE3_Hack_VFXPassEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entE3_Hack_VFXPassEvent.cs
+++ b/CP77.CR2W/Types/cp77/entE3_Hack_VFXPassEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEditorMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEditorMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEditorMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEditorMeshComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEffectAttachmentComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEffectAttachmentComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEffectAttachmentComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEffectAttachmentComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEffectDesc.cs
+++ b/CP77.CR2W/Types/cp77/entEffectDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEffectSpawnerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEffectSpawnerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntity.cs
+++ b/CP77.CR2W/Types/cp77/entEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityGameInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityGameInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityGameInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityGameInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityID.cs
+++ b/CP77.CR2W/Types/cp77/entEntityID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityInstanceData.cs
+++ b/CP77.CR2W/Types/cp77/entEntityInstanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entEntityOrientationProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityParameter.cs
+++ b/CP77.CR2W/Types/cp77/entEntityParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityParameter.cs
+++ b/CP77.CR2W/Types/cp77/entEntityParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityParametersBuffer.cs
+++ b/CP77.CR2W/Types/cp77/entEntityParametersBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityParametersStorage.cs
+++ b/CP77.CR2W/Types/cp77/entEntityParametersStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entEntityPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entEntityPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityPreview.cs
+++ b/CP77.CR2W/Types/cp77/entEntityPreview.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityPreview.cs
+++ b/CP77.CR2W/Types/cp77/entEntityPreview.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityRequestComponentsInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityRequestComponentsInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityRequestComponentsInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityRequestComponentsInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityResolveComponentsInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityResolveComponentsInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityResolveComponentsInterface.cs
+++ b/CP77.CR2W/Types/cp77/entEntityResolveComponentsInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntitySpawnToken.cs
+++ b/CP77.CR2W/Types/cp77/entEntitySpawnToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntitySpawnToken.cs
+++ b/CP77.CR2W/Types/cp77/entEntitySpawnToken.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entEntityTemplate.cs
+++ b/CP77.CR2W/Types/cp77/entEntityTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEntityUserComponentResolution.cs
+++ b/CP77.CR2W/Types/cp77/entEntityUserComponentResolution.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entEnvProbeComponent.cs
+++ b/CP77.CR2W/Types/cp77/entEnvProbeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entExternalComponent.cs
+++ b/CP77.CR2W/Types/cp77/entExternalComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFacialCustomizationComponent.cs
+++ b/CP77.CR2W/Types/cp77/entFacialCustomizationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFactory.cs
+++ b/CP77.CR2W/Types/cp77/entFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFactory.cs
+++ b/CP77.CR2W/Types/cp77/entFactory.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entFallbackSlot.cs
+++ b/CP77.CR2W/Types/cp77/entFallbackSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFogVolumeComponent.cs
+++ b/CP77.CR2W/Types/cp77/entFogVolumeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFoleyActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/entFoleyActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFootPhaseChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entFootPhaseChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFootPlantedEvent.cs
+++ b/CP77.CR2W/Types/cp77/entFootPlantedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFuncOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entFuncOrientationProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFuncOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entFuncOrientationProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entFuncPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entFuncPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entFuncPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entFuncPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entGameEntity.cs
+++ b/CP77.CR2W/Types/cp77/entGameEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGameEntity.cs
+++ b/CP77.CR2W/Types/cp77/entGameEntity.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entGameplayVOEvent.cs
+++ b/CP77.CR2W/Types/cp77/entGameplayVOEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGarmentParameter.cs
+++ b/CP77.CR2W/Types/cp77/entGarmentParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGarmentParameterChunkData.cs
+++ b/CP77.CR2W/Types/cp77/entGarmentParameterChunkData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGarmentParameterComponentData.cs
+++ b/CP77.CR2W/Types/cp77/entGarmentParameterComponentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGarmentSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entGarmentSkinnedMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGarmentSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entGarmentSkinnedMeshComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entGenericListFactory.cs
+++ b/CP77.CR2W/Types/cp77/entGenericListFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entGenericListFactory.cs
+++ b/CP77.CR2W/Types/cp77/entGenericListFactory.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entHardAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entHardAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entHardAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entHardAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entHardTransformBinding.cs
+++ b/CP77.CR2W/Types/cp77/entHardTransformBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entHistoryPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entHistoryPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entHistoryPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entHistoryPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entHitRepresentationDataParameter.cs
+++ b/CP77.CR2W/Types/cp77/entHitRepresentationDataParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entIAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIBinding.cs
+++ b/CP77.CR2W/Types/cp77/entIBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIComponent.cs
+++ b/CP77.CR2W/Types/cp77/entIComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIDestinationBinding.cs
+++ b/CP77.CR2W/Types/cp77/entIDestinationBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIDestinationBinding.cs
+++ b/CP77.CR2W/Types/cp77/entIDestinationBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entIKTargetAddEvent.cs
+++ b/CP77.CR2W/Types/cp77/entIKTargetAddEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIKTargetRemoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/entIKTargetRemoveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIMoverComponent.cs
+++ b/CP77.CR2W/Types/cp77/entIMoverComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIMoverComponent.cs
+++ b/CP77.CR2W/Types/cp77/entIMoverComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entIOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIOrientationProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIOrientationProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entIPlacedComponent.cs
+++ b/CP77.CR2W/Types/cp77/entIPlacedComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entISkinTargetComponent.cs
+++ b/CP77.CR2W/Types/cp77/entISkinTargetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entISkinableComponent.cs
+++ b/CP77.CR2W/Types/cp77/entISkinableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entISkinableComponent.cs
+++ b/CP77.CR2W/Types/cp77/entISkinableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entISkinningAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entISkinningAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entISkinningAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entISkinningAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entISourceBinding.cs
+++ b/CP77.CR2W/Types/cp77/entISourceBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entISourceBinding.cs
+++ b/CP77.CR2W/Types/cp77/entISourceBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entITransformAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entITransformAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entITransformAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entITransformAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entITransformBinding.cs
+++ b/CP77.CR2W/Types/cp77/entITransformBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entITransformBinding.cs
+++ b/CP77.CR2W/Types/cp77/entITransformBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entIVelocityProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIVelocityProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entIVelocityProvider.cs
+++ b/CP77.CR2W/Types/cp77/entIVelocityProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entIVisualComponent.cs
+++ b/CP77.CR2W/Types/cp77/entIVisualComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entInjectVoiceTagEvent.cs
+++ b/CP77.CR2W/Types/cp77/entInjectVoiceTagEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entInstancedAnimationComponent.cs
+++ b/CP77.CR2W/Types/cp77/entInstancedAnimationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entKillEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/entKillEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLODDefinition.cs
+++ b/CP77.CR2W/Types/cp77/entLODDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLightBlockingComponent.cs
+++ b/CP77.CR2W/Types/cp77/entLightBlockingComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLightChannelComponent.cs
+++ b/CP77.CR2W/Types/cp77/entLightChannelComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLightComponent.cs
+++ b/CP77.CR2W/Types/cp77/entLightComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLocalizationStringComponent.cs
+++ b/CP77.CR2W/Types/cp77/entLocalizationStringComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLocalizationStringMapEntry.cs
+++ b/CP77.CR2W/Types/cp77/entLocalizationStringMapEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLocomotionSlideEvent.cs
+++ b/CP77.CR2W/Types/cp77/entLocomotionSlideEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLocomotionSlideEvent.cs
+++ b/CP77.CR2W/Types/cp77/entLocomotionSlideEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entLookAtAddEvent.cs
+++ b/CP77.CR2W/Types/cp77/entLookAtAddEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLookAtLimits.cs
+++ b/CP77.CR2W/Types/cp77/entLookAtLimits.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entLookAtRemoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/entLookAtRemoveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMarketingAnimationComponent.cs
+++ b/CP77.CR2W/Types/cp77/entMarketingAnimationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMarketingAnimationEntry.cs
+++ b/CP77.CR2W/Types/cp77/entMarketingAnimationEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMorphTargetManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entMorphTargetManagerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMorphTargetManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entMorphTargetManagerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entMorphTargetSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entMorphTargetSkinnedMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMorphTargetWeightEntry.cs
+++ b/CP77.CR2W/Types/cp77/entMorphTargetWeightEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entMusicSyncEvent.cs
+++ b/CP77.CR2W/Types/cp77/entMusicSyncEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entParticlesComponent.cs
+++ b/CP77.CR2W/Types/cp77/entParticlesComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalBodyInterface.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalBodyInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalBodyInterface.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalBodyInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entPhysicalDestructionComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalDestructionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalImpulseAreaComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalImpulseAreaComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalSkinnedMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPhysicalTriggerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPhysicalTriggerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPlacedComponentPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entPlacedComponentPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPlacedComponentPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entPlacedComponentPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entPlaceholderComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPlaceholderComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPlaceholderComponent.cs
+++ b/CP77.CR2W/Types/cp77/entPlaceholderComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entPreloadAllEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entPreloadAllEffectsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entPreloadAllEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entPreloadAllEffectsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRagdollActivationRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollActivationRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollApplyImpulseEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollApplyImpulseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollComponent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollDisableEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollDisableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollDisableEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollDisableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRagdollImpactEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollImpactEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollImpactPointData.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollImpactPointData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollNotifyDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollNotifyDisabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollNotifyDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollNotifyDisabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRagdollNotifyEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollNotifyEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollNotifyEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollNotifyEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRagdollNotifyVelocityTresholdEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollNotifyVelocityTresholdEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollPutToSleepEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollPutToSleepEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollPutToSleepEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollPutToSleepEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRagdollRequestCollectAnimPose.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollRequestCollectAnimPose.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRagdollRequestCollectAnimPose.cs
+++ b/CP77.CR2W/Types/cp77/entRagdollRequestCollectAnimPose.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entReleasePreloadedEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entReleasePreloadedEffectsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReleasePreloadedEffectsEvent.cs
+++ b/CP77.CR2W/Types/cp77/entReleasePreloadedEffectsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRenderHighlightEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderHighlightEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRenderHighlightOpacityEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderHighlightOpacityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRenderOverlayEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderOverlayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRenderOverlayEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderOverlayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entRenderScanEvent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderScanEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRenderToTextureCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/entRenderToTextureCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entRenderToTextureFeatures.cs
+++ b/CP77.CR2W/Types/cp77/entRenderToTextureFeatures.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedAnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedAnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedAnimFeaturesState.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedAnimFeaturesState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedAnimWrapperVars.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedAnimWrapperVars.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetterBase.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetterBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetterBool.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetterBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetterFloat.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetterFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetterInt.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetterInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetterVector.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedInputSetters.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedInputSetters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedItem.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedLookAtAdd.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedLookAtAdd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedLookAtData.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedLookAtData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedLookAtRemove.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedLookAtRemove.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entReplicatedVariableValue.cs
+++ b/CP77.CR2W/Types/cp77/entReplicatedVariableValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSceneAnimSetEvent.cs
+++ b/CP77.CR2W/Types/cp77/entSceneAnimSetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSceneAnimSetEvent.cs
+++ b/CP77.CR2W/Types/cp77/entSceneAnimSetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entShadowMeshChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/entShadowMeshChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSimpleColliderComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSimpleColliderComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSimpleSkinningAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entSimpleSkinningAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSimpleSkinningAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entSimpleSkinningAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entSkinnedClothComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSkinnedClothComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSkinnedMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSkinnedMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSkinningBinding.cs
+++ b/CP77.CR2W/Types/cp77/entSkinningBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSkinningBinding.cs
+++ b/CP77.CR2W/Types/cp77/entSkinningBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entSlot.cs
+++ b/CP77.CR2W/Types/cp77/entSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSlotAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entSlotAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSlotAttachment.cs
+++ b/CP77.CR2W/Types/cp77/entSlotAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entSlotComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSlotComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSlotPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entSlotPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSlotPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entSlotPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entSoundEvent.cs
+++ b/CP77.CR2W/Types/cp77/entSoundEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSoundListenerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSoundListenerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSoundListenerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entSoundListenerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entSpawnEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/entSpawnEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSpawnersContainer.cs
+++ b/CP77.CR2W/Types/cp77/entSpawnersContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entSpawnersContainer.cs
+++ b/CP77.CR2W/Types/cp77/entSpawnersContainer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entStaticOccluderMeshComponent.cs
+++ b/CP77.CR2W/Types/cp77/entStaticOccluderMeshComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entStaticOrientationProvider.cs
+++ b/CP77.CR2W/Types/cp77/entStaticOrientationProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entStaticPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entStaticPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entStaticPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/entStaticPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entStoppedMovingEvent.cs
+++ b/CP77.CR2W/Types/cp77/entStoppedMovingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entStoppedMovingEvent.cs
+++ b/CP77.CR2W/Types/cp77/entStoppedMovingEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTagMask.cs
+++ b/CP77.CR2W/Types/cp77/entTagMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTargetPointComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTargetPointComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTargetPointComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTargetPointComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTemplateAppearance.cs
+++ b/CP77.CR2W/Types/cp77/entTemplateAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTemplateBindingOverride.cs
+++ b/CP77.CR2W/Types/cp77/entTemplateBindingOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTemplateComponentBackendDataOverrideInfo.cs
+++ b/CP77.CR2W/Types/cp77/entTemplateComponentBackendDataOverrideInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTemplateComponentResolveSettings.cs
+++ b/CP77.CR2W/Types/cp77/entTemplateComponentResolveSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTemplateInclude.cs
+++ b/CP77.CR2W/Types/cp77/entTemplateInclude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTransformComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTransformComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTransformComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTransformComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTransformHistoryComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTransformHistoryComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerActivatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTriggerDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerDestructionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTriggerEvent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_Entity.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_Entity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_EntityInstance.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_EntityInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_EntityInstance.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_EntityInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_Script.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_Script.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_Script.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_Script.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_ScriptInstance.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_ScriptInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entTriggerNotifier_ScriptInstance.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerNotifier_ScriptInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entTriggerVOEvent.cs
+++ b/CP77.CR2W/Types/cp77/entTriggerVOEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entUncontrolledMovementEndEvent.cs
+++ b/CP77.CR2W/Types/cp77/entUncontrolledMovementEndEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entUncontrolledMovementEndEvent.cs
+++ b/CP77.CR2W/Types/cp77/entUncontrolledMovementEndEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entUncontrolledMovementStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/entUncontrolledMovementStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entUpdateRenderProxyStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/entUpdateRenderProxyStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entUpdateRenderProxyStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/entUpdateRenderProxyStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entVectorFieldComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVectorFieldComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationBinding.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationBinding.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entVertexAnimationComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationMapper.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationMapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationMapperDestination.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationMapperDestination.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationMapperEntry.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationMapperEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVertexAnimationMapperSource.cs
+++ b/CP77.CR2W/Types/cp77/entVertexAnimationMapperSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVirtualCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVirtualCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVirtualCameraViewComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVirtualCameraViewComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVisualControllerComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVisualControllerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVisualControllerDependency.cs
+++ b/CP77.CR2W/Types/cp77/entVisualControllerDependency.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVisualOffsetTransformComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVisualOffsetTransformComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVisualOffsetTransformComponent.cs
+++ b/CP77.CR2W/Types/cp77/entVisualOffsetTransformComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entVisualTagsSchema.cs
+++ b/CP77.CR2W/Types/cp77/entVisualTagsSchema.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entVoicesetInputToBlock.cs
+++ b/CP77.CR2W/Types/cp77/entVoicesetInputToBlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entWetnessComponent.cs
+++ b/CP77.CR2W/Types/cp77/entWetnessComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entWetnessComponent.cs
+++ b/CP77.CR2W/Types/cp77/entWetnessComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entWorkspotItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/entWorkspotItemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entWorkspotItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/entWorkspotItemEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/entdismembermentAppearanceMatch.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentAppearanceMatch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentBodyMaterialConfig.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentBodyMaterialConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentCullObject.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentCullObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentDangleInfo.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentDangleInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentDebris.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentDebris.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentDebrisResourceItem.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentDebrisResourceItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentEffectResource.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentEffectResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentFillMeshInfo.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentFillMeshInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentMeshInfo.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentMeshInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentPhysicsInfo.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentPhysicsInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundConfig.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundConfigContainer.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundConfigContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundDecal.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundDecal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundMeshes.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundMeshes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundResource.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entdismembermentWoundsConfigSet.cs
+++ b/CP77.CR2W/Types/cp77/entdismembermentWoundsConfigSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsEntityResize.cs
+++ b/CP77.CR2W/Types/cp77/enteventsEntityResize.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsHitCharacterControllerEvent.cs
+++ b/CP77.CR2W/Types/cp77/enteventsHitCharacterControllerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsPhysicalCollisionEvent.cs
+++ b/CP77.CR2W/Types/cp77/enteventsPhysicalCollisionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsPhysicalImpulseEvent.cs
+++ b/CP77.CR2W/Types/cp77/enteventsPhysicalImpulseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsSetCustomCameraTarget.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetCustomCameraTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsSetCustomCameraTarget.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetCustomCameraTarget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/enteventsSetDissolveVisibility.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetDissolveVisibility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsSetDissolveVisibility.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetDissolveVisibility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/enteventsSetPlaneSetting.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetPlaneSetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/enteventsSetPlaneSetting.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetPlaneSetting.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/enteventsSetVisibility.cs
+++ b/CP77.CR2W/Types/cp77/enteventsSetVisibility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/entragdollActivationRequestData.cs
+++ b/CP77.CR2W/Types/cp77/entragdollActivationRequestData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/forklift.cs
+++ b/CP77.CR2W/Types/cp77/forklift.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/fullscreenDpadSupported.cs
+++ b/CP77.CR2W/Types/cp77/fullscreenDpadSupported.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/fxCompositionShaderParams.cs
+++ b/CP77.CR2W/Types/cp77/fxCompositionShaderParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAIDirectorSpawner.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAIDirectorSpawner.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorSpawner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAIDirectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAIDirectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzeComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzeComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzeComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzer.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzer.cs
+++ b/CP77.CR2W/Types/cp77/gameAIDirectorTensionAnalyzer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAINetStateComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameAINetStateComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAINetStateComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameAINetStateComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAINetStateComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameAINetStateComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAchievementSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAchievementSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAchievementSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAchievementSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameActionAnimationSlideParams.cs
+++ b/CP77.CR2W/Types/cp77/gameActionAnimationSlideParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionAnimationState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionAnimationState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionDieState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionDieState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionEquipItemState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionEquipItemState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionHitReactionState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionHitReactionState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionInternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameActionInternalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionInternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameActionInternalEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameActionMoveToDynamicNodeState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionMoveToDynamicNodeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionMoveToPositionState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionMoveToPositionState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionMoveToSmartObjectState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionMoveToSmartObjectState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionMoveToState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionMoveToState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionPrereqs.cs
+++ b/CP77.CR2W/Types/cp77/gameActionPrereqs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionRotateBaseState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionRotateBaseState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionRotateToObjectState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionRotateToObjectState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionRotateToState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionRotateToState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionRotateToState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionRotateToState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameActionScript.cs
+++ b/CP77.CR2W/Types/cp77/gameActionScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionUnequipItemState.cs
+++ b/CP77.CR2W/Types/cp77/gameActionUnequipItemState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionsReplicationBuffer.cs
+++ b/CP77.CR2W/Types/cp77/gameActionsReplicationBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActionsReplicationBuffer.cs
+++ b/CP77.CR2W/Types/cp77/gameActionsReplicationBuffer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameActivateTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameActivateTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActivateTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameActivateTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameActivityLogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameActivityLogSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameActivityLogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameActivityLogSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAmmoData.cs
+++ b/CP77.CR2W/Types/cp77/gameAmmoData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAndroidTurnOff.cs
+++ b/CP77.CR2W/Types/cp77/gameAndroidTurnOff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAndroidTurnOff.cs
+++ b/CP77.CR2W/Types/cp77/gameAndroidTurnOff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAndroidTurnOn.cs
+++ b/CP77.CR2W/Types/cp77/gameAndroidTurnOn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAndroidTurnOn.cs
+++ b/CP77.CR2W/Types/cp77/gameAndroidTurnOn.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAnimFeature_TPPRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimFeature_TPPRepresentation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimParamSlotsOption.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimParamSlotsOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimationExtractedData.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimationExtractedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimationOverrideDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimationOverrideDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimationPersistentDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimationPersistentDataSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimationPersistentDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimationPersistentDataSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAnimationTransforms.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimationTransforms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAnimsetOverrideData.cs
+++ b/CP77.CR2W/Types/cp77/gameAnimsetOverrideData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset.cs
+++ b/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset_AppearanceTags.cs
+++ b/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset_AppearanceTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset_Entity.cs
+++ b/CP77.CR2W/Types/cp77/gameAppearanceNameVisualTagsPreset_Entity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAppearancesReadyTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAppearancesReadyTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAppearancesReadyTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAppearancesReadyTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAreaData.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAreaProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAreaProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAreaResource.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAreaVolume.cs
+++ b/CP77.CR2W/Types/cp77/gameAreaVolume.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotData.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsAttachmentSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsAttachmentSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsAttachmentSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsAttachmentSlotEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipEnd.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipEnd.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipEnd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipStart.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipStart.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsEquipStart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemAddedToSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemAddedToSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemAddedToSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemAddedToSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemEquippedInSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemEquippedInSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemEquippedInSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemEquippedInSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemRemovedFromSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemRemovedFromSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemRemovedFromSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemRemovedFromSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemUnequippedFromSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemUnequippedFromSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemUnequippedFromSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsItemUnequippedFromSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsMoveEquip.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsMoveEquip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsMoveEquip.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsMoveEquip.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsPartAddedToSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsPartAddedToSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsPartRemovedFromSlotEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsPartRemovedFromSlotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipEnd.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipEnd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipEnd.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipEnd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipStart.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipStart.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotEventsUnequipStart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlots.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlots.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsFunctorListener.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsFunctorListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsFunctorListener.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsFunctorListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsListenerData.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsListenerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsListenerData.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsListenerData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameAttachmentSlotsScriptListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttackComputed.cs
+++ b/CP77.CR2W/Types/cp77/gameAttackComputed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttackComputed.cs
+++ b/CP77.CR2W/Types/cp77/gameAttackComputed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttackDebugData.cs
+++ b/CP77.CR2W/Types/cp77/gameAttackDebugData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttackInitContext.cs
+++ b/CP77.CR2W/Types/cp77/gameAttackInitContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttack_Continuous.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_Continuous.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttack_Continuous.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_Continuous.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttack_GameEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_GameEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttack_GameEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_GameEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttack_Projectile.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_Projectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttack_Projectile.cs
+++ b/CP77.CR2W/Types/cp77/gameAttack_Projectile.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAttitudeAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameAttitudeAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttitudeAgentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameAttitudeAgentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttitudePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameAttitudePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttitudePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameAttitudePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAttitudePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameAttitudePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAudioClueObject.cs
+++ b/CP77.CR2W/Types/cp77/gameAudioClueObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAudioClueObject.cs
+++ b/CP77.CR2W/Types/cp77/gameAudioClueObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAudioEmitterComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameAudioEmitterComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAudioSyncs.cs
+++ b/CP77.CR2W/Types/cp77/gameAudioSyncs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAutoSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAutoSaveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAutoSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameAutoSaveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameAvailableAnimset.cs
+++ b/CP77.CR2W/Types/cp77/gameAvailableAnimset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameAvailableExposureMethodResult.cs
+++ b/CP77.CR2W/Types/cp77/gameAvailableExposureMethodResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBaseGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gameBaseGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBaseGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gameBaseGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBaseTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameBaseTimer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBaseTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameBaseTimer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBinkComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkMeshTargetAttachment.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkMeshTargetAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkMeshTargetAttachment.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkMeshTargetAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBinkMeshTargetBinding.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkMeshTargetBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkMeshTargetBinding.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkMeshTargetBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBinkVideoData.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkVideoData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkVideoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkVideoRecord.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkVideoRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBinkVideoSummary.cs
+++ b/CP77.CR2W/Types/cp77/gameBinkVideoSummary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBlackboardPropertyBindingDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardPropertyBindingDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardSerializableID.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardSerializableID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardUpdateProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameBlackboardUpdateProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBlueprintStackableItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameBlueprintStackableItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBlueprintStackableItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameBlueprintStackableItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBodyTriggerDestructionComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameBodyTriggerDestructionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBodyTypeAnimationDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameBodyTypeAnimationDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBodyTypeData.cs
+++ b/CP77.CR2W/Types/cp77/gameBodyTypeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBoolSignalTable.cs
+++ b/CP77.CR2W/Types/cp77/gameBoolSignalTable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameBoolSignalTable.cs
+++ b/CP77.CR2W/Types/cp77/gameBoolSignalTable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameBraindanceDissolveComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameBraindanceDissolveComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCActionAIProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameCActionAIProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCActionAIProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameCActionAIProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCActionsFactory.cs
+++ b/CP77.CR2W/Types/cp77/gameCActionsFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCActionsFactory.cs
+++ b/CP77.CR2W/Types/cp77/gameCActionsFactory.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCAttitudeManager.cs
+++ b/CP77.CR2W/Types/cp77/gameCAttitudeManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCAttitudeManager.cs
+++ b/CP77.CR2W/Types/cp77/gameCAttitudeManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCDebugSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCDebugSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCDebugSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCDebugSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCameraCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraCurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCameraCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraCurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCameraCurvesLibrary.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraCurvesLibrary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCameraLocation.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCameraSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCameraSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCameraSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCarriedObjectAttached.cs
+++ b/CP77.CR2W/Types/cp77/gameCarriedObjectAttached.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCarriedObjectAttached.cs
+++ b/CP77.CR2W/Types/cp77/gameCarriedObjectAttached.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCarriedObjectDestroy.cs
+++ b/CP77.CR2W/Types/cp77/gameCarriedObjectDestroy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCarriedObjectDestroy.cs
+++ b/CP77.CR2W/Types/cp77/gameCarriedObjectDestroy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCategorySelectionProbability.cs
+++ b/CP77.CR2W/Types/cp77/gameCategorySelectionProbability.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameChangeDestination.cs
+++ b/CP77.CR2W/Types/cp77/gameChangeDestination.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameChatterHelper.cs
+++ b/CP77.CR2W/Types/cp77/gameChatterHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameChatterHelper.cs
+++ b/CP77.CR2W/Types/cp77/gameChatterHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameChildEffectsMovingInCone_State.cs
+++ b/CP77.CR2W/Types/cp77/gameChildEffectsMovingInCone_State.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameChildEffectsMovingInCone_State.cs
+++ b/CP77.CR2W/Types/cp77/gameChildEffectsMovingInCone_State.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameClientEntitySpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameClientEntitySpawnSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameClientEntitySpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameClientEntitySpawnSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCollidableEntityId.cs
+++ b/CP77.CR2W/Types/cp77/gameCollidableEntityId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCollidableEntityId.cs
+++ b/CP77.CR2W/Types/cp77/gameCollidableEntityId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCollisionQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCollisionQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCollisionQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCollisionQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCombatQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCombatQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCombatQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCombatQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCombinedStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameCombinedStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunityID.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunityID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunityProxyPSPresentEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunityProxyPSPresentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunityProxyPSPresentEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunityProxyPSPresentEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCommunitySpawnSetNameToID.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunitySpawnSetNameToID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunitySpawnSetNameToIDEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunitySpawnSetNameToIDEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunitySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunitySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCommunityTrafficConnectionsEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunityTrafficConnectionsEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCommunityTrafficConnectionsEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameCommunityTrafficConnectionsEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompanionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCompanionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompanionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCompanionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompiledCoverData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledCoverData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledCoverData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledCoverData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompiledCrowdData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledCrowdData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledCrowdTrafficData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledCrowdTrafficData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledNodes.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledNodes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledShootingSpotData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledShootingSpotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledShootingSpotData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledShootingSpotData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompiledSmartObjectData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledSmartObjectData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompiledSmartObjectData.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledSmartObjectData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompiledSmartObjectNode.cs
+++ b/CP77.CR2W/Types/cp77/gameCompiledSmartObjectNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameComponentsStateSaveComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentsStateSaveComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameComponentsStateSaveComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentsStateSaveComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameComponentsStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentsStateSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameComponentsStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameComponentsStateSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCompressedSmartObjectPointProperties.cs
+++ b/CP77.CR2W/Types/cp77/gameCompressedSmartObjectPointProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCompressedSmartObjectPointTransform.cs
+++ b/CP77.CR2W/Types/cp77/gameCompressedSmartObjectPointTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameConstantStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameConstantStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerFilledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerFilledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerFilledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerFilledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameContainerInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameContainerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameContainerObjectAnimated.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerObjectAnimated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerObjectBase.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerObjectBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerObjectBasePS.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerObjectBasePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerObjectBasePS.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerObjectBasePS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameContainerObjectSingleItem.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerObjectSingleItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerVisibilityChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerVisibilityChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContainerVisibilityChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameContainerVisibilityChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameContinuousEffector.cs
+++ b/CP77.CR2W/Types/cp77/gameContinuousEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameContinuousEffector.cs
+++ b/CP77.CR2W/Types/cp77/gameContinuousEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameController.cs
+++ b/CP77.CR2W/Types/cp77/gameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameController.cs
+++ b/CP77.CR2W/Types/cp77/gameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameConveyorControlEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameConveyorControlEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedAreaData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedAreaData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedGpsMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedGpsMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedLootData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedLootData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedMultiMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedMultiMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCookedPointOfInterestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gameCookedPointOfInterestMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCooldownFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCooldownFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownFinishedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCooldownRemovedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownRemovedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCooldownRemovedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownRemovedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCooldownSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCooldownSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCooldownSystemEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownSystemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCooldownSystemEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCooldownSystemEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCoordinates.cs
+++ b/CP77.CR2W/Types/cp77/gameCoordinates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCoverDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameCoverDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCoverInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameCoverInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCoverInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameCoverInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCoverObject.cs
+++ b/CP77.CR2W/Types/cp77/gameCoverObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCoveringArc.cs
+++ b/CP77.CR2W/Types/cp77/gameCoveringArc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCpoArmouryItem.cs
+++ b/CP77.CR2W/Types/cp77/gameCpoArmouryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCpoPickableItem.cs
+++ b/CP77.CR2W/Types/cp77/gameCpoPickableItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdCommunityEntryOwnerInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdCommunityEntryOwnerInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdCommunityEntryOwnersData.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdCommunityEntryOwnersData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdCreationData.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdCreationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdCreationDataRegistry.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdCreationDataRegistry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdEntityReuseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdEntityReuseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdEntityReuseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdEntityReuseEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCrowdMemberComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdMemberComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdMemberComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdMemberComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCrowdPhaseTimePeriod.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdPhaseTimePeriod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdTemplateCharacterData.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdTemplateCharacterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdTemplateEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdTemplateEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdTemplateEntryPhase.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdTemplateEntryPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCrowdTrafficDataPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameCrowdTrafficDataPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCurrentTargetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameCurrentTargetPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCurrentTargetPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameCurrentTargetPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCurrentTargetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameCurrentTargetPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCurrentTargetPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameCurrentTargetPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCursorInterpolationOverrides.cs
+++ b/CP77.CR2W/Types/cp77/gameCursorInterpolationOverrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCurveStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameCurveStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCustomRequestFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameCustomRequestFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCustomRequestFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameCustomRequestFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCustomValueStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameCustomValueStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCustomValueStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameCustomValueStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNode.cs
+++ b/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameCyberspaceBoundaryNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameCyberspacePixelsortEffectParams.cs
+++ b/CP77.CR2W/Types/cp77/gameCyberspacePixelsortEffectParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDamage.cs
+++ b/CP77.CR2W/Types/cp77/gameDamage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDamagePack.cs
+++ b/CP77.CR2W/Types/cp77/gameDamagePack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDamageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDamageSystemSharedState.cs
+++ b/CP77.CR2W/Types/cp77/gameDamageSystemSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeactivateTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeactivateTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeactivateTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeactivateTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugCheatsSharedState.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugCheatsSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugCheatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugCheatsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugCheatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugCheatsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugContextPtr.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugContextPtr.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugContextPtr.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugContextPtr.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugContextUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugContextUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugContextUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugContextUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugDrawHistorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugDrawHistorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugFreeCamera.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugFreeCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugFreeCamera.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugFreeCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugPath.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugPlayerBreadcrumbs.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugPlayerBreadcrumbs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugPlayerBreadcrumbs.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugPlayerBreadcrumbs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugTimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugTimeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugTimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugTimeState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDebugVisualizerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugVisualizerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDebugVisualizerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDebugVisualizerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDefaultAppearancePreset_Entity.cs
+++ b/CP77.CR2W/Types/cp77/gameDefaultAppearancePreset_Entity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelayID.cs
+++ b/CP77.CR2W/Types/cp77/gameDelayID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelayID.cs
+++ b/CP77.CR2W/Types/cp77/gameDelayID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemCallbackInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemCallbackInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemCallbackInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemCallbackInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemDelayStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemDelayStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemDelayStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemDelayStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemEventStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemPSEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemPSEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemPSEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemPSEventStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemScriptableSysRequestStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemScriptableSysRequestStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemScriptableSysRequestStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemScriptableSysRequestStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemScriptedDelayCallbackWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemScriptedDelayCallbackWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemScriptedDelayCallbackWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemScriptedDelayCallbackWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickOnEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickOnEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickOnEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickOnEventStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickWithCallbackStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickWithCallbackStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelaySystemTickWithCallbackStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameDelaySystemTickWithCallbackStruct.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDelayedFunctionsScheduler.cs
+++ b/CP77.CR2W/Types/cp77/gameDelayedFunctionsScheduler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelayedTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameDelayedTimer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDelayedTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameDelayedTimer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDependentWorkspotData.cs
+++ b/CP77.CR2W/Types/cp77/gameDependentWorkspotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDependentWorkspotData.cs
+++ b/CP77.CR2W/Types/cp77/gameDependentWorkspotData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeprecated_GameplayEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeprecated_GameplayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeprecated_GameplayEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeprecated_GameplayEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDestructibleObject.cs
+++ b/CP77.CR2W/Types/cp77/gameDestructibleObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDestructibleSpotsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDestructibleSpotsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDestructibleSpotsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDestructibleSpotsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDestructionPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDestructionPersistencySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDestructionPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDestructionPersistencySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceBase.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceBase.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceBaseReplicationProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceBaseReplicationProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceCameraControlComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceCameraControlComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceCameraControlComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceCameraControlComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceDynamicConnectionChange.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceDynamicConnectionChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceDynamicConnectionChange.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceDynamicConnectionChange.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceInteractionManager.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceInteractionManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceInteractionManager.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceInteractionManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceLoaded.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceLoaded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceLoaded.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceLoaded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDevicePSChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameDevicePSChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDevicePSChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameDevicePSChanged.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceResource.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceResourceData_.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceResourceData_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDeviceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDeviceVisibilityChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameDeviceVisibilityChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDisableAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameDisableAimAssist.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDisableAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameDisableAimAssist.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDismemberedLimbCount.cs
+++ b/CP77.CR2W/Types/cp77/gameDismemberedLimbCount.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDismembermentComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDismembermentComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDismembermentComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDismembermentComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDoorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameDoorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDrawItemByContextRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameDrawItemByContextRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDrawItemRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameDrawItemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDropInstruction.cs
+++ b/CP77.CR2W/Types/cp77/gameDropInstruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDynamicCookedDeviceData.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicCookedDeviceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDynamicEntityIDSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicEntityIDSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDynamicEntityIDSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicEntityIDSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameDynamicEventNode.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicEventNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDynamicEventNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicEventNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameDynamicEventNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameDynamicEventNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectAction_ChildEffectsMovingInCone.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction_ChildEffectsMovingInCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAction_KillFX.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction_KillFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAction_NewEffect_ReverseFromLastHit.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction_NewEffect_ReverseFromLastHit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAction_NewEffect_Ricochet.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction_NewEffect_Ricochet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAction_TerminateChildEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAction_TerminateChildEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAttachment.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectAttachment.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectComponentBinding.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectComponentBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectComponentBinding.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectComponentBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectData.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectData.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectData_Pierce.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_Pierce.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectData_Pierce.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_Pierce.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectData_Splatter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_Splatter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectData_Splatter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_Splatter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectData_SplatterList.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_SplatterList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectData_SplatterList.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectData_SplatterList.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDebugSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDebugSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifierScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifierScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifierScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifierScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifier_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifier_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDurationModifier_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDurationModifier_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Duration_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Duration_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Duration_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Duration_Blackboard.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Infinite.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Infinite.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Infinite.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Infinite.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Instant.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Instant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_Instant.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_Instant.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectDuration_PredefinedTimeout.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectDuration_PredefinedTimeout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutionScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutionScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutionScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutionScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_AnimFeature.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_AnimFeature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_BulletImpact.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_BulletImpact.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_DamageProjection.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_DamageProjection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_DamageProjection.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_DamageProjection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_Finisher.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_Finisher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_HitReaction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_HitReaction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_HitReaction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_HitReaction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_KatanaBulletBending.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_KatanaBulletBending.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_KatanaBulletBendingEffectEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_KatanaBulletBendingEffectEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_LandingFX.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_LandingFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_LandingFX.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_LandingFX.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_CopyData.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_CopyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_CopyData.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_CopyData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_ReflectedVector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_ReflectedVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_ReflectedVector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_ReflectedVector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_RicochetScan.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_NewEffect_RicochetScan.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_OverrideMaterial.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_OverrideMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_PhysicalImpulseFromInstigator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_Ricochet.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_Ricochet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStatusEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStimuli.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStimuli.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStimuli.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_SendStimuli.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_TerminateGameEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_TerminateGameEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_TriggerDestruction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_TriggerDestruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_TriggerDestruction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_TriggerDestruction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_VisualEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_VisualEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectExecutor_VisualEffectAtInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectExecutor_VisualEffectAtInstigator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectFilter_NotObstructed.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectFilter_NotObstructed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectFilter_ReachableByAcousticGraph.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectFilter_ReachableByAcousticGraph.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectFilter_ReachableByNavigation.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectFilter_ReachableByNavigation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectGroupFilterScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectGroupFilterScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectGroupFilterScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectGroupFilterScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectInfoEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInfoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Bool.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Bool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_CName.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_CName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Float.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Float.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Int.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Int.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Quat.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Quat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_String.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_String.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Variant.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Variant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInputParameter_Vector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInputParameter_Vector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectNode.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectNode.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_AxisRange.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_AxisRange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_BlockingGeometry.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_BlockingGeometry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_Cone.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_Cone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_Cone.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_Cone.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Raycast.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Raycast.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sphere.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sphere.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sphere.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_SweepOverTime_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_SweepOverTime_Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_SweepOverTime_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_SweepOverTime_Box.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sweep_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sweep_Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sweep_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitRepresentation_Sweep_Box.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitType.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_HitType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoDuplicates.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoDuplicates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoDuplicates.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoDuplicates.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigatorIfPlayerControlled.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigatorIfPlayerControlled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigatorIfPlayerControlled.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoInstigatorIfPlayerControlled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPuppet.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPuppet.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoPuppet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoSource.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoSource.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_NoWeapon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearest.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearestMelee.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearestMelee.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearest_Pierce.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_OnlyNearest_Pierce.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_RejectOnPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_RejectOnPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_TechPreview.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_TechPreview.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectFilter_TechPreview.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectFilter_TechPreview.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectGroupFilter_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Explosion.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Explosion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_PhysicalRay.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_PhysicalRay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_PhysicalRayFan.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_PhysicalRayFan.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_ProjectileHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_ProjectileHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_ProjectileHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_ProjectileHitEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_GrowOverTime.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_GrowOverTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_GrowOverTime.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_GrowOverTime.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_QuerySphere_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleEntity.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleEntity.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleEntity.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleRicochetTarget.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SingleRicochetTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepMelee_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepMelee_Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Box.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Capsule.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Capsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Sphere.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_SweepOverTime_Sphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Sweep_Box.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_Sweep_Box.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectProvider_TargetingObjectsInCone.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectProvider_TargetingObjectsInCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_BlackboardBoolCondition.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_BlackboardBoolCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectObjectSingleFilter_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Bool.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Bool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_CName.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_CName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Float.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Float.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Int.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Int.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Quat.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Quat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_String.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_String.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Variant.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Variant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Vector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectOutputParameter_Vector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_BoolEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_CNameEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_FloatEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_IntEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_QuatEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_StringEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_Blackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_Blackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_Value.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_Value.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_ValueOrBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectParameter_VectorEvaluator_ValueOrBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX_Custom.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_BeamVFX_Custom.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_Beam_RicochetPreview.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_Beam_RicochetPreview.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_Beam_RicochetPreviewPreviewEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_Beam_RicochetPreviewPreviewEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_BulletTrace.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_BulletTrace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_BulletTrace.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_BulletTrace.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPostAction_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPostAction_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPreAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPreAction.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPreAction_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreAction_Scripted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPreAction_Scripted.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreAction_Scripted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectPreAction_VisualEffectAtPosition.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreAction_VisualEffectAtPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPreloadScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreloadScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectPreloadScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectPreloadScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectProviderScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectProviderScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectProviderScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectProviderScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectRef.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectSet.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectSingleFilterScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSingleFilterScriptContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectSingleFilterScriptContext.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSingleFilterScriptContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerEffectDesc.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerEffectDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerNode.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectTriggerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectTriggerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitDirection.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitDirection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitDirection.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitDirection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitNormal.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitNormal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitNormal.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectVectorEvaluator_HitNormal.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffector.cs
+++ b/CP77.CR2W/Types/cp77/gameEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectorObject.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectorObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectorObject.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectorObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEffectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEffectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEffectorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEnableAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameEnableAimAssist.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnableAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameEnableAimAssist.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEnableScanningStatePropagationToParentEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameEnableScanningStatePropagationToParentEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityIDArrayPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntityReference.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntitySpawnerComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEntitySpawnerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntitySpawnerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameEntitySpawnerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntitySpawnerEventsBroadcasterImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameEntitySpawnerEventsBroadcasterImpl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntitySpawnerEventsBroadcasterImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameEntitySpawnerEventsBroadcasterImpl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntitySpawnerSlotData.cs
+++ b/CP77.CR2W/Types/cp77/gameEntitySpawnerSlotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityStubComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityStubComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntityStubComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityStubComponentPlacedProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubComponentPlacedProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityStubComponentPlacedProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubComponentPlacedProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntityStubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEntityStubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityStubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEntityTemplateDefaultAppearancePreset.cs
+++ b/CP77.CR2W/Types/cp77/gameEntityTemplateDefaultAppearancePreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnumNameToIndexCache.cs
+++ b/CP77.CR2W/Types/cp77/gameEnumNameToIndexCache.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnumNameToIndexCache.cs
+++ b/CP77.CR2W/Types/cp77/gameEnumNameToIndexCache.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverBox.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverCapsule.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverCapsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverShape.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageReceiverShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEnvironmentDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameEnvironmentDamageSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEquipParam.cs
+++ b/CP77.CR2W/Types/cp77/gameEquipParam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEquipRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameEquipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEquippedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameEquippedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEquippedPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/gameEquippedPrereqListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEquippedPrereqListener.cs
+++ b/CP77.CR2W/Types/cp77/gameEquippedPrereqListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEquippedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameEquippedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEquippedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameEquippedPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEthnicityComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEthnicityComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEthnicityComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameEthnicityComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameEthnicityPicker.cs
+++ b/CP77.CR2W/Types/cp77/gameEthnicityPicker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameEthnicityPicker.cs
+++ b/CP77.CR2W/Types/cp77/gameEthnicityPicker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameExistingWorkspotFinisherScenario.cs
+++ b/CP77.CR2W/Types/cp77/gameExistingWorkspotFinisherScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameExtendedWorkspotInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameExtendedWorkspotInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameExternalMovementCameraDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameExternalMovementCameraDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameExternalMovementCameraDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameExternalMovementCameraDataEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFPPCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameFPPCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFPPCameraComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameFPPCameraComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFactChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFactChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFastTravelPointData.cs
+++ b/CP77.CR2W/Types/cp77/gameFastTravelPointData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFinalTimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalTimeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFinalTimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalTimeState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFinalizeActivationTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalizeActivationTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFinalizeActivationTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalizeActivationTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFinalizeDeactivationTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalizeDeactivationTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFinalizeDeactivationTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFinalizeDeactivationTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFlattenedLootData.cs
+++ b/CP77.CR2W/Types/cp77/gameFlattenedLootData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFocusClueStateChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFocusClueStateChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFootstepComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameFootstepComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFootstepEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFootstepEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFootstepEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameFootstepEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFootstepSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFootstepSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFootstepSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFootstepSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameForceResetAmmoEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameForceResetAmmoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameForceResetAmmoEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameForceResetAmmoEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameForceVisionModuleQuestEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameForceVisionModuleQuestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFppRepDetachedObjectInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameFppRepDetachedObjectInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFreeCamera.cs
+++ b/CP77.CR2W/Types/cp77/gameFreeCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFreeCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameFreeCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFreeCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameFreeCameraComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFriendlyFireParams.cs
+++ b/CP77.CR2W/Types/cp77/gameFriendlyFireParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFriendlyFireSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFriendlyFireSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFriendlyFireSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFriendlyFireSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFuncCallEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameFuncCallEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFxInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameFxInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFxInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameFxInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameFxResource.cs
+++ b/CP77.CR2W/Types/cp77/gameFxResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFxSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFxSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameFxSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameFxSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGOGRewardPack.cs
+++ b/CP77.CR2W/Types/cp77/gameGOGRewardPack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGOGRewardsScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameGOGRewardsScriptListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGOGRewardsScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameGOGRewardsScriptListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGOGRewardsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGOGRewardsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGOGRewardsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGOGRewardsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameAudioSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameAudioSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameRulesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameRulesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameRulesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameRulesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gameGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gameGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameSessionDesc.cs
+++ b/CP77.CR2W/Types/cp77/gameGameSessionDesc.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameSessionDesc.cs
+++ b/CP77.CR2W/Types/cp77/gameGameSessionDesc.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameTagSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameTagSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameTagSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameTagSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameTimeInterval.cs
+++ b/CP77.CR2W/Types/cp77/gameGameTimeInterval.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObject.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObject.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObjectID.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObjectID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObjectID.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageObjectID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGameplayLogicPackageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGameplayLogicPackageSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGarmentItemObject.cs
+++ b/CP77.CR2W/Types/cp77/gameGarmentItemObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGarmentItemObject.cs
+++ b/CP77.CR2W/Types/cp77/gameGarmentItemObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGeometryDescriptionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGeometryDescriptionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGeometryDescriptionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGeometryDescriptionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGetActionsContext.cs
+++ b/CP77.CR2W/Types/cp77/gameGetActionsContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGlobalTierSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameGlobalTierSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeData.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeEntityData.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeEntityData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSaveEntityData.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSaveEntityData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSharedState.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSharedStateData.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSharedStateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGodModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameGodModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGrenadeThrowQuery.cs
+++ b/CP77.CR2W/Types/cp77/gameGrenadeThrowQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameGrenadeThrowQuery.cs
+++ b/CP77.CR2W/Types/cp77/gameGrenadeThrowQuery.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameGrenadeThrowQueryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameGrenadeThrowQueryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHACK_UseSensePresetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameHACK_UseSensePresetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHardcodedSignalPriorityDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameHardcodedSignalPriorityDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameHasDialogVisualizerVisiblePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameHitDetectionDebugFrameData.cs
+++ b/CP77.CR2W/Types/cp77/gameHitDetectionDebugFrameData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitDetectionDebugFrameDataShapeEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameHitDetectionDebugFrameDataShapeEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationOverride.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationResource.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationResult.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationResults.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationResults.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameHitRepresentationVisualTaggedOverride.cs
+++ b/CP77.CR2W/Types/cp77/gameHitRepresentationVisualTaggedOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitResult.cs
+++ b/CP77.CR2W/Types/cp77/gameHitResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShapeBVH.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShapeBVH.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShapeBase.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShapeBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShapeContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShapeContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShapeUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShapeUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShapeUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShapeUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameHitShape_Capsule.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShape_Capsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShape_ColliderComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShape_ColliderComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShape_OBB.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShape_OBB.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHitShape_Sphere.cs
+++ b/CP77.CR2W/Types/cp77/gameHitShape_Sphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHudActor.cs
+++ b/CP77.CR2W/Types/cp77/gameHudActor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameHumanoidBody.cs
+++ b/CP77.CR2W/Types/cp77/gameHumanoidBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAIDirectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAIDirectorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAIDirectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAIDirectorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAchievementSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAchievementSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAchievementSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAchievementSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIActionsFactory.cs
+++ b/CP77.CR2W/Types/cp77/gameIActionsFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIActionsFactory.cs
+++ b/CP77.CR2W/Types/cp77/gameIActionsFactory.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIActivityLogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIActivityLogSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIActivityLogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIActivityLogSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIAreaManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIAreaManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAttitudeManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttitudeManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAttitudeManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIAttitudeManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIAutoSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAutoSaveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIAutoSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIAutoSaveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboard.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIBlackboardSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboardSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIBlackboardSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboardSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboardUpdateProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameIBlackboardUpdateProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICameraSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICameraSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICameraSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICameraSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIClientEntitySpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIClientEntitySpawnSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIClientEntitySpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIClientEntitySpawnSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICollisionQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICollisionQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICollisionQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICollisionQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICombatQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICombatQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICombatQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICombatQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICommunitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICommunitySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICommunitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICommunitySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICompanionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICompanionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICompanionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICompanionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIComparisonPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIComparisonPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIComponentsStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIComponentsStateSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIComponentsStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIComponentsStateSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIContainerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIContainerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIContainerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIContainerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameICooldownSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICooldownSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameICooldownSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameICooldownSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDamageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDamageSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDamageSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIDamageSystemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDamageSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIDamageSystemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDebugCheatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugCheatsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDebugCheatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugCheatsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugDrawHistorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugDrawHistorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDebugPlayerBreadcrumbs.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugPlayerBreadcrumbs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDebugPlayerBreadcrumbs.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugPlayerBreadcrumbs.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDebugSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDebugSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDebugVisualizerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugVisualizerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDebugVisualizerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDebugVisualizerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDelaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDelaySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDelaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDelaySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDestructionPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDestructionPersistencySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDestructionPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDestructionPersistencySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDeviceInteractionManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIDeviceInteractionManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDeviceInteractionManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIDeviceInteractionManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDeviceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDeviceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDeviceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDeviceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIDynamicEntityIDSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDynamicEntityIDSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIDynamicEntityIDSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIDynamicEntityIDSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectInputParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectInputParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectInputParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectInputParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectOutputParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectOutputParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectOutputParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectOutputParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_BoolEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_BoolEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_BoolEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_BoolEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_CNameEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_CNameEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_CNameEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_CNameEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_FloatEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_FloatEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_FloatEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_FloatEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_IntEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_IntEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_IntEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_IntEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_QuatEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_QuatEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_QuatEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_QuatEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_StringEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_StringEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_StringEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_StringEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_VectorEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_VectorEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectParameter_VectorEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectParameter_VectorEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectTriggerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectTriggerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectTriggerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectTriggerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEffectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEffectorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEffectorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEntitySpawnerEventsBroadcaster.cs
+++ b/CP77.CR2W/Types/cp77/gameIEntitySpawnerEventsBroadcaster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEntitySpawnerEventsBroadcaster.cs
+++ b/CP77.CR2W/Types/cp77/gameIEntitySpawnerEventsBroadcaster.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEntityStubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEntityStubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEntityStubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEntityStubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIEnvironmentDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEnvironmentDamageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIEnvironmentDamageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIEnvironmentDamageSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIFinisherScenario.cs
+++ b/CP77.CR2W/Types/cp77/gameIFinisherScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIFinisherScenario.cs
+++ b/CP77.CR2W/Types/cp77/gameIFinisherScenario.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIFootstepSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFootstepSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIFootstepSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFootstepSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIFriendlyFireSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFriendlyFireSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIFriendlyFireSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFriendlyFireSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIFxSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFxSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIFxSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIFxSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGameAudioSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameAudioSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGameAudioSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameAudioSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGameRulesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameRulesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGameRulesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameRulesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGameSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGameSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameSystemReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGameplayLogicPackageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameplayLogicPackageSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGameplayLogicPackageSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGameplayLogicPackageSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGlobalTvSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGlobalTvSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGlobalTvSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGlobalTvSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIGodModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGodModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIGodModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIGodModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIHitRepresentationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIHitRepresentationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIHitRepresentationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIHitRepresentationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIHitShape.cs
+++ b/CP77.CR2W/Types/cp77/gameIHitShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIHitShape.cs
+++ b/CP77.CR2W/Types/cp77/gameIHitShape.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIInventoryManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIInventoryManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIInventoryManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIInventoryManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIItemFactorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIItemFactorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIItemFactorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIItemFactorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIJournalManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIJournalManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIJournalManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIJournalManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameILevelAssignmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameILevelAssignmentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameILevelAssignmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameILevelAssignmentSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameILocationManager.cs
+++ b/CP77.CR2W/Types/cp77/gameILocationManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameILocationManager.cs
+++ b/CP77.CR2W/Types/cp77/gameILocationManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameILootManager.cs
+++ b/CP77.CR2W/Types/cp77/gameILootManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameILootManager.cs
+++ b/CP77.CR2W/Types/cp77/gameILootManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIMarketSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMarketSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMarketSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMarketSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIMinimapSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMinimapSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMinimapSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMinimapSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformMovement.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformMovement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementPointToPoint.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementPointToPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementPointToPoint.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformMovementPointToPoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMovingPlatformSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIMovingPlatformSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIMuppetInputAction.cs
+++ b/CP77.CR2W/Types/cp77/gameIMuppetInputAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIMuppetInputAction.cs
+++ b/CP77.CR2W/Types/cp77/gameIMuppetInputAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIObjectCarrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIObjectCarrySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIObjectCarrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIObjectCarrySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIObjectPoolSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIObjectPoolSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIObjectPoolSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIObjectPoolSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIObjectScriptBase.cs
+++ b/CP77.CR2W/Types/cp77/gameIObjectScriptBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPersistencySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPersistencySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPhantomEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPhantomEntitySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPhantomEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPhantomEntitySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPhotoModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPhotoModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPhotoModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPhotoModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIPlayerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIPlayerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPlayerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPlayerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPopulationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPopulationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPopulationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPopulationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPrereqManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIPrereqManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPrereqManager.cs
+++ b/CP77.CR2W/Types/cp77/gameIPrereqManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPreventionSpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPreventionSpawnSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPreventionSpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPreventionSpawnSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIProjectileSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIProjectileSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIProjectileSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIProjectileSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIPuppetUpdaterSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPuppetUpdaterSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIPuppetUpdaterSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIPuppetUpdaterSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIRPGPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIRPGPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIRPGPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIRPGPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIRenderGameplayEffectsManagerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIRenderGameplayEffectsManagerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIRenderGameplayEffectsManagerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIRenderGameplayEffectsManagerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIReplicatedGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIReplicatedGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIReplicatedGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIReplicatedGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIRichPresenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIRichPresenceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIRichPresenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIRichPresenceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameISaveSanitizationForbiddenAreaSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISaveSanitizationForbiddenAreaSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameISaveSanitizationForbiddenAreaSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISaveSanitizationForbiddenAreaSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameISceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISceneSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameISceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISceneSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameISchematicSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISchematicSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameISchematicSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISchematicSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIScriptablePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptablePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIScriptablePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptablePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIScriptableSystemsContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptableSystemsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIScriptableSystemsContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptableSystemsContainer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIScriptsDebugOverlaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptsDebugOverlaySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIScriptsDebugOverlaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIScriptsDebugOverlaySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIShootingAccuracySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIShootingAccuracySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIShootingAccuracySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIShootingAccuracySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameISpatialQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISpatialQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameISpatialQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISpatialQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatPoolsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatPoolsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatPoolsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatPoolsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatsDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsDataSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatsDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsDataSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatusComboSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusComboSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatusComboSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusComboSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusEffectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusEffectListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStatusEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusEffectSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStatusEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStatusEffectSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIStreamingMonitorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStreamingMonitorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIStreamingMonitorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIStreamingMonitorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameISubtitleHandlerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISubtitleHandlerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameISubtitleHandlerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameISubtitleHandlerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITargetingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITargetingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITargetingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITargetingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITelemetrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITelemetrySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITelemetrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITelemetrySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITeleportationFacility.cs
+++ b/CP77.CR2W/Types/cp77/gameITeleportationFacility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITeleportationFacility.cs
+++ b/CP77.CR2W/Types/cp77/gameITeleportationFacility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITierSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITierSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITierSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITierSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameITimeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITimeState.cs
+++ b/CP77.CR2W/Types/cp77/gameITimeState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITimeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITimeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransactionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITransformAnimatorSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransformAnimatorSaveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITransformAnimatorSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransformAnimatorSaveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameITransformsHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransformsHistorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameITransformsHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameITransformsHistorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIVehicleSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIVehicleSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIVehicleSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIVehicleSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIVisionModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIVisionModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIVisionModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIVisionModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIWatchdogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWatchdogSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIWatchdogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWatchdogSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIWorkspotGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWorkspotGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIWorkspotGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWorkspotGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIWorldBoundarySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWorldBoundarySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIWorldBoundarySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameIWorldBoundarySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameImpostorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameImpostorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameImpostorComponentAttachEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameImpostorComponentAttachEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameImpostorComponentAttachEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameImpostorComponentAttachEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameImpostorComponentSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameImpostorComponentSlotListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameImpostorComponentSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameImpostorComponentSlotListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInCrowd.cs
+++ b/CP77.CR2W/Types/cp77/gameInCrowd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInCrowd.cs
+++ b/CP77.CR2W/Types/cp77/gameInCrowd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInnerItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameInnerItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInnerItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameInnerItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIntervalTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameIntervalTimer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIntervalTimer.cs
+++ b/CP77.CR2W/Types/cp77/gameIntervalTimer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventory.cs
+++ b/CP77.CR2W/Types/cp77/gameInventory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryItemAbility.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryItemAbility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_Base.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_Base.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_Base.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_InventoryEmpty.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_InventoryEmpty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_InventoryEmpty.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_InventoryEmpty.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemAdded.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemAdded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemAdded.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemAdded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemExtracted.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemExtracted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemExtracted.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemExtracted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemNotification.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemNotification.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemNotification.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemNotification.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemQuantityChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemQuantityChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemQuantityChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemQuantityChanged.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemRemoved.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemRemoved.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemRemoved.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_ItemRemoved.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartAdded.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartAdded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartAdded.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartAdded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartRemoved.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartRemoved.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartRemoved.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryListenerData_PartRemoved.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryManager.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryManager.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryPS.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameInventoryScriptCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryScriptCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryScriptListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameInventoryScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/gameInventoryScriptListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameIsQuickhackPanelOpenedPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameIsVisualizerActivePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemAddedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameItemAddedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemBeingRemovedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameItemBeingRemovedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameItemChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemCreationPrereqDataWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameItemCreationPrereqDataWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemCreationPrereqDataWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameItemCreationPrereqDataWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemDecorationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDecorationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemDecorationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDecorationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemDropObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDropObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemDropStorageInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDropStorageInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemDropStorageInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDropStorageInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemDropStorageManager.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDropStorageManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemDropStorageManager.cs
+++ b/CP77.CR2W/Types/cp77/gameItemDropStorageManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemEventsEquippedToObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsEquippedToObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemEventsEquippedToObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsEquippedToObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemEventsPropagateRenderingPlane.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsPropagateRenderingPlane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemEventsPropagateRenderingPlane.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsPropagateRenderingPlane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemEventsRemoveActiveItem.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsRemoveActiveItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemEventsRemoveActiveItem.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsRemoveActiveItem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemEventsUnequipStarted.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsUnequipStarted.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemEventsUnequipStarted.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsUnequipStarted.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemEventsUnequippedFromObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsUnequippedFromObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemEventsUnequippedFromObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemEventsUnequippedFromObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemFactorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameItemFactorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemFactorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameItemFactorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemFactorySystemPool.cs
+++ b/CP77.CR2W/Types/cp77/gameItemFactorySystemPool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemFactorySystemPool.cs
+++ b/CP77.CR2W/Types/cp77/gameItemFactorySystemPool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameItemID.cs
+++ b/CP77.CR2W/Types/cp77/gameItemID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemModParams.cs
+++ b/CP77.CR2W/Types/cp77/gameItemModParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemObject.cs
+++ b/CP77.CR2W/Types/cp77/gameItemObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameItemViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemsMeshesLoaded.cs
+++ b/CP77.CR2W/Types/cp77/gameItemsMeshesLoaded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameItemsMeshesLoaded.cs
+++ b/CP77.CR2W/Types/cp77/gameItemsMeshesLoaded.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJoinTrafficSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameJoinTrafficSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJoinTrafficSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameJoinTrafficSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalBaseResource.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBaseResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalBaseResource.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBaseResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalBriefing.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalBriefing.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingBaseSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingBaseSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingBaseSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingBaseSection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingMapSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingMapSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingPaperDollSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingPaperDollSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingPaperDollSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingPaperDollSection.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalBriefingVideoSection.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalBriefingVideoSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalCodexCategory.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalCodexCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalCodexDescription_.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalCodexDescription_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalCodexEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalCodexEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalCodexGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalCodexGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalContact.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalContact.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalContactModifierEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalContactModifierEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalContactModifierEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalContactModifierEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalContainerEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalContainerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalDescriptorResource.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalDescriptorResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalEmail.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEmail.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalEmailGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEmailGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalEmailGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEmailGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalEntryStateChangeData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEntryStateChangeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalEntryVisitedStatusData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalEntryVisitedStatusData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFactNameValue.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFactNameValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFile.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFileEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFileEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFileEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFileEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalFileGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFileGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFileGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFileGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalFolderEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFolderEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalFolderEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalFolderEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalInternetBase.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetImage.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetImage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetPage.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetPage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetRectangle.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetRectangle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetRectangle.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetRectangle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalInternetSite.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetSite.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetText.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetText.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalInternetVideo.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalInternetVideo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalManager.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalManager.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalManagerSharedState.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalManagerSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalMetaQuest.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalMetaQuest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalMetaQuestObjective.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalMetaQuestObjective.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalMetaQuestScriptedData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalMetaQuestScriptedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalOnscreen.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalOnscreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalOnscreenGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalOnscreenGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalOnscreenGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalOnscreenGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalOnscreensStructuredGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalOnscreensStructuredGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalOnscreensStructuredGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalOnscreensStructuredGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalPath.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPhoneChoiceGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalPhoneConversation.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPhoneConversation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPhoneMessage.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPhoneMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPointOfInterestGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPointOfInterestGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPointOfInterestGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPointOfInterestGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalPointOfInterestMappin.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPointOfInterestMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPrimaryFolderEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPrimaryFolderEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalPrimaryFolderEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalPrimaryFolderEntry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalQuest.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestCodexLink.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestCodexLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestDescription.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestGuidanceMarker.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestGuidanceMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestMapPin.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestMapPin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestMapPinBase.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestMapPinBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestMapPinLink.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestMapPinLink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestMultiMapPin.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestMultiMapPin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestObjective.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestObjective.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestObjective.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestObjective.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalQuestObjectiveBase.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestObjectiveBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestObjectiveCounterData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestObjectiveCounterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestPhase.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestPointOfInterestMapPin.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestPointOfInterestMapPin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestPointOfInterestMapPin.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestPointOfInterestMapPin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalQuestSubObjective.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestSubObjective.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestSubObjective.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestSubObjective.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalQuestTitleModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestTitleModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalQuestTrackedData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalQuestTrackedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalRequestClassFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalRequestClassFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalRequestContext.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalRequestContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalRequestStateFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalRequestStateFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalResource.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalRootFolderEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalRootFolderEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalSharedStateData.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalSharedStateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalTarot.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalTarot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalTarotGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalTarotGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameJournalTarotGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalTarotGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameJournalTree.cs
+++ b/CP77.CR2W/Types/cp77/gameJournalTree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameKillTriggerNode.cs
+++ b/CP77.CR2W/Types/cp77/gameKillTriggerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameKillTriggerNode.cs
+++ b/CP77.CR2W/Types/cp77/gameKillTriggerNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameKillTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameKillTriggerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameKillTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameKillTriggerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLadderComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameLadderComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLadderObject.cs
+++ b/CP77.CR2W/Types/cp77/gameLadderObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLastHitData.cs
+++ b/CP77.CR2W/Types/cp77/gameLastHitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLevelAssignmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLevelAssignmentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLevelAssignmentSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLevelAssignmentSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLightComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameLightComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLightSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameLightSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLoSFinderParams.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSFinderParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLoSFinderParams.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSFinderParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLoSFinderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSFinderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLoSFinderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSFinderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLoSIFinderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSIFinderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLoSIFinderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameLoSIFinderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLoadoutData.cs
+++ b/CP77.CR2W/Types/cp77/gameLoadoutData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLocationManager.cs
+++ b/CP77.CR2W/Types/cp77/gameLocationManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLocationManager.cs
+++ b/CP77.CR2W/Types/cp77/gameLocationManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLocationPrefabMetadata.cs
+++ b/CP77.CR2W/Types/cp77/gameLocationPrefabMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLocationResource_.cs
+++ b/CP77.CR2W/Types/cp77/gameLocationResource_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLocationResource_.cs
+++ b/CP77.CR2W/Types/cp77/gameLocationResource_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLookAtFacingPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameLookAtFacingPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLookAtFacingPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameLookAtFacingPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLootBag.cs
+++ b/CP77.CR2W/Types/cp77/gameLootBag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootBag.cs
+++ b/CP77.CR2W/Types/cp77/gameLootBag.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLootBagInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameLootBagInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootBagInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/gameLootBagInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLootContainerBase.cs
+++ b/CP77.CR2W/Types/cp77/gameLootContainerBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootContainerBasePS.cs
+++ b/CP77.CR2W/Types/cp77/gameLootContainerBasePS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootManager.cs
+++ b/CP77.CR2W/Types/cp77/gameLootManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootManager.cs
+++ b/CP77.CR2W/Types/cp77/gameLootManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLootObject.cs
+++ b/CP77.CR2W/Types/cp77/gameLootObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootPrefabMetadata.cs
+++ b/CP77.CR2W/Types/cp77/gameLootPrefabMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootResource.cs
+++ b/CP77.CR2W/Types/cp77/gameLootResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootResourceData_.cs
+++ b/CP77.CR2W/Types/cp77/gameLootResourceData_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootSlotSingleAppearance.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlotSingleAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootSlotSingleItem.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlotSingleItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootSlotSingleItemLongStreaming.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlotSingleItemLongStreaming.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameLootSlotSingleItemLongStreaming.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlotSingleItemLongStreaming.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameLootSlotSingleQuery.cs
+++ b/CP77.CR2W/Types/cp77/gameLootSlotSingleQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMakeInventoryShareableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameMakeInventoryShareableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMakeInventoryShareableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameMakeInventoryShareableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMappinResource.cs
+++ b/CP77.CR2W/Types/cp77/gameMappinResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMasterDeviceComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameMasterDeviceComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMeshDef.cs
+++ b/CP77.CR2W/Types/cp77/gameMeshDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMinimapSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameMinimapSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMinimapSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameMinimapSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMountAIEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameMountAIEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMountDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/gameMountDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMountEventData.cs
+++ b/CP77.CR2W/Types/cp77/gameMountEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMountEventOptions.cs
+++ b/CP77.CR2W/Types/cp77/gameMountEventOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatform.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformArrivedAt.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformArrivedAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformAttachEntity.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformAttachEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformBeforeArrivedAt.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformBeforeArrivedAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformBeforeArrivedAt.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformBeforeArrivedAt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformDetachEntity.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformDetachEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMountableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMountableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMoveTo.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMoveTo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMovementDynamic.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMovementDynamic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMovementLinear.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMovementLinear.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformMovementLinear.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformMovementLinear.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformRestoreMoveTo.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformRestoreMoveTo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformRestoreMoveTo.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformRestoreMoveTo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformSavedData.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformSavedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformTeleportTo.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformTeleportTo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMovingPlatformsSavedState.cs
+++ b/CP77.CR2W/Types/cp77/gameMovingPlatformsSavedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMultiPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameMultiPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMultiPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameMultiPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppet.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetAbilities.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetAbilities.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetAbility.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetAbility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetComparisonReportItem.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetComparisonReportItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetCompressedInputStates.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetCompressedInputStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetControllerSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetControllerSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetControllersSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetControllersSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetDebugState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetDebugState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetHealthState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetHealthState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetHighLevelState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetHighLevelState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionActivateScanning.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionActivateScanning.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionActivateScanning.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionActivateScanning.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionAimDownSight.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionAimDownSight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionAimDownSight.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionAimDownSight.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionCrouch.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionCrouch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionCrouch.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionCrouch.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionDebugCommand.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionDebugCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionJump.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionJump.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionJump.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionJump.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionLook.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionLook.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionMeleeAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionMeleeAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionMeleeAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionMeleeAttack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionMoveForward.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionMoveForward.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionQuickMelee.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionQuickMelee.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionQuickMelee.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionQuickMelee.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionRangedAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionRangedAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionReloadWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionReloadWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionReloadWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionReloadWeapon.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionSelectSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionSelectSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionSelectWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionSelectWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionUseConsumable.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionUseConsumable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputActionUseConsumable.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputActionUseConsumable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInputState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInputStates.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInputStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInventoryGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInventoryGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInventoryGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInventoryGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetInventorySlotInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInventorySlotInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetInventoryState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetInventoryState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetLoadoutsGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetLoadoutsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetLoadoutsGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetLoadoutsGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetLookState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetLookState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetMoveState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetMoveState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetPhysicalState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetPhysicalState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetScanningState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetScanningState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetStateComparisonReport.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetStateComparisonReport.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetStateMachineSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetStateMachineSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetStateMachinesSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetStateMachinesSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetStates.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetStates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetStates.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetStates.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameMuppetSubStepData.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetSubStepData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameMuppetUpperBodyState.cs
+++ b/CP77.CR2W/Types/cp77/gameMuppetUpperBodyState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNPCHealthStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCHealthStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNPCHealthStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCHealthStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNPCHealthStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCHealthStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNPCHealthStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCHealthStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNPCQuickHackUploadStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCQuickHackUploadStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNPCQuickHackUploadStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameNPCQuickHackUploadStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNarrationPlateBlackboardUpdater.cs
+++ b/CP77.CR2W/Types/cp77/gameNarrationPlateBlackboardUpdater.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNarrationPlateBlackboardUpdater.cs
+++ b/CP77.CR2W/Types/cp77/gameNarrationPlateBlackboardUpdater.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNarrationPlateComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameNarrationPlateComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNativeHudManager.cs
+++ b/CP77.CR2W/Types/cp77/gameNativeHudManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNativeHudManager.cs
+++ b/CP77.CR2W/Types/cp77/gameNativeHudManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNavmeshDetector.cs
+++ b/CP77.CR2W/Types/cp77/gameNavmeshDetector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNavmeshDetector.cs
+++ b/CP77.CR2W/Types/cp77/gameNavmeshDetector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNetAIState.cs
+++ b/CP77.CR2W/Types/cp77/gameNetAIState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeDespawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeDespawnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeDespawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeDespawnEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeNetworkNode.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeNetworkNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeNodeSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeNodeSetupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeSpawnCompletedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeSpawnCompletedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeSpawnRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeSpawnRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeStruct.cs
+++ b/CP77.CR2W/Types/cp77/gameNetrunnerPrototypeStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNewMappinID.cs
+++ b/CP77.CR2W/Types/cp77/gameNewMappinID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNotPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameNotPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNotPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameNotPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNotPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameNotPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameNotificationsReceiverTest.cs
+++ b/CP77.CR2W/Types/cp77/gameNotificationsReceiverTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNotificationsTest.cs
+++ b/CP77.CR2W/Types/cp77/gameNotificationsTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameNpcPuppetReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameNpcPuppetReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObject.cs
+++ b/CP77.CR2W/Types/cp77/gameObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectActionRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectActionRefreshEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectActionRefreshEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectActionRefreshEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectActionsCallbackController.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectActionsCallbackController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectActionsCallbackController.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectActionsCallbackController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectCarrierComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrierComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectCarrierComponentAttached.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrierComponentAttached.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectCarrierComponentAttached.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrierComponentAttached.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectCarrierComponentDetached.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrierComponentDetached.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectCarrierComponentDetached.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrierComponentDetached.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectCarrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectCarrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectCarrySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectDeathListener.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectDeathListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectDeathListener.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectDeathListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectMountableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectMountableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectPS.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectPS.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectPoolSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectPoolSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectPoolSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectPoolSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectSpawnParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectSpawnParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameObjectSpawnParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectSpawnParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameObjectSpawnParametersList.cs
+++ b/CP77.CR2W/Types/cp77/gameObjectSpawnParametersList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOccupantSlotComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameOccupantSlotComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOccupantSlotData.cs
+++ b/CP77.CR2W/Types/cp77/gameOccupantSlotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOffPavement.cs
+++ b/CP77.CR2W/Types/cp77/gameOffPavement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOffPavement.cs
+++ b/CP77.CR2W/Types/cp77/gameOffPavement.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnCarHitPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameOnCarHitPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/gameOnExecutionContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnExecutionContext.cs
+++ b/CP77.CR2W/Types/cp77/gameOnExecutionContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnInventoryEmptyEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnInventoryEmptyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnInventoryEmptyEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnInventoryEmptyEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnLootAllEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnLootAllEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnLootAllEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnLootAllEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnLootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnLootEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnPavement.cs
+++ b/CP77.CR2W/Types/cp77/gameOnPavement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnPavement.cs
+++ b/CP77.CR2W/Types/cp77/gameOnPavement.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueDisabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueDisabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueDisabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameOnScannableBraindanceClueEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameOutOfCrowd.cs
+++ b/CP77.CR2W/Types/cp77/gameOutOfCrowd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameOutOfCrowd.cs
+++ b/CP77.CR2W/Types/cp77/gameOutOfCrowd.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePSChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePSChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePSChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePSChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePSDeviceChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePSDeviceChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePartRemovedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePartRemovedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePatrolSplineControlPoint.cs
+++ b/CP77.CR2W/Types/cp77/gamePatrolSplineControlPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePatrolSplineControlPoint.cs
+++ b/CP77.CR2W/Types/cp77/gamePatrolSplineControlPoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePatrolSplineProgress.cs
+++ b/CP77.CR2W/Types/cp77/gamePatrolSplineProgress.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePendingSubtitles.cs
+++ b/CP77.CR2W/Types/cp77/gamePendingSubtitles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistencySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePersistencySystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistencySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePersistentID.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistentID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePersistentState.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistentState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePersistentState.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistentState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePersistentStateDataResource.cs
+++ b/CP77.CR2W/Types/cp77/gamePersistentStateDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhantomEntityComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhantomEntityComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhantomEntityParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamePhantomEntityParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhantomEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePhantomEntitySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhantomEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePhantomEntitySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeAutoFocusPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeAutoFocusPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeAutoFocusPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeAutoFocusPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeBackgroundCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeBackgroundCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeBackgroundViewComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeBackgroundViewComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeCameraObject.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeCameraObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeCameraObject.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeCameraObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeEnableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeObjectPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeObjectPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeObjectPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeObjectPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhotoModeUtils.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePhotoModeUtils.cs
+++ b/CP77.CR2W/Types/cp77/gamePhotoModeUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePhysicalDestructionListenerComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePhysicalDestructionListenerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePickupObject.cs
+++ b/CP77.CR2W/Types/cp77/gamePickupObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePingComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePingComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePingEntry.cs
+++ b/CP77.CR2W/Types/cp77/gamePingEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePingSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamePingSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayer.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerArmorStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerArmorStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerArmorStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerArmorStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerArmorStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerArmorStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerArmorStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerArmorStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerAttachRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerAttachRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerAttachRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerAttachRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerClimbInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerClimbInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerCommandConsumerComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerCommandConsumerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerCommandConsumerComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerCommandConsumerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerControlledComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerControlledComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerControlledComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerControlledComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerCoverInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerCoverInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerCoverInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerCoverInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerCoverStatusChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerCoverStatusChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerDetachRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerDetachRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerDetachRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerDetachRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerHealthStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerHealthStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerHealthStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerHealthStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerHealthStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerHealthStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerHealthStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerHealthStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerLevelBasedQuestRequestFilter.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerLevelBasedQuestRequestFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerMappinComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerMappinComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerMappinComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerMappinComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerObstacleSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerObstacleSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerObstacleSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerObstacleSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerProximityPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerProximityPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerProximityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerProximityPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerProximityPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerProximityPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerPuppetReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerPuppetReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerPuppetReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerPuppetReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsChild.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsChild.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsChild.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsChild.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsParent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsParent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsParent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerReleaseControlAsParent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerScriptableSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerScriptableSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerSocket.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerSocket.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerSocket.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerSpawnParams.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerSpawnParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsChild.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsChild.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsChild.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsChild.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsParent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsParent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsParent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTakeControlAsParent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePlayerTierComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTierComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePlayerTierComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePlayerTierComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePointOfInterestMappinResource.cs
+++ b/CP77.CR2W/Types/cp77/gamePointOfInterestMappinResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePopulationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePopulationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePopulationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePopulationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePopupData.cs
+++ b/CP77.CR2W/Types/cp77/gamePopupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePopupSettings.cs
+++ b/CP77.CR2W/Types/cp77/gamePopupSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrepareTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePrepareTPPRepresentationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrepareTPPRepresentationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePrepareTPPRepresentationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePrereqCheckData.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqCheckData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqData.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqManager.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqManager.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePrereqParams.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePrereqStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqStateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePrereqStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqStateChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePrereqsResource.cs
+++ b/CP77.CR2W/Types/cp77/gamePrereqsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePreventionSpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePreventionSpawnSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePreventionSpawnSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePreventionSpawnSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePreviewItemData.cs
+++ b/CP77.CR2W/Types/cp77/gamePreviewItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePreviewItemData.cs
+++ b/CP77.CR2W/Types/cp77/gamePreviewItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameProjectileSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameProjectileSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameProjectileSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameProjectileSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppet.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppet.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetBase.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetBase.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetBlackboardUpdater.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetBlackboardUpdater.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetBlackboardUpdater.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetBlackboardUpdater.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetMountableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetMountableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetPS.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamePuppetUpdaterSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetUpdaterSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamePuppetUpdaterSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamePuppetUpdaterSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameQueryResult.cs
+++ b/CP77.CR2W/Types/cp77/gameQueryResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameQuestDistanceRequestFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameQuestDistanceRequestFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameQuestOrSceneSetVehiclePhysicsActive.cs
+++ b/CP77.CR2W/Types/cp77/gameQuestOrSceneSetVehiclePhysicsActive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameQuestOrSceneSetVehiclePhysicsActive.cs
+++ b/CP77.CR2W/Types/cp77/gameQuestOrSceneSetVehiclePhysicsActive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameQuestTypeRequestFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameQuestTypeRequestFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRPGManager.cs
+++ b/CP77.CR2W/Types/cp77/gameRPGManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRPGManager.cs
+++ b/CP77.CR2W/Types/cp77/gameRPGManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRPGPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameRPGPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRPGPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameRPGPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRagdollHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameRagdollHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRandomStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameRandomStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRecordIdSpawnModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameRecordIdSpawnModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRecordIdSpawnModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameRecordIdSpawnModifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRegenerateLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameRegenerateLootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRegenerateLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameRegenerateLootEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRegisterCooldownFromRecordRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameRegisterCooldownFromRecordRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRegisterNewAbilityCooldownRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameRegisterNewAbilityCooldownRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRegisterNewCooldownRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameRegisterNewCooldownRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRegular1v1FinisherScenario.cs
+++ b/CP77.CR2W/Types/cp77/gameRegular1v1FinisherScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRemains.cs
+++ b/CP77.CR2W/Types/cp77/gameRemains.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRemains.cs
+++ b/CP77.CR2W/Types/cp77/gameRemains.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRemoveCooldownEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameRemoveCooldownEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRemoveCooldownEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameRemoveCooldownEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRemoveCooldownRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameRemoveCooldownRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameRenderGameplayEffectsManagerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformOperationRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformOperationRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformPlayRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformPlayRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformRequestBase.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformRequestBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformSkipRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformSkipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncAnimRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncAnimRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncAnimRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncAnimRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncElem.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncElem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncMatrixRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameReplAnimTransformSyncMatrixRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedAnimControllerEventsState.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedAnimControllerEventsState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedContinuousAttack.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedContinuousAttack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedEntityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedEntityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedEntityEventsState.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedEntityEventsState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameReplicatedShotData.cs
+++ b/CP77.CR2W/Types/cp77/gameReplicatedShotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRequestStats.cs
+++ b/CP77.CR2W/Types/cp77/gameRequestStats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRequestStats.cs
+++ b/CP77.CR2W/Types/cp77/gameRequestStats.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameResetFppCameraEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameResetFppCameraEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRichPresenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameRichPresenceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRichPresenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameRichPresenceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameRicochetData.cs
+++ b/CP77.CR2W/Types/cp77/gameRicochetData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRootTransformAnimatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameRootTransformAnimatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRuntimeSystemLights.cs
+++ b/CP77.CR2W/Types/cp77/gameRuntimeSystemLights.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameRuntimeSystemLights.cs
+++ b/CP77.CR2W/Types/cp77/gameRuntimeSystemLights.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSDOClickedRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameSDOClickedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSEquipArea.cs
+++ b/CP77.CR2W/Types/cp77/gameSEquipArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSEquipSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameSEquipSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSEquipmentSet.cs
+++ b/CP77.CR2W/Types/cp77/gameSEquipmentSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSItemInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameSItemInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSItemStack.cs
+++ b/CP77.CR2W/Types/cp77/gameSItemStack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSItemStackRequirementData.cs
+++ b/CP77.CR2W/Types/cp77/gameSItemStackRequirementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSLastUsedWeapon.cs
+++ b/CP77.CR2W/Types/cp77/gameSLastUsedWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSLoadout.cs
+++ b/CP77.CR2W/Types/cp77/gameSLoadout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSPartSlots.cs
+++ b/CP77.CR2W/Types/cp77/gameSPartSlots.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSSlotActiveItems.cs
+++ b/CP77.CR2W/Types/cp77/gameSSlotActiveItems.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSSlotInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameSSlotInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSVisualTagProcessing.cs
+++ b/CP77.CR2W/Types/cp77/gameSVisualTagProcessing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSaveLock.cs
+++ b/CP77.CR2W/Types/cp77/gameSaveLock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSaveSanitizationForbiddenAreaSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameSaveSanitizationForbiddenAreaSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSaveSanitizationForbiddenAreaSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameSaveSanitizationForbiddenAreaSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSavedStatsData.cs
+++ b/CP77.CR2W/Types/cp77/gameSavedStatsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningActionFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningActionFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningActionFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningActionFinishedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningActivatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningActivatorComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningController.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningController.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningControllerReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningControllerReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningControllerSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningControllerSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningEventForInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningEventForInstigator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningEventForInstigator.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningEventForInstigator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningInternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningInternalEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningInternalEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningInternalEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningLookAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningLookAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningPulseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningPulseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningPulseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningPulseEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScanningPulseStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningPulseStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningTooltipElementData.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningTooltipElementData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScanningTooltipElementDef.cs
+++ b/CP77.CR2W/Types/cp77/gameScanningTooltipElementDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneAnimationMotionActionParams.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneAnimationMotionActionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScenePlayerAnimationParams.cs
+++ b/CP77.CR2W/Types/cp77/gameScenePlayerAnimationParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScenePlayerAnimationParams.cs
+++ b/CP77.CR2W/Types/cp77/gameScenePlayerAnimationParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSceneTier.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSceneTier1Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier1Data.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier1Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier1Data.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSceneTier2Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier2Data.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier3Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier3Data.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier4Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier4Data.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier4Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier4Data.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSceneTier5Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier5Data.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTier5Data.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTier5Data.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSceneTierData.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSceneTierDataMotionConstrained.cs
+++ b/CP77.CR2W/Types/cp77/gameSceneTierDataMotionConstrained.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScreenshot360CameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScreenshot360CameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScreenshot360CameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScreenshot360CameraComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatPoolsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptStatPoolsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatPoolsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatusEffectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptStatusEffectListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptStatusEffectListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptableSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptableSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptableSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystemRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptableSystemRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystemRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptableSystemsContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystemsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptableSystemsContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptableSystemsContainer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptedDamageSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedDamageSystemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptedDamageSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedDamageSystemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqAttitudeListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqAttitudeListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqAttitudeListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqAttitudeListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqMountingListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqMountingListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqMountingListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqMountingListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqPSChangeListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqPSChangeListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqPSChangeListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqPSChangeListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqSceneInspectionListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqSceneInspectionListenerWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptedPrereqSceneInspectionListenerWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptedPrereqSceneInspectionListenerWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySink.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySink.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameScriptsDebugOverlaySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameServerBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameServerBlackboardUpdateProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameServerBlackboardUpdateProxy.cs
+++ b/CP77.CR2W/Types/cp77/gameServerBlackboardUpdateProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSetAggressiveMask.cs
+++ b/CP77.CR2W/Types/cp77/gameSetAggressiveMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetAggressiveMask.cs
+++ b/CP77.CR2W/Types/cp77/gameSetAggressiveMask.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSetAsQuestImportantEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetAsQuestImportantEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetCameraParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetCameraParamsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetCameraParamsWithOverridesEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetCameraParamsWithOverridesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetDestinationActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetDestinationActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetExclusiveFocusClueEntityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetExclusiveFocusClueEntityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetLootInteractionAccessibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetLootInteractionAccessibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetProgressionBuildRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameSetProgressionBuildRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetQuickHackableMask.cs
+++ b/CP77.CR2W/Types/cp77/gameSetQuickHackableMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetScannableThroughWallsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetScannableThroughWallsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetScanningBlockedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetScanningBlockedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetScanningTimeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetScanningTimeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetupControlledByStoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetupControlledByStoryEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetupControlledByStoryEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetupControlledByStoryEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSetupWorkspotActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetupWorkspotActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSetupWorkspotActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSetupWorkspotActionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameShapeData.cs
+++ b/CP77.CR2W/Types/cp77/gameShapeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameShootingAccuracySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingAccuracySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameShootingAccuracySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingAccuracySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameShootingSpotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingSpotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameShootingSpotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingSpotDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameShootingSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingSpotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameShootingSpotInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameShootingSpotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSignalId.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSignalPriorityDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalPriorityDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSignalUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSignalUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSignalUserDataDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalUserDataDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSignalUserDataDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameSignalUserDataDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSimpleOccupantSlotSpawner.cs
+++ b/CP77.CR2W/Types/cp77/gameSimpleOccupantSlotSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSimpleOccupantSlotSpawner.cs
+++ b/CP77.CR2W/Types/cp77/gameSimpleOccupantSlotSpawner.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSimpleScreenMessage.cs
+++ b/CP77.CR2W/Types/cp77/gameSimpleScreenMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSlotDataHolder.cs
+++ b/CP77.CR2W/Types/cp77/gameSlotDataHolder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameSlotListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameSlotListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSlotWeaponData.cs
+++ b/CP77.CR2W/Types/cp77/gameSlotWeaponData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectAnimationDatabase.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectAnimationDatabase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectGate.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectGate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSmartObjectMembership.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectMembership.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectMembershipMemberShip.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectMembershipMemberShip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectPoint.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectPropertyDictionary.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectPropertyDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectPropertyDictionaryPropertyEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectPropertyDictionaryPropertyEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectResource.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectTransformDictionary.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectTransformDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectTransformDictionaryTransformEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectTransformDictionaryTransformEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectTransformSequenceDictionary.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectTransformSequenceDictionary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectTransformSequenceDictionaryEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectTransformSequenceDictionaryEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectWorkspotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSmartObjectsCompiledResource.cs
+++ b/CP77.CR2W/Types/cp77/gameSmartObjectsCompiledResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSourceData.cs
+++ b/CP77.CR2W/Types/cp77/gameSourceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSourceShootComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameSourceShootComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSourceShootComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameSourceShootComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSpatialQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameSpatialQueriesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSpatialQueriesSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameSpatialQueriesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSpawnOccupantsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSpawnOccupantsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSpawnOccupantsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameSpawnOccupantsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSpotSequenceCategory.cs
+++ b/CP77.CR2W/Types/cp77/gameSpotSequenceCategory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSquadMemberComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameSquadMemberComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSquadMemberComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameSquadMemberComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSquadMemberComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameSquadMemberComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSquadMemberDataEntry.cs
+++ b/CP77.CR2W/Types/cp77/gameSquadMemberDataEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStackedItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameStackedItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStackedItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameStackedItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatDetailedData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatDetailedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatModifierDetailedData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatModifierDetailedData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatModifierGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameStatModifierGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatModifierSave.cs
+++ b/CP77.CR2W/Types/cp77/gameStatModifierSave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolDataModifierStatListener.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolDataModifierStatListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolDataModifierStatListener.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolDataModifierStatListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatPoolModifier.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatPoolsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPoolsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatPoolsSystemSave.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPoolsSystemSave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameStatPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatTotalValue.cs
+++ b/CP77.CR2W/Types/cp77/gameStatTotalValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameStatViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStaticAreaShapeComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStaticAreaShapeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStaticTriggerAreaComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStaticTriggerAreaComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsBundle.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsBundle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsBundle.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsBundle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsBundleHandler.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsBundleHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsBundleHandler.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsBundleHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsComponentPS.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsDataSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsDataSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsDataSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsObjectID.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsObjectID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsSeedKey.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsSeedKey.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsStateMapStructure.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsStateMapStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatsSystemSave.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsSystemSave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatsUnit.cs
+++ b/CP77.CR2W/Types/cp77/gameStatsUnit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusComboSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusComboSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusComboSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusComboSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectBase.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatusEffectComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectReplicatedInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectReplicatedInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStatusEffectSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStatusEffectTDBPicker.cs
+++ b/CP77.CR2W/Types/cp77/gameStatusEffectTDBPicker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStoryTierChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameStoryTierChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStreamingMonitorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStreamingMonitorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStreamingMonitorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameStreamingMonitorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameStreamingSmartObjectsDataExtractor.cs
+++ b/CP77.CR2W/Types/cp77/gameStreamingSmartObjectsDataExtractor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameStreamingSmartObjectsDataExtractor.cs
+++ b/CP77.CR2W/Types/cp77/gameStreamingSmartObjectsDataExtractor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameSubStatModifierData.cs
+++ b/CP77.CR2W/Types/cp77/gameSubStatModifierData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameSynchronizeAttachmentSlotRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameSynchronizeAttachmentSlotRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTPPCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTPPCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTPPCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTPPCameraComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTPPRepresentationComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTPPRepresentationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTPPRepresentationPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameTPPRepresentationPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTPPRepresentationPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameTPPRepresentationPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTagObjectRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameTagObjectRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTagSpawParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameTagSpawParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTaggedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTaggedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTaggedSignalUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameTaggedSignalUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTaggedSignalUserDataDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameTaggedSignalUserDataDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetSearchFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetSearchFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetSearchFilter.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetSearchFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTargetSearchQuery.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetSearchQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetShootComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetShootComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetShootComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetShootComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTargetingActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingActivatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetingActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingActivatorComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTargetingComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetingComponentData.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingComponentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTargetingComponentData.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingComponentData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTargetingLocalizedEffectComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTargetingLocalizedEffectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryDamage.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryDamage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryDamageDealt.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryDamageDealt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryEnemy.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryEnemy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryEnemyDown.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryEnemyDown.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryInventoryItem.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryInventoryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryLevelGained.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryLevelGained.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryPostMortem.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryPostMortem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryPostMortemContainer.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryPostMortemContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryQuickHack.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryQuickHack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryTelemetrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryTelemetrySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTelemetryTelemetrySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryTelemetrySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTelemetryTrackedQuest.cs
+++ b/CP77.CR2W/Types/cp77/gameTelemetryTrackedQuest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTeleportationFacility.cs
+++ b/CP77.CR2W/Types/cp77/gameTeleportationFacility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTeleportationFacility.cs
+++ b/CP77.CR2W/Types/cp77/gameTeleportationFacility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTickableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTickableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTier3CameraSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameTier3CameraSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTierPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameTierPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTierPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameTierPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTierPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameTierPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTierSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameTierSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTierSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTierSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTierSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTierSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTimeDilatable.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeDilatable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTimeDilatable.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeDilatable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTimeDilationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeDilationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTimeDilationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeDilationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTimeSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameTimeSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTppRepAttachedObjectInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameTppRepAttachedObjectInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTppRepItemAppearanceInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameTppRepItemAppearanceInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTrafficLaneSpanInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameTrafficLaneSpanInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTrafficWorkspotTransitionData.cs
+++ b/CP77.CR2W/Types/cp77/gameTrafficWorkspotTransitionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransactionSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransactionSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransactionSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationPauseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationPauseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationPauseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationPauseEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationPlayEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationPlayEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationResetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationResetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationResetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationResetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationSkipEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationSkipEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationTimeline.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationTimeline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItemImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItemImpl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItemImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimationTrackItemImpl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_BreakEffectLoop.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_BreakEffectLoop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Effects.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Effects.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Effects.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Effects.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_KillEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_KillEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Move.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Move.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_MoveOnSpline.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_MoveOnSpline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CustomCurve.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_CustomCurve.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_PredefinedFunction.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Movement_PredefinedFunction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_PlaySound.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_PlaySound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Position.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Position.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Position.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Position.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_InitialPosition.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_InitialPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_LocalPosition.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_LocalPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_MarkerPosition.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Position_MarkerPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_RotateFromTo.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_RotateFromTo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_RotateOnAxis.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_RotateOnAxis.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_CurrentRotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_CurrentRotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_InitialRotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_InitialRotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_InitialRotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_InitialRotation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_LocalRotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_LocalRotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_MarkerRotation.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_Rotation_MarkerRotation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimation_SpawnEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimation_SpawnEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimatorComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimatorComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimatorComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimatorComponentReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformAnimatorSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimatorSaveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformAnimatorSaveSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformAnimatorSaveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTransformsHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformsHistorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTransformsHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameTransformsHistorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameTutorialBracketData.cs
+++ b/CP77.CR2W/Types/cp77/gameTutorialBracketData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTutorialOverlayData.cs
+++ b/CP77.CR2W/Types/cp77/gameTutorialOverlayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameTutorialOverlayUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameTutorialOverlayUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUIItemsHelper.cs
+++ b/CP77.CR2W/Types/cp77/gameUIItemsHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUIItemsHelper.cs
+++ b/CP77.CR2W/Types/cp77/gameUIItemsHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameUILocalizationDataPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameUILocalizationDataPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUnTagObjectRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameUnTagObjectRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUnequipByContextRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameUnequipByContextRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUnequipByTDBIDRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameUnequipByTDBIDRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUniqueItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameUniqueItemData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameUniqueItemData.cs
+++ b/CP77.CR2W/Types/cp77/gameUniqueItemData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVehicleCommonCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleCommonCurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVehicleCommonCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleCommonCurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVehicleCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleCurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVehicleCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleCurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVehicleCurvesLibrary.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleCurvesLibrary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVehicleSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameVehicleSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVendorData.cs
+++ b/CP77.CR2W/Types/cp77/gameVendorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionActivatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionActivatorComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVisionAppearance.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionAppearanceForcedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionAppearanceForcedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeActivationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeHideEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeHideEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeMappinEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeMappinEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModePrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModePrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModePrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModePrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModePrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVisionModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameVisionModeSystemRevealIdentifier.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeSystemRevealIdentifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeUpdateVisuals.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeUpdateVisuals.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModeVisualEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModeVisualEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModuleEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModuleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionModuleParams.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionModuleParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisionRevealExpiredEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameVisionRevealExpiredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset.cs
+++ b/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset_Entity.cs
+++ b/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset_Entity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset_TagsAppearances.cs
+++ b/CP77.CR2W/Types/cp77/gameVisualTagsAppearanceNamesPreset_TagsAppearances.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWasScannedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameWasScannedPrereq.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWasScannedPrereq.cs
+++ b/CP77.CR2W/Types/cp77/gameWasScannedPrereq.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWasScannedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameWasScannedPrereqState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWasScannedPrereqState.cs
+++ b/CP77.CR2W/Types/cp77/gameWasScannedPrereqState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWaypoint.cs
+++ b/CP77.CR2W/Types/cp77/gameWaypoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWaypoint.cs
+++ b/CP77.CR2W/Types/cp77/gameWaypoint.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeakSpotReplicatedInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakSpotReplicatedInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeakspotComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeakspotComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeakspotComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeakspotDestroyedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotDestroyedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeakspotDestroyedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotDestroyedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeakspotObject.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeakspotObject.cs
+++ b/CP77.CR2W/Types/cp77/gameWeakspotObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeaponAudio.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponAudio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeaponAudio.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponAudio.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeaponAudioComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponAudioComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeaponAudioComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponAudioComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWeaponReplicationHistory.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponReplicationHistory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeaponsReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponsReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWeaponsReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameWeaponsReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWorkspotGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameWorkspotGameSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWorkspotGameSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameWorkspotGameSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWorldBoundaryNode.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundaryNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWorldBoundaryNode.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundaryNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWorldBoundaryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundaryNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWorldBoundaryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundaryNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWorldBoundarySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundarySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWorldBoundarySystem.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldBoundarySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWorldSpaceBlendCamera.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldSpaceBlendCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameWorldSpaceBlendCamera.cs
+++ b/CP77.CR2W/Types/cp77/gameWorldSpaceBlendCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameWrappedEntIDArray.cs
+++ b/CP77.CR2W/Types/cp77/gameWrappedEntIDArray.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaimAssistAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameaimAssistAimAssist.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaimAssistAimAssist.cs
+++ b/CP77.CR2W/Types/cp77/gameaimAssistAimAssist.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaimAssistAimAssistRemotePlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameaimAssistAimAssistRemotePlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaimAssistAimAssistRemotePlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameaimAssistAimAssistRemotePlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaimAssistAimRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameaimAssistAimRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioAcousticPortalComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioAcousticPortalComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioBreathingSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioBreathingSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioFlybySubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioFlybySubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioFlybySubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioFlybySubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioIAudioSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIAudioSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioIAudioSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIAudioSubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioIScanningSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIScanningSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioIScanningSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIScanningSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioISoundComponentSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioISoundComponentSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioISoundComponentSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioISoundComponentSubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioIWeaponAudioComponentSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIWeaponAudioComponentSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioIWeaponAudioComponentSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioIWeaponAudioComponentSubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioMeleeAudioSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioMeleeAudioSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioMeleeAudioSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioMeleeAudioSubSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioMusicSyncComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioMusicSyncComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioRagdollSubSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioRagdollSubSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioScanningSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioScanningSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioScanningSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioScanningSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioSoundComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioSoundComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioSoundComponentBase.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioSoundComponentBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioSoundComponentSubSystemWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioSoundComponentSubSystemWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioVehicleAudioComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioVehicleAudioComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioVehicleAudioComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioVehicleAudioComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsDialogLine.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsDialogLine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsDropBodyBreathingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsDropBodyBreathingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsDropBodyBreathingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsDropBodyBreathingEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsEmitterEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsEmitterEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsMusicEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsMusicEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyBreathingSubSystemStateChangeRequested.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyBreathingSubSystemStateChangeRequested.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyBreathingSubSystemStateChangeRequested.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyBreathingSubSystemStateChangeRequested.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepMaterialContextChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepMaterialContextChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepSubSystemStateChangeRequested.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepSubSystemStateChangeRequested.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepSubSystemStateChangeRequested.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyFootstepSubSystemStateChangeRequested.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyItemEquippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyItemEquippedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifyItemUnequippedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifyItemUnequippedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsNotifySurfaceDirectionChanged.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsNotifySurfaceDirectionChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPickUpBodyBreathingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPickUpBodyBreathingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPickUpBodyBreathingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPickUpBodyBreathingEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPlaySound.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPlaySound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPlaySoundOnEmitter.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPlaySoundOnEmitter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPreFireEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPreFireEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsPreFireEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsPreFireEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsSetListenerOverride.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsSetListenerOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsSetParameterOnEmitter.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsSetParameterOnEmitter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsSoundParameter.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsSoundParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsSoundSwitch.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsSoundSwitch.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopDialogLine.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopDialogLine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopSound.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopSound.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopSoundOnEmitter.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopSoundOnEmitter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopTaggedSounds.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopTaggedSounds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopWeaponFire.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopWeaponFire.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsStopWeaponFire.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsStopWeaponFire.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsToggleAimDownSightsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsToggleAimDownSightsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsVehicleCollision.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsVehicleCollision.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsVehicleCollision.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsVehicleCollision.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameaudioeventsVoiceEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsVoiceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameaudioeventsVoicePlayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameaudioeventsVoicePlayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbAllScriptDefinitions.cs
+++ b/CP77.CR2W/Types/cp77/gamebbAllScriptDefinitions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbDynArrayBlackboardStorage.cs
+++ b/CP77.CR2W/Types/cp77/gamebbDynArrayBlackboardStorage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbDynArrayBlackboardStorage.cs
+++ b/CP77.CR2W/Types/cp77/gamebbDynArrayBlackboardStorage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbID.cs
+++ b/CP77.CR2W/Types/cp77/gamebbID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Bool.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Bool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Bool.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Bool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_CName.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_CName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_CName.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_CName.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EntityID.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EntityID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EntityID.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EntityID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EntityPtr.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EntityPtr.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EntityPtr.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EntityPtr.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EulerAngles.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EulerAngles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_EulerAngles.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_EulerAngles.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Float.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Float.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Float.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Float.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Int32.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Int32.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Int32.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Int32.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Quaternion.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Quaternion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Quaternion.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Quaternion.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_String.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_String.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_String.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_String.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Uint32.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Uint32.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Uint32.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Uint32.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Variant.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Variant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Variant.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Variant.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Vector2.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Vector2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Vector2.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Vector2.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Vector4.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Vector4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamebbScriptID_Vector4.cs
+++ b/CP77.CR2W/Types/cp77/gamebbScriptID_Vector4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamecameraISettingManager.cs
+++ b/CP77.CR2W/Types/cp77/gamecameraISettingManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamecameraISettingManager.cs
+++ b/CP77.CR2W/Types/cp77/gamecameraISettingManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamecameraSettingManager.cs
+++ b/CP77.CR2W/Types/cp77/gamecameraSettingManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamecameraSettingManager.cs
+++ b/CP77.CR2W/Types/cp77/gamecameraSettingManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToEntity.cs
+++ b/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToNode.cs
+++ b/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToWorld.cs
+++ b/CP77.CR2W/Types/cp77/gamecarryReplicatedEntitySetAttachmentToWorld.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamecheatsystemObjCheats.cs
+++ b/CP77.CR2W/Types/cp77/gamecheatsystemObjCheats.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageAttackData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageAttackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageCacheData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageCacheData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageDamageDebugData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageDamageDebugData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageHitDebugData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageHitDebugData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageServerHitData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageServerHitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedamageServerKillData.cs
+++ b/CP77.CR2W/Types/cp77/gamedamageServerKillData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAbilityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAbilityCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAbilityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAbilityCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAND_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAND_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAND_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAND_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimDirection_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimDirection_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimSlot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionAnimSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionAnimSlot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionChangeNPCState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionChangeNPCState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionChangeNPCState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionChangeNPCState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionCooldown_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionCooldown_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionLookAtData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionLookAtData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionLookAtData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionLookAtData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionOR_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionOR_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionOR_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionOR_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionPhase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionPhase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionPhase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionPhase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSecurityAreaType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSecurityAreaType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSecurityAreaType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSecurityAreaType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSecurityNotificationType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSecurityNotificationType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSecurityNotificationType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSecurityNotificationType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSelector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSelector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSelector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSelector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSequence_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSequence_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSequence_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSequence_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSlideData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSlideData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSlideData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSlideData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSmartComposite_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSmartComposite_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSmartComposite_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSmartComposite_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSubCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSubCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionSubCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionSubCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionTarget_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionTarget_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionTicket_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionTicket_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIActionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIAdditionalTraceType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAdditionalTraceType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAdditionalTraceType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAdditionalTraceType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIAffiliationCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAffiliationCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAffiliationCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAffiliationCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIAmmoCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAmmoCountCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIAmmoCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIAmmoCountCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIBlockCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIBlockCountCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIBlockCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIBlockCountCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICalculateLineOfSightVector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICalculateLineOfSightVector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICalculateLineOfSightVector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICalculateLineOfSightVector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICalculatePathCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICalculatePathCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICalculatePathCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICalculatePathCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICommandCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICommandCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICommandCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICommandCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICommand_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICommand_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICommand_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICommand_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICooldownCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICooldownCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICooldownCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICooldownCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAICoverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICoverCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAICoverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAICoverCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorEntryStartType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorEntryStartType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorEntryStartType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorEntryStartType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlanEnemyEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlanEnemyEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlanEnemyEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlanEnemyEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlan_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlan_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlan_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedulePlan_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleSpawningDesc_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleSpawningDesc_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleSpawningDesc_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorScheduleSpawningDesc_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedule_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedule_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedule_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDirectorSchedule_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDodgeCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDodgeCountCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDodgeCountCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDodgeCountCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIDriverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDriverCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIDriverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIDriverCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIExposureMethodType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIExposureMethodType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIExposureMethodType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIExposureMethodType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIExtendTargetCirclingCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIExtendTargetCirclingCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIExtendTargetCirclingCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIExtendTargetCirclingCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIFriendlyFireCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIFriendlyFireCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIFriendlyFireCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIFriendlyFireCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIGoToCoverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIGoToCoverCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIGoToCoverCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIGoToCoverCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIHasWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIHasWeapon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIHasWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIHasWeapon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIHitCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIHitCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIHitCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIHitCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIInTacticPositionCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIInTacticPositionCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIInTacticPositionCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIInTacticPositionCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIIsInActiveCameraCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIIsInActiveCameraCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIIsInActiveCameraCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIIsInActiveCameraCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIIsOnNavmeshCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIIsOnNavmeshCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIIsOnNavmeshCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIIsOnNavmeshCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIItemCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIItemCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIItemCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIItemCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAILookAtCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAILookAtCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAILookAtCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAILookAtCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIMovementCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIMovementCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIMovementCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIMovementCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAINPCTypeCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINPCTypeCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAINPCTypeCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINPCTypeCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAINodeMapField_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINodeMapField_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAINodeMapField_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINodeMapField_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAINodeMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINodeMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAINodeMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINodeMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAINode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAINode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAINode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIOptimalDistanceCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIOptimalDistanceCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIOptimalDistanceCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIOptimalDistanceCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIPatternDelay_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPatternDelay_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIPatternDelay_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPatternDelay_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIPattern_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPattern_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIPattern_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPattern_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIPatternsPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPatternsPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIPatternsPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPatternsPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIPreviousAttackCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPreviousAttackCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIPreviousAttackCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIPreviousAttackCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIReactionCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIReactionCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIReactionCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIReactionCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIRecord_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRecord_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIRecord_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRecord_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIRestrictedMovementAreaCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRestrictedMovementAreaCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIRestrictedMovementAreaCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRestrictedMovementAreaCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIRingTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRingTicket_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIRingTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRingTicket_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIRingType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRingType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIRingType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRingType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIRole_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRole_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIRole_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIRole_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISectorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISectorType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISectorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISectorType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISecurityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISecurityCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISecurityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISecurityCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISignalCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISignalCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISignalCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISignalCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISlotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISlotCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISlotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISlotCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISmartCompositeType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISmartCompositeType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISmartCompositeType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISmartCompositeType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISpatialCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISpatialCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISpatialCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISpatialCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadANDCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadANDCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadANDCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadANDCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadAvoidLastFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadAvoidLastFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadAvoidLastFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadAvoidLastFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadClosestToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadClosestToSectorCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadClosestToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadClosestToSectorCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadClosestToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadClosestToTargetCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadClosestToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadClosestToTargetCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadContainsSelfCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadContainsSelfCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadContainsSelfCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadContainsSelfCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToSectorCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToSectorCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToTargetCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadDistanceRelationToTargetCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFilterByAICondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFilterByAICondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFilterByAICondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFilterByAICondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFilterOwnTargetSpotted_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFilterOwnTargetSpotted_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFilterOwnTargetSpotted_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFilterOwnTargetSpotted_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToSectorCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToSectorCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToSectorCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToTargetCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToTargetCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadFurthestToTargetCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadInSectorFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadInSectorFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadInSectorFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadInSectorFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemCategoryPriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemCategoryPriorityFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemCategoryPriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemCategoryPriorityFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemPriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemPriorityFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemPriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemPriorityFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemTypePriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemTypePriorityFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadItemTypePriorityFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadItemTypePriorityFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadJustSelfFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadJustSelfFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadJustSelfFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadJustSelfFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadMembersAmountCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadMembersAmountCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadMembersAmountCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadMembersAmountCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadORCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadORCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadORCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadORCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadSpatialForOwnTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadSpatialForOwnTarget_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadSpatialForOwnTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadSpatialForOwnTarget_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISquadType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISquadType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISquadType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIStatPoolCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStatPoolCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIStatPoolCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStatPoolCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIStateCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStateCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIStateCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStateCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIStatusEffectCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStatusEffectCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIStatusEffectCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIStatusEffectCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionActivateLightPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionActivateLightPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionActivateLightPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionActivateLightPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionActivateStrongArmsFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionActivateStrongArmsFX_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionActivateStrongArmsFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionActivateStrongArmsFX_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionAddFact_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionAddFact_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionAddFact_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionAddFact_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionApplyTimeDilation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionApplyTimeDilation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionApplyTimeDilation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionApplyTimeDilation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionAttackWithWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionAttackWithWeapon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionAttackWithWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionAttackWithWeapon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCallReinforcements_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCallReinforcements_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCallReinforcements_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCallReinforcements_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCallSquadSearchBackUp_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCallSquadSearchBackUp_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCallSquadSearchBackUp_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCallSquadSearchBackUp_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionChangeAttitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionChangeAttitude_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionChangeAttitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionChangeAttitude_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionChangeCoverSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionChangeCoverSelectionPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionChangeCoverSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionChangeCoverSelectionPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordEquip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordEquip_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordEquip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordEquip_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordUnequip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordUnequip_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordUnequip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCharacterRecordUnequip_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCompleteCommand_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCompleteCommand_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCompleteCommand_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCompleteCommand_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionConditionalFailure_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionConditionalFailure_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionConditionalFailure_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionConditionalFailure_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCover_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCover_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCover_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCover_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCreateGameEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCreateGameEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCreateGameEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCreateGameEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCustomEffectors_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCustomEffectors_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionCustomEffectors_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionCustomEffectors_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDisableAimAssist_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDisableAimAssist_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDisableAimAssist_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDisableAimAssist_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDisableCollider_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDisableCollider_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDisableCollider_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDisableCollider_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDroneModifyAltitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDroneModifyAltitude_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionDroneModifyAltitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionDroneModifyAltitude_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnBody_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnBody_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnBody_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnBody_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnSlot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionEquipOnSlot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFailIfFriendlyFire_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFailIfFriendlyFire_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFailIfFriendlyFire_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFailIfFriendlyFire_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFail_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFail_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFail_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFail_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFastExitWorkspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFastExitWorkspot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionFastExitWorkspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionFastExitWorkspot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceDeath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceDeath_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceDeath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceDeath_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceEquip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceEquip_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceEquip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceEquip_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceHitReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceHitReaction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceHitReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceHitReaction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceUnequip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceUnequip_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionForceUnequip_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionForceUnequip_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionGameplayLogicPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionGameplayLogicPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionGameplayLogicPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionGameplayLogicPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionGeneratePointOfInterestTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionGeneratePointOfInterestTarget_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionGeneratePointOfInterestTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionGeneratePointOfInterestTarget_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionHitData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionHitData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionHitData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionHitData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionInitialReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionInitialReaction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionInitialReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionInitialReaction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionLeaveCover_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionLeaveCover_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionLeaveCover_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionLeaveCover_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackAttemptEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackAttemptEvent_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackAttemptEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackAttemptEvent_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackManager_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackManager_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackManager_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMeleeAttackManager_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainCircular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainCircular_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainCircular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainCircular_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainGrid_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainGrid_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainGrid_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMissileRainGrid_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionModifyStatPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionModifyStatPool_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionModifyStatPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionModifyStatPool_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMountVehicle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMountVehicle_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionMountVehicle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionMountVehicle_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionPlaySound_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionPlaySound_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionPlaySound_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionPlaySound_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionPlayVoiceOver_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionPlayVoiceOver_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionPlayVoiceOver_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionPlayVoiceOver_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQueueAIEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQueueAIEvent_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQueueAIEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQueueAIEvent_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQueueCommunicationEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQueueCommunicationEvent_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQueueCommunicationEvent_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQueueCommunicationEvent_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQuickHack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQuickHack_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionQuickHack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionQuickHack_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionRandomize_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionRandomize_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionRandomize_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionRandomize_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionRegisterActionName_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionRegisterActionName_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionRegisterActionName_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionRegisterActionName_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionReloadWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionReloadWeapon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionReloadWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionReloadWeapon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionScaleDurationWithDistance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionScaleDurationWithDistance_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionScaleDurationWithDistance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionScaleDurationWithDistance_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSecuritySystemNotification_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSecuritySystemNotification_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSecuritySystemNotification_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSecuritySystemNotification_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSendSignal_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSendSignal_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSendSignal_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSendSignal_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipPrimaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipPrimaryWeapons_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipPrimaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipPrimaryWeapons_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipSecondaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipSecondaryWeapons_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipSecondaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetEquipSecondaryWeapons_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetInfluenceMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetInfluenceMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetInfluenceMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetInfluenceMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetInt_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetInt_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetInt_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetInt_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetItemAsTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetItemAsTarget_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetItemAsTarget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetItemAsTarget_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetStimSource_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetStimSource_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetStimSource_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetStimSource_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetTargetByTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetTargetByTag_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetTargetByTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetTargetByTag_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipPrimaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipPrimaryWeapons_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipPrimaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipPrimaryWeapons_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipSecondaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipSecondaryWeapons_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipSecondaryWeapons_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetUnequipSecondaryWeapons_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetWaypointByTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetWaypointByTag_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetWaypointByTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetWaypointByTag_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetWorldPosition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetWorldPosition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSetWorldPosition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSetWorldPosition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionShootToPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionShootToPoint_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionShootToPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionShootToPoint_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionShootWithWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionShootWithWeapon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionShootWithWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionShootWithWeapon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSpawnFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSpawnFX_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSpawnFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSpawnFX_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSquadSync_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSquadSync_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionSquadSync_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionSquadSync_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionStartCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionStartCooldown_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionStartCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionStartCooldown_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionStatusEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionStatusEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionThrowItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionThrowItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionThrowItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionThrowItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerItemActivation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerItemActivation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerItemActivation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerItemActivation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerStim_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerStim_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerStim_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionTriggerStim_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUnequipOnSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUnequipOnSlot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUnequipOnSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUnequipOnSlot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUpdateFriendlyFireParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUpdateFriendlyFireParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUpdateFriendlyFireParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUpdateFriendlyFireParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUseSensePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUseSensePreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionUseSensePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionUseSensePreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionWorkspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionWorkspot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubActionWorkspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubActionWorkspot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAISubAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAISubAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAISubAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITacticTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITacticTicket_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITacticTicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITacticTicket_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITacticType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITacticType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITacticType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITacticType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITargetCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITargetCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITargetCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITargetCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIThrowCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIThrowCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIThrowCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIThrowCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITicketCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITicketCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITicketCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITicketCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITicketFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITicketFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITicketType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITicketType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicketType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicket_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITicket_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITicket_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAITresspassingCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITresspassingCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAITresspassingCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAITresspassingCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIValidCoversCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIValidCoversCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIValidCoversCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIValidCoversCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIVehicleCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVehicleCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIVehicleCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVehicleCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocitiesDotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocitiesDotCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocitiesDotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocitiesDotCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocityCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocityCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocityCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocityDotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocityDotCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIVelocityDotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIVelocityDotCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIWeakSpotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWeakSpotCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIWeakSpotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWeakSpotCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIWeaponLockedOnTargetCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWeaponLockedOnTargetCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIWeaponLockedOnTargetCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWeaponLockedOnTargetCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAIWorkspotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWorkspotCond_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAIWorkspotCond_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAIWorkspotCond_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAbsoluteZLimiterCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAbsoluteZLimiterCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAbsoluteZLimiterCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAbsoluteZLimiterCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAccelerateTowardsParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAccelerateTowardsParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAccelerateTowardsParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAccelerateTowardsParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAccuracy_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAccuracy_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAchievement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAchievement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAchievement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAchievement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionMapField_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionMapField_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionMapField_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionMapField_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionPayment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionPayment_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionPayment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionPayment_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionRestrictionGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionRestrictionGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionRestrictionGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionRestrictionGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionTargetPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionTargetPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionTargetPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionTargetPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataActionWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionWidgetDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataActionWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataActionWidgetDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAddItemsEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAddItemsEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAddItemsEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAddItemsEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAddStatusEffectToAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAddStatusEffectToAttackEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAddStatusEffectToAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAddStatusEffectToAttackEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatDef_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatDef_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatDef_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatDef_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatsEnum_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatsEnum_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatsEnum_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementFormatsEnum_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisementGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisementGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAdvertisement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAdvertisement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAffiliation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAffiliation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAffiliation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAffiliation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistAimSnap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistAimSnap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistAimSnap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistAimSnap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistBulletMagnetism_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistBulletMagnetism_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistBulletMagnetism_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistBulletMagnetism_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistCommon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistCommon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistCommon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistCommon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistConfigPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistConfigPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistConfigPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistConfigPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistFinishing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistFinishing_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistFinishing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistFinishing_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistMagnetism_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistMagnetism_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistMagnetism_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistMagnetism_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistMelee_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistMelee_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistMelee_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistMelee_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistTargetData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistTargetData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistTargetData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistTargetData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAimAssistType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAimAssistType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAngleDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAngleDistanceCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAngleDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAngleDistanceCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAngleRange_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAngleRange_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAngleRange_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAngleRange_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAppearance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAppearance_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAppearance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAppearance_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicitiesMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicitiesMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicitiesMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicitiesMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicities_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicities_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicities_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApperanceToEthnicities_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApplyEffectorEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyEffectorEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApplyEffectorEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyEffectorEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApplyLightPresetEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyLightPresetEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApplyLightPresetEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyLightPresetEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApplyStatGroupEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyStatGroupEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApplyStatGroupEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyStatGroupEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataApplyStatusEffectEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyStatusEffectEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataApplyStatusEffectEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataApplyStatusEffectEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataArchetypeData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataArchetypeData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataArchetypeData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataArchetypeData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataArchetypeType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataArchetypeType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataArchetypeType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataArchetypeType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttachableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttachableObject_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttachableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttachableObject_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttachmentSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttachmentSlot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttachmentSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttachmentSlot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttackDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackDirection_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttackDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackDirection_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttackSubtype_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackSubtype_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttackSubtype_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackSubtype_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttackType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttackType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttackType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttack_GameEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_GameEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttack_GameEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_GameEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Landing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Landing_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Landing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Landing_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Melee_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Melee_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Melee_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Melee_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Projectile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Projectile_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Projectile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Projectile_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttack_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttitudeGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttitudeGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttitudeGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttitudeGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttitude_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttitude_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttitude_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttribute_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAttribute_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataAvoidLineOfSightSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAvoidLineOfSightSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataAvoidLineOfSightSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataAvoidLineOfSightSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBaseDrivingParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseDrivingParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBaseDrivingParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseDrivingParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBaseObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseObject_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBaseObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseObject_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBaseSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseSign_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBaseSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBaseSign_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBase_MappinDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBase_MappinDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBase_MappinDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBase_MappinDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBounce_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBounce_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBounce_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBounce_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBountyDrawTable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBountyDrawTable_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBountyDrawTable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBountyDrawTable_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBounty_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBounty_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBounty_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBounty_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBox_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBox_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBox_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBox_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildAttributeSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildAttributeSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildAttributeSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildAttributeSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildAttribute_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildAttribute_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildCyberwareSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildCyberwareSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildCyberwareSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildCyberwareSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildCyberware_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildCyberware_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildCyberware_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildCyberware_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildEquipmentSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildEquipmentSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildEquipmentSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildEquipmentSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildEquipment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildEquipment_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildEquipment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildEquipment_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildPerkSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildPerkSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildPerkSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildPerkSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildPerk_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildPerk_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildPerk_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildPerk_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildProficiencySet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildProficiencySet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildProficiencySet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildProficiencySet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataBuildProficiency_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildProficiency_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataBuildProficiency_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataBuildProficiency_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCPOItemCategoryBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCPOItemCategoryBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCPOItemCategoryBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCPOItemCategoryBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCPOLoadoutBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCPOLoadoutBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCPOLoadoutBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCPOLoadoutBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCarriableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCarriableObject_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCarriableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCarriableObject_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChannelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChannelData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChannelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChannelData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCharacterEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacterEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCharacterEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacterEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCharacterList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacterList_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCharacterList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacterList_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCharacter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChatterHelperRadius_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChatterHelperRadius_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChatterHelperRadius_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChatterHelperRadius_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionIconPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionIconPart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionIconPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionIconPart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPartType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPartType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPartType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPartType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionPart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionTagPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionTagPart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataChoiceCaptionTagPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataChoiceCaptionTagPart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataClearLineOfSightCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClearLineOfSightCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataClearLineOfSightCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClearLineOfSightCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataClosestToOwnerCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClosestToOwnerCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataClosestToOwnerCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClosestToOwnerCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataClothing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataClothing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataClothing_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataClothing_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataClothing_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_inline1_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataClothing_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataClothing_inline1_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCodexRecordPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodexRecordPart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCodexRecordPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodexRecordPart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCodexRecord_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodexRecord_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCodexRecord_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodexRecord_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCodex_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodex_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCodex_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCodex_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCombinedStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCombinedStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCombinedStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCombinedStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCompanionDistancePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCompanionDistancePreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCompanionDistancePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCompanionDistancePreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataComplexValueNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataComplexValueNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCompoundSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCompoundSelectionPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCompoundSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCompoundSelectionPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataComputerScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataComputerScreenType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataComputerScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataComputerScreenType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCone_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCone_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCone_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCone_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataConstantStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConstantStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataConstantStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConstantStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataConsumableBaseName_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableBaseName_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataConsumableBaseName_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableBaseName_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataConsumableItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataConsumableItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataConsumableType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataConsumableType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataConsumableType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataContentAssignment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContentAssignment_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataContentAssignment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContentAssignment_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataContinuousAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContinuousAttackEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataContinuousAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContinuousAttackEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataContinuousEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContinuousEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataContinuousEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataContinuousEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCooldownType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCooldownType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCooldownType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCooldownType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCooldown_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCooldown_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCooldown_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCoverHealthCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverHealthCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCoverHealthCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverHealthCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCoverSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverSelectionPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCoverSelectionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverSelectionPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCoverTypeCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverTypeCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCoverTypeCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCoverTypeCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCrackAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrackAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCrackAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrackAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCraftable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftable_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCraftable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftable_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCraftingPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftingPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCraftingPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftingPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCraftingResult_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftingResult_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCraftingResult_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCraftingResult_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCrosshair_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrosshair_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCrosshair_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrosshair_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSettingsPackageBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSettingsPackageBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSettingsPackageBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSettingsPackageBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementPatternBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementPatternBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementPatternBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementPatternBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementSettingsBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementSettingsBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementSettingsBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCrowdSlotMovementSettingsBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCurrencyReward_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurrencyReward_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCurrencyReward_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurrencyReward_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCurrencyReward_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurrencyReward_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCurrencyReward_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurrencyReward_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCurveStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurveStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCurveStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurveStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCurve_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurve_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCurve_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurve_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCurves_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurves_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCurves_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCurves_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataCyberwareArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCyberwareArea_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataCyberwareArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataCyberwareArea_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDPadUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDPadUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDPadUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDPadUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDamageType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDamageType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDamageType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDamageType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDataNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDataNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDefenseMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDefenseMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDefenseMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDefenseMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDestructibleObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDestructibleObject_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDestructibleObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDestructibleObject_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDetectionCurve_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDetectionCurve_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDetectionCurve_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDetectionCurve_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDevelopmentPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDevelopmentPoint_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDevelopmentPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDevelopmentPoint_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceAreaAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceAreaAttack_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceAreaAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceAreaAttack_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceContentAssignment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceContentAssignment_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceContentAssignment_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceContentAssignment_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceFX_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceFX_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceScreenType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceScreenType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceUIDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceUIDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceUIDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceUIDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDeviceWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceWidgetDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDeviceWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDeviceWidgetDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDevice_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDevice_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDevice_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDevice_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDisassemblingResult_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDisassemblingResult_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDisassemblingResult_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDisassemblingResult_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDistanceFromOthersCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistanceFromOthersCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDistanceFromOthersCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistanceFromOthersCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDistrictPreventionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistrictPreventionData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDistrictPreventionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistrictPreventionData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDistrict_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistrict_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDistrict_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDistrict_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDriveHelperType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveHelperType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDriveHelperType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveHelperType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDriveHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveHelper_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDriveHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveHelper_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDriveWheelsAccelerateNoise_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveWheelsAccelerateNoise_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDriveWheelsAccelerateNoise_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDriveWheelsAccelerateNoise_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDroneAnimationSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDroneAnimationSetup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDroneAnimationSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDroneAnimationSetup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataDynamicDownforceHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDynamicDownforceHelper_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataDynamicDownforceHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataDynamicDownforceHelper_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEnvLight_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEnvLight_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEnvLight_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEnvLight_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEquipmentArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEquipmentArea_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEquipmentArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEquipmentArea_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEquipmentMovementSound_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEquipmentMovementSound_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEquipmentMovementSound_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEquipmentMovementSound_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEthnicNames_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEthnicNames_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEthnicNames_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEthnicNames_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataEthnicity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEthnicity_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataEthnicity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataEthnicity_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFacialPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFacialPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFacialPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFacialPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelBinkData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelBinkData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelBinkData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelBinkData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelBinksGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelBinksGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelBinksGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelBinksGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelPoint_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelPoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelPoint_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelScreenDataGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelScreenDataGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelScreenDataGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelScreenDataGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelScreenData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelScreenData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFastTravelScreenData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFastTravelScreenData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFileNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFileNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFocusClue_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFocusClue_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFocusClue_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFocusClue_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFootstep_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFootstep_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFootstep_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFootstep_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataForceDismembermentEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataForceDismembermentEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataForceDismembermentEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataForceDismembermentEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFriendlyTargetAngleDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFriendlyTargetAngleDistanceCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFriendlyTargetAngleDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFriendlyTargetAngleDistanceCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFriendlyTargetDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFriendlyTargetDistanceCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFriendlyTargetDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFriendlyTargetDistanceCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFxActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFxActionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFxActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFxActionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataFxAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFxAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataFxAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataFxAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGOGReward_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGOGReward_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGOGReward_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGOGReward_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGadget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGadget_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGadget_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGadget_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGameplayAbilityGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayAbilityGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGameplayAbilityGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayAbilityGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGameplayAbility_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayAbility_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGameplayAbility_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayAbility_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackageUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackageUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackageUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackageUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayLogicPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGameplayRestrictionStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayRestrictionStatusEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGameplayRestrictionStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGameplayRestrictionStatusEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGenderEntity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenderEntity_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGenderEntity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenderEntity_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGender_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGender_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGender_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGender_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGenericHighwaySign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericHighwaySign_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGenericHighwaySign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericHighwaySign_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGenericMetroSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericMetroSign_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGenericMetroSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericMetroSign_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGenericStreetNameSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericStreetNameSign_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGenericStreetNameSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGenericStreetNameSign_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethodType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethodType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethodType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethodType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethod_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethod_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethod_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenadeDeliveryMethod_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGrenade_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenade_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGrenade_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGrenade_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataGroupNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGroupNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataGroupNodeGroupVariable.cs
+++ b/CP77.CR2W/Types/cp77/gamedataGroupNodeGroupVariable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHUD_Preset_Entry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHUD_Preset_Entry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHUD_Preset_Entry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHUD_Preset_Entry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHackCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHackCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHackCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHackCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHackingMiniGame_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHackingMiniGame_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHackingMiniGame_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHackingMiniGame_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHandbrakeFrictionModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHandbrakeFrictionModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHandbrakeFrictionModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHandbrakeFrictionModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereqConditionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereqConditionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereqConditionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereqConditionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereqCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereqCondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereqCondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereqCondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHitPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHitPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHomingGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHomingGDM_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHomingGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHomingGDM_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHomingParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHomingParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHomingParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHomingParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataHudEnhancer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHudEnhancer_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataHudEnhancer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataHudEnhancer_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataIPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataIPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataIPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataIPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataIconsGeneratorContext_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataIconsGeneratorContext_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataIconsGeneratorContext_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataIconsGeneratorContext_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataImprovementRelation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataImprovementRelation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataImprovementRelation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataImprovementRelation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInAirGravityModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInAirGravityModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInAirGravityModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInAirGravityModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInitLoadingScreen_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInitLoadingScreen_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInitLoadingScreen_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInitLoadingScreen_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInteractionBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInteractionBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInteractionBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInteractionBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInteractionMountBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInteractionMountBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInteractionMountBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInteractionMountBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItemGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItemGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItemGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItemGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItemSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItemSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItemSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItemSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataInventoryItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataInventoryItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemArrayQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemArrayQuery_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemArrayQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemArrayQuery_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemBlueprintElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemBlueprintElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemBlueprintElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemBlueprintElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemBlueprint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemBlueprint_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemBlueprint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemBlueprint_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCost_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCost_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemCreationPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCreationPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemCreationPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemCreationPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemDropSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemDropSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemDropSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemDropSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemPartConnection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemPartConnection_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemPartConnection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemPartConnection_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemPartListElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemPartListElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemPartListElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemPartListElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemQueryElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemQueryElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemQueryElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemQueryElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemQuery_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemQuery_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemRecipe_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemRecipe_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemRecipe_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemRecipe_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemRequiredSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemRequiredSlot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemRequiredSlot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemRequiredSlot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemStructure_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemStructure_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemStructure_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemStructure_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixOrder_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixOrder_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixOrder_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataItemsFactoryAppearanceSuffixOrder_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataJournalIcon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataJournalIcon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataJournalIcon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataJournalIcon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataKeepCurrentCoverCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataKeepCurrentCoverCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataKeepCurrentCoverCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataKeepCurrentCoverCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLCDScreen_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLCDScreen_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLCDScreen_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLCDScreen_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLandingFxMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLandingFxMaterial_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLandingFxMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLandingFxMaterial_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLandingFxPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLandingFxPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLandingFxPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLandingFxPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLayout_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLayout_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLayout_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLayout_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLifePath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLifePath_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLifePath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLifePath_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLightPreset.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLightPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLightPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLightPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLightPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLightPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLinearAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLinearAccuracy_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLinearAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLinearAccuracy_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLoadingTipsGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLoadingTipsGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLoadingTipsGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLoadingTipsGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLocomotionMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLocomotionMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLocomotionMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLocomotionMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLookAtPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLookAtPart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLookAtPart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLookAtPart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLookAtPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLookAtPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLookAtPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLookAtPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLootItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLootItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLootTableElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootTableElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLootTableElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootTableElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataLootTable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootTable_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataLootTable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataLootTable_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinClampingSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinClampingSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinClampingSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinClampingSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinPhaseDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinPhaseDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinPhaseDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinPhaseDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinPhase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinPhase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinPhase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinPhase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUICustomOpacityParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUICustomOpacityParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUICustomOpacityParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUICustomOpacityParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIFilterGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIFilterGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIFilterGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIFilterGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIGlobalProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIGlobalProfile_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIGlobalProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIGlobalProfile_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIParamGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIParamGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIParamGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIParamGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIRuntimeProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIRuntimeProfile_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUIRuntimeProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUIRuntimeProfile_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUISettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUISettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUISettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUISettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinUISpawnProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUISpawnProfile_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinUISpawnProfile_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinUISpawnProfile_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMappinVariant_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinVariant_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMappinVariant_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMappinVariant_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMaterialFx_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMaterialFx_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMaterialFx_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMaterialFx_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMaterial_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMaterial_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMeleeAttackDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMeleeAttackDirection_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMeleeAttackDirection_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMeleeAttackDirection_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMetaQuest_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMetaQuest_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMetaQuest_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMetaQuest_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline1_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline1_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline2_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline2_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline2_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline2_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline3_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline3_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline3_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline3_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline4_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline4_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline4_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_AllSymbols_inline4_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_SymbolsWithRarity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_SymbolsWithRarity_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_SymbolsWithRarity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_SymbolsWithRarity_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_Trap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_Trap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMiniGame_Trap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMiniGame_Trap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMinigameActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameActionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMinigameActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameActionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMinigameAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMinigameAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMinigameCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMinigameCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMinigameTrapType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameTrapType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMinigameTrapType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigameTrapType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMinigame_Def_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigame_Def_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMinigame_Def_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMinigame_Def_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataModifyStatPoolModifierEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataModifyStatPoolModifierEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataModifyStatPoolModifierEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataModifyStatPoolModifierEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMovementParam_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementParam_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMovementParam_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementParam_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMovementParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMovementParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMovementPolicyTagList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementPolicyTagList_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMovementPolicyTagList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementPolicyTagList_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMovementPolicy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementPolicy_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMovementPolicy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMovementPolicy_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMultiPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMultiPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMultiPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMultiPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataMutablePoolValueModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMutablePoolValueModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataMutablePoolValueModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataMutablePoolValueModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCBehaviorState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCBehaviorState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCBehaviorState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCBehaviorState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroupEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroupEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroupEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroupEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemPool_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemPool_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemsPoolEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemsPoolEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemsPoolEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCEquipmentItemsPoolEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCHighLevelState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCHighLevelState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCHighLevelState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCHighLevelState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCQuestAffiliation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCQuestAffiliation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCQuestAffiliation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCQuestAffiliation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCRarity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCRarity_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCRarity_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCRarity_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCStanceState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCStanceState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCStanceState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCStanceState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCTypePrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCTypePrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCTypePrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCTypePrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNPCUpperBodyState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCUpperBodyState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNPCUpperBodyState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNPCUpperBodyState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNetworkPingingParameteres_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNetworkPingingParameteres_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNetworkPingingParameteres_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNetworkPingingParameteres_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNetworkPresetBinderParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNetworkPresetBinderParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNetworkPresetBinderParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNetworkPresetBinderParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNewsFeedTitle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNewsFeedTitle_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNewsFeedTitle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNewsFeedTitle_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNonLinearAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNonLinearAccuracy_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNonLinearAccuracy_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNonLinearAccuracy_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataNumberPlate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNumberPlate_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataNumberPlate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataNumberPlate_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionCost_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionCost_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionGameplayCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionGameplayCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionGameplayCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionGameplayCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionReference_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionReference_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionReference_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionReference_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectActionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataObjectAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataObjectAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataObjectAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataOffMeshLinkTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOffMeshLinkTag_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataOffMeshLinkTag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOffMeshLinkTag_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataOutput_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOutput_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataOutput_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOutput_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataOwnerAngleCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerAngleCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataOwnerAngleCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerAngleCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataOwnerDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerDistanceCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataOwnerDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerDistanceCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataOwnerThreatCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerThreatCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataOwnerThreatCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataOwnerThreatCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPackageNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPackageNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataParentAttachmentType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataParentAttachmentType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataParentAttachmentType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataParentAttachmentType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataParticleDamage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataParticleDamage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataParticleDamage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataParticleDamage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonusUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonusUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonusUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonusUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonus_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonus_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonus_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPassiveProficiencyBonus_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPathLengthCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPathLengthCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPathLengthCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPathLengthCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPathSecurityCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPathSecurityCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPathSecurityCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPathSecurityCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPerkArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkArea_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPerkArea_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkArea_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPerkLevelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkLevelData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPerkLevelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkLevelData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPerkLevelUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkLevelUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPerkLevelUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkLevelUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPerkUtility_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkUtility_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPerkUtility_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerkUtility_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPerk_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerk_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPerk_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPerk_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeBackground_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeBackground_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeBackground_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeBackground_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeFace_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeFace_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeFace_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeFace_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeFrame_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeFrame_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeFrame_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeFrame_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModePoseCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModePoseCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModePoseCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModePoseCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModePose_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModePose_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModePose_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModePose_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeSticker_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeSticker_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPhotoModeSticker_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPhotoModeSticker_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPierce_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPierce_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPierce_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPierce_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPing_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPing_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPing_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPlayerBuild_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPlayerBuild_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPlayerBuild_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPlayerBuild_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPlayerPossesion_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPlayerPossesion_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPlayerPossesion_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPlayerPossesion_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPoolValueModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPoolValueModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPoolValueModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPoolValueModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPrereqCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPrereqCheck_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPrereqCheck_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPrereqCheck_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPresetMapper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPresetMapper_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPresetMapper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPresetMapper_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPreventionHeatData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPreventionHeatData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPreventionHeatData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPreventionHeatData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataPreventionUnitPoolData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPreventionUnitPoolData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataPreventionUnitPoolData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataPreventionUnitPoolData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProficiency_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProficiency_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProficiency_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProficiency_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProgram_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProgram_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProgram_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProgram_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProgressionBuild_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProgressionBuild_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProgressionBuild_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProgressionBuild_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProjectileCollision_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileCollision_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProjectileCollision_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileCollision_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProjectileLaunchMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileLaunchMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProjectileLaunchMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileLaunchMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProjectileLaunch_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileLaunch_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProjectileLaunch_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileLaunch_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProjectileOnCollisionAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileOnCollisionAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProjectileOnCollisionAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProjectileOnCollisionAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataProp_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProp_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataProp_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataProp_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataQuality_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuality_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataQuality_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuality_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuery_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataQuery_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuery_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataQuestRestrictionMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuestRestrictionMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataQuestRestrictionMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuestRestrictionMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataQuestSystemSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuestSystemSetup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataQuestSystemSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataQuestSystemSetup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRPGAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRPGAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRPGAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRPGAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRPGDataPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRPGDataPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRPGDataPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRPGDataPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRaceCheckpoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRaceCheckpoint_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRaceCheckpoint_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRaceCheckpoint_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRadioStation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRadioStation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRadioStation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRadioStation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRandomNewsFeedBatch_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomNewsFeedBatch_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRandomNewsFeedBatch_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomNewsFeedBatch_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRandomPassengerEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomPassengerEntry_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRandomPassengerEntry_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomPassengerEntry_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRandomRatioCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomRatioCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRandomRatioCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomRatioCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRandomStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRandomStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRandomStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRangedAttackPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRangedAttackPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRangedAttackPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRangedAttackPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRangedAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRangedAttack_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRangedAttack_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRangedAttack_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionLimit_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionLimit_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionLimit_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionLimit_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetCivilian_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetCivilian_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetCivilian_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetCivilian_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetCorpo_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetCorpo_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetCorpo_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetCorpo_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetGanger_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetGanger_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetGanger_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetGanger_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetMechanical_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetMechanical_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetMechanical_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetMechanical_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetNoReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetNoReaction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetNoReaction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetNoReaction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetPolice_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetPolice_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPresetPolice_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPresetPolice_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataReactionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataReactionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataReactionPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRearWheelsFrictionModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRearWheelsFrictionModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRearWheelsFrictionModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRearWheelsFrictionModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRecipeElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRecipeElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRecipeElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRecipeElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRecipeItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRecipeItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRecipeItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRecipeItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRegularGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRegularGDM_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRegularGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRegularGDM_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRegular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRegular_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRegular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRegular_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRewardBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRewardBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRewardBase_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardBase_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRewardBase_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardBase_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRewardSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRewardSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRewardSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRigs_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRigs_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRigs_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRigs_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRotationLimiter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRotationLimiter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRotationLimiter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRotationLimiter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRowSymbols_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRowSymbols_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRowSymbols_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRowSymbols_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRowTraps_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRowTraps_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRowTraps_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRowTraps_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataRule_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRule_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataRule_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataRule_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataScannableData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScannableData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataScannableData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScannableData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataScannerModuleVisibilityPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScannerModuleVisibilityPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataScannerModuleVisibilityPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScannerModuleVisibilityPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSceneCameraDoF_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSceneCameraDoF_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSceneCameraDoF_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSceneCameraDoF_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataScreenMessageData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScreenMessageData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataScreenMessageData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScreenMessageData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataScreenMessagesList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScreenMessagesList_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataScreenMessagesList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataScreenMessagesList_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSeatState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSeatState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSeatState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSeatState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSectorSelector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSectorSelector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSectorSelector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSectorSelector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSenseObjectType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSenseObjectType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSenseObjectType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSenseObjectType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSensePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSensePreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSensePreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSensePreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSenseShape_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSenseShape_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSenseShape_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSenseShape_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSimpleValueNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSimpleValueNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartListElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartListElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartListElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartListElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSlotItemPartPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSlotItemPartPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunMissParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunMissParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunMissParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunMissParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortConfigurations_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortConfigurations_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortConfigurations_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortConfigurations_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSmartGunTargetSortData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSpawnableObjectPriority_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpawnableObjectPriority_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSpawnableObjectPriority_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpawnableObjectPriority_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSpawnableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpawnableObject_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSpawnableObject_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpawnableObject_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSpreadEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpreadEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSpreadEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpreadEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSpreadInitEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpreadInitEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSpreadInitEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSpreadInitEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSquadBackyardBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadBackyardBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSquadBackyardBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadBackyardBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSquadBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSquadBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSquadFenceBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadFenceBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSquadFenceBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadFenceBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSquadInstance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadInstance_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSquadInstance_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSquadInstance_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatDistributionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatDistributionData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatDistributionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatDistributionData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatModifierGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatModifierGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatModifierGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatModifierGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolCost_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolCost_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolCost_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolDistributionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolDistributionData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolDistributionData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolDistributionData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolUpdate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolUpdate_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPoolUpdate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPoolUpdate_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPool_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPool_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPool_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStat_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStat_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatsArray_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsArray_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatsArray_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsArray_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatsFolder_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsFolder_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatsFolder_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsFolder_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatsList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsList_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatsList_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatsList_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorFlag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorFlag_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorFlag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorFlag_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIBehaviorType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAttackData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAttackData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectAttackData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectAttackData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectFX_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectFX_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectFX_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectPlayerData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectPlayerData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectPlayerData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectPlayerData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectVariation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectVariation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffectVariation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffectVariation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline1_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline1_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStatusEffect_inline1_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStickyGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStickyGDM_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStickyGDM_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStickyGDM_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStimPriority_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimPriority_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStimPriority_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimPriority_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStimPropagation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimPropagation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStimPropagation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimPropagation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStimType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStimType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStimType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStim_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStim_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStim_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStim_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStopAndStickPerpendicular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStopAndStickPerpendicular_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStopAndStickPerpendicular_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStopAndStickPerpendicular_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStopAndStick_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStopAndStick_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStopAndStick_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStopAndStick_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStop_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStop_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStop_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStop_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStreetCredTier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStreetCredTier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStreetCredTier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStreetCredTier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataStreetSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStreetSign_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataStreetSign_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataStreetSign_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSubCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubCharacter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSubCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubCharacter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSubStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubStatModifier_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSubStatModifier_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubStatModifier_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataSubstat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubstat_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataSubstat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataSubstat_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTDBIDHelper.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTDBIDHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTDBIDHelper.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTDBIDHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTPPCameraSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTPPCameraSetup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTPPCameraSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTPPCameraSetup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTPPLookAtPresets_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTPPLookAtPresets_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTPPLookAtPresets_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTPPLookAtPresets_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTVBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTVBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTVBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTVBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTacticLimiterCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTacticLimiterCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTacticLimiterCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTacticLimiterCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTemporalPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTemporalPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTemporalPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTemporalPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTerminalScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTerminalScreenType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTerminalScreenType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTerminalScreenType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataThreatDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThreatDistanceCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataThreatDistanceCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThreatDistanceCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataThreatTrackingPresetBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThreatTrackingPresetBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataThreatTrackingPresetBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThreatTrackingPresetBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataThumbnailWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThumbnailWidgetDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataThumbnailWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataThumbnailWidgetDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTime_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTime_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTime_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTime_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTrackingMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrackingMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTrackingMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrackingMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTracking_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTracking_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTracking_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTracking_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTraitData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTraitData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTraitData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTraitData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTrait_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrait_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTrait_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrait_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTransgression_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTransgression_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTransgression_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTransgression_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTrapType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrapType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTrapType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrapType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTrap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTrap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTrap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTriggerAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerAttackEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTriggerAttackEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerAttackEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTriggerHackingMinigameEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerHackingMinigameEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTriggerHackingMinigameEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerHackingMinigameEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTriggerMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerMode_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTriggerMode_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTriggerMode_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTweakDBInterface.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTweakDBInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTweakDBInterface.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTweakDBInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataTweakDBRecord.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTweakDBRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataTweakDBRecord.cs
+++ b/CP77.CR2W/Types/cp77/gamedataTweakDBRecord.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIAnimation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIAnimation_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIAnimation_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIAnimation_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttribute_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttribute_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttribute_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttributesPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttributesPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttributesPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICharacterCreationAttributesPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUICondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICondition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUICondition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUICondition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIElement_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIElement_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIElement_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIIconCensorFlag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIconCensorFlag_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIIconCensorFlag_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIconCensorFlag_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIIconCensorship_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIconCensorship_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIIconCensorship_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIconCensorship_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIIcon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIcon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIIcon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIIcon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUINameplateDisplayType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUINameplateDisplayType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUINameplateDisplayType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUINameplateDisplayType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUINameplate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUINameplate_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUINameplate_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUINameplate_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUIStatsMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIStatsMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUIStatsMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUIStatsMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUncontrolledMovementEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUncontrolledMovementEffector_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUncontrolledMovementEffector_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUncontrolledMovementEffector_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUpgradingData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUpgradingData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUpgradingData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUpgradingData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUphillDriveHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUphillDriveHelper_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUphillDriveHelper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUphillDriveHelper_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataUtilityLossCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUtilityLossCoverSelectionParameters_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataUtilityLossCoverSelectionParameters_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataUtilityLossCoverSelectionParameters_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataValueDataNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataValueDataNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataValueDataNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataValueDataNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataValueNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataValueNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVariableNode.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVariableNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVariableNodeVariableValue.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVariableNodeVariableValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAIBoostSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAIBoostSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAIBoostSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAIBoostSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAirControlAxis_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAirControlAxis_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAirControlAxis_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAirControlAxis_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAirControl_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAirControl_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleAirControl_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleAirControl_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleBehaviorData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleBehaviorData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleBehaviorData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleBehaviorData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleCameraManager_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleCameraManager_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleCameraManager_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleCameraManager_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleCrowdCollisionsParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleCrowdCollisionsParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleCrowdCollisionsParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleCrowdCollisionsParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDataPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDataPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDataPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDataPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDefaultState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDefaultState_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDefaultState_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDefaultState_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDeformablePart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDeformablePart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDeformablePart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDeformablePart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDeformableZone_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDeformableZone_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDeformableZone_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDeformableZone_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleGlass_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleGlass_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleGlass_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleGlass_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleLight_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleLight_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleLight_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleLight_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleWheel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleWheel_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleWheel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructibleWheel_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructionPointDamper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructionPointDamper_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestructionPointDamper_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestructionPointDamper_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestruction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestruction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDestruction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDestruction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDetachablePart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDetachablePart_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDetachablePart_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDetachablePart_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDriveModelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDriveModelData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleDriveModelData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleDriveModelData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleEngineData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleEngineData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleEngineData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleEngineData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFPPCameraParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFPPCameraParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxCollisionMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxCollisionMaterial_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxCollisionMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxCollisionMaterial_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxCollision_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxCollision_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxCollision_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxCollision_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterialSmear_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterialSmear_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterialSmear_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterialSmear_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterial_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecalsMaterial_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecals_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecals_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecals_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsDecals_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticlesMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticlesMaterial_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticlesMaterial_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticlesMaterial_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticles_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticles_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticles_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleFxWheelsParticles_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleGear_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleGear_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleGear_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleGear_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleImpactTraffic_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleImpactTraffic_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleImpactTraffic_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleImpactTraffic_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleManufacturer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleManufacturer_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleManufacturer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleManufacturer_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleModel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleModel_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleModel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleModel_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehiclePIDSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehiclePIDSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehiclePIDSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehiclePIDSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleProceduralFPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleProceduralFPPCameraParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleProceduralFPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleProceduralFPPCameraParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSeatSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSeatSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSeatSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSeatSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSeat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSeat_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSeat_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSeat_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSteeringSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSteeringSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSteeringSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSteeringSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleStoppingSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleStoppingSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleStoppingSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleStoppingSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceBinding_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceBinding_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceBinding_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceBinding_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleSurfaceType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraPresetParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraPresetParams_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraPresetParams_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleTPPCameraPresetParams_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleUIData_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleUIData_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleUIData_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleVisualDestruction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleVisualDestruction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleVisualDestruction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleVisualDestruction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWater_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWater_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWater_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWater_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWeapon_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWeapon_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWeapon_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsSetup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDimensionsSetup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_2_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_2_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_2_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_2_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_4_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_4_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_4_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_4_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelDrivingSetup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelRole_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelRole_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelRole_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelRole_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionMap_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionMap_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionMap_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicleWheelsFrictionPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVehicle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicle_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVehicle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVehicle_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorCraftable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorCraftable_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorCraftable_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorCraftable_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorExperience_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorExperience_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorExperience_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorExperience_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorProgressionBasedStock_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorProgressionBasedStock_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorProgressionBasedStock_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorProgressionBasedStock_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendorWare_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorWare_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendorWare_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendorWare_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVendor_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendor_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVendor_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVendor_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVirtualNetworkPath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVirtualNetworkPath_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVirtualNetworkPath_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVirtualNetworkPath_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVirtualNetwork_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVirtualNetwork_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVirtualNetwork_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVirtualNetwork_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVisionGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisionGroup_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVisionGroup_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisionGroup_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVisionModuleBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisionModuleBase_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVisionModuleBase_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisionModuleBase_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataVisualTagsPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisualTagsPrereq_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataVisualTagsPrereq_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataVisualTagsPrereq_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeakspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeakspot_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeakspot_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeakspot_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponEvolution_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponEvolution_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponEvolution_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponEvolution_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponFxPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponFxPackage_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponFxPackage_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponFxPackage_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponItem_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponItem_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponItem_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponManufacturer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponManufacturer_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponManufacturer_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponManufacturer_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponVFXAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponVFXAction_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponVFXAction_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponVFXAction_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeaponVFXSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponVFXSet_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeaponVFXSet_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeaponVFXSet_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeatherPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeatherPreset_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeatherPreset_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeatherPreset_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeather_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeather_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeather_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeather_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWebsite_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWebsite_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWebsite_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWebsite_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWeightedCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeightedCharacter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWeightedCharacter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWeightedCharacter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetDefinition_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWidgetDefinition_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetDefinition_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWidgetRatio_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetRatio_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWidgetRatio_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetRatio_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWidgetStyle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetStyle_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWidgetStyle_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWidgetStyle_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotActionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotActionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotActionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotCategory_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotCategory_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotCategory_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotReactionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotReactionType_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotReactionType_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotReactionType_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotStatusEffect_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorkspotStatusEffect_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorkspotStatusEffect_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapFilter_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapFilter_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapFilter_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapFreeCameraSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapFreeCameraSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapFreeCameraSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapFreeCameraSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapSettings_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapSettings_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapSettings_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapZoomLevel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapZoomLevel_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataWorldMapZoomLevel_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataWorldMapZoomLevel_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataXPPoints_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataXPPoints_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataXPPoints_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataXPPoints_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedataXPPoints_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataXPPoints_inline0_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedataXPPoints_inline0_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedataXPPoints_inline0_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedatadevice_gameplay_role_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_gameplay_role_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedatadevice_gameplay_role_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_gameplay_role_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedatadevice_role_action_desctiption_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_role_action_desctiption_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedatadevice_role_action_desctiption_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_role_action_desctiption_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedatadevice_scanning_data_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_scanning_data_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedatadevice_scanning_data_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatadevice_scanning_data_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedatanpc_scanning_data_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatanpc_scanning_data_Record.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedatanpc_scanning_data_Record.cs
+++ b/CP77.CR2W/Types/cp77/gamedatanpc_scanning_data_Record.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamedebugFailure.cs
+++ b/CP77.CR2W/Types/cp77/gamedebugFailure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedebugFailureId.cs
+++ b/CP77.CR2W/Types/cp77/gamedebugFailureId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceAction.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceActionProperty.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceActionProperty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceClearance.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceClearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceComputerUIData.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceComputerUIData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceDataElement.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceDataElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceGenericDataContent.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceGenericDataContent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceQuestInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceQuestInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamedeviceUIScreenDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamedeviceUIScreenDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsApplyStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsApplyStatusEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsAttitudeChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsAttitudeChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsAttitudeGroupChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsAttitudeGroupChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsAttitudeGroupChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsAttitudeGroupChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsCloseByEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsCloseByEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsCoverHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsCoverHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDamageReceivedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDamageReceivedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDeathDirectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeathDirectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDeathEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeathEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDeathParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeathParamsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDefeatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDefeatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDefeatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDefeatedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsDeviceEndPlayerCameraControlEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeviceEndPlayerCameraControlEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDeviceEndPlayerCameraControlEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeviceEndPlayerCameraControlEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsDeviceRegisterCameraControlOnPuppetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeviceRegisterCameraControlOnPuppetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDeviceStartPlayerCameraControlEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDeviceStartPlayerCameraControlEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsDropItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsDropItemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsEndTakedownEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsEndTakedownEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsEndTakedownEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsEndTakedownEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsHighLevelStateDataEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsHighLevelStateDataEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsKillRewardEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsKillRewardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsLootedItemEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsLootedItemEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsMuppetUseLoadoutEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsMuppetUseLoadoutEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsObjectMarkerVisibilityUpdated.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsObjectMarkerVisibilityUpdated.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsPotentialDeathEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsPotentialDeathEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsProjectedHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsProjectedHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsProjectedHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsProjectedHitEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsProperlySeenByPlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsProperlySeenByPlayerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsProperlySeenByPlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsProperlySeenByPlayerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsQuickItemsEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsQuickItemsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsReactionChangeRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsReactionChangeRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsRefreshVisibility.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsRefreshVisibility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsRefreshVisibility.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsRefreshVisibility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsReloadLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsReloadLootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsReloadLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsReloadLootEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsRemoveStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsRemoveStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsResurrectEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsResurrectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsResurrectEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsResurrectEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsRevealObjectEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsRevealObjectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsSquadStartedCombatEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsSquadStartedCombatEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsStartTakedownEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsStartTakedownEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsStatusEffectEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsStatusEffectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsStealthMappinCheckLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsStealthMappinCheckLootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsStealthMappinCheckLootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsStealthMappinCheckLootEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsTargetDamageEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsTargetDamageEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsTargetHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsTargetHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsTargetHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsTargetHitEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsToggleMinimapVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsToggleMinimapVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsToggleStealthMappinVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsToggleStealthMappinVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsUnconsciousEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsUnconsciousEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsUnconsciousEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsUnconsciousEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsUserEnteredCoverEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsUserEnteredCoverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsUserLeftCoverEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsUserLeftCoverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameeventsUserLeftCoverEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsUserLeftCoverEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameeventsVehicleHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameeventsVehicleHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegpsGPSSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamegpsGPSSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegpsGPSSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamegpsGPSSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamegpsIGPSSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamegpsIGPSSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegpsIGPSSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamegpsIGPSSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamegpsSettings.cs
+++ b/CP77.CR2W/Types/cp77/gamegpsSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegraphCGraphResource.cs
+++ b/CP77.CR2W/Types/cp77/gamegraphCGraphResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegraphCGraphResource.cs
+++ b/CP77.CR2W/Types/cp77/gamegraphCGraphResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamegraphCNode.cs
+++ b/CP77.CR2W/Types/cp77/gamegraphCNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamegraphCNode.cs
+++ b/CP77.CR2W/Types/cp77/gamegraphCNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetAllScaleMultipliers.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetAllScaleMultipliers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetAllScaleMultipliers.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetAllScaleMultipliers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetMultipleScaleMultipliers.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetMultipleScaleMultipliers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetSingleScaleMultiplier.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsResetSingleScaleMultiplier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetMultipleScaleMultipliers_MultipleShapes.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetMultipleScaleMultipliers_MultipleShapes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_AllShapes.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_AllShapes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_MultipleShapes.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_MultipleShapes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_SingleShape.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsSetSingleScaleMultiplier_SingleShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamehitRepresentationEventsToggleHitShapeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamehitRepresentationEventsToggleHitShapeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceBumpAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceBumpAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceBumpAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceBumpAgent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinfluenceBumpComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceBumpComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceBumpReactionSetting.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceBumpReactionSetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceHeatAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceHeatAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceHeatAgentComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceHeatAgentComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceHeatAgentComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceHeatAgentComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinfluenceIAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceIAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceIAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceIAgent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinfluenceISystem.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceISystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceISystem.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceISystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinfluenceObstacleAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceObstacleAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceObstacleComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceObstacleComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceReservationAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceReservationAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceSeparationAgent.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceSeparationAgent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinfluenceSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameinfluenceSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinputActionDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/gameinputActionDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinputContextDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/gameinputContextDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinputScriptListenerAction.cs
+++ b/CP77.CR2W/Types/cp77/gameinputScriptListenerAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinputScriptListenerAction.cs
+++ b/CP77.CR2W/Types/cp77/gameinputScriptListenerAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinputScriptListenerActionConsumer.cs
+++ b/CP77.CR2W/Types/cp77/gameinputScriptListenerActionConsumer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinputScriptListenerActionConsumer.cs
+++ b/CP77.CR2W/Types/cp77/gameinputScriptListenerActionConsumer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsActiveLayerData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsActiveLayerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsAlwaysSamePredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsAlwaysSamePredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsAttemptedChoice.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsAttemptedChoice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsBumpEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsBumpEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCAabbDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCAabbDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCFunctorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCFunctorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotAreaFilterDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotAreaFilterDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotGameLogicFilterDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotGameLogicFilterDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCHotSpotLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCLinkedLayersDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCLinkedLayersDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCManager.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCManager.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsCOrientedBoxDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCOrientedBoxDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCPredicateDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCPredicateDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCSharedDataDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCSharedDataDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCSphereDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCSphereDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoice.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaption.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionBluelinePart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionBluelinePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionIconPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionIconPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionPart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionScriptPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionScriptPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionScriptPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionScriptPart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionStringPart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceCaptionStringPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceLookAtDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceLookAtDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceMetaData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceMetaData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsChoiceTypeWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsChoiceTypeWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsConeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsConeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsContainedInShapesPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsContainedInShapesPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsCrosswalkEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsCrosswalkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsDistanceFromScreenCenterPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsDistanceFromScreenCenterPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsEnableClientSideInteractionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsEnableClientSideInteractionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsEnableClientSideInteractionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsEnableClientSideInteractionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsHotSpotActivationResult.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsHotSpotActivationResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsIFunctorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIFunctorDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsIFunctorDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIFunctorDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsIManager.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsIManager.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsIPredicateType.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIPredicateType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsIPredicateType.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIPredicateType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsIShapeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIShapeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsIShapeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsIShapeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsInteractionDefinitionOverrider.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsInteractionDefinitionOverrider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsInteractionDescriptorResource.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsInteractionDescriptorResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsInteractionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsInteractionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsInteractionScriptedCondition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsInteractionScriptedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsInteractionScriptedCondition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsInteractionScriptedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsLayerActivatedPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLayerActivatedPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsLayerData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLayerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsLookAtPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLookAtPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsLootChoiceActionWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLootChoiceActionWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsLootVisualiserControlWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLootVisualiserControlWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsLootVisualiserControlWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsLootVisualiserControlWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsMultipleSetEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsMultipleSetEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsOnScreenTestPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsOnScreenTestPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsOnScreenTestPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsOnScreenTestPredicate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsOrbActivationPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsOrbActivationPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsOrbActivationPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsOrbActivationPredicate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsOrbID.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsOrbID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsPieDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsPieDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsReactionComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsReactionComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsReactionData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsReactionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsReactionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsReactionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsResetChoicesEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsResetChoicesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsSetChoicesEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsSetChoicesEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsSetEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsSetEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsSuppressedPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsSuppressedPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsSuppressedPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsSuppressedPredicate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsTargetFilterResult_Logical.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsTargetFilterResult_Logical.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsTargetFilterResult_Logical.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsTargetFilterResult_Logical.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsTargetFilter_Logical.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsTargetFilter_Logical.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsTargetFilter_Logical.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsTargetFilter_Logical.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsVisibleTargetPredicate.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsVisibleTargetPredicate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisBluelineDescription.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisBluelineDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisBluelinePart.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisBluelinePart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerFamily.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerFamily.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDeviceVisualizerLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogChoiceHubs.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogChoiceHubs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerFamily.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerFamily.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisDialogVisualizerLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisFamilyBase.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisFamilyBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisFamilyBase.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisFamilyBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIGroupedVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIGroupedVisualizerLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIGroupedVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIGroupedVisualizerLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerLogicInterface.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerLogicInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerLogicInterface.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerLogicInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerTimeProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerTimeProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerTimeProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisIVisualizerTimeProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionChoiceData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionChoiceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionChoiceHubData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionChoiceHubData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionDisplayData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisInteractionDisplayData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisListChoiceData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisListChoiceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisListChoiceHubData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisListChoiceHubData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootData.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerFamily.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerFamily.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerFamily.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisLootVisualizerLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameinteractionsvisVisualizersInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameinteractionsvisVisualizersInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsCommonVariant.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsCommonVariant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsCustomPositionMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsCustomPositionMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsCustomPositionMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsCustomPositionMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsDistrictEnteredEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsDistrictEnteredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsDynamicQuestMappinRepInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsDynamicQuestMappinRepInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsFastTravelMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsFastTravelMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsFastTravelMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsFastTravelMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsGrenadeMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsGrenadeMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsGrenadeMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsGrenadeMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIArea.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIArea.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinUpdateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinUpdateData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinVolume.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinVolume.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIMappinVolume.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIMappinVolume.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIPointOfInterestVariant.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIPointOfInterestVariant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIPointOfInterestVariant.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIPointOfInterestVariant.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIRuntimeMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIRuntimeMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIRuntimeMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIRuntimeMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsIVisualObject.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIVisualObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsIVisualObject.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsIVisualObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinInitialData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinInitialData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinInitialData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinInitialData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinUpdateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinUpdateData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsInteractionMappinUpdateData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinEntry.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinScriptData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinScriptData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsMappinSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsMappinSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsOutlineArea.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsOutlineArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsOutlineArea.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsOutlineArea.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsOutlineMappinVolume.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsOutlineMappinVolume.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsPhaseVariant.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsPhaseVariant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsPingSystemMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsPingSystemMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsPointOfInterestMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsQuestMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsQuestMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsQuestMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsQuestMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsQuestMappinManagerReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsQuestMappinManagerReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRemotePlayerMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRemotePlayerMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeGenericMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeGenericMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeGenericMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeGenericMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeInteractionMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeInteractionMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeInteractionMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeInteractionMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimePointOfInterestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimePointOfInterestMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimePointOfInterestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimePointOfInterestMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeQuestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeQuestMappinData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsRuntimeQuestMappinData.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsRuntimeQuestMappinData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsSenseCone.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsSenseCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsStealthMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsStealthMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsStealthMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsStealthMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsStealthMappinStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsStealthMappinStatsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsStealthMappinStatsListener.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsStealthMappinStatsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemappinsVehicleMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsVehicleMappin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemappinsVehicleMappin.cs
+++ b/CP77.CR2W/Types/cp77/gamemappinsVehicleMappin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingIMountingFacility.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingIMountingFacility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingIMountingFacility.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingIMountingFacility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingIMountingPublisher.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingIMountingPublisher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingIMountingPublisher.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingIMountingPublisher.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingMountingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingFacility.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingFacility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingFacility.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingFacility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingMountingFacilitySharedState.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingFacilitySharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingInfo.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingPublisher.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingPublisher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingPublisher.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingPublisher.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamemountingMountingRelationship.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingRelationship.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingMountingSlotId.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingMountingSlotId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingUnmountingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingUnmountingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamemountingUnmountingRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamemountingUnmountingRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameplayeractionsAttachSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameplayeractionsAttachSlotListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameplayeractionsAttachSlotListener.cs
+++ b/CP77.CR2W/Types/cp77/gameplayeractionsAttachSlotListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileAccelerateTowardsTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileAccelerateTowardsTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileAcceleratedMovementEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileAcceleratedMovementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileAcceleratedMovementEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileAcceleratedMovementEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileBroadPhaseHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileBroadPhaseHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluatorParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileCollisionEvaluatorParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileFollowCurveTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileFollowCurveTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileFollowEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileFollowEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileFollowTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileFollowTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileForceActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileForceActivationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileForceActivationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileForceActivationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileForwardEventToProjectileEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileForwardEventToProjectileEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileHitEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileHitEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileHitInstance.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileHitInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileLaunchEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileLaunchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileLaunchParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileLaunchParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileLinearMovementEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileLinearMovementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileLinearTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileLinearTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileParabolicTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileParabolicTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileParabolicTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileParabolicTrajectoryParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileProjectilePreviewEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileProjectilePreviewEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileScriptCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileScriptCollisionEvaluator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileScriptCollisionEvaluator.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileScriptCollisionEvaluator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileSetUpAndLaunchEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSetUpAndLaunchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSetUpEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSetUpEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileShootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileShootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileShootTargetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileShootTargetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileShootTargetEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileShootTargetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileSlideTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSlideTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpawnComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpawnComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpawnerAttachEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpawnerAttachEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpawnerAttachExistingEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpawnerAttachExistingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpawnerLaunchEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpawnerLaunchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpawnerPreviewEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpawnerPreviewEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileSpiralParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileSpiralParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileTickEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileTickEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileTrajectoryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileTrajectoryParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileTrajectoryParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameprojectileVelocityParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileVelocityParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameprojectileWeaponParams.cs
+++ b/CP77.CR2W/Types/cp77/gameprojectileWeaponParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamesmartGunSmartGunLockEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamesmartGunSmartGunLockEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamesmartGunUIParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamesmartGunUIParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamesmartGunUISightParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamesmartGunUISightParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamesmartGunUITargetParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamesmartGunUITargetParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterBool.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterCName.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterDouble.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterDouble.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterFloat.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterIScriptable.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterIScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterInt.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterTweakDBID.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterTweakDBID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterVector.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineActionParameterWeakIScriptable.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineActionParameterWeakIScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineComponent.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterBool.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterCName.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterDouble.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterDouble.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterFloat.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterIScriptable.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterIScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterInt.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterTweakDBID.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterTweakDBID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterVector.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterWeakIScriptable.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineConsumableParameterWeakIScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineFunctor.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineFunctor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineFunctor.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineFunctor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineGameScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineGameScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineGameScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineGameScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineIStateActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineIStateActionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineIStateActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineIStateActionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineIStateMachineBody.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineIStateMachineBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineIStateMachineBody.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineIStateMachineBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultBool.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultCName.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultFloat.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultInt.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultString.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultString.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineResultVector.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineResultVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineSnapshotResult.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineSnapshotResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateActionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateActionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateActionDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateContext.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateContextConsumableParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateContextConsumableParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateContextParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateContextParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateContextScript.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateContextScript.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateContextScript.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateContextScript.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateDefinitionSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateDefinitionSocketDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateDefinitionSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateDefinitionSocketDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBody.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBody.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBody.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBodyLocomotionTier1.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBodyLocomotionTier1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBodyLocomotionTier1.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineBodyLocomotionTier1.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineIdentifier.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineIdentifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineInstanceData.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineInstanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineListDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineListDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineResource.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateMachineResource.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateMachineResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateSnapshotsContainer.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateSnapshotsContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateSocketDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineStateSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineStateSocketDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineTransition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineTransitionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineTransitionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventAddOnDemandStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventAddOnDemandStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventBaseEvent.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventBaseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventDrawClimbDebug.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventDrawClimbDebug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventDrawClimbDebug.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventDrawClimbDebug.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventDrawVaultDebug.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventDrawVaultDebug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventDrawVaultDebug.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventDrawVaultDebug.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventFall.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventFall.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventFall.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventFall.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventImpulse.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventImpulse.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterBool.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterCName.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterCName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterFloat.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterInt.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterScriptable.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterScriptable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterVector.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventPostponedParameterVector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventRemoveOnDemandStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventRemoveOnDemandStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventResetPhysicalRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventResetPhysicalRepresentation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventResetPhysicalRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventResetPhysicalRepresentation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventStartStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventStartStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventStopStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventStopStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventTeleport.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventTeleport.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineeventTeleport.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineeventTeleport.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionBraindanceParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionBraindanceParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionBraindanceParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionBraindanceParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionSwimmingParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionSwimmingParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionSwimmingParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeActionLocomotionSwimmingParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransform.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransformWithDurations.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransformWithDurations.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransformWithDurations.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeAdjustTransformWithDurations.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParametersBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParametersBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParametersBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeClimbParametersBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeInteractionDescription.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeInteractionDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeItemEquipRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeItemEquipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeItemUnequipRequest.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeItemUnequipRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeLadderDescription.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeLadderDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeRequestItem.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeRequestItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeRequestReload.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeRequestReload.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeVaultParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeVaultParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeVaultParameters.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineparameterTypeVaultParameters.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCharge.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCharge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCharge.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCharge.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeMax.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeMax.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeMax.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeMax.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeReady.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeReady.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeReady.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionChargeReady.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCycleTriggerMode.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCycleTriggerMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCycleTriggerMode.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionCycleTriggerMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionDischarge.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionDischarge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionDischarge.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionDischarge.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileAttach.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileAttach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileAttach.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileAttach.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileDetach.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileDetach.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileDetach.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileDetach.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileShowPreview.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileShowPreview.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileShowPreview.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionProjectileShowPreview.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReady.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReady.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReady.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReady.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReload.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReload.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReload.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionReload.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionShoot.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionShoot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionShoot.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionShoot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionWindup.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionWindup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionWindup.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsActionWindup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsClimb.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsClimb.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsClimb.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsClimb.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsEquipItem.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsEquipItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsEquipItem.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsEquipItem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsHighLevelAiControlled.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsHighLevelAiControlled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsHighLevelAiControlled.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsHighLevelAiControlled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionAir.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionAir.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionAir.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionAir.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBraindance.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBraindance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBraindance.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionBraindance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceFreeze.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceFreeze.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceFreeze.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceFreeze.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceIdle.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceIdle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceIdle.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionForceIdle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionLadder.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionLadder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionLadder.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionLadder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSimple.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSimple.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSimple.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSimple.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionStart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingDiving.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingDiving.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingDiving.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingDiving.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingStart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingSurface.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingSurface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingSurface.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionSwimmingSurface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionWallRun.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionWallRun.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionWallRun.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsLocomotionWallRun.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsUpperBodyBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsUpperBodyBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsUpperBodyBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsUpperBodyBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVault.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVault.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVault.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVault.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleDrive.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleDrive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleDrive.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleDrive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleExiting.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleExiting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleExiting.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsVehicleExiting.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponActionBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponActionBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponActionBase.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponActionBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponStart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponStart.cs
+++ b/CP77.CR2W/Types/cp77/gamestateMachineplayeractionsWeaponStart.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingSystemEntityTargetedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemEntityTargetedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemEntityUntargetedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemEntityUntargetedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemHitInfo.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemHitInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemObjectLookedAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemObjectLookedAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterResult.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterTicket.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterTicket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterTicket.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilterTicket.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Closest.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Closest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Closest.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Closest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_ClosestOpaque.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_ClosestOpaque.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_ClosestOpaque.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_ClosestOpaque.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Script.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Script.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Script.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingSystemTargetFilter_Script.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingTargetPartInfo.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingTargetPartInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingTargetPartInfo.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingTargetPartInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametargetingTargetingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingTargetingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gametargetingTargetingSystem.cs
+++ b/CP77.CR2W/Types/cp77/gametargetingTargetingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gametimeLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gametimeLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAccessPointMiniGameStatus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAccessPointMiniGameStatus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAddInputGroupEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAddInputGroupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAdvertGlitchEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAdvertGlitchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAdvertLightColorPickerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAdvertLightColorPickerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAdvertTranslationController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAdvertTranslationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAppearanceInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAppearanceInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiAuthorisationNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiAuthorisationNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBackpackMainGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBackpackMainGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseCharacterCreationController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseCharacterCreationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseDirectionalIndicatorPartLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseDirectionalIndicatorPartLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseGOGProfileController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseGOGProfileController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseGOGProfileController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseGOGProfileController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiBaseGOGRegisterController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseGOGRegisterController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseGOGRegisterController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseGOGRegisterController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiBaseItemDataSource.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseItemDataSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseItemDataSource.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseItemDataSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiBaseMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseMenuGameControllerPuppetSceneInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseMenuGameControllerPuppetSceneInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseMinimapMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseMinimapMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseUIData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseUIData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseVehicleHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseVehicleHUDGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBaseWorldMapMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBaseWorldMapMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBinkResource.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBinkResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBraindanceClueDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBraindanceClueDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBriefingGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBriefingGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiBriefingGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBriefingGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiBuffInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiBuffInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCensorshipInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCensorshipInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCreationPuppetPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCreationPuppetPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationAction.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationAttribute.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationAttribute.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyPartsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyPartsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyPartsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBodyPartsController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBrokenNoseController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBrokenNoseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBrokenNoseControllerBrokenNoseAppearance.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationBrokenNoseControllerBrokenNoseAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationFeetController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationFeetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationGenitalsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationGenitalsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationHairstyleController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationHairstyleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationInfoResource.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationInfoResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOption.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOptionImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOptionImpl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOptionImpl.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationOptionImpl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationPersonalLinkController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationPersonalLinkController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationPreset.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnAppearanceSwitchedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnAppearanceSwitchedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnInitializeOptionsListEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnInitializeOptionsListEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnInitializeOptionsListEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnInitializeOptionsListEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnOptionUpdatedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnOptionUpdatedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnPresetAppliedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnPresetAppliedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnPresetAppliedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnPresetAppliedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnRandomizeCompleteEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnRandomizeCompleteEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnRandomizeCompleteEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationSystem_OnRandomizeCompleteEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPreset.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPresetInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPresetInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPresetValue.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterCustomizationUiPresetValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterReplicaInitializedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterReplicaInitializedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCharacterReplicaInitializedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharacterReplicaInitializedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCharactersChain.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCharactersChain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiChatBoxGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiChatBoxGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiChatBoxText.cs
+++ b/CP77.CR2W/Types/cp77/gameuiChatBoxText.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContextChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContextChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraGameState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiContraLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraMiniGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraMiniGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraMiniGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraMiniGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiContraPlatform.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraPlatform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraPlatformCollision.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraPlatformCollision.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiContraPlatformCollision.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraPlatformCollision.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiContraPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiContraPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCooldownGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCooldownGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCreditsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCreditsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCreditsPositionController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCreditsPositionController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCreditsSectionController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCreditsSectionController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCrosshairBaseGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCrosshairBaseGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCrosshairBaseMelee.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCrosshairBaseMelee.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCrosshairContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCrosshairContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCustomizationAppearance.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCustomizationAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCustomizationGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCustomizationGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCustomizationMorph.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCustomizationMorph.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCyberspaceMappinsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCyberspaceMappinsContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiCyberspaceMappinsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCyberspaceMappinsContainerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiCyberspaceUIObject.cs
+++ b/CP77.CR2W/Types/cp77/gameuiCyberspaceUIObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDamageIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDamageIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDamageIndicatorPartLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDamageIndicatorPartLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDamageInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDamageInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDamageInfoUserData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDamageInfoUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDelayedNextVOEvt.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDelayedNextVOEvt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDelayedNextVOEvt.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDelayedNextVOEvt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiDeleteInputGroupEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDeleteInputGroupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDeleteInputHintBySourceEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDeleteInputHintBySourceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDetectionParams.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDetectionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDialogListChoiceVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDialogListChoiceVisualizer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDialogListChoiceVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDialogListChoiceVisualizer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiDistrictTriggerData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDistrictTriggerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDynamicIconLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDynamicIconLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiDynamicIconLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiDynamicIconLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiEnableStickerEditorEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiEnableStickerEditorEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiEnableStickerEditorEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiEnableStickerEditorEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiEntityPreviewCameraSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameuiEntityPreviewCameraSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiEntityPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiEntityPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiEntityPreviewGameObject.cs
+++ b/CP77.CR2W/Types/cp77/gameuiEntityPreviewGameObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiFinalBoardsGoToMainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gameuiFinalBoardsGoToMainMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiFinalBoardsGoToMainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gameuiFinalBoardsGoToMainMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiForceAttributeValueEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiForceAttributeValueEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiForceAttributeValueEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiForceAttributeValueEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiForceStickerTransformEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiForceStickerTransformEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiForceStickerTransformEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiForceStickerTransformEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGPSGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGPSGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGameStatePropertyChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameStatePropertyChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGameStatePropertyChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameStatePropertyChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGameSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameSystemUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGameSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameSystemUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGameVersionTextController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameVersionTextController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGameVersionTextController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGameVersionTextController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGenderSelectionPuppetPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenderSelectionPuppetPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationReceiverGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationReceiverGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationSaveData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGenericNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGenericNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGlobalTvSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGlobalTvSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGlobalTvSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGlobalTvSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGlobaltvWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGlobaltvWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGridCell.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGridCell.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGridDataFillFinished.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGridDataFillFinished.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGridDataFillFinished.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGridDataFillFinished.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiGridNoiseGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGridNoiseGenRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiGridNoiseGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiGridNoiseGenRule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiHDRSettingsGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHDRSettingsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHUDGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHUDVideoPlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHUDVideoPlayerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHUDVideoStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHUDVideoStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHUDVideoStopEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHUDVideoStopEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHackingMinigameGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHackingMinigameGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHackingMinigameLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHackingMinigameLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHideCustomTooltipEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHideCustomTooltipEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHideCustomTooltipEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHideCustomTooltipEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiHoldIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHoldIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHoldIndicatorProgressCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHoldIndicatorProgressCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHoldIndicatorProgressCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHoldIndicatorProgressCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiHolocallCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHolocallCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHolocallCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHolocallCameraComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiHolocallStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHolocallStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiHolocallStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiHolocallStartEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyPartsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyPartsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyPartsController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationBodyPartsController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationComponent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiICharacterCustomizationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIChoiceVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIChoiceVisualizer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIChoiceVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIChoiceVisualizer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIGameSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIGameSystemUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIGameSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIGameSystemUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIUIIconsGeneratorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIIconsGeneratorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIUIIconsGeneratorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIIconsGeneratorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIUIObjectsLoaderSystemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiIconsNameResolver.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIconsNameResolver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIconsNameResolver.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIconsNameResolver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiInGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInGameMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInGameMenuGameControllerGarmentSwitchEffectController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInGameMenuGameControllerGarmentSwitchEffectController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInGameMenuGameControllerItemSceneInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInGameMenuGameControllerItemSceneInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIndexedAppearanceDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIndexedAppearanceDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIndexedMorphName.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIndexedMorphName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInkChoiceVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInkChoiceVisualizer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintGroupController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintGroupController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintGroupData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintGroupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintInitializedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintInitializedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintManagerGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintManagerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInputHintManagerGameControllerData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInputHintManagerGameControllerData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInteractionMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInteractionMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInventoryGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInventoryGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiInventoryPuppetPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiInventoryPuppetPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIronsightGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIronsightGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiIronsightGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiIronsightGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiItemAddedNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemAddedNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemDataSourceListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataSourceListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemDataSourceListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataSourceListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiItemDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataSourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataSourceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiItemDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataViewWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemDataViewWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiItemPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemPreview_WaitOneFrame.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemPreview_WaitOneFrame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiItemPreview_WaitOneFrame.cs
+++ b/CP77.CR2W/Types/cp77/gameuiItemPreview_WaitOneFrame.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiKillInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiKillInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiLevelUpNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiLevelUpNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiLogTutorialHintActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiLogTutorialHintActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiLootVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiLootVisualizer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiLootVisualizer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiLootVisualizer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMainMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMainMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMainProgramGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMainProgramGenRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMainProgramGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMainProgramGenRule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMappinBaseController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinBaseController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMappinControllerCustomData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinControllerCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMappinControllerCustomData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinControllerCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMappinUIProfile.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinUIProfile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMappinUtils.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMappinUtils.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMappinsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMappinsContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMenuItemListGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMenuItemListGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinigameData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinigameData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinigameGenerationRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinigameGenerationRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinigameProgramData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinigameProgramData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinigameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinigameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapDeviceMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapDeviceMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapDynamicEventMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapDynamicEventMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapHazardWarningMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapHazardWarningMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapHazardWarningMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapHazardWarningMappinController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMinimapPingSystemMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapPingSystemMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaInitData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapQuestAreaMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapQuestMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapQuestMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapRemotePlayerMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapRemotePlayerMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaInitData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapSecurityAreaMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMinimapStealthMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMinimapStealthMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiMorphInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiMorphInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNPCNextToTheCrosshair.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNPCNextToTheCrosshair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNarrationEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNarrationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNarrativePlateData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNarrativePlateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNewsFeedDataProvider.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNewsFeedDataProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNewsFeedDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNewsFeedDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiNpcNameplateGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiNpcNameplateGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnCollideCallbackAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnCollideCallbackAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnCollideCallbackAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnCollideCallbackAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiOnGameFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnGameFinishEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnGameFinishEventAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnGameFinishEventAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnHitCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnHitCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnHitCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnHitCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiOnHitPlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnHitPlayerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnMiniGameStateUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnMiniGameStateUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnMiniGameStateUpdateEventAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnMiniGameStateUpdateEventAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnRecycleEventAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnRecycleEventAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOnRecycleEventAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnRecycleEventAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiOnscreenVOPlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOnscreenVOPlayerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiOptionsGroup.cs
+++ b/CP77.CR2W/Types/cp77/gameuiOptionsGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerBonus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerBonus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerBullet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerCloud.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerCloud.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerCloud.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerCloud.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerEnemy.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerEnemy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerEnemyAV.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerEnemyAV.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerEnemyBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerEnemyBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerEnemyBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerEnemyBullet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerEnemyDrone.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerEnemyDrone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerExplosion.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerExplosion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerFriendlyBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerFriendlyBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerFriendlyBullet.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerFriendlyBullet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerGameLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerGameLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerGameState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerHUDGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerLifeBonus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerLifeBonus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerLifeBonus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerLifeBonus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerMiniGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerMiniGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerMiniGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerMiniGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerPlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerPlayerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerScoreBoard.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerScoreBoard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerScoreBonus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerScoreBonus.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerScoreBonus.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerScoreBonus.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPanzerScoreRecord.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerScoreRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPanzerScoreRecordData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPanzerScoreRecordData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPersonalLinkSwitcherEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPersonalLinkSwitcherEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPerspectiveInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPerspectiveInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhoneMessageNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhoneMessageNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhoneWaveformData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhoneWaveformData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhoneWaveformGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhoneWaveformGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeFailedToOpenEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeFailedToOpenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeFailedToOpenEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeFailedToOpenEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeLastInputDeviceEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeLastInputDeviceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeLastInputDeviceEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeLastInputDeviceEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeMenuController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeMenuController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeOptionSelectorData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeOptionSelectorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeRegisaterCallbacksEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeRegisaterCallbacksEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeRegisaterCallbacksEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeRegisaterCallbacksEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeStickersController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeStickersController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeUIHideForScreenshotEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeUIHideForScreenshotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeUIInteractiveEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeUIInteractiveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPhotoModeUIVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPhotoModeUIVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPinInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPinInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPlayerBioMonitor.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPlayerBioMonitor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPlayerListGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPlayerListGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPopupsManager.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPopupsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPreGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPreGameMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPreGameMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPreGameMenuGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPreGamePuppetAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPreGamePuppetAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPreGamePuppetAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPreGamePuppetAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiProgramFromDataGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProgramFromDataGenRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiProgramFromDataGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProgramFromDataGenRule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiProgramsGridGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProgramsGridGenRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiProgramsGridGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProgramsGridGenRule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiProgressionViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProgressionViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiProjectedHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProjectedHUDGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiProjectedHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiProjectedHUDGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPuppetAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetAttachmentSlotsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPuppetAttachmentSlotsListener.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetAttachmentSlotsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiPuppetPreviewCameraController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetPreviewCameraController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPuppetPreviewCameraSetup.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetPreviewCameraSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPuppetPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPuppetPreview_ReadyToBeDisplayed.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetPreview_ReadyToBeDisplayed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiPuppetPreview_SetCameraSetupEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiPuppetPreview_SetCameraSetupEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerRoad.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerRoad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerSprite.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerSprite.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuadRacerSprite.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuadRacerSprite.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiQuestMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuestMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiQuestUpdateNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiQuestUpdateNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRandomNewsFeedAnimator.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRandomNewsFeedAnimator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRefreshGOGState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRefreshGOGState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRequestPopContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRequestPopContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRequestPushContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRequestPushContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRequestResetContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRequestResetContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRequestResetContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRequestResetContextEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiRequestSwapContextEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRequestSwapContextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiResetStickersEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiResetStickersEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiResetStickersEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiResetStickersEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceChunk.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceChunkLayer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceChunkLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceDynObjectLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceDynObjectLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceGameLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceGameLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRaceObstacle.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRaceObstacle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoachRacePlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoachRacePlayerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoadEditorDecorationSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoadEditorDecorationSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoadEditorObstacleSettings.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoadEditorObstacleSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRoadEditorSegment.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRoadEditorSegment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiRootHudGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiRootHudGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSaveHandlingController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSaveHandlingController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSaveHandlingController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSaveHandlingController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiScannerGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiScannerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiScreenAreaMultiplierChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiScreenAreaMultiplierChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiScreenProjectionsData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiScreenProjectionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetAttributeEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetAttributeEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetAttributeEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetAttributeEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetBackgroundEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetBackgroundEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetBackgroundEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetBackgroundEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetCategoryEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetCategoryEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetCategoryEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetCategoryEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetCharacterCreationDataRequest.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetCharacterCreationDataRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetFrameImageEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetFrameImageEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetFrameImageEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetFrameImageEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetPhotoModeKeyEnabledCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetPhotoModeKeyEnabledCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetPhotoModeKeyEnabledCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetPhotoModeKeyEnabledCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetSelectedStickerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetSelectedStickerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetSelectedStickerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetSelectedStickerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetStickerImageEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetStickerImageEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetStickerImageEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetStickerImageEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSettingsControlsGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSettingsControlsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSettingsControlsGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSettingsControlsGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSetupOptionButtonForAttributeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetupOptionButtonForAttributeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetupOptionSelectorForAttributeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetupOptionSelectorForAttributeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSetupScrollBarForAttributeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSetupScrollBarForAttributeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiShowCustomTooltipEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiShowCustomTooltipEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerCheatCode.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerCheatCode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogicAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogicAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogicAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameCollisionLogicAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameControllerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameControllerAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogic.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogicAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogicAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogicAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameDynObjectLogicAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameLogicControllerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameLogicControllerAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerControllerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerControllerAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerControllerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGamePlayerControllerAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameStateAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerMiniGameStateAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerSpawnerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerSpawnerAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSideScrollerSpawnerAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSideScrollerSpawnerAdvanced.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSpawnNewFeedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSpawnNewFeedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSpawnNewFeedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSpawnNewFeedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStadiaControllersGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStadiaControllersGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStaticIconLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStaticIconLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStealthIndicatorGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStealthIndicatorGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStealthIndicatorPartLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStealthIndicatorPartLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStealthMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStealthMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerBackgroundCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerBackgroundCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerBackgroundCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerBackgroundCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStickerCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStickerEditorEnableCursorInputEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerEditorEnableCursorInputEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerEditorEnableCursorInputEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerEditorEnableCursorInputEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStickerFrameCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerFrameCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerFrameCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerFrameCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStickerImageCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerImageCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickerImageCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickerImageCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiStickersRegisterCallbacksEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickersRegisterCallbacksEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiStickersRegisterCallbacksEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiStickersRegisterCallbacksEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSubtitleHandlerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSubtitleHandlerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSubtitleHandlerSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSubtitleHandlerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiSwitchPair.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSwitchPair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSwitcherInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSwitcherInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiSwitcherOption.cs
+++ b/CP77.CR2W/Types/cp77/gameuiSwitcherOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTarotCardAddedNotificationViewData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTarotCardAddedNotificationViewData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTimeDisplayLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTimeDisplayLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTooltipAttachmentSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTooltipAttachmentSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTooltipAttachmentSlot.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTooltipAttachmentSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiTooltipSlotData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTooltipSlotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTooltipsManager.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTooltipsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTrackedMappinControllerCustomData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTrackedMappinControllerCustomData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTrackedMappinControllerCustomData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTrackedMappinControllerCustomData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiTrapTooltipDisplayer.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTrapTooltipDisplayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTrapsGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTrapsGenRule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTrapsGenRule.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTrapsGenRule.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiTutorialArea.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialAreaDespawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialAreaDespawnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialAreaSpawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialAreaSpawnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialBracketHideEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialBracketHideEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialBracketLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialBracketLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialBracketShowEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialBracketShowEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialOverlayHideEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialOverlayHideEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialOverlayLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialOverlayLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialOverlayShowEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialOverlayShowEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTutorialPopupGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTutorialPopupGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiTweakDBIconReference.cs
+++ b/CP77.CR2W/Types/cp77/gameuiTweakDBIconReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUIGameState.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUIIconsGeneratorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIIconsGeneratorSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUIIconsGeneratorSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIIconsGeneratorSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiUIInteractionData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIInteractionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUIObjectsLoaderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIObjectsLoaderSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUIObjectsLoaderSystem.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUIObjectsLoaderSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiUnlockableProgram.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUnlockableProgram.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiUpdateInputHintEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameuiUpdateInputHintEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiVOWithDelay.cs
+++ b/CP77.CR2W/Types/cp77/gameuiVOWithDelay.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWeaponRosterInfo.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWeaponRosterInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWeaponShootParams.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWeaponShootParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWidgetGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapDebugOutlineLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapDebugOutlineLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapDistrictLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapDistrictLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapFloorPlanController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapFloorPlanController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapFloorPlanController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapFloorPlanController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapGameObject.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapGameObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapMenuGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapMenuGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerInitData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerInitData.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerInitData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerMappinController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerMappinController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapPlayerMappinController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiWorldMapPreviewGameController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMapPreviewGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMappinsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMappinsContainerController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiWorldMappinsContainerController.cs
+++ b/CP77.CR2W/Types/cp77/gameuiWorldMappinsContainerController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiZoomChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiZoomChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiZoomChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiZoomChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameuiZoomLevelChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiZoomLevelChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameuiZoomLevelChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/gameuiZoomLevelChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gamewatchdogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamewatchdogSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gamewatchdogSystem.cs
+++ b/CP77.CR2W/Types/cp77/gamewatchdogSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponAnimFeature_AimPlayer.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponAnimFeature_AimPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponAnimFeature_LoopableAction.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponAnimFeature_LoopableAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponAnimFeature_WeaponData.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponAnimFeature_WeaponData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponFxPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponFxPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponFxPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponFxPackage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponGrenade.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponGrenade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponGrenade.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponGrenade.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponGrenadeReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponGrenadeReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponIFxPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponIFxPackage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponIFxPackage.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponIFxPackage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponObject.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsAIAttackAttemptEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsAIAttackAttemptEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsChangeTriggerModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsChangeTriggerModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsCycleTriggerModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsCycleTriggerModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsCycleTriggerModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsCycleTriggerModeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsEnableSmartGunHandlerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsEnableSmartGunHandlerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsEnableSmartGunHandlerEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsEnableSmartGunHandlerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsOwnerAimEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsOwnerAimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadFinishEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadFinishEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadFinishEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadInterruptedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadInterruptedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadInterruptedEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadInterruptedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsReloadStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsReloadStartEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsRemoveActiveWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsRemoveActiveWeaponEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsRemoveActiveWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsRemoveActiveWeaponEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsRequestAmmoChange.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsRequestAmmoChange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsRequestAmmoChange.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsRequestAmmoChange.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsSetActiveWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsSetActiveWeaponEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsSetActiveWeaponEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsSetActiveWeaponEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsSetMaxChargeEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsSetMaxChargeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsShootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsShootEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsShootEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsShootEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gameweaponeventsStopFiringEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsStopFiringEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gameweaponeventsStopFiringEvent.cs
+++ b/CP77.CR2W/Types/cp77/gameweaponeventsStopFiringEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/garmentBendingParams.cs
+++ b/CP77.CR2W/Types/cp77/garmentBendingParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentCollarAreaParams.cs
+++ b/CP77.CR2W/Types/cp77/garmentCollarAreaParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentGarmentLayerParams.cs
+++ b/CP77.CR2W/Types/cp77/garmentGarmentLayerParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentHiddenTrianglesRemovalParams.cs
+++ b/CP77.CR2W/Types/cp77/garmentHiddenTrianglesRemovalParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentMeshParamGarment.cs
+++ b/CP77.CR2W/Types/cp77/garmentMeshParamGarment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentMeshParamGarmentChunkData.cs
+++ b/CP77.CR2W/Types/cp77/garmentMeshParamGarmentChunkData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/garmentSmoothingParams.cs
+++ b/CP77.CR2W/Types/cp77/garmentSmoothingParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gearboxLogicController.cs
+++ b/CP77.CR2W/Types/cp77/gearboxLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genIRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genIRandomizationSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genIRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genIRandomizationSupervisor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/genLevelRandomizer.cs
+++ b/CP77.CR2W/Types/cp77/genLevelRandomizer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genLevelRandomizerEntry.cs
+++ b/CP77.CR2W/Types/cp77/genLevelRandomizerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genNullRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genNullRandomizationSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genNullRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genNullRandomizationSupervisor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/genRandomizationDataEntry.cs
+++ b/CP77.CR2W/Types/cp77/genRandomizationDataEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genRandomizerMarker.cs
+++ b/CP77.CR2W/Types/cp77/genRandomizerMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genScriptedRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genScriptedRandomizationSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/genScriptedRandomizationSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/genScriptedRandomizationSupervisor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/graphGraphConnectionDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphGraphConnectionDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphGraphDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphGraphDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphGraphNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphGraphNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphGraphResource.cs
+++ b/CP77.CR2W/Types/cp77/graphGraphResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphGraphSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphGraphSocketDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphIGraphNodeCondition.cs
+++ b/CP77.CR2W/Types/cp77/graphIGraphNodeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphIGraphNodeCondition.cs
+++ b/CP77.CR2W/Types/cp77/graphIGraphNodeCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/graphIGraphObjectDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphIGraphObjectDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/graphIGraphObjectDefinition.cs
+++ b/CP77.CR2W/Types/cp77/graphIGraphObjectDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/grenadeSpawner.cs
+++ b/CP77.CR2W/Types/cp77/grenadeSpawner.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsDeathmatchPlayerGameInfo.cs
+++ b/CP77.CR2W/Types/cp77/grsDeathmatchPlayerGameInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsDeathmatchState.cs
+++ b/CP77.CR2W/Types/cp77/grsDeathmatchState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsGatherAreaManager.cs
+++ b/CP77.CR2W/Types/cp77/grsGatherAreaManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsGatherAreaReplicatedInfo.cs
+++ b/CP77.CR2W/Types/cp77/grsGatherAreaReplicatedInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsHeistPlayerGameInfo.cs
+++ b/CP77.CR2W/Types/cp77/grsHeistPlayerGameInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/grsHeistState.cs
+++ b/CP77.CR2W/Types/cp77/grsHeistState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmBaseRequestsHandler.cs
+++ b/CP77.CR2W/Types/cp77/gsmBaseRequestsHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmGameDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gsmGameDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmIStateObserver.cs
+++ b/CP77.CR2W/Types/cp77/gsmIStateObserver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmIStateObserver.cs
+++ b/CP77.CR2W/Types/cp77/gsmIStateObserver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_CreateSingleplayerSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_CreateSingleplayerSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_CreateSingleplayerSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_CreateSingleplayerSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_ErrorPopup.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_ErrorPopup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_ErrorPopup.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_ErrorPopup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_FindSessions.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_FindSessions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_FindSessions.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_FindSessions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_GatheringSaves.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_GatheringSaves.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_GatheringSaves.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_GatheringSaves.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_InGamePause.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_InGamePause.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_InGamePause.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_InGamePause.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_LoadGameDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_LoadGameDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_LoadGameDefinition.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_LoadGameDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_LoadSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_LoadSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_LoadSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_LoadSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_MainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_MainMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_MainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_MainMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_ModalPopup.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_ModalPopup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_ModalPopup.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_ModalPopup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_Multiplayer.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_Multiplayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_Multiplayer.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_Multiplayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_MultiplayerSelectCharacter.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_MultiplayerSelectCharacter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_MultiplayerSelectCharacter.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_MultiplayerSelectCharacter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_PlayRecordedSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_PlayRecordedSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_PlayRecordedSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_PlayRecordedSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmMenuState_Singleplayer.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_Singleplayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmMenuState_Singleplayer.cs
+++ b/CP77.CR2W/Types/cp77/gsmMenuState_Singleplayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmPopupState.cs
+++ b/CP77.CR2W/Types/cp77/gsmPopupState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmPopupState.cs
+++ b/CP77.CR2W/Types/cp77/gsmPopupState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmSavingRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/gsmSavingRequesResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmSavingRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/gsmSavingRequesResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState.cs
+++ b/CP77.CR2W/Types/cp77/gsmState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState.cs
+++ b/CP77.CR2W/Types/cp77/gsmState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_RichPresence.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_RichPresence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_RichPresence.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_RichPresence.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_SessionAutomation.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_SessionAutomation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_SessionAutomation.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_SessionAutomation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_SessionChanged.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_SessionChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_SessionChanged.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_SessionChanged.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_UserSignInOut.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_UserSignInOut.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmStateObserver_UserSignInOut.cs
+++ b/CP77.CR2W/Types/cp77/gsmStateObserver_UserSignInOut.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_AutoJoinServer.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_AutoJoinServer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_AutoJoinServer.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_AutoJoinServer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_BoothModeMainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_BoothModeMainMenu.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_BoothModeMainMenu.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_BoothModeMainMenu.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_Initialization.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_Initialization.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_Initialization.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_Initialization.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_PreGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_PreGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_PreGameSession.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_PreGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_ReconnectController.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_ReconnectController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_ReconnectController.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_ReconnectController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_Session.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_Session.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_Session.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_Session.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionActive.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionActive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionActive.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionActive.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionLoading.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionLoading.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionLoading.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionLoading.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionNewGame.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionNewGame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionNewGame.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionNewGame.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionPaused.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionPaused.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionPaused.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionPaused.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionRestoreFromSave.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionRestoreFromSave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionRestoreFromSave.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionRestoreFromSave.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmState_SessionStreamingAware.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionStreamingAware.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmState_SessionStreamingAware.cs
+++ b/CP77.CR2W/Types/cp77/gsmState_SessionStreamingAware.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/gsmgameStateObserver_FunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/gsmgameStateObserver_FunctionalTests.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/gsmgameStateObserver_FunctionalTests.cs
+++ b/CP77.CR2W/Types/cp77/gsmgameStateObserver_FunctionalTests.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/healthbarWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/healthbarWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hubSelectorController.cs
+++ b/CP77.CR2W/Types/cp77/hubSelectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hubSelectorSingleCarouselController.cs
+++ b/CP77.CR2W/Types/cp77/hubSelectorSingleCarouselController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hubSelectorSingleSmallCarouselController.cs
+++ b/CP77.CR2W/Types/cp77/hubSelectorSingleSmallCarouselController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hubSelectorSingleSmallCarouselController.cs
+++ b/CP77.CR2W/Types/cp77/hubSelectorSingleSmallCarouselController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/hudButtonReminderGameController.cs
+++ b/CP77.CR2W/Types/cp77/hudButtonReminderGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudCameraController.cs
+++ b/CP77.CR2W/Types/cp77/hudCameraController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudCarController.cs
+++ b/CP77.CR2W/Types/cp77/hudCarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudCarRaceController.cs
+++ b/CP77.CR2W/Types/cp77/hudCarRaceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudCorpoController.cs
+++ b/CP77.CR2W/Types/cp77/hudCorpoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudDroneController.cs
+++ b/CP77.CR2W/Types/cp77/hudDroneController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudJohnnyController.cs
+++ b/CP77.CR2W/Types/cp77/hudJohnnyController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudMilitechWarningGameController.cs
+++ b/CP77.CR2W/Types/cp77/hudMilitechWarningGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudRecordingController.cs
+++ b/CP77.CR2W/Types/cp77/hudRecordingController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/hudTurretController.cs
+++ b/CP77.CR2W/Types/cp77/hudTurretController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAbstractDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkAbstractDataSourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAbstractDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkAbstractDataSourceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkActionName.cs
+++ b/CP77.CR2W/Types/cp77/inkActionName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkActionName.cs
+++ b/CP77.CR2W/Types/cp77/inkActionName.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkAdvertisementsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkAdvertisementsLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAdvertisementsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkAdvertisementsLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkAdvertisementsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkAdvertisementsLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAdvertisementsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkAdvertisementsLayerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkAnimatedAdvertController.cs
+++ b/CP77.CR2W/Types/cp77/inkAnimatedAdvertController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAudioHandlerUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkAudioHandlerUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkAudioHandlerUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkAudioHandlerUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBasePanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkBasePanelWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBasePanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkBasePanelWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBasePanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkBasePanelWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBasePanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkBasePanelWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBaseScriptableDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseScriptableDataSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBaseScriptableDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseScriptableDataSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBaseShapeWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseShapeWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBaseShapeWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseShapeWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBaseVariantDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseVariantDataSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBaseVariantDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseVariantDataSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBaseWeakScriptableDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseWeakScriptableDataSource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBaseWeakScriptableDataSource.cs
+++ b/CP77.CR2W/Types/cp77/inkBaseWeakScriptableDataSource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBinkLanguageDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/inkBinkLanguageDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBoolCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkBoolCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBoolCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkBoolCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBorderWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkBorderWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBorderWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkBorderWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBorderWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkBorderWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkBoxBlurEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkBoxBlurEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkBrushWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkBrushWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonAnimatedController.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonAnimatedController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonClickCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonClickCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonClickCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonClickCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkButtonController.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonDpadSupportedController.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonDpadSupportedController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonHoldCompleteCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonHoldCompleteCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonHoldCompleteCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonHoldCompleteCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkButtonProgressChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonProgressChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonProgressChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonProgressChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkButtonSelectionCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonSelectionCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonSelectionCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonSelectionCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkButtonStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonStateChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkButtonStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonStateChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkButtonTintController.cs
+++ b/CP77.CR2W/Types/cp77/inkButtonTintController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCacheWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkCacheWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCacheWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCacheWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCacheWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCacheWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCallbackBase.cs
+++ b/CP77.CR2W/Types/cp77/inkCallbackBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCallbackData.cs
+++ b/CP77.CR2W/Types/cp77/inkCallbackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCallbackListener.cs
+++ b/CP77.CR2W/Types/cp77/inkCallbackListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCanvasWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkCanvasWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCanvasWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkCanvasWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCanvasWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCanvasWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCanvasWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCanvasWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCensorshipController.cs
+++ b/CP77.CR2W/Types/cp77/inkCensorshipController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCensorshipEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkCensorshipEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCharacterEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkCharacterEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCharacterEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkCharacterEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCharacterEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCharacterEventCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCharacterEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCharacterEventCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkChildren.cs
+++ b/CP77.CR2W/Types/cp77/inkChildren.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkChildren.cs
+++ b/CP77.CR2W/Types/cp77/inkChildren.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCircleWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkCircleWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCircleWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCircleWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCircleWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCircleWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkClippedMenuScenarioData.cs
+++ b/CP77.CR2W/Types/cp77/inkClippedMenuScenarioData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkColorCorrectionEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkColorCorrectionEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkColorFillEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkColorFillEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkComboBoxController.cs
+++ b/CP77.CR2W/Types/cp77/inkComboBoxController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkComboBoxObjectController.cs
+++ b/CP77.CR2W/Types/cp77/inkComboBoxObjectController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkComboBoxVisibleChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkComboBoxVisibleChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkComboBoxVisibleChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkComboBoxVisibleChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCompositionInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkCompositionInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompositionPreset.cs
+++ b/CP77.CR2W/Types/cp77/inkCompositionPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompositionPreviewSettings.cs
+++ b/CP77.CR2W/Types/cp77/inkCompositionPreviewSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompositionTransition.cs
+++ b/CP77.CR2W/Types/cp77/inkCompositionTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompoundWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkCompoundWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompoundWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCompoundWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCompoundWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkCompoundWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkContainerNavigationController.cs
+++ b/CP77.CR2W/Types/cp77/inkContainerNavigationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkControllerProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkControllerProcessor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkControllerProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkControllerProcessor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCreditsResource.cs
+++ b/CP77.CR2W/Types/cp77/inkCreditsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCreditsSectionEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkCreditsSectionEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCursorContextCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCursorContextCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCursorContextCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCursorContextCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkCursorInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkCursorInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCustomCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCustomCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkCustomCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkCustomCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDebugLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkDebugLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDebugLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkDebugLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDebugLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkDebugLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDebugLayerEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkDebugLayerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDefaultCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkDefaultCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDefaultCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkDefaultCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDefaultLoadingScreenLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkDefaultLoadingScreenLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDelayedSetLoadingScreenEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkDelayedSetLoadingScreenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDelayedSetLoadingScreenEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkDelayedSetLoadingScreenEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDelayedSetStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkDelayedSetStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDelayedSetStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkDelayedSetStateEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDeleteRequestResult.cs
+++ b/CP77.CR2W/Types/cp77/inkDeleteRequestResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDeleteRequestResult.cs
+++ b/CP77.CR2W/Types/cp77/inkDeleteRequestResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkDexLimoGameController.cs
+++ b/CP77.CR2W/Types/cp77/inkDexLimoGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDiscreteNavigationController.cs
+++ b/CP77.CR2W/Types/cp77/inkDiscreteNavigationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDrawArea.cs
+++ b/CP77.CR2W/Types/cp77/inkDrawArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkDynamicTextureSlot.cs
+++ b/CP77.CR2W/Types/cp77/inkDynamicTextureSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEditorLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkEditorLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEditorLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkEditorLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkEditorModeState.cs
+++ b/CP77.CR2W/Types/cp77/inkEditorModeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEditorModeState.cs
+++ b/CP77.CR2W/Types/cp77/inkEditorModeState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkEmptyCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkEmptyCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEmptyCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkEmptyCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkEndGameLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkEndGameLoadingState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEndGameLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkEndGameLoadingState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkEngagementScreenState.cs
+++ b/CP77.CR2W/Types/cp77/inkEngagementScreenState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEngagementScreenState.cs
+++ b/CP77.CR2W/Types/cp77/inkEngagementScreenState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingControllerSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingControllerSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingScreenLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFastTravelLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkFastTravelLoadingState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFinalConfigurationController.cs
+++ b/CP77.CR2W/Types/cp77/inkFinalConfigurationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFitToViewport.cs
+++ b/CP77.CR2W/Types/cp77/inkFitToViewport.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFitToViewport.cs
+++ b/CP77.CR2W/Types/cp77/inkFitToViewport.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFlexWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkFlexWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFlexWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkFlexWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFlexWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkFlexWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFlexWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkFlexWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFocusEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkFocusEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFocusEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkFocusEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFocusEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkFocusEventCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFocusEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkFocusEventCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFontFamilyResource.cs
+++ b/CP77.CR2W/Types/cp77/inkFontFamilyResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFontStyle.cs
+++ b/CP77.CR2W/Types/cp77/inkFontStyle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFullScreenLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkFullScreenLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFullScreenLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkFullScreenLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFullscreenCompositionManager.cs
+++ b/CP77.CR2W/Types/cp77/inkFullscreenCompositionManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkFullscreenCompositionManager.cs
+++ b/CP77.CR2W/Types/cp77/inkFullscreenCompositionManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkFullscreenCompositionResource.cs
+++ b/CP77.CR2W/Types/cp77/inkFullscreenCompositionResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkGameNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationEvt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationEvt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkGameNotificationToken.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationToken.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationToken.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkGameNotificationsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationsLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameNotificationsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationsLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkGameNotificationsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkGameNotificationsLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameSettingsResource.cs
+++ b/CP77.CR2W/Types/cp77/inkGameSettingsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameState.cs
+++ b/CP77.CR2W/Types/cp77/inkGameState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGameState.cs
+++ b/CP77.CR2W/Types/cp77/inkGameState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkGenericSystemNotificationLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkGenericSystemNotificationLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGlitchEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkGlitchEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGradientWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkGradientWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridController.cs
+++ b/CP77.CR2W/Types/cp77/inkGridController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridItem.cs
+++ b/CP77.CR2W/Types/cp77/inkGridItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridItemTemplate.cs
+++ b/CP77.CR2W/Types/cp77/inkGridItemTemplate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkGridWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkGridWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkGridWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkGridWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHUDLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkHUDLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHUDLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkHUDLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHUDLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkHUDLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHideLoadingScreenDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkHideLoadingScreenDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHideLoadingScreenDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkHideLoadingScreenDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHighwaySignLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkHighwaySignLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHoldControllerActionData.cs
+++ b/CP77.CR2W/Types/cp77/inkHoldControllerActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHorizontalPanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkHorizontalPanelWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHorizontalPanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkHorizontalPanelWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHorizontalPanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkHorizontalPanelWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHorizontalPanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkHorizontalPanelWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHoverResizeController.cs
+++ b/CP77.CR2W/Types/cp77/inkHoverResizeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHudEntriesResource.cs
+++ b/CP77.CR2W/Types/cp77/inkHudEntriesResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHudEntryInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkHudEntryInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHudEntrySpawnedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkHudEntrySpawnedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHudEntrySpawnedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkHudEntrySpawnedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkHudWidgetSpawnEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkHudWidgetSpawnEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHyperlinkCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkHyperlinkCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkHyperlinkCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkHyperlinkCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIAdvertisementWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIAdvertisementWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIAdvertisementWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIAdvertisementWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkIEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkIIconAtlas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkIIconAtlas.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkIIconAtlasManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkIIconAtlasManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkILoadingLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkILoadingLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkILoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingScreenData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkILoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingScreenData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkILoadingScreenPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingScreenPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkILoadingScreenPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/inkILoadingScreenPersistentData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIStateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/inkIStateMachineState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIStateMachineState.cs
+++ b/CP77.CR2W/Types/cp77/inkIStateMachineState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIStreetNameSignLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkIStreetNameSignLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIStreetNameSignLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkIStreetNameSignLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIStreetSignWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIStreetSignWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIStreetSignWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIStreetSignWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkISystemRequestsHandler.cs
+++ b/CP77.CR2W/Types/cp77/inkISystemRequestsHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIWidgetController.cs
+++ b/CP77.CR2W/Types/cp77/inkIWidgetController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkIWidgetLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWidgetSlotController.cs
+++ b/CP77.CR2W/Types/cp77/inkIWidgetSlotController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWorldFluffWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWorldFluffWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWorldFluffWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWorldFluffWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIWorldWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWorldWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIWorldWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkIWorldWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkIconAtlas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkIconAtlas.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkIconAtlasManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkIconAtlasManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIconReference.cs
+++ b/CP77.CR2W/Types/cp77/inkIconReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIconReference.cs
+++ b/CP77.CR2W/Types/cp77/inkIconReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIgnoreOnConsoles.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoreOnConsoles.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIgnoreOnConsoles.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoreOnConsoles.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIgnoreSwapHorizontallyMode.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoreSwapHorizontallyMode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIgnoreSwapHorizontallyMode.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoreSwapHorizontallyMode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIgnoresCursorState.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoresCursorState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIgnoresCursorState.cs
+++ b/CP77.CR2W/Types/cp77/inkIgnoresCursorState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkImageWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkImageWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkImageWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkImageWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkImageWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkImageWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInGameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkInGameMenuState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInGameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkInGameMenuState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitEngineState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitEngineState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitEngineState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitEngineState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingControllerSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingControllerSupervisor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingControllerSupervisor.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingControllerSupervisor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingScreenData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingScreenData.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingScreenData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingScreenLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingScreenLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingScreenSaveData.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingScreenSaveData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingScreenSaveData.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingScreenSaveData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitialLoadingState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitialLoadingState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInitializeUserScreenState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitializeUserScreenState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInitializeUserScreenState.cs
+++ b/CP77.CR2W/Types/cp77/inkInitializeUserScreenState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInnerGlowEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkInnerGlowEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputDeviceCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDeviceCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputDeviceCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDeviceCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInputDeviceIdCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDeviceIdCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputDeviceIdCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDeviceIdCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInputDevicesMappingsJSON.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDevicesMappingsJSON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputDisplayController.cs
+++ b/CP77.CR2W/Types/cp77/inkInputDisplayController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkInputEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkInputEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInputIconMappingJSON.cs
+++ b/CP77.CR2W/Types/cp77/inkInputIconMappingJSON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputKeyData.cs
+++ b/CP77.CR2W/Types/cp77/inkInputKeyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputKeyData.cs
+++ b/CP77.CR2W/Types/cp77/inkInputKeyData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkInputKeyDictionaryJSON.cs
+++ b/CP77.CR2W/Types/cp77/inkInputKeyDictionaryJSON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputKeyIconManager.cs
+++ b/CP77.CR2W/Types/cp77/inkInputKeyIconManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkInputKeyIconManager.cs
+++ b/CP77.CR2W/Types/cp77/inkInputKeyIconManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkIsAbleToSwapHorizontally.cs
+++ b/CP77.CR2W/Types/cp77/inkIsAbleToSwapHorizontally.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkIsAbleToSwapHorizontally.cs
+++ b/CP77.CR2W/Types/cp77/inkIsAbleToSwapHorizontally.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkItemPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/inkItemPositionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkItemPositionProvider.cs
+++ b/CP77.CR2W/Types/cp77/inkItemPositionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkItemPositionProviderWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkItemPositionProviderWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkItemPositionProviderWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkItemPositionProviderWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkKeyBindingEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkKeyBindingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageFont.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageFont.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageFontMapper.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageFontMapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageFontMapping.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageFontMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageOverrideProvider.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageOverrideProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageSpecificImageController.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageSpecificImageController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLanguageSpecificVideoController.cs
+++ b/CP77.CR2W/Types/cp77/inkLanguageSpecificVideoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLatestSaveMetadataInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkLatestSaveMetadataInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLayerDefinitionCollection.cs
+++ b/CP77.CR2W/Types/cp77/inkLayerDefinitionCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLayerProxy.cs
+++ b/CP77.CR2W/Types/cp77/inkLayerProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLayerProxy.cs
+++ b/CP77.CR2W/Types/cp77/inkLayerProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLayersResource.cs
+++ b/CP77.CR2W/Types/cp77/inkLayersResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLeafWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkLeafWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLeafWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkLeafWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLeafWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkLeafWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLeafWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkLeafWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLightSweepEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkLightSweepEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLinePatternWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkLinePatternWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLinePatternWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkLinePatternWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLinePatternWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkLinePatternWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLineVertex.cs
+++ b/CP77.CR2W/Types/cp77/inkLineVertex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLinearWipeEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkLinearWipeEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkListController.cs
+++ b/CP77.CR2W/Types/cp77/inkListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkListControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkListControllerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkListControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkListControllerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkListItemController.cs
+++ b/CP77.CR2W/Types/cp77/inkListItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkListItemControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkListItemControllerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkListItemControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkListItemControllerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLoadingFadeInOutCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingFadeInOutCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLoadingFadeInOutCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingFadeInOutCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLoadingLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLoadingLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLoadingLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLoadingStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingStateChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLoadingStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkLoadingStateChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLocalizationChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkLocalizationChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkLocalizationChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkLocalizationChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkLocalizedBink.cs
+++ b/CP77.CR2W/Types/cp77/inkLocalizedBink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMargin.cs
+++ b/CP77.CR2W/Types/cp77/inkMargin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMaskEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkMaskEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMaskWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkMaskWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMaskWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkMaskWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMaskWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkMaskWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuAccountLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuAccountLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuEventDispatcher.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuEventDispatcher.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuEventDispatcher.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuEventDispatcher.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstance.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstance.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstanceImpl.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstanceImpl.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstanceImpl.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstanceImpl.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_MenuInstanceListener.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_MenuInstanceListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_MenuInstanceListener.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_MenuInstanceListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnAddressedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnAddressedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnAddressedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnAddressedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SpawnEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SwitchToScenario.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SwitchToScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuInstance_SwitchToScenario.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuInstance_SwitchToScenario.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_AbortHackingMinigame.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_AbortHackingMinigame.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_AbortHackingMinigame.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_AbortHackingMinigame.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetCursorVisibility.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetCursorVisibility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetCursorVisibility.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetCursorVisibility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetGender.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetGender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetGender.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetGender.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetMenuModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetMenuModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLayer_SetMenuModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLayer_SetMenuModeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuResource.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuScenario.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuScenario.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuScenario.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenuVisibilityChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuVisibilityChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenuVisibilityChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkMenuVisibilityChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMenusState.cs
+++ b/CP77.CR2W/Types/cp77/inkMenusState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMenusState.cs
+++ b/CP77.CR2W/Types/cp77/inkMenusState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMetroSignLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkMetroSignLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMinigameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkMinigameMenuState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMinigameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkMinigameMenuState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkMotorcycleHUDGameController.cs
+++ b/CP77.CR2W/Types/cp77/inkMotorcycleHUDGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMultiChildren.cs
+++ b/CP77.CR2W/Types/cp77/inkMultiChildren.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMultisamplingEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkMultisamplingEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkMultisamplingEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkMultisamplingEffect.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkNavigationOverrideEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkNavigationOverrideEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkNewHudSpawnedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkNewHudSpawnedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkNewHudSpawnedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkNewHudSpawnedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkNoChildren.cs
+++ b/CP77.CR2W/Types/cp77/inkNoChildren.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkNoChildren.cs
+++ b/CP77.CR2W/Types/cp77/inkNoChildren.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkNullIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkNullIconAtlas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkNullIconAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkNullIconAtlas.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkNullIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkNullIconAtlasManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkNullIconAtlasManager.cs
+++ b/CP77.CR2W/Types/cp77/inkNullIconAtlasManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkOffscreenLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOffscreenLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkOffscreenLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOffscreenLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenLayerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkOffscreenWidgetSpawnEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenWidgetSpawnEvt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOffscreenWidgetSpawnEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkOffscreenWidgetSpawnEvt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkOnUIStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkOnUIStateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOnUIStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkOnUIStateChangedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkOnscreenVOData.cs
+++ b/CP77.CR2W/Types/cp77/inkOnscreenVOData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOnscreenVOHandler.cs
+++ b/CP77.CR2W/Types/cp77/inkOnscreenVOHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkOnscreenVOHandler.cs
+++ b/CP77.CR2W/Types/cp77/inkOnscreenVOHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPauseMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkPauseMenuState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPauseMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkPauseMenuState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPermanentLayerDefinitionCollection.cs
+++ b/CP77.CR2W/Types/cp77/inkPermanentLayerDefinitionCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPhotoModeCursorStateChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeCursorStateChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPhotoModeLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPhotoModeLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPhotoModeLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPhotoModeState.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPhotoModeState.cs
+++ b/CP77.CR2W/Types/cp77/inkPhotoModeState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPlatformSpecificImageController.cs
+++ b/CP77.CR2W/Types/cp77/inkPlatformSpecificImageController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPlatformSpecificTextController.cs
+++ b/CP77.CR2W/Types/cp77/inkPlatformSpecificTextController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPlatformSpecificVideoController.cs
+++ b/CP77.CR2W/Types/cp77/inkPlatformSpecificVideoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPointCloudEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkPointCloudEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPointerEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkPointerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPointerEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkPointerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPointerEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkPointerEventCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPointerEventCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkPointerEventCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPreGameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkPreGameMenuState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPreGameMenuState.cs
+++ b/CP77.CR2W/Types/cp77/inkPreGameMenuState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkProcessLoadingScreenDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkProcessLoadingScreenDelayedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkProcessLoadingScreenDelayedEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkProcessLoadingScreenDelayedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkPropertyBinding.cs
+++ b/CP77.CR2W/Types/cp77/inkPropertyBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkPropertyManager.cs
+++ b/CP77.CR2W/Types/cp77/inkPropertyManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkQuadShapeWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkQuadShapeWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkQuadWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkQuadWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkQuadWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkQuadWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRadialWipeEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkRadialWipeEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRadioGroupChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkRadioGroupChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRadioGroupChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkRadioGroupChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRadioGroupController.cs
+++ b/CP77.CR2W/Types/cp77/inkRadioGroupController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRectangle.cs
+++ b/CP77.CR2W/Types/cp77/inkRectangle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRectangleWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkRectangleWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRectangleWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkRectangleWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRectangleWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRectangleWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRectangleWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRectangleWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRequestNewHudEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkRequestNewHudEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRichTextBoxWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkRichTextBoxWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRichTextBoxWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkRichTextBoxWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRichTextBoxWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRichTextBoxWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRichTextBoxWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRichTextBoxWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRollingListController.cs
+++ b/CP77.CR2W/Types/cp77/inkRollingListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRootWidgetIdentifier.cs
+++ b/CP77.CR2W/Types/cp77/inkRootWidgetIdentifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRootWidgetIdentifier.cs
+++ b/CP77.CR2W/Types/cp77/inkRootWidgetIdentifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkRuntimeStylePropertyReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRuntimeStylePropertyReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkRuntimeStylePropertyReference.cs
+++ b/CP77.CR2W/Types/cp77/inkRuntimeStylePropertyReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSaveMetadataInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkSaveMetadataInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSaveMetadataRequestResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSaveMetadataRequestResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSaveMetadataRequestResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSaveMetadataRequestResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScanlineWipeEffect.cs
+++ b/CP77.CR2W/Types/cp77/inkScanlineWipeEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScreenProjection.cs
+++ b/CP77.CR2W/Types/cp77/inkScreenProjection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScreenProjectionCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkScreenProjectionCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScreenProjectionCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkScreenProjectionCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScreenProjectionData.cs
+++ b/CP77.CR2W/Types/cp77/inkScreenProjectionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScriptDynArray.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptDynArray.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScriptDynArray.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptDynArray.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScriptFIFOQueue.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptFIFOQueue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScriptFIFOQueue.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptFIFOQueue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScriptableDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptableDataSourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScriptableDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptableDataSourceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScriptableDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptableDataViewWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScriptableDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkScriptableDataViewWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScrollAreaWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkScrollAreaWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScrollAreaWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkScrollAreaWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkScrollAreaWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkScrollAreaWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkScrollController.cs
+++ b/CP77.CR2W/Types/cp77/inkScrollController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSelectionChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSelectionChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSelectionChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSelectionChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSelectorController.cs
+++ b/CP77.CR2W/Types/cp77/inkSelectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkServerInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkServerInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSetNextLoadingScreenEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkSetNextLoadingScreenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSetNextLoadingScreenEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkSetNextLoadingScreenEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSettingChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSettingChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSettingChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSettingChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSettingsSelectorController.cs
+++ b/CP77.CR2W/Types/cp77/inkSettingsSelectorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSettingsSelectorControllerKeyBinding.cs
+++ b/CP77.CR2W/Types/cp77/inkSettingsSelectorControllerKeyBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapeCollectionResource.cs
+++ b/CP77.CR2W/Types/cp77/inkShapeCollectionResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapePreset.cs
+++ b/CP77.CR2W/Types/cp77/inkShapePreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapePresetWraper.cs
+++ b/CP77.CR2W/Types/cp77/inkShapePresetWraper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapeWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkShapeWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapeWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkShapeWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShapeWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkShapeWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkShowEngagementScreen.cs
+++ b/CP77.CR2W/Types/cp77/inkShowEngagementScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkShowInitializeUserScreen.cs
+++ b/CP77.CR2W/Types/cp77/inkShowInitializeUserScreen.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSingleDrawMetric.cs
+++ b/CP77.CR2W/Types/cp77/inkSingleDrawMetric.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSize.cs
+++ b/CP77.CR2W/Types/cp77/inkSize.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSliderController.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSliderControllerHandleReleasedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerHandleReleasedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSliderControllerHandleReleasedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerHandleReleasedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSliderControllerInputCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerInputCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSliderControllerInputCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerInputCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSliderControllerValueChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerValueChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSliderControllerValueChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkSliderControllerValueChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSpawningProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkSpawningProcessor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSpawningProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkSpawningProcessor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSplashScreenLoadingScreenLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkSplashScreenLoadingScreenLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkStateChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStateChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkStateChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStateChangeRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkStateChangeRequestEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStateChangeRequestEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkStateChangeRequestEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/inkStateMachine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStateMachine.cs
+++ b/CP77.CR2W/Types/cp77/inkStateMachine.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStateTransitionAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkStateTransitionAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStepperChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkStepperChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStepperChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkStepperChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStepperController.cs
+++ b/CP77.CR2W/Types/cp77/inkStepperController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStepperData.cs
+++ b/CP77.CR2W/Types/cp77/inkStepperData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStreetNameSignLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkStreetNameSignLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStreetSignsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkStreetSignsLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStreetSignsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkStreetSignsLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStreetSignsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkStreetSignsLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStreetSignsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkStreetSignsLayerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkStyle.cs
+++ b/CP77.CR2W/Types/cp77/inkStyle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStyleProperty.cs
+++ b/CP77.CR2W/Types/cp77/inkStyleProperty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStylePropertyReference.cs
+++ b/CP77.CR2W/Types/cp77/inkStylePropertyReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStyleResource.cs
+++ b/CP77.CR2W/Types/cp77/inkStyleResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStyleResourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkStyleResourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStyleTheme.cs
+++ b/CP77.CR2W/Types/cp77/inkStyleTheme.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkStyleThemeDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/inkStyleThemeDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSubtitlesLanguageOverride.cs
+++ b/CP77.CR2W/Types/cp77/inkSubtitlesLanguageOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSubtitlesLanguageOverride.cs
+++ b/CP77.CR2W/Types/cp77/inkSubtitlesLanguageOverride.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSystemNotificationEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemNotificationEvt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSystemNotificationEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemNotificationEvt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSystemNotificationsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemNotificationsLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSystemNotificationsLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemNotificationsLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSystemNotificationsLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemNotificationsLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSystemRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemRequesResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSystemRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemRequesResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkSystemServerRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemServerRequesResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkSystemServerRequesResult.cs
+++ b/CP77.CR2W/Types/cp77/inkSystemServerRequesResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkTextAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkTextCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkTextCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkTextInputWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkTextInputWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextInputWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkTextInputWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkTextInputWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkTextInputWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextInputWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkTextInputWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkTextKiroshiAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextKiroshiAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextMotherTongueController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextMotherTongueController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextOffsetAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextOffsetAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextReplaceAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextReplaceAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextValueProgressAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkTextValueProgressAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkTextWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkTextWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkTextWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkTextureAtlas.cs
+++ b/CP77.CR2W/Types/cp77/inkTextureAtlas.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextureAtlasMapper.cs
+++ b/CP77.CR2W/Types/cp77/inkTextureAtlasMapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextureAtlasSlice.cs
+++ b/CP77.CR2W/Types/cp77/inkTextureAtlasSlice.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTextureSlot.cs
+++ b/CP77.CR2W/Types/cp77/inkTextureSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkToggleChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkToggleChangedCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkToggleChangedCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkToggleChangedCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkToggleController.cs
+++ b/CP77.CR2W/Types/cp77/inkToggleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTutorialOverlayInputRequest.cs
+++ b/CP77.CR2W/Types/cp77/inkTutorialOverlayInputRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTweakDBIDSelector.cs
+++ b/CP77.CR2W/Types/cp77/inkTweakDBIDSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkTypographyResource.cs
+++ b/CP77.CR2W/Types/cp77/inkTypographyResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUITransform.cs
+++ b/CP77.CR2W/Types/cp77/inkUITransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUniformGridWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkUniformGridWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUniformGridWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkUniformGridWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUniformGridWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkUniformGridWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkUserIdResult.cs
+++ b/CP77.CR2W/Types/cp77/inkUserIdResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkUserIdResult.cs
+++ b/CP77.CR2W/Types/cp77/inkUserIdResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVORequestEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkVORequestEvt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVORequestEvt.cs
+++ b/CP77.CR2W/Types/cp77/inkVORequestEvt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVariantCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVariantCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVariantDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantDataSourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVariantDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantDataSourceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVariantDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantDataViewWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVariantDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVariantDataViewWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVector2Callback.cs
+++ b/CP77.CR2W/Types/cp77/inkVector2Callback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVector2Callback.cs
+++ b/CP77.CR2W/Types/cp77/inkVector2Callback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVectorGraphicWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVectorGraphicWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVectorGraphicWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVectorGraphicWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVerticalPanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVerticalPanelWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVerticalPanelWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVerticalPanelWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVerticalPanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVerticalPanelWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVerticalPanelWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVerticalPanelWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVideoInstanceDoneCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoInstanceDoneCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoInstanceDoneCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoInstanceDoneCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVideoLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVideoLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoLayerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVideoSequenceController.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoSequenceController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoSequenceEntry.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoSequenceEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVideoWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVideoWidgetSummary.cs
+++ b/CP77.CR2W/Types/cp77/inkVideoWidgetSummary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundBackgroundController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundBackgroundController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundBackgroundController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundBackgroundController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundControllerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundControllerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemControllerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemControllerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemSelectControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemSelectControllerCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundItemSelectControllerCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundItemSelectControllerCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualCompoundWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualCompoundWidgetReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualGridController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualGridController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualGridController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualGridController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifier.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifierWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifierWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifierWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualItemTemplateClassifierWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualListController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualUniformGridController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualUniformGridController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualUniformGridController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualUniformGridController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVirtualUniformListController.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualUniformListController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualWindow.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualWindow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVirtualWindow.cs
+++ b/CP77.CR2W/Types/cp77/inkVirtualWindow.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVisualStateChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkVisualStateChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVisualStatePopStateMachineEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkVisualStatePopStateMachineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkVisualStatePopStateMachineEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkVisualStatePopStateMachineEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkVisualStateRestorePreviousEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkVisualStateRestorePreviousEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWatermarksLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWatermarksLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWatermarksLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWatermarksLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWatermarksLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkWatermarksLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWatermarksLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkWatermarksLayerDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWeakScriptableDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkWeakScriptableDataSourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWeakScriptableDataSourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkWeakScriptableDataSourceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWeakScriptableDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkWeakScriptableDataViewWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWeakScriptableDataViewWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkWeakScriptableDataViewWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWidget.cs
+++ b/CP77.CR2W/Types/cp77/inkWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetBackendData.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetBackendData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetBrush.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetBrush.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetBrushResource.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetBrushResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetClipboardData.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetClipboardData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetCompositor.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetCompositor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetCompositor.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetCompositor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWidgetLayout.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLayout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryItem.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryItemClipboardData.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryItemClipboardData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryItemInstance.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryItemInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryItemUnpackedView.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryItemUnpackedView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryReference.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryResource.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryResourceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryResourceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLibraryUnpackedView.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLibraryUnpackedView.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWidgetPath.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetReference.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetSlotAttachmentParams.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetSlotAttachmentParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetSlotController.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetSlotController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetSlotController.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetSlotController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWidgetStateAnimatedTransition.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetStateAnimatedTransition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetUtils.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetUtils.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetUtils.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetUtils.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWidgetsSet.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetsSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWidgetsSet.cs
+++ b/CP77.CR2W/Types/cp77/inkWidgetsSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWindow.cs
+++ b/CP77.CR2W/Types/cp77/inkWindow.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWindow.cs
+++ b/CP77.CR2W/Types/cp77/inkWindow.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWindowDrawMetrics.cs
+++ b/CP77.CR2W/Types/cp77/inkWindowDrawMetrics.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldFluffLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldFluffLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldFluffLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldFluffLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWorldLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldLayer.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldLayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWorldLayerDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldLayerDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldWidgetComponentUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldWidgetComponentUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldWidgetComponentUserData.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldWidgetComponentUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkWorldWidgetInfos.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldWidgetInfos.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkWorldWidgetInfos.cs
+++ b/CP77.CR2W/Types/cp77/inkWorldWidgetInfos.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimAdvertPauseEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAdvertPauseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimAdvertPauseEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAdvertPauseEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimAnchorInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnchorInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimAnimationCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnimationCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimAnimationCallback.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnimationCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnimationController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimAnimationLibraryResource.cs
+++ b/CP77.CR2W/Types/cp77/inkanimAnimationLibraryResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimBuilder.cs
+++ b/CP77.CR2W/Types/cp77/inkanimBuilder.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimBuilder.cs
+++ b/CP77.CR2W/Types/cp77/inkanimBuilder.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimChangeStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimChangeStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimColorInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimColorInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimController.cs
+++ b/CP77.CR2W/Types/cp77/inkanimController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimController.cs
+++ b/CP77.CR2W/Types/cp77/inkanimController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimDefinition.cs
+++ b/CP77.CR2W/Types/cp77/inkanimDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimEffectInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimEffectInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimExecuteCodeEventEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimExecuteCodeEventEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimExecuteControllerFunctionEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimExecuteControllerFunctionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimMarginInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimMarginInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimMarkerEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimMarkerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPaddingInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPaddingInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPivotInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPivotInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPlayAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPlayAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPlaySoundEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPlaySoundEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPlayVOEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPlayVOEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPlayVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPlayVideoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimPlaybackOptions.cs
+++ b/CP77.CR2W/Types/cp77/inkanimPlaybackOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkanimProcessor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimProcessor.cs
+++ b/CP77.CR2W/Types/cp77/inkanimProcessor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimProxy.cs
+++ b/CP77.CR2W/Types/cp77/inkanimProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimProxy.cs
+++ b/CP77.CR2W/Types/cp77/inkanimProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimRotationInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimRotationInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimScaleInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimScaleInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSequence.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSequenceTargetInfo.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSequenceTargetInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSetStyleEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSetStyleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSetTextEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSetTextEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSetVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSetVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimShapeBorderTransparencyInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimShapeBorderTransparencyInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimShapeFillTransparencyInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimShapeFillTransparencyInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimShearInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimShearInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimSizeInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimSizeInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimStopAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimStopAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimStopVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimStopVideoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimStopVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimStopVideoEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimTextInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTextKiroshiInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextKiroshiInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTextKiroshiInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextKiroshiInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimTextOffsetInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextOffsetInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTextOffsetInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextOffsetInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimTextReplaceInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextReplaceInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTextReplaceInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextReplaceInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimTextValueProgressInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextValueProgressInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTextValueProgressInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTextValueProgressInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimToggleVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimToggleVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimToggleVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/inkanimToggleVisibilityEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inkanimTranslationInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTranslationInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimTransparencyInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimTransparencyInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inkanimVideoInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/inkanimVideoInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputIInputSystem.cs
+++ b/CP77.CR2W/Types/cp77/inputIInputSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputIInputSystem.cs
+++ b/CP77.CR2W/Types/cp77/inputIInputSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inputInputSystemEditor.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemEditor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputInputSystemEditor.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemEditor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inputInputSystemNullInterface.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemNullInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputInputSystemNullInterface.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemNullInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inputInputSystemWin32Base.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemWin32Base.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputInputSystemWin32Base.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemWin32Base.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/inputInputSystemWin32Game.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemWin32Game.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/inputInputSystemWin32Game.cs
+++ b/CP77.CR2W/Types/cp77/inputInputSystemWin32Game.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/instrumentPanelLogicController.cs
+++ b/CP77.CR2W/Types/cp77/instrumentPanelLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interactionItemLogicController.cs
+++ b/CP77.CR2W/Types/cp77/interactionItemLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interactionWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/interactionWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopDispatchPrefabProxyJobsResult.cs
+++ b/CP77.CR2W/Types/cp77/interopDispatchPrefabProxyJobsResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopEntityEffectSelectionSyncData.cs
+++ b/CP77.CR2W/Types/cp77/interopEntityEffectSelectionSyncData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopEntityEffectSpawnerSyncData.cs
+++ b/CP77.CR2W/Types/cp77/interopEntityEffectSpawnerSyncData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopGlobalNodeIDInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopGlobalNodeIDInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopGlobalNodeIDResult.cs
+++ b/CP77.CR2W/Types/cp77/interopGlobalNodeIDResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopGraphConnectionCreationData.cs
+++ b/CP77.CR2W/Types/cp77/interopGraphConnectionCreationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopMaterialListDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/interopMaterialListDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopNodeTransformInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopNodeTransformInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopOpaqueData.cs
+++ b/CP77.CR2W/Types/cp77/interopOpaqueData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopRTTIClassDump.cs
+++ b/CP77.CR2W/Types/cp77/interopRTTIClassDump.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopRTTIClassDumpEntry.cs
+++ b/CP77.CR2W/Types/cp77/interopRTTIClassDumpEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopRTTIResourceDumpInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopRTTIResourceDumpInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopReExportOptions.cs
+++ b/CP77.CR2W/Types/cp77/interopReExportOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopSelectByDefinitionOptions.cs
+++ b/CP77.CR2W/Types/cp77/interopSelectByDefinitionOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopSelectionChangeInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopSelectionChangeInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopStringUint64Pair.cs
+++ b/CP77.CR2W/Types/cp77/interopStringUint64Pair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopStringWithID.cs
+++ b/CP77.CR2W/Types/cp77/interopStringWithID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainEditToolCreationSlotInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainEditToolCreationSlotInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainEditToolInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainEditToolInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainImportParams.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainImportParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainImportedTile.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainImportedTile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainNodeInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainNodeInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTerrainSystemInstanceInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopTerrainSystemInstanceInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopTransformInfo.cs
+++ b/CP77.CR2W/Types/cp77/interopTransformInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/interopUint64Pair.cs
+++ b/CP77.CR2W/Types/cp77/interopUint64Pair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/itempreviewUIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/itempreviewUIObjectsLoaderSystemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/itempreviewUIObjectsLoaderSystemListener.cs
+++ b/CP77.CR2W/Types/cp77/itempreviewUIObjectsLoaderSystemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/keyboardHintGameController.cs
+++ b/CP77.CR2W/Types/cp77/keyboardHintGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/linkedClueTagEvent.cs
+++ b/CP77.CR2W/Types/cp77/linkedClueTagEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/linkedClueUpdateEvent.cs
+++ b/CP77.CR2W/Types/cp77/linkedClueUpdateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locPackageLocalizationStringSerializer.cs
+++ b/CP77.CR2W/Types/cp77/locPackageLocalizationStringSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locPackageLocalizationStringSerializer.cs
+++ b/CP77.CR2W/Types/cp77/locPackageLocalizationStringSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/locVoLanguageDataEntry.cs
+++ b/CP77.CR2W/Types/cp77/locVoLanguageDataEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoLanguageDataMap.cs
+++ b/CP77.CR2W/Types/cp77/locVoLanguageDataMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoLengthEntry.cs
+++ b/CP77.CR2W/Types/cp77/locVoLengthEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoLineEntry.cs
+++ b/CP77.CR2W/Types/cp77/locVoLineEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoResource.cs
+++ b/CP77.CR2W/Types/cp77/locVoResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoResource.cs
+++ b/CP77.CR2W/Types/cp77/locVoResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/locVoiceTag.cs
+++ b/CP77.CR2W/Types/cp77/locVoiceTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoiceTagListResource.cs
+++ b/CP77.CR2W/Types/cp77/locVoiceTagListResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoiceoverLengthMap.cs
+++ b/CP77.CR2W/Types/cp77/locVoiceoverLengthMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/locVoiceoverMap.cs
+++ b/CP77.CR2W/Types/cp77/locVoiceoverMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceCLNumberDateContainer.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceCLNumberDateContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceLocDataMap.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceLocDataMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceLocDataMapEntry.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceLocDataMapEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceOnScreenEntries.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceOnScreenEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceOnScreenEntry.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceOnScreenEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleEntries.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleEntries.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleEntry.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleMap.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleMap.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleMapEntry.cs
+++ b/CP77.CR2W/Types/cp77/localizationPersistenceSubtitleMapEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/lookAtPresetGunBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetGunBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/lookAtPresetGunBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetGunBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/lookAtPresetGunBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetGunBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/lookAtPresetItemBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetItemBaseDecisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/lookAtPresetItemBaseDecisions.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetItemBaseDecisions.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/lookAtPresetItemBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetItemBaseEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/lookAtPresetItemBaseEvents.cs
+++ b/CP77.CR2W/Types/cp77/lookAtPresetItemBaseEvents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mathExprExpression.cs
+++ b/CP77.CR2W/Types/cp77/mathExprExpression.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/megatronChargeController.cs
+++ b/CP77.CR2W/Types/cp77/megatronChargeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/megatronCrosshairGameController.cs
+++ b/CP77.CR2W/Types/cp77/megatronCrosshairGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/megatronFullAutoController.cs
+++ b/CP77.CR2W/Types/cp77/megatronFullAutoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/megatronModeInfoController.cs
+++ b/CP77.CR2W/Types/cp77/megatronModeInfoController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshChunkFlags.cs
+++ b/CP77.CR2W/Types/cp77/meshChunkFlags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshChunkIndicesOffset.cs
+++ b/CP77.CR2W/Types/cp77/meshChunkIndicesOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshChunkMaterials.cs
+++ b/CP77.CR2W/Types/cp77/meshChunkMaterials.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshChunkOffset.cs
+++ b/CP77.CR2W/Types/cp77/meshChunkOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshCookedClothMeshTopologyData.cs
+++ b/CP77.CR2W/Types/cp77/meshCookedClothMeshTopologyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshDestructionBond.cs
+++ b/CP77.CR2W/Types/cp77/meshDestructionBond.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshGfxClothChunkData.cs
+++ b/CP77.CR2W/Types/cp77/meshGfxClothChunkData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshImportedSnapTags.cs
+++ b/CP77.CR2W/Types/cp77/meshImportedSnapTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshLocalMaterialHeader.cs
+++ b/CP77.CR2W/Types/cp77/meshLocalMaterialHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshAppearance.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshImportedSnapPoint.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshImportedSnapPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshMaterialBuffer.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshMaterialBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamBakedDestructionData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamBakedDestructionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamBendedRoad.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamBendedRoad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamCloth.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamCloth.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamCloth_Graphical.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamCloth_Graphical.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamCompiledPhysics.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamCompiledPhysics.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamDeformableShapesData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamDeformableShapesData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamDestructionBonds.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamDestructionBonds.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamDestructionBoneChunkMapping.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamDestructionBoneChunkMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamDestructionChunkIndicesOffsets.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamDestructionChunkIndicesOffsets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamDestructionStepData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamDestructionStepData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamGarmentSupport.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamGarmentSupport.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamGpuBuffer.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamGpuBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamImportedSnapPoint.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamImportedSnapPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamOccluderData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamOccluderData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamPhysics.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamPhysics.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamShadowMeshCreationData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamShadowMeshCreationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamSpeedTreeWind_.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamSpeedTreeWind_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamSpeedTreeWind_.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamSpeedTreeWind_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/meshMeshParamTerrain.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamTerrain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamTopologyData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamTopologyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamTopologyMetadata.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamTopologyMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamUICollisionData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamUICollisionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamWaterPatchData.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamWaterPatchData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParamWorkspotOffsets.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParamWorkspotOffsets.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParameter.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshMeshParameter.cs
+++ b/CP77.CR2W/Types/cp77/meshMeshParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/meshPhxClothChunkData.cs
+++ b/CP77.CR2W/Types/cp77/meshPhxClothChunkData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshRawClothData.cs
+++ b/CP77.CR2W/Types/cp77/meshRawClothData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/meshRegionData.cs
+++ b/CP77.CR2W/Types/cp77/meshRegionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/minibossPlasmaProjectile.cs
+++ b/CP77.CR2W/Types/cp77/minibossPlasmaProjectile.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/minimapEncodedShapes.cs
+++ b/CP77.CR2W/Types/cp77/minimapEncodedShapes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/minimapuiGeometryWidget.cs
+++ b/CP77.CR2W/Types/cp77/minimapuiGeometryWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/minimapuiSettings.cs
+++ b/CP77.CR2W/Types/cp77/minimapuiSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/moveComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveCustomMoveEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveCustomMoveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveDroneMotionPlannerComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveDroneMotionPlannerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveDroneMotionPlannerComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveDroneMotionPlannerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveEnteredSplineEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveEnteredSplineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveExitedSplineEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveExitedSplineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveExitedSplineEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveExitedSplineEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveExplorationEnteredEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveExplorationEnteredEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveExplorationLeftEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveExplorationLeftEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveIMotionPlannerComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveIMotionPlannerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveIMotionPlannerComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveIMotionPlannerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveIPoliciesSystem.cs
+++ b/CP77.CR2W/Types/cp77/moveIPoliciesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveIPoliciesSystem.cs
+++ b/CP77.CR2W/Types/cp77/moveIPoliciesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveMotionPlannerComponent.cs
+++ b/CP77.CR2W/Types/cp77/moveMotionPlannerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveMoveComponentVelocityProvider.cs
+++ b/CP77.CR2W/Types/cp77/moveMoveComponentVelocityProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveMoveComponentVelocityProvider.cs
+++ b/CP77.CR2W/Types/cp77/moveMoveComponentVelocityProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveMovePoliciesComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/moveMovePoliciesComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveMovementParameters.cs
+++ b/CP77.CR2W/Types/cp77/moveMovementParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveObstacleDetectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveObstacleDetectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveObstacleDetectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/moveObstacleDetectedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/movePolicies.cs
+++ b/CP77.CR2W/Types/cp77/movePolicies.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesComponent.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesComponent.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/movePoliciesContract.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContract.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesContract.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContract.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/movePoliciesContractMoveToSmartObject.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContractMoveToSmartObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesContractMoveToSmartObject.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContractMoveToSmartObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/movePoliciesContractMoveToWorkspot.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContractMoveToWorkspot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesContractMoveToWorkspot.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesContractMoveToWorkspot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/movePoliciesSystem.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/movePoliciesSystem.cs
+++ b/CP77.CR2W/Types/cp77/movePoliciesSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/moveReplicatedMovePolicies.cs
+++ b/CP77.CR2W/Types/cp77/moveReplicatedMovePolicies.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveReplicatedMovePoliciesState.cs
+++ b/CP77.CR2W/Types/cp77/moveReplicatedMovePoliciesState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveSecureFootingParameters.cs
+++ b/CP77.CR2W/Types/cp77/moveSecureFootingParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveSecureFootingResult.cs
+++ b/CP77.CR2W/Types/cp77/moveSecureFootingResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/moveStrafingTarget.cs
+++ b/CP77.CR2W/Types/cp77/moveStrafingTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpClientGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpClientGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpClientGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpClientGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpInteractionActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/mpInteractionActivatorComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpInteractionActivatorComponent.cs
+++ b/CP77.CR2W/Types/cp77/mpInteractionActivatorComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpLocalPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpLocalPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpLocalPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpLocalPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpPersistentTestBox.cs
+++ b/CP77.CR2W/Types/cp77/mpPersistentTestBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpPersistentTestBox.cs
+++ b/CP77.CR2W/Types/cp77/mpPersistentTestBox.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpPersistentTestBoxState.cs
+++ b/CP77.CR2W/Types/cp77/mpPersistentTestBoxState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpPlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/mpPlayerManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpPlayerManager.cs
+++ b/CP77.CR2W/Types/cp77/mpPlayerManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpRemotePlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpRemotePlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpRemotePlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpRemotePlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpServerGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpServerGameSession.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpServerGameSession.cs
+++ b/CP77.CR2W/Types/cp77/mpServerGameSession.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/mpServerPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpServerPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/mpServerPlayer.cs
+++ b/CP77.CR2W/Types/cp77/mpServerPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/muliplayerInteractionTest.cs
+++ b/CP77.CR2W/Types/cp77/muliplayerInteractionTest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/nanowireGrenade.cs
+++ b/CP77.CR2W/Types/cp77/nanowireGrenade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPath.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPathPointInfo.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathPointInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPathPointUserData.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathPointUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPathPointUserData.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathPointUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/navLocomotionPathPointUserDataEntry.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathPointUserDataEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPathResource.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navLocomotionPathSegmentInfo.cs
+++ b/CP77.CR2W/Types/cp77/navLocomotionPathSegmentInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navRuntimeSystemPathfinding.cs
+++ b/CP77.CR2W/Types/cp77/navRuntimeSystemPathfinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/navRuntimeSystemPathfinding.cs
+++ b/CP77.CR2W/Types/cp77/navRuntimeSystemPathfinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/navSerializableSplineProgression.cs
+++ b/CP77.CR2W/Types/cp77/navSerializableSplineProgression.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/naviINavmeshGenerationSystem.cs
+++ b/CP77.CR2W/Types/cp77/naviINavmeshGenerationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/naviINavmeshGenerationSystem.cs
+++ b/CP77.CR2W/Types/cp77/naviINavmeshGenerationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netChargesWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/netChargesWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netDefaultComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/netDefaultComponentReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netDefaultComponentReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/netDefaultComponentReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netEntityAttachmentInterface.cs
+++ b/CP77.CR2W/Types/cp77/netEntityAttachmentInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netEntityReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/netEntityReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netEntityReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/netEntityReplicatedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/netEntitySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netEntitySystem.cs
+++ b/CP77.CR2W/Types/cp77/netEntitySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netFrameInputs.cs
+++ b/CP77.CR2W/Types/cp77/netFrameInputs.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netFramesInputsHistory.cs
+++ b/CP77.CR2W/Types/cp77/netFramesInputsHistory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netIComponentState.cs
+++ b/CP77.CR2W/Types/cp77/netIComponentState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netIEntityState.cs
+++ b/CP77.CR2W/Types/cp77/netIEntityState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netIIngameProfilerSystem.cs
+++ b/CP77.CR2W/Types/cp77/netIIngameProfilerSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netIIngameProfilerSystem.cs
+++ b/CP77.CR2W/Types/cp77/netIIngameProfilerSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netInputAction.cs
+++ b/CP77.CR2W/Types/cp77/netInputAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netInputAction.cs
+++ b/CP77.CR2W/Types/cp77/netInputAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/netInputOrientation.cs
+++ b/CP77.CR2W/Types/cp77/netInputOrientation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netPeerID.cs
+++ b/CP77.CR2W/Types/cp77/netPeerID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/netTime.cs
+++ b/CP77.CR2W/Types/cp77/netTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/panelApperanceSwitchEvent.cs
+++ b/CP77.CR2W/Types/cp77/panelApperanceSwitchEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/panzerGameController.cs
+++ b/CP77.CR2W/Types/cp77/panzerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/panzerGameController.cs
+++ b/CP77.CR2W/Types/cp77/panzerGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/parameterRequestEquip.cs
+++ b/CP77.CR2W/Types/cp77/parameterRequestEquip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsApperanceMaterial.cs
+++ b/CP77.CR2W/Types/cp77/physicsApperanceMaterial.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCacheEntry.cs
+++ b/CP77.CR2W/Types/cp77/physicsCacheEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCacheKey.cs
+++ b/CP77.CR2W/Types/cp77/physicsCacheKey.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsColliderBox.cs
+++ b/CP77.CR2W/Types/cp77/physicsColliderBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsColliderCapsule.cs
+++ b/CP77.CR2W/Types/cp77/physicsColliderCapsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsColliderConvex.cs
+++ b/CP77.CR2W/Types/cp77/physicsColliderConvex.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsColliderMesh_.cs
+++ b/CP77.CR2W/Types/cp77/physicsColliderMesh_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsColliderSphere.cs
+++ b/CP77.CR2W/Types/cp77/physicsColliderSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCollisionFilterResource.cs
+++ b/CP77.CR2W/Types/cp77/physicsCollisionFilterResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCollisionPreset.cs
+++ b/CP77.CR2W/Types/cp77/physicsCollisionPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCollisionPresetOverride.cs
+++ b/CP77.CR2W/Types/cp77/physicsCollisionPresetOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCollisionPresetsOverridesResource.cs
+++ b/CP77.CR2W/Types/cp77/physicsCollisionPresetsOverridesResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCollisionPresetsResource.cs
+++ b/CP77.CR2W/Types/cp77/physicsCollisionPresetsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsControllerHit.cs
+++ b/CP77.CR2W/Types/cp77/physicsControllerHit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsCustomFilterData.cs
+++ b/CP77.CR2W/Types/cp77/physicsCustomFilterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsDeferredCollection.cs
+++ b/CP77.CR2W/Types/cp77/physicsDeferredCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsDestructionHierarchyOffset.cs
+++ b/CP77.CR2W/Types/cp77/physicsDestructionHierarchyOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsDestructionLevelData.cs
+++ b/CP77.CR2W/Types/cp77/physicsDestructionLevelData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsDestructionParams.cs
+++ b/CP77.CR2W/Types/cp77/physicsDestructionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsFilterData.cs
+++ b/CP77.CR2W/Types/cp77/physicsFilterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsGeometryCache.cs
+++ b/CP77.CR2W/Types/cp77/physicsGeometryCache.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsGeometryKey.cs
+++ b/CP77.CR2W/Types/cp77/physicsGeometryKey.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsICollider.cs
+++ b/CP77.CR2W/Types/cp77/physicsICollider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsISystemObject.cs
+++ b/CP77.CR2W/Types/cp77/physicsISystemObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsMaterialLibraryResource_.cs
+++ b/CP77.CR2W/Types/cp77/physicsMaterialLibraryResource_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsMaterialReference.cs
+++ b/CP77.CR2W/Types/cp77/physicsMaterialReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsMaterialResource.cs
+++ b/CP77.CR2W/Types/cp77/physicsMaterialResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsMaterialTags.cs
+++ b/CP77.CR2W/Types/cp77/physicsMaterialTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicalJointPin.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicalJointPin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointAngularLimitPair.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointAngularLimitPair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointDrive.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointDrive.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointDriveVelocity.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointDriveVelocity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointLimitBase.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointLimitBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointLimitConePair.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointLimitConePair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsPhysicsJointLinearLimit.cs
+++ b/CP77.CR2W/Types/cp77/physicsPhysicsJointLinearLimit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsQueryFilter.cs
+++ b/CP77.CR2W/Types/cp77/physicsQueryFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsRagdollBodyInfo.cs
+++ b/CP77.CR2W/Types/cp77/physicsRagdollBodyInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsRagdollBodyNames.cs
+++ b/CP77.CR2W/Types/cp77/physicsRagdollBodyNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSectorCacheArtifact.cs
+++ b/CP77.CR2W/Types/cp77/physicsSectorCacheArtifact.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSectorCacheEntry.cs
+++ b/CP77.CR2W/Types/cp77/physicsSectorCacheEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSectorEntry.cs
+++ b/CP77.CR2W/Types/cp77/physicsSectorEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSimulationFilter.cs
+++ b/CP77.CR2W/Types/cp77/physicsSimulationFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsStaticCollisionShapeDebugInfo.cs
+++ b/CP77.CR2W/Types/cp77/physicsStaticCollisionShapeDebugInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSystemBody.cs
+++ b/CP77.CR2W/Types/cp77/physicsSystemBody.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSystemBodyParams.cs
+++ b/CP77.CR2W/Types/cp77/physicsSystemBodyParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSystemJoint.cs
+++ b/CP77.CR2W/Types/cp77/physicsSystemJoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsSystemResource.cs
+++ b/CP77.CR2W/Types/cp77/physicsSystemResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsTraceResult.cs
+++ b/CP77.CR2W/Types/cp77/physicsTraceResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsTriggerShape.cs
+++ b/CP77.CR2W/Types/cp77/physicsTriggerShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsclothClothCapsuleExportData.cs
+++ b/CP77.CR2W/Types/cp77/physicsclothClothCapsuleExportData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsclothExportedCapsule.cs
+++ b/CP77.CR2W/Types/cp77/physicsclothExportedCapsule.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsclothPhaseConfig.cs
+++ b/CP77.CR2W/Types/cp77/physicsclothPhaseConfig.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsclothRuntimeInfo.cs
+++ b/CP77.CR2W/Types/cp77/physicsclothRuntimeInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/physicsclothState.cs
+++ b/CP77.CR2W/Types/cp77/physicsclothState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/piercingGrenade.cs
+++ b/CP77.CR2W/Types/cp77/piercingGrenade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/populationModifier.cs
+++ b/CP77.CR2W/Types/cp77/populationModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/populationModifier.cs
+++ b/CP77.CR2W/Types/cp77/populationModifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/populationPopulationSpawnParameter.cs
+++ b/CP77.CR2W/Types/cp77/populationPopulationSpawnParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/populationPopulationSpawnParameter.cs
+++ b/CP77.CR2W/Types/cp77/populationPopulationSpawnParameter.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/populationSpawnModifier.cs
+++ b/CP77.CR2W/Types/cp77/populationSpawnModifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/previewTargetStruct.cs
+++ b/CP77.CR2W/Types/cp77/previewTargetStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/prvFunctionalTestQueryOverlapResult.cs
+++ b/CP77.CR2W/Types/cp77/prvFunctionalTestQueryOverlapResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/prvFunctionalTestsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/prvFunctionalTestsTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/prvFunctionalTestsTrigger.cs
+++ b/CP77.CR2W/Types/cp77/prvFunctionalTestsTrigger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAICommandNodeBase.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandNodeBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAICommandNodeBase.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandNodeBase.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAICommandNodeFunction.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandNodeFunction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAICommandNodeFunctionProvider.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandNodeFunctionProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAICommandNodeFunctionProvider.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandNodeFunctionProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questAICommandParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAchievementManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questAchievementManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questActorOverrideEntry.cs
+++ b/CP77.CR2W/Types/cp77/questActorOverrideEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddBraindanceClue_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAddBraindanceClue_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddCombatLogMessage_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAddCombatLogMessage_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddRemoveContact_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAddRemoveContact_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddRemoveContact_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questAddRemoveContact_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddRemoveItem_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAddRemoveItem_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAddRemoveItem_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questAddRemoveItem_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAnimMoveOnSplineParams.cs
+++ b/CP77.CR2W/Types/cp77/questAnimMoveOnSplineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAnimationEventsOverrideClearNode.cs
+++ b/CP77.CR2W/Types/cp77/questAnimationEventsOverrideClearNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAnimationEventsOverrideNode.cs
+++ b/CP77.CR2W/Types/cp77/questAnimationEventsOverrideNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAssignCharacter_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAssignCharacter_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAssignConvoy_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAssignConvoy_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioCharacterManagerBreathing_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterManagerBreathing_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioCharacterManagerBreathing_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterManagerBreathing_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAudioCharacterManagerFootsteps_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterManagerFootsteps_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioCharacterManagerFootsteps_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterManagerFootsteps_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAudioCharacterManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioCharacterSystemsManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioCharacterSystemsManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioEventNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioEventNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioEventPrefetchNode.cs
+++ b/CP77.CR2W/Types/cp77/questAudioEventPrefetchNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioEventPrefetchStruct.cs
+++ b/CP77.CR2W/Types/cp77/questAudioEventPrefetchStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioFocusNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioFocusNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioFocusNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioFocusNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questAudioLoadingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioLoadingNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioMixNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioMixNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioMusicSyncNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioMusicSyncNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questAudioNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioParameterNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioParameterNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioSetListenerOverrideNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioSetListenerOverrideNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questAudioSwitchNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questAudioSwitchNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBaseObjectNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questBaseObjectNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBehaviourManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questBehaviourManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBehind_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questBehind_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBlockTokenActivation_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questBlockTokenActivation_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBluelineObject.cs
+++ b/CP77.CR2W/Types/cp77/questBluelineObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBluelineObject.cs
+++ b/CP77.CR2W/Types/cp77/questBluelineObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questBriefingSequencePlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/questBriefingSequencePlayerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBriefingSequencePlayerEvent.cs
+++ b/CP77.CR2W/Types/cp77/questBriefingSequencePlayerEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questBriefingSequencePlayer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questBriefingSequencePlayer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBuild_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questBuild_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questBuild_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questBuild_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCallContact_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCallContact_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCameraClippingPlane_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCameraClippingPlane_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCameraFocus_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCameraFocus_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questChangeContactList_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questChangeContactList_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questChangeVoicesetState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questChangeVoicesetState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questChangeVoicesetState_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questChangeVoicesetState_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterAim_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterAim_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterAppearancePrefetched_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterAppearancePrefetched_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterAttack_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterAttack_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterBodyType_CondtionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterBodyType_CondtionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterCallReinforcements_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterCallReinforcements_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterCombat_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterCombat_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterCondition.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterControlledObjectHit_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterControlledObjectHit_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterCover_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterCover_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterCyberdeckProgram_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterCyberdeckProgram_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterEquippedItemListener.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterEquippedItemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterEquippedItemListener.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterEquippedItemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCharacterEquippedItem_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterEquippedItem_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterEquippedWeapon_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterEquippedWeapon_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterGender_CondtionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterGender_CondtionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterGroupAttitude_CondtionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterGroupAttitude_CondtionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterHealth_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterHealth_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterHit_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterHit_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterKilled_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterKilled_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterLifePath_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterLifePath_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_AssignSquad.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_AssignSquad.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ChangeLevel.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ChangeLevel.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_EquipWeapon.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_EquipWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_Kill.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_Kill.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ManageRagdoll.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ManageRagdoll.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ModifyHealth.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_ModifyHealth.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_SetDeathDirection.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_SetDeathDirection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerCombat_SetWeaponState.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerCombat_SetWeaponState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_EnableBumps.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_EnableBumps.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_HealPlayer.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_HealPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAnimset.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAnimset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAsCrowdObstacle.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAsCrowdObstacle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAttitudeGroupForPuppet.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetAttitudeGroupForPuppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetCombatSpace.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetCombatSpace.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetGender.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetGender.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetGroupsAttitude.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetGroupsAttitude.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetLifePath.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetLifePath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetLowGravity.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetLowGravity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetMortality.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetMortality.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetProgressionBuild.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetProgressionBuild.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetReactionPreset.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetReactionPreset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetStatusEffect.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerParameters_SetStatusEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_BreastSizeController.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_BreastSizeController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_ChangeEntityAppearance.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_ChangeEntityAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_ChangeEntityAppearance.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_ChangeEntityAppearance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_EntityAppearanceOperationBase.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_EntityAppearanceOperationBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_EntityAppearanceOperationBaseEntityAppearanceEntry.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_EntityAppearanceOperationBaseEntityAppearanceEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_GenitalsManager.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_GenitalsManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_PrefetchEntityAppearance.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_PrefetchEntityAppearance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_PrefetchEntityAppearance.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_PrefetchEntityAppearance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_SetBrokenNoseStage.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterManagerVisuals_SetBrokenNoseStage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterMount_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterMount_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterMountedTogether_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterMountedTogether_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterQuickHacked_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterQuickHacked_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterReaction_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterReaction_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterSpawned_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterSpawned_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterStatPool_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterStatPool_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterState_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterState_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterState_PlayerSubType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterState_PlayerSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterState_PuppetSubType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterState_PuppetSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterStatusEffect_CondtionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterStatusEffect_CondtionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterStatusEffectsListener.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterStatusEffectsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterStatusEffectsListener.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterStatusEffectsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCharacterTriggeredCombatInSecuritySystem_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterTriggeredCombatInSecuritySystem_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCharacterWorkspot_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCharacterWorkspot_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCheckpointNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questCheckpointNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questClearForcedBehavioursNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questClearForcedBehavioursNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCloseMessage_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCloseMessage_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_CombatTarget.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_CombatTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_LookAtTarget.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_LookAtTarget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_PrimaryWeapon.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_PrimaryWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_RestrictMovementToArea.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_RestrictMovementToArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_SecondaryWeapon.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_SecondaryWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_ShootAt.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_ShootAt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_SwitchWeapon.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_SwitchWeapon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_ThrowGrenade.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_ThrowGrenade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCombatNodeParams_UseCover.cs
+++ b/CP77.CR2W/Types/cp77/questCombatNodeParams_UseCover.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCommunityTemplate_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCommunityTemplate_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questComparisonParam.cs
+++ b/CP77.CR2W/Types/cp77/questComparisonParam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questComponentCollisionMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/questComponentCollisionMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCondition.cs
+++ b/CP77.CR2W/Types/cp77/questCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCondition.cs
+++ b/CP77.CR2W/Types/cp77/questCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questConditionItem.cs
+++ b/CP77.CR2W/Types/cp77/questConditionItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questConfigurableAICommandNode.cs
+++ b/CP77.CR2W/Types/cp77/questConfigurableAICommandNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questConfigurableAICommandNode.cs
+++ b/CP77.CR2W/Types/cp77/questConfigurableAICommandNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questConstAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questConstAICommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questContentCondition.cs
+++ b/CP77.CR2W/Types/cp77/questContentCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questContentLock_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questContentLock_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questContentTokenManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questContentTokenManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questContentToken_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questContentToken_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questControlObject_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questControlObject_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCreditsForceStopped_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCreditsForceStopped_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCreditsForceStopped_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCreditsForceStopped_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCreditsRolling_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCreditsRolling_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCreditsRolling_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questCreditsRolling_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questCrowdManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questCrowdManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCrowdManagerNodeType_ControlCrowd.cs
+++ b/CP77.CR2W/Types/cp77/questCrowdManagerNodeType_ControlCrowd.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCrowdManagerNodeType_EnableNullArea.cs
+++ b/CP77.CR2W/Types/cp77/questCrowdManagerNodeType_EnableNullArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCustomQuestNotificationData.cs
+++ b/CP77.CR2W/Types/cp77/questCustomQuestNotificationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCutControlNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questCutControlNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCyberdrill_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questCyberdrill_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questCyberdrill_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questCyberdrill_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDebugShowMessageNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questDebugShowMessageNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDebugShowMessageNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questDebugShowMessageNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questDeletionMarkerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questDeletionMarkerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDestruction_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questDestruction_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDeviceManager_ActionProperty.cs
+++ b/CP77.CR2W/Types/cp77/questDeviceManager_ActionProperty.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDeviceManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questDeviceManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDeviceManager_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questDeviceManager_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDevice_ConditionFunctionParameter.cs
+++ b/CP77.CR2W/Types/cp77/questDevice_ConditionFunctionParameter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDevice_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questDevice_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDisableableNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questDisableableNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDisableableNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questDisableableNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questDiscoverBraindanceClue_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questDiscoverBraindanceClue_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDisplayMessageBox_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questDisplayMessageBox_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDistanceComparison_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questDistanceComparison_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDistanceCondition.cs
+++ b/CP77.CR2W/Types/cp77/questDistanceCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDistanceVsDistanceComparison_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questDistanceVsDistanceComparison_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDrillingState_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questDrillingState_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDropItemFromSlot_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questDropItemFromSlot_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questDropItemFromSlot_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questDropItemFromSlot_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questElevator_ManageNPCAttachment_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questElevator_ManageNPCAttachment_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questElevator_ManageNPCAttachment_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questElevator_ManageNPCAttachment_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEmbeddedGraphNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEmbeddedGraphNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEmbeddedGraphNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEmbeddedGraphNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questEnableBraindanceFinish_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnableBraindanceFinish_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnableBraindanceFinish_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnableBraindanceFinish_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questEnablePlayerGameplayLookAt_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnablePlayerGameplayLookAt_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnablePlayerVehicle_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnablePlayerVehicle_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnableScanning_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnableScanning_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnableVehicleSummon_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnableVehicleSummon_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEndNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEndNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questEnforceScreenSpaceReflectionsUberQuality_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnforceScreenSpaceReflectionsUberQuality_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnterVisionMode_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEnterVisionMode_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityAppearance_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityAppearance_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityCondition.cs
+++ b/CP77.CR2W/Types/cp77/questEntityCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerChangeAppearance_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerChangeAppearance_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerDestroyCarriedObject.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerDestroyCarriedObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerEnablePlayerTPPRepresentation_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerEnablePlayerTPPRepresentation_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerManageBinkComponent_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerManageBinkComponent_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerManageBinkComponent_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerManageBinkComponent_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerMountPuppet_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerMountPuppet_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSendAnimationEvent_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSendAnimationEvent_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToActor.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToActor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToNode.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToWorld.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetAttachment_ToWorld.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetDestructionState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetDestructionState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetDestructionState_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetDestructionState_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetMeshAppearance_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetMeshAppearance_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetMeshAppearance_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetMeshAppearance_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerSetStat_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerSetStat_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerToggleComponent_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerToggleComponent_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerToggleComponent_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerToggleComponent_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntityManagerToggleMirrorsArea_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questEntityManagerToggleMirrorsArea_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEntryScanned_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questEntryScanned_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEnvironmentManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEnvironmentManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEquipItemNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEquipItemNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEquipItemParams.cs
+++ b/CP77.CR2W/Types/cp77/questEquipItemParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questEventManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questEventManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFXManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questFXManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFactsDBCondition.cs
+++ b/CP77.CR2W/Types/cp77/questFactsDBCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFactsDBManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questFactsDBManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFinalBoardsEnableSkipCredits_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFinalBoardsEnableSkipCredits_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFinalBoardsOpenSpeakerScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFinalBoardsOpenSpeakerScreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFinalBoardsVideosFinished_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFinalBoardsVideosFinished_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFinalBoardsVideosFinished_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFinalBoardsVideosFinished_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questFlowControlNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questFlowControlNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFlushAutopilot_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFlushAutopilot_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFollowObject_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFollowObject_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFollowParams.cs
+++ b/CP77.CR2W/Types/cp77/questFollowParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForbiddenTrigger_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questForbiddenTrigger_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForceModule_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questForceModule_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForceModule_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questForceModule_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForcePhysicsWakeUp_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questForcePhysicsWakeUp_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForceTokenActivation_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questForceTokenActivation_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForceVMModule_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questForceVMModule_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForcedBehaviorReference.cs
+++ b/CP77.CR2W/Types/cp77/questForcedBehaviorReference.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questForcedBehaviorReference.cs
+++ b/CP77.CR2W/Types/cp77/questForcedBehaviorReference.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questForcedBehaviourNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questForcedBehaviourNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFormConvoy_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questFormConvoy_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFulfillInfo.cs
+++ b/CP77.CR2W/Types/cp77/questFulfillInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questFulfillInfo.cs
+++ b/CP77.CR2W/Types/cp77/questFulfillInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questGOGReward_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questGOGReward_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGameManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questGameManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGameTimeDelay_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questGameTimeDelay_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGameplayRestrictions_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questGameplayRestrictions_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGatherTriggerCondition.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGatherTriggerCondition.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_Quest.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_Quest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_Quest.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_Quest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_QuestInstance.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_QuestInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_QuestInstance.cs
+++ b/CP77.CR2W/Types/cp77/questGatherTriggerNotifier_QuestInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questGiveReward_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questGiveReward_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGlitchLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questGlitchLoadingScreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGlitchLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questGlitchLoadingScreen_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questGlobalTvScheduler_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questGlobalTvScheduler_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGraphDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questGraphDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questGraphDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questGraphDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questHUDEntryVisibilityData.cs
+++ b/CP77.CR2W/Types/cp77/questHUDEntryVisibilityData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHUDEntryVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/questHUDEntryVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHUDVideo_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questHUDVideo_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHackingManager_ActionType.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_ActionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHackingManager_ActionType.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_ActionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questHackingManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHackingManager_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHackingManager_SetEnabled.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_SetEnabled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHackingManager_SetHacked.cs
+++ b/CP77.CR2W/Types/cp77/questHackingManager_SetHacked.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHolocallStateListener.cs
+++ b/CP77.CR2W/Types/cp77/questHolocallStateListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questHolocallStateListener.cs
+++ b/CP77.CR2W/Types/cp77/questHolocallStateListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIAchievementManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAchievementManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIAchievementManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAchievementManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeSubTypeCharacterEntry.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeSubTypeCharacterEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioCharacterManager_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIAudioNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIAudioNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIAudioNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIBaseCondition.cs
+++ b/CP77.CR2W/Types/cp77/questIBaseCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIBaseCondition.cs
+++ b/CP77.CR2W/Types/cp77/questIBaseCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIBaseNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIBaseNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIBaseNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIBaseNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIBehaviourManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIBehaviourManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterConditionSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterConditionSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterConditionSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterConditionSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterManagerCombat_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerCombat_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterManagerCombat_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerCombat_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterManagerParameters_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerParameters_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterManagerParameters_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerParameters_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterManagerVisuals_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerVisuals_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterManagerVisuals_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManagerVisuals_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManager_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManager_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICharacterManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICharacterManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questICharacterManager_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIContentConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIContentConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIContentConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIContentConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIContentTokenManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIContentTokenManager_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIContentTokenManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIContentTokenManager_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questICrowdManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questICrowdManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questICrowdManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questICrowdManager_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIDistance.cs
+++ b/CP77.CR2W/Types/cp77/questIDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIDistance.cs
+++ b/CP77.CR2W/Types/cp77/questIDistance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIDistanceConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIDistanceConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIDistanceConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIDistanceConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEntityConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEntityConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEntityManagerSetAttachment_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManagerSetAttachment_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEntityManagerSetAttachment_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManagerSetAttachment_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEntityManagerSetDestructionState_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManagerSetDestructionState_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEntityManagerSetDestructionState_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManagerSetDestructionState_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEntityManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManager_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEntityManager_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManager_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEntityManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEntityManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIEntityManager_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIEnvironmentManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIEnvironmentManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIEnvironmentManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIEnvironmentManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIFXManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIFXManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIFXManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIFXManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIFactsDBConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIFactsDBConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIFactsDBConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIFactsDBConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIFactsDBManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIFactsDBManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIFactsDBManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIFactsDBManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIGameManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIGameManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIGameManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIGameManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIGameManagerNonSignalStoppingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIGameManagerNonSignalStoppingNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIGameManagerNonSignalStoppingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIGameManagerNonSignalStoppingNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIInspectListener.cs
+++ b/CP77.CR2W/Types/cp77/questIInspectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIInspectListener.cs
+++ b/CP77.CR2W/Types/cp77/questIInspectListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIInt32ValueProvider.cs
+++ b/CP77.CR2W/Types/cp77/questIInt32ValueProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIInt32ValueProvider.cs
+++ b/CP77.CR2W/Types/cp77/questIInt32ValueProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIInteractiveObjectManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIInteractiveObjectManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIInteractiveObjectManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIInteractiveObjectManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIItemManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIItemManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIItemManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIItemManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIJournalConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIJournalConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIJournalConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIJournalConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIJournal_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIJournal_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIJournal_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIJournal_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIMultiplayerHeistNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIMultiplayerHeistNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIMultiplayerHeistNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIMultiplayerHeistNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questINodeType.cs
+++ b/CP77.CR2W/Types/cp77/questINodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questINodeType.cs
+++ b/CP77.CR2W/Types/cp77/questINodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIONodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questIONodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIObjectConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIObjectConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIObjectConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIObjectConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIPayment_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIPayment_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIPhoneConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIPhoneConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIPhoneManager.cs
+++ b/CP77.CR2W/Types/cp77/questIPhoneManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIPhoneManager.cs
+++ b/CP77.CR2W/Types/cp77/questIPhoneManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIPhoneManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIPhoneManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIPhoneManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIPhoneManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIQuestsContentSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsContentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIQuestsContentSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsContentSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIQuestsHelper.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIQuestsHelper.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIQuestsSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIQuestsSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIQuestsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIRecordingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRecordingNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIRecordingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRecordingNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIRenderFxManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRenderFxManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIRenderFxManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRenderFxManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIRetNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRetNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIRetNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRetNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIRetOutputNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRetOutputNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIRetOutputNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRetOutputNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIRewardManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRewardManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIRewardManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIRewardManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questISceneConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISceneConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISceneConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISceneConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questISceneManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questISceneManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISceneManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questISceneManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questISensesConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISensesConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISensesConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISensesConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questISignalStoppingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questISignalStoppingNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISignalStoppingNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questISignalStoppingNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questISpawnerConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISpawnerConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISpawnerConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISpawnerConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIStatsConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIStatsConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIStatsConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIStatsConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIStatsScriptConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIStatsScriptConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISystemConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISystemConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questISystemConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questISystemConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questITimeConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questITimeConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questITimeConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questITimeConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questITimeManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questITimeManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questITimeManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questITimeManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questITriggerManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questITriggerManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questITriggerManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questITriggerManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questITutorialManager.cs
+++ b/CP77.CR2W/Types/cp77/questITutorialManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questITutorialManager.cs
+++ b/CP77.CR2W/Types/cp77/questITutorialManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questITutorial_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questITutorial_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questITutorial_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questITutorial_NodeSubType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIUIConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIUIConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIUIConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIUIConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIUIManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIUIManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIUIManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIUIManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIVehicleConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIVehicleConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIVehicleManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIVehicleManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIVehicleMoveOnSpline_Overrides.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleMoveOnSpline_Overrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIVehicleMoveOnSpline_Overrides.cs
+++ b/CP77.CR2W/Types/cp77/questIVehicleMoveOnSpline_Overrides.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIVisionModeNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVisionModeNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIVisionModeNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVisionModeNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIVoicesetManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVoicesetManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIVoicesetManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIVoicesetManager_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIWorldDataManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIWorldDataManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIWorldDataManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questIWorldDataManagerNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questIWorldStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIWorldStateSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIWorldStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/questIWorldStateSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questInjectLoot_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questInjectLoot_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInjectLoot_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questInjectLoot_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInjectLoot_NodeTypeParams_OperationData.cs
+++ b/CP77.CR2W/Types/cp77/questInjectLoot_NodeTypeParams_OperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputAction_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questInputAction_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputController_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questInputController_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputHintGroup_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questInputHintGroup_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputHint_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questInputHint_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questInputNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInputNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questInputNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questInspectListenerEvent.cs
+++ b/CP77.CR2W/Types/cp77/questInspectListenerEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInspect_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questInspect_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInstancedCrowdControlNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questInstancedCrowdControlNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInt32FactDBProvider.cs
+++ b/CP77.CR2W/Types/cp77/questInt32FactDBProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInt32FixedValueProvider.cs
+++ b/CP77.CR2W/Types/cp77/questInt32FixedValueProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInt32ValueWrapper.cs
+++ b/CP77.CR2W/Types/cp77/questInt32ValueWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInteraction_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questInteraction_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInteractiveObjectManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questInteractiveObjectManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questInventory_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questInventory_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questIsInMirrorsAreaMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/questIsInMirrorsAreaMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questItemManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questItemManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalBulkUpdate_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalBulkUpdate_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalChangeMappinPhase_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalChangeMappinPhase_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalCondition.cs
+++ b/CP77.CR2W/Types/cp77/questJournalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalEntryState_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalEntryState_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalEntryVisited_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalEntryVisited_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalEntry_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalEntry_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalEntry_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalEntry_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questJournalNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalNotification_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalNotification_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalQuestEntry_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalQuestEntry_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalQuestObjectiveCounter_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalQuestObjectiveCounter_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJournalTrackQuest_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJournalTrackQuest_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questJumpWorkspotAnim_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questJumpWorkspotAnim_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLanguage_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questLanguage_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLegacy_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questLegacy_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLevelUpData.cs
+++ b/CP77.CR2W/Types/cp77/questLevelUpData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLifePath_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questLifePath_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLifePath_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questLifePath_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questLogGameController.cs
+++ b/CP77.CR2W/Types/cp77/questLogGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogV2GameController.cs
+++ b/CP77.CR2W/Types/cp77/questLogV2GameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalAndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalAndNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalAndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalAndNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questLogicalBaseNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalBaseNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalCondition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalHubNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalHubNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalHubNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalHubNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questLogicalXorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalXorNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLogicalXorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questLogicalXorNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questLookAtDrivenTurnsNode.cs
+++ b/CP77.CR2W/Types/cp77/questLookAtDrivenTurnsNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLootPurge_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questLootPurge_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLootPurge_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questLootPurge_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questLootTokenManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questLootTokenManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questLootTokenManager_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questLootTokenManager_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questManageCollision_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questManageCollision_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questManageCollision_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questManageCollision_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMappinManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMappinManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMappinState_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questMappinState_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMappinVariantChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/questMappinVariantChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMenuState_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questMenuState_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMinigameNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMinigameNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMinimizeCallRequest.cs
+++ b/CP77.CR2W/Types/cp77/questMinimizeCallRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMinimize_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questMinimize_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMiscAICommandNode.cs
+++ b/CP77.CR2W/Types/cp77/questMiscAICommandNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMiscAICommandNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questMiscAICommandNodeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMiscAICommandNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questMiscAICommandNodeParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questMountedObjectInfo.cs
+++ b/CP77.CR2W/Types/cp77/questMountedObjectInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveOnSplineAdditionalParams.cs
+++ b/CP77.CR2W/Types/cp77/questMoveOnSplineAdditionalParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveOnSplineAndKeepDistance_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questMoveOnSplineAndKeepDistance_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveOnSplineControlRubberbanding_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questMoveOnSplineControlRubberbanding_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveOnSplineParams.cs
+++ b/CP77.CR2W/Types/cp77/questMoveOnSplineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveOnSpline_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questMoveOnSpline_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMovePuppetNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMovePuppetNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMovePuppetNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questMovePuppetNodeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMoveToParams.cs
+++ b/CP77.CR2W/Types/cp77/questMoveToParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerAIDirectorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerAIDirectorNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerAIDirectorParams.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerAIDirectorParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerChoiceTokenNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerChoiceTokenNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerChoiceTokenParams.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerChoiceTokenParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerGiveChoiceTokenEvent.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerGiveChoiceTokenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerHeistNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerHeistNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerJunctionDialogNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerJunctionDialogNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerJunctionDialogNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerJunctionDialogNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questMultiplayerTeleportPuppetNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerTeleportPuppetNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questMultiplayerTeleportPuppetParams.cs
+++ b/CP77.CR2W/Types/cp77/questMultiplayerTeleportPuppetParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNPCLookAt_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questNPCLookAt_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNewPlayerPuppetAttached_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questNewPlayerPuppetAttached_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNewPlayerPuppetAttached_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questNewPlayerPuppetAttached_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questNodeCollisionMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/questNodeCollisionMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNodeLoadingCondition.cs
+++ b/CP77.CR2W/Types/cp77/questNodeLoadingCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNodeVisibilityMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/questNodeVisibilityMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNotImplementedAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questNotImplementedAICommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questNotImplementedAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questNotImplementedAICommandParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questObjectCondition.cs
+++ b/CP77.CR2W/Types/cp77/questObjectCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectDistance.cs
+++ b/CP77.CR2W/Types/cp77/questObjectDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectInspectListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectInspectListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectInspectListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectInspectListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questObjectInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectInventoryListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectInventoryListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectInventoryListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questObjectItemListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectItemListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectItemListener.cs
+++ b/CP77.CR2W/Types/cp77/questObjectItemListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questObjectNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questObjectNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObjectNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questObjectNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questObservableUniversalRef.cs
+++ b/CP77.CR2W/Types/cp77/questObservableUniversalRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questObservableUniversalRef.cs
+++ b/CP77.CR2W/Types/cp77/questObservableUniversalRef.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questOpenBriefing_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questOpenBriefing_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questOpenMessage_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questOpenMessage_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questOpenPhotoMode_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questOpenPhotoMode_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questOutputNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questOutputNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questOverrideLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questOverrideLoadingScreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questOverrideSplineSpeed_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questOverrideSplineSpeed_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questParamKeepDistance.cs
+++ b/CP77.CR2W/Types/cp77/questParamKeepDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questParamRubberbanding.cs
+++ b/CP77.CR2W/Types/cp77/questParamRubberbanding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPatrolParams.cs
+++ b/CP77.CR2W/Types/cp77/questPatrolParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPauseConditionNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPauseConditionNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPauseTime_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPauseTime_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPaymentBalanced_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentBalanced_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPaymentBalanced_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentBalanced_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPaymentCondition.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPaymentConditionData.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentConditionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPaymentFixedAmount_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentFixedAmount_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPaymentFixedAmount_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPaymentFixedAmount_ConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseFreezingAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhaseInstance.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhaseInstance.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhaseNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPhaseNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhoneCallInformation.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneCallInformation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhoneCallMode_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneCallMode_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhoneCallPhase_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneCallPhase_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhoneManager.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhoneManager.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhoneManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPhoneManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhonePickUp_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPhonePickUp_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhonePrefabsListener.cs
+++ b/CP77.CR2W/Types/cp77/questPhonePrefabsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPhonePrefabsListener.cs
+++ b/CP77.CR2W/Types/cp77/questPhonePrefabsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPhone_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPhone_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlaceholderNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPlaceholderNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlaceholderNodeSocketInfo.cs
+++ b/CP77.CR2W/Types/cp77/questPlaceholderNodeSocketInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlatform_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPlatform_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayEnv_ForceRelitEnvProbe.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_ForceRelitEnvProbe.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayEnv_ForceRelitEnvProbe.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_ForceRelitEnvProbe.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPlayEnv_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayEnv_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayEnv_OverrideGlobalLight.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_OverrideGlobalLight.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayEnv_SetWeather.cs
+++ b/CP77.CR2W/Types/cp77/questPlayEnv_SetWeather.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayFX_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPlayFX_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayFX_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questPlayFX_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayVoiceset_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPlayVoiceset_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayVoiceset_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questPlayVoiceset_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlayerLookAt_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPlayerLookAt_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlaylistTrackChanged_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPlaylistTrackChanged_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPlaylistTrackNode.cs
+++ b/CP77.CR2W/Types/cp77/questPlaylistTrackNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPopulactionControllerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPopulactionControllerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPrefabVariantMapArrayElement.cs
+++ b/CP77.CR2W/Types/cp77/questPrefabVariantMapArrayElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPrefabVariantReplicatedInfo.cs
+++ b/CP77.CR2W/Types/cp77/questPrefabVariantReplicatedInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPrefetchStreaming_NodeTypeV2.cs
+++ b/CP77.CR2W/Types/cp77/questPrefetchStreaming_NodeTypeV2.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPrepareBlendCamera_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPrepareBlendCamera_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPrepareBlendCamera_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPrepareBlendCamera_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPrereq_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questPrereq_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questProgressBar_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questProgressBar_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questProximityProgressBar_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questProximityProgressBar_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questProximityProgressBar_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questProximityProgressBar_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetAIManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetAIManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetAIManagerNodeDefinitionEntry.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetAIManagerNodeDefinitionEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPuppeteerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questPuppeteerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetsEffector.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetsEffector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetsEffector.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetsEffector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPuppetsKill.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetsKill.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questPuppetsKill.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetsKill.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questPuppetsUnconscious.cs
+++ b/CP77.CR2W/Types/cp77/questPuppetsUnconscious.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestPhaseResource.cs
+++ b/CP77.CR2W/Types/cp77/questQuestPhaseResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestPrefabEntry.cs
+++ b/CP77.CR2W/Types/cp77/questQuestPrefabEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestPrefabsEntry.cs
+++ b/CP77.CR2W/Types/cp77/questQuestPrefabsEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestPrefabsHandler.cs
+++ b/CP77.CR2W/Types/cp77/questQuestPrefabsHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestPrefabsHandler.cs
+++ b/CP77.CR2W/Types/cp77/questQuestPrefabsHandler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestResource.cs
+++ b/CP77.CR2W/Types/cp77/questQuestResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestResource.cs
+++ b/CP77.CR2W/Types/cp77/questQuestResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestStatPoolListener.cs
+++ b/CP77.CR2W/Types/cp77/questQuestStatPoolListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestStatPoolListener.cs
+++ b/CP77.CR2W/Types/cp77/questQuestStatPoolListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestsContentSystem.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsContentSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestsContentSystem.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsContentSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestsHelper.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsHelper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestsHelper.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsHelper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestsSystem.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuestsSystem.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questQuestsSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/questQuestsSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questQuickItemsManager_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questQuickItemsManager_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadioAnnouncementNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRadioAnnouncementNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadioAnnouncementPlayer.cs
+++ b/CP77.CR2W/Types/cp77/questRadioAnnouncementPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadioAnnouncementPlayer.cs
+++ b/CP77.CR2W/Types/cp77/questRadioAnnouncementPlayer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questRadioSongNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRadioSongNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadioStationAnnouncementEventStruct.cs
+++ b/CP77.CR2W/Types/cp77/questRadioStationAnnouncementEventStruct.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadioTrack_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questRadioTrack_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRadio_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questRadio_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRandomizerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questRandomizerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questReactionPresetRecordSelector.cs
+++ b/CP77.CR2W/Types/cp77/questReactionPresetRecordSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRealtimeDelay_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questRealtimeDelay_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRecordSelector.cs
+++ b/CP77.CR2W/Types/cp77/questRecordSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRecordingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questRecordingNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRemoveAllContacts_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRemoveAllContacts_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRemoveToken_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questRemoveToken_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRenderFxManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questRenderFxManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRenderPlane_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRenderPlane_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRepair_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRepair_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questReplacer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questReplacer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRequestVehicleCameraPerspective_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRequestVehicleCameraPerspective_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questResetMovement_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questResetMovement_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRewardEvent.cs
+++ b/CP77.CR2W/Types/cp77/questRewardEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRewardManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questRewardManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRewindableSectionTimeJump_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRewindableSectionTimeJump_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRootInstance.cs
+++ b/CP77.CR2W/Types/cp77/questRootInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRootInstance.cs
+++ b/CP77.CR2W/Types/cp77/questRootInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questRotateToNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questRotateToNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRotateToParams.cs
+++ b/CP77.CR2W/Types/cp77/questRotateToParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questRumble_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questRumble_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSaveLock_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSaveLock_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questScan_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questScan_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneCondition.cs
+++ b/CP77.CR2W/Types/cp77/questSceneCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneInterrupt_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSceneInterrupt_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneLocation.cs
+++ b/CP77.CR2W/Types/cp77/questSceneLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSceneManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSceneNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneNode_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSceneNode_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneReturn_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSceneReturn_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneTalking_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSceneTalking_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSceneTier_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSceneTier_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questScene_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questScene_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questScriptedAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questScriptedAICommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questScriptedAICommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questScriptedAICommandParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questSectionNode_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSectionNode_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSendAICommandNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSendAICommandNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSendMessage_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSendMessage_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSensesCondition.cs
+++ b/CP77.CR2W/Types/cp77/questSensesCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetAsCrowdObstacle_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questSetAsCrowdObstacle_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetAutopilot_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetAutopilot_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetBriefingAlignment_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetBriefingAlignment_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetBriefingSize_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetBriefingSize_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetConveyorState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetConveyorState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetCustomStyle_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetCustomStyle_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetCyberspacePostFX_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetCyberspacePostFX_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetDebugView_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetDebugView_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetFOV_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetFOV_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetFadeInOut_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetFadeInOut_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetFastTravelBinksGroup_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetFastTravelBinksGroup_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetFocusClueState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetFocusClueState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetGender_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questSetGender_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetHUDEntryForcedVisibility_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetHUDEntryForcedVisibility_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetHUDEntryVisibility_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetHUDEntryVisibility_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetImmovable_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetImmovable_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetInspectMode_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetInspectMode_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetInteractionState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetInteractionState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetInteractionVisualizerOverride.cs
+++ b/CP77.CR2W/Types/cp77/questSetInteractionVisualizerOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetItemTags_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetItemTags_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetItemTags_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questSetItemTags_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetLifePathRequest.cs
+++ b/CP77.CR2W/Types/cp77/questSetLifePathRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetLocationName_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetLocationName_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetLootInteractionAccess_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetLootInteractionAccess_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetMetaQuestProgress_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetMetaQuestProgress_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetMultiplayerHeistSpawnPointTag_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetMultiplayerHeistSpawnPointTag_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetMultiplayerHeistState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetMultiplayerHeistState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetPhoneRestriction_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetPhoneRestriction_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetPhoneStatusRequest.cs
+++ b/CP77.CR2W/Types/cp77/questSetPhoneStatusRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetPhoneStatus_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetPhoneStatus_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetPossesion_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetPossesion_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetProgress_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetProgress_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetProgressionBuildRequest.cs
+++ b/CP77.CR2W/Types/cp77/questSetProgressionBuildRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetRenderLayer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetRenderLayer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetSaveDataLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetSaveDataLoadingScreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetScanningState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetScanningState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetScanningTime_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetScanningTime_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTier2Params_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTier2Params_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTier3Params_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTier3Params_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTier4Params_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTier4Params_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTier_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTier_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTime_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTime_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTimer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTimer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTriggerState_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetTriggerState_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetTriggerState_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questSetTriggerState_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetUIGameContext_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetUIGameContext_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetVar_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetVar_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSetVehicleCamera_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSetVehicleCamera_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShiftTime_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShiftTime_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowBracket_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questShowBracket_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowCustomQuestNotification_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowCustomQuestNotification_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowCustomTooltip_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowCustomTooltip_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowDialogIndicator_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowDialogIndicator_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowDialogIndicator_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questShowDialogIndicator_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowHighlight_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questShowHighlight_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowLevelUpNotification_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowLevelUpNotification_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowNarrativeEvent_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowNarrativeEvent_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowOnscreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowOnscreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowOverlay_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questShowOverlay_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowPopup_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questShowPopup_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questShowWorldNode_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questShowWorldNode_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSignalStoppingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSignalStoppingNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSignalStoppingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSignalStoppingNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questSimpleMoveOnSplineParams.cs
+++ b/CP77.CR2W/Types/cp77/questSimpleMoveOnSplineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSocketDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSocketDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnManagerNodeActionEntry.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnManagerNodeActionEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnManagerNodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnManagerNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnPlayerVehicle_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnPlayerVehicle_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnSet_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnSet_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnToken_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnToken_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnerCondition.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnerCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnerNotReady_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnerNotReady_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawnerReady_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawnerReady_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSpawner_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSpawner_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStartEndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questStartEndNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStartEndNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questStartEndNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questStartNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questStartNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStartNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questStartNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questStartRecording_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStartRecording_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStartVehicle_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStartVehicle_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStat_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questStat_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStatsCondition.cs
+++ b/CP77.CR2W/Types/cp77/questStatsCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStimuli_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questStimuli_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStopRecording_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStopRecording_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStopRecording_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStopRecording_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questStopVehicle_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStopVehicle_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStopWorkspot_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStopWorkspot_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStreamingTestCheckpoint_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questStreamingTestCheckpoint_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questStreetCredTier_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questStreetCredTier_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSwitchNameplate_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSwitchNameplate_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSwitchNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questSwitchNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSwitchToScenario_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questSwitchToScenario_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questSystemCondition.cs
+++ b/CP77.CR2W/Types/cp77/questSystemCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTagged_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questTagged_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTeleportPuppetNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTeleportPuppetNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTeleportPuppetParams.cs
+++ b/CP77.CR2W/Types/cp77/questTeleportPuppetParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTeleportPuppetParamsV1.cs
+++ b/CP77.CR2W/Types/cp77/questTeleportPuppetParamsV1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTeleportVehicleNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTeleportVehicleNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTeleport_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTeleport_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTestNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTestNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTestNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTestNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTimeCondition.cs
+++ b/CP77.CR2W/Types/cp77/questTimeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Entity.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Entity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_NodeTypeParam.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_NodeTypeParam.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_NodeTypeParam.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_NodeTypeParam.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Operation.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Operation.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Operation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Player.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Player.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Puppet.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Puppet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Start.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Start.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_Stop.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_Stop.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeDilation_World.cs
+++ b/CP77.CR2W/Types/cp77/questTimeDilation_World.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimeManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTimeManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTimePeriod_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questTimePeriod_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleBrokenTire_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleBrokenTire_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleCombatForPlayer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleCombatForPlayer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleDoor_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleDoor_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleEventExecutionTag_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleEventExecutionTag_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleForceBrake_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleForceBrake_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleMinimapVisibility_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleMinimapVisibility_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTogglePrefabVariant_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTogglePrefabVariant_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTogglePrefabVariant_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questTogglePrefabVariant_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleStealthMappinVisibility_NodeSubType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleStealthMappinVisibility_NodeSubType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleSwitchSeatsForPlayer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleSwitchSeatsForPlayer_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleSwitchSeatsForPlayer_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleSwitchSeatsForPlayer_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questToggleTankCustomFPPLockOff_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleTankCustomFPPLockOff_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleVisionMode_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleVisionMode_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleWeaponEnabled_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleWeaponEnabled_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questToggleWindow_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questToggleWindow_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransferItem_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTransferItem_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_OperationData.cs
+++ b/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_OperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_TagOperationData.cs
+++ b/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_TagOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_TransferAllOperationData.cs
+++ b/CP77.CR2W/Types/cp77/questTransferItems_NodeTypeParams_TransferAllOperationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_ActionType.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_ActionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_ActionType.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_ActionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Pause.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Pause.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Pause.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Pause.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Play.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Play.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Reset.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Reset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Reset.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Reset.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Skip.cs
+++ b/CP77.CR2W/Types/cp77/questTransformAnimatorNode_Action_Skip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerCallRequest.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerCallRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerCondition.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerCondition_FulfillInfo.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerCondition_FulfillInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerCondition_FulfillInfo.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerCondition_FulfillInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTriggerIconGeneration_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerIconGeneration_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerIconGeneration_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerIconGeneration_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTriggerManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerNotifier_Quest.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerNotifier_Quest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerNotifier_Quest.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerNotifier_Quest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTriggerNotifier_QuestInstance.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerNotifier_QuestInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTriggerNotifier_QuestInstance.cs
+++ b/CP77.CR2W/Types/cp77/questTriggerNotifier_QuestInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTutorialManager.cs
+++ b/CP77.CR2W/Types/cp77/questTutorialManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTutorialManager.cs
+++ b/CP77.CR2W/Types/cp77/questTutorialManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTutorial_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questTutorial_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTypedCondition.cs
+++ b/CP77.CR2W/Types/cp77/questTypedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTypedCondition.cs
+++ b/CP77.CR2W/Types/cp77/questTypedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questTypedSignalStoppingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTypedSignalStoppingNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questTypedSignalStoppingNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questTypedSignalStoppingNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questUICondition.cs
+++ b/CP77.CR2W/Types/cp77/questUICondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUIElement_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questUIElement_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUIManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questUIManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUnassignAll_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questUnassignAll_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUnequipItemNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questUnequipItemNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUnequipItemParams.cs
+++ b/CP77.CR2W/Types/cp77/questUnequipItemParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUniversalRef.cs
+++ b/CP77.CR2W/Types/cp77/questUniversalRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWeapon_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questUseWeapon_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWorkspotCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questUseWorkspotCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWorkspotNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questUseWorkspotNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWorkspotParams.cs
+++ b/CP77.CR2W/Types/cp77/questUseWorkspotParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWorkspotParamsV1.cs
+++ b/CP77.CR2W/Types/cp77/questUseWorkspotParamsV1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questUseWorkspotPlayerParams.cs
+++ b/CP77.CR2W/Types/cp77/questUseWorkspotPlayerParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questValueDistance.cs
+++ b/CP77.CR2W/Types/cp77/questValueDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVarComparison_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVarComparison_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVarVsVarComparison_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVarVsVarComparison_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVariantState.cs
+++ b/CP77.CR2W/Types/cp77/questVariantState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleAVArrived_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleAVArrived_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleAirtime_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleAirtime_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleAvailable_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleAvailable_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleCollision_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleCollision_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleCondition.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleCrowdHit_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleCrowdHit_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleDoor_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleDoor_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleNodeCommandDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleNodeCommandDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleSpawned_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleSpawned_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleSpecificCommandParams.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleSpecificCommandParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleSpeed_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleSpeed_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleSummoned_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleSummoned_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleTrunk_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleTrunk_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleWater_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleWater_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVehicleWeaponUsed_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVehicleWeaponUsed_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVendorPanelData.cs
+++ b/CP77.CR2W/Types/cp77/questVendorPanelData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVendorPanel_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questVendorPanel_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVisionMode_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVisionMode_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVisionModesManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questVisionModesManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVision_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questVision_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questVoicesetManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questVoicesetManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWaitForAnyKeyLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questWaitForAnyKeyLoadingScreen_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWaitForAnyKeyLoadingScreen_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questWaitForAnyKeyLoadingScreen_NodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questWarningMessage_NodeType.cs
+++ b/CP77.CR2W/Types/cp77/questWarningMessage_NodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWeather_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/questWeather_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWithCompanionMoveOnSplineParams.cs
+++ b/CP77.CR2W/Types/cp77/questWithCompanionMoveOnSplineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWorldDataManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/questWorldDataManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWorldStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/questWorldStateSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questWorldStateSystem.cs
+++ b/CP77.CR2W/Types/cp77/questWorldStateSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questWorldStateSystemReplicatedState.cs
+++ b/CP77.CR2W/Types/cp77/questWorldStateSystemReplicatedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questdbgCallstackBlock.cs
+++ b/CP77.CR2W/Types/cp77/questdbgCallstackBlock.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questdbgCallstackData.cs
+++ b/CP77.CR2W/Types/cp77/questdbgCallstackData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questdbgCallstackPhase.cs
+++ b/CP77.CR2W/Types/cp77/questdbgCallstackPhase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questdbgRuntimeData.cs
+++ b/CP77.CR2W/Types/cp77/questdbgRuntimeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questvehicleFollowParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleFollowParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questvehicleJoinTrafficParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleJoinTrafficParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questvehicleJoinTrafficParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleJoinTrafficParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/questvehicleOnSplineParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleOnSplineParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questvehicleRacingParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleRacingParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/questvehicleToNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/questvehicleToNodeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redCHelpCommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redCHelpCommandlet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redCHelpCommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redCHelpCommandlet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redCVersionCommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redCVersionCommandlet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redCVersionCommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redCVersionCommandlet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redConvexHullEx.cs
+++ b/CP77.CR2W/Types/cp77/redConvexHullEx.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redEvent.cs
+++ b/CP77.CR2W/Types/cp77/redEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redEvent.cs
+++ b/CP77.CR2W/Types/cp77/redEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redICommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redICommandlet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redICommandlet.cs
+++ b/CP77.CR2W/Types/cp77/redICommandlet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redPackageCustomTypeSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageCustomTypeSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redPackageCustomTypeSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageCustomTypeSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redPackageDataBufferSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageDataBufferSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redPackageDataBufferSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageDataBufferSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redPackageRUIDSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageRUIDSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redPackageRUIDSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageRUIDSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redPackageStringSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageStringSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redPackageStringSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageStringSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redPackageTweakDBIDSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageTweakDBIDSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redPackageTweakDBIDSerializer.cs
+++ b/CP77.CR2W/Types/cp77/redPackageTweakDBIDSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redResourceListResource.cs
+++ b/CP77.CR2W/Types/cp77/redResourceListResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redResourceReferenceScriptToken.cs
+++ b/CP77.CR2W/Types/cp77/redResourceReferenceScriptToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redStageMessage.cs
+++ b/CP77.CR2W/Types/cp77/redStageMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayBool.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayBool.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayBool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLArrayFloat.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayFloat.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLArrayInt64.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayInt64.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayInt64.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayInt64.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLArrayString.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayString.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayString.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayString.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLArrayTable.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayTable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayTable.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayTable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLArrayTransform.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLArrayTransform.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLArrayTransform.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLBaseValue.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLBaseValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLBaseValue.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLBaseValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLKeyValue.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLKeyValue.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLKeyValue.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLKeyValue.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTOMLTable.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLTable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTOMLTable.cs
+++ b/CP77.CR2W/Types/cp77/redTOMLTable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTagList.cs
+++ b/CP77.CR2W/Types/cp77/redTagList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTagSystem.cs
+++ b/CP77.CR2W/Types/cp77/redTagSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTagSystem.cs
+++ b/CP77.CR2W/Types/cp77/redTagSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/redTaskNameMessage.cs
+++ b/CP77.CR2W/Types/cp77/redTaskNameMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTaskProgressMessage.cs
+++ b/CP77.CR2W/Types/cp77/redTaskProgressMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/redTaskTextMessage.cs
+++ b/CP77.CR2W/Types/cp77/redTaskTextMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendCaptureParameters.cs
+++ b/CP77.CR2W/Types/cp77/rendCaptureParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendChunk.cs
+++ b/CP77.CR2W/Types/cp77/rendChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendDebugDrawerScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/rendDebugDrawerScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendDebugDrawerScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/rendDebugDrawerScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendEmitterDelaySettings.cs
+++ b/CP77.CR2W/Types/cp77/rendEmitterDelaySettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendEmitterDurationSettings.cs
+++ b/CP77.CR2W/Types/cp77/rendEmitterDurationSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendEmitterLOD.cs
+++ b/CP77.CR2W/Types/cp77/rendEmitterLOD.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendEmitterSimulationShaders.cs
+++ b/CP77.CR2W/Types/cp77/rendEmitterSimulationShaders.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendFont.cs
+++ b/CP77.CR2W/Types/cp77/rendFont.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendFragmentBuilderScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/rendFragmentBuilderScriptProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendFragmentBuilderScriptProxy.cs
+++ b/CP77.CR2W/Types/cp77/rendFragmentBuilderScriptProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendGradientEntry.cs
+++ b/CP77.CR2W/Types/cp77/rendGradientEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendGridGeneratorData.cs
+++ b/CP77.CR2W/Types/cp77/rendGridGeneratorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendHairProfileGradientEntry.cs
+++ b/CP77.CR2W/Types/cp77/rendHairProfileGradientEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendHistogramBias.cs
+++ b/CP77.CR2W/Types/cp77/rendHistogramBias.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendIDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/rendIDebugDrawHistorySystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendIDebugDrawHistorySystem.cs
+++ b/CP77.CR2W/Types/cp77/rendIDebugDrawHistorySystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendIRenderTextureBlob.cs
+++ b/CP77.CR2W/Types/cp77/rendIRenderTextureBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendIndexBufferChunk.cs
+++ b/CP77.CR2W/Types/cp77/rendIndexBufferChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendInfoBox.cs
+++ b/CP77.CR2W/Types/cp77/rendInfoBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendInfoBox.cs
+++ b/CP77.CR2W/Types/cp77/rendInfoBox.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendParticleBurst.cs
+++ b/CP77.CR2W/Types/cp77/rendParticleBurst.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMeshBlob.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMeshBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMeshBlobHeader.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMeshBlobHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlob.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlobHeader.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlobHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlobTextureData.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMorphTargetMeshBlobTextureData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlob.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobHeader.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPC.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPC.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPC.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPS4.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPS4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPS4.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobPS4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobXboxOne.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobXboxOne.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobXboxOne.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskBlobXboxOne.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskResource.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderMultilayerMaskResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderParticleBlob.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderParticleBlob.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderParticleBlobEmitterInfo.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderParticleBlobEmitterInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderParticleBlobHeader.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderParticleBlobHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderParticleUpdaterData.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderParticleUpdaterData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobHeader.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobMemoryLayout.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobMemoryLayout.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobMipMapInfo.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobMipMapInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobPC.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobPC.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobPC.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobPC.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobPS4.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobPS4.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobPS4.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobPS4.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobPlacement.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobPlacement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobSizeInfo.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobSizeInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobStreamable.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobStreamable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobStreamable.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobStreamable.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobTextureInfo.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobTextureInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobXboxOne.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobXboxOne.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendRenderTextureBlobXboxOne.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureBlobXboxOne.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/rendRenderTextureResource.cs
+++ b/CP77.CR2W/Types/cp77/rendRenderTextureResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendSLightFlickering.cs
+++ b/CP77.CR2W/Types/cp77/rendSLightFlickering.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendScreenshotBatchData.cs
+++ b/CP77.CR2W/Types/cp77/rendScreenshotBatchData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendSingleScreenShotData.cs
+++ b/CP77.CR2W/Types/cp77/rendSingleScreenShotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendTextureRegion.cs
+++ b/CP77.CR2W/Types/cp77/rendTextureRegion.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendTextureRegionPart.cs
+++ b/CP77.CR2W/Types/cp77/rendTextureRegionPart.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendTopologyData.cs
+++ b/CP77.CR2W/Types/cp77/rendTopologyData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/rendVertexBufferChunk.cs
+++ b/CP77.CR2W/Types/cp77/rendVertexBufferChunk.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/resIStreamedResourceDataExtractor.cs
+++ b/CP77.CR2W/Types/cp77/resIStreamedResourceDataExtractor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/resIStreamedResourceDataExtractor.cs
+++ b/CP77.CR2W/Types/cp77/resIStreamedResourceDataExtractor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/resResourceMetricsReportGenerator.cs
+++ b/CP77.CR2W/Types/cp77/resResourceMetricsReportGenerator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/resResourceMetricsReportGenerator.cs
+++ b/CP77.CR2W/Types/cp77/resResourceMetricsReportGenerator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/resResourceSnapshot.cs
+++ b/CP77.CR2W/Types/cp77/resResourceSnapshot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/resStreamedResource.cs
+++ b/CP77.CR2W/Types/cp77/resStreamedResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/resStreamedResource.cs
+++ b/CP77.CR2W/Types/cp77/resStreamedResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/sampleBullet.cs
+++ b/CP77.CR2W/Types/cp77/sampleBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleBulletGeneric.cs
+++ b/CP77.CR2W/Types/cp77/sampleBulletGeneric.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleGranade.cs
+++ b/CP77.CR2W/Types/cp77/sampleGranade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleImageChanger.cs
+++ b/CP77.CR2W/Types/cp77/sampleImageChanger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleScreenProjectionGameController.cs
+++ b/CP77.CR2W/Types/cp77/sampleScreenProjectionGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleScreenProjectionGameController.cs
+++ b/CP77.CR2W/Types/cp77/sampleScreenProjectionGameController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/sampleScreenProjectionLogicController.cs
+++ b/CP77.CR2W/Types/cp77/sampleScreenProjectionLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleSmartBullet.cs
+++ b/CP77.CR2W/Types/cp77/sampleSmartBullet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleStyleManagerGameController.cs
+++ b/CP77.CR2W/Types/cp77/sampleStyleManagerGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleStylesGameController.cs
+++ b/CP77.CR2W/Types/cp77/sampleStylesGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleTextScrolling.cs
+++ b/CP77.CR2W/Types/cp77/sampleTextScrolling.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleTimeDilatable.cs
+++ b/CP77.CR2W/Types/cp77/sampleTimeDilatable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleTimeListener.cs
+++ b/CP77.CR2W/Types/cp77/sampleTimeListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIAnchorButton.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIAnchorButton.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIAnchorController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIAnchorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIAnimationController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIAnimationController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUICustomizableAnimationsController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUICustomizableAnimationsController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIEventTestLogicController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIEventTestLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIInteractionWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIInteractionWidgetLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUILoadingBarController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUILoadingBarController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIPathAndReferenceGameController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIPathAndReferenceGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUISoundsLogicController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUISoundsLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIStatusWidgetLogicController.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIStatusWidgetLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleUIVideoPlayer.cs
+++ b/CP77.CR2W/Types/cp77/sampleUIVideoPlayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisClueMaster.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisClueMaster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisClueSlave.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisClueSlave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisClueSlave.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisClueSlave.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/sampleVisWireMaster.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireMaster.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisWireMasterTwo.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireMasterTwo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisWireSlave.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireSlave.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisWireSlave.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireSlave.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/sampleVisWireSlaveTwo.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireSlaveTwo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sampleVisWireSlaveTwo.cs
+++ b/CP77.CR2W/Types/cp77/sampleVisWireSlaveTwo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/saveGameMetadata.cs
+++ b/CP77.CR2W/Types/cp77/saveGameMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/saveMetadata.cs
+++ b/CP77.CR2W/Types/cp77/saveMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/saveMetadataContainer.cs
+++ b/CP77.CR2W/Types/cp77/saveMetadataContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scannerBorderGameController.cs
+++ b/CP77.CR2W/Types/cp77/scannerBorderGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scannerBorderLogicController.cs
+++ b/CP77.CR2W/Types/cp77/scannerBorderLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scannerDataStructure.cs
+++ b/CP77.CR2W/Types/cp77/scannerDataStructure.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scannerDetailsGameController.cs
+++ b/CP77.CR2W/Types/cp77/scannerDetailsGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scannerQuestEntry.cs
+++ b/CP77.CR2W/Types/cp77/scannerQuestEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAICommandFactory.cs
+++ b/CP77.CR2W/Types/cp77/scnAICommandFactory.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAICommandFactory.cs
+++ b/CP77.CR2W/Types/cp77/scnAICommandFactory.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnActorDef.cs
+++ b/CP77.CR2W/Types/cp77/scnActorDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnActorId.cs
+++ b/CP77.CR2W/Types/cp77/scnActorId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnActorRid.cs
+++ b/CP77.CR2W/Types/cp77/scnActorRid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAddIdleAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnAddIdleAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAddIdleWithBlendAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnAddIdleWithBlendAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAdditionalSpeaker.cs
+++ b/CP77.CR2W/Types/cp77/scnAdditionalSpeaker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAdditionalSpeakers.cs
+++ b/CP77.CR2W/Types/cp77/scnAdditionalSpeakers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAndNode.cs
+++ b/CP77.CR2W/Types/cp77/scnAndNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimName_.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimName_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimSetAnimNames.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimSetAnimNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimSetDynAnimNames.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimSetDynAnimNames.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimTargetBasicData.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimTargetBasicData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimationMotionSample.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimationMotionSample.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimationRidAudioData.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimationRidAudioData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAnimationRid_.cs
+++ b/CP77.CR2W/Types/cp77/scnAnimationRid_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAudioDurationEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnAudioDurationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnAudioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBluelineSelectedRequest.cs
+++ b/CP77.CR2W/Types/cp77/scnBluelineSelectedRequest.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBluelineSelectedRequest.cs
+++ b/CP77.CR2W/Types/cp77/scnBluelineSelectedRequest.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnBraindanceJumpInProgress_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindanceJumpInProgress_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindanceLayer_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindanceLayer_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindancePaused_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindancePaused_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindancePerspective_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindancePerspective_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindancePlaying_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindancePlaying_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindanceResetting_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindanceResetting_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnBraindanceRewinding_ConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnBraindanceRewinding_ConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCameraAnimationRid.cs
+++ b/CP77.CR2W/Types/cp77/scnCameraAnimationRid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCameraRid.cs
+++ b/CP77.CR2W/Types/cp77/scnCameraRid.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChangeIdleAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnChangeIdleAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChatter.cs
+++ b/CP77.CR2W/Types/cp77/scnChatter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChatterModuleSharedState.cs
+++ b/CP77.CR2W/Types/cp77/scnChatterModuleSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckAnyoneDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckAnyoneDistractedInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckAnyoneDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckAnyoneDistractedInterruptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnCheckDistractedReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckDistractedReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckDistractedReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckDistractedReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckFactInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckFactInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckFactInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckFactInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckFactReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckFactReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckFactReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckFactReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckMountedVehicleImpactInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckMountedVehicleImpactInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckMountedVehicleImpactInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckMountedVehicleImpactInterruptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerCombatInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerCombatInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerCombatInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerCombatInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerCombatReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerCombatReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerCombatReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerCombatReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetEntityDistanceReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckPlayerTargetNodeDistanceReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakerDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakerDistractedInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakerDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakerDistractedInterruptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakerOrAddressDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakerOrAddressDistractedInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakerOrAddressDistractedInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakerOrAddressDistractedInterruptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckSpeakersDistanceReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckTriggerInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckTriggerInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckTriggerInterruptConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckTriggerInterruptConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckTriggerReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckTriggerReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCheckTriggerReturnConditionParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCheckTriggerReturnConditionParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceHubPartId.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceHubPartId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNode.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsActorReminderParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsActorReminderParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAdaptiveLookAtParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAdaptiveLookAtParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAdaptiveLookAtReferencePoint.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAdaptiveLookAtReferencePoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToActorParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToActorParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToGameObjectParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToGameObjectParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToPropParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToPropParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToScreenParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToScreenParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToScreenParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToScreenParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToWorldParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsAttachToWorldParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsBasicLookAtParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsBasicLookAtParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsDeprecatedParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsDeprecatedParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsLookAtParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsLookAtParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsLookAtParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsLookAtParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsMappinParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsMappinParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsReminderParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsReminderParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeNsTimedParams.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeNsTimedParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnChoiceNodeOption.cs
+++ b/CP77.CR2W/Types/cp77/scnChoiceNodeOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnCinematicAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnCommunityParams.cs
+++ b/CP77.CR2W/Types/cp77/scnCommunityParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCutControlNode.cs
+++ b/CP77.CR2W/Types/cp77/scnCutControlNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnCutControlNode.cs
+++ b/CP77.CR2W/Types/cp77/scnCutControlNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnDebugSymbols.cs
+++ b/CP77.CR2W/Types/cp77/scnDebugSymbols.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDeletionMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/scnDeletionMarkerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDeletionMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/scnDeletionMarkerNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnDialogDisplayString.cs
+++ b/CP77.CR2W/Types/cp77/scnDialogDisplayString.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDialogLineData.cs
+++ b/CP77.CR2W/Types/cp77/scnDialogLineData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDialogLineDuplicationParams.cs
+++ b/CP77.CR2W/Types/cp77/scnDialogLineDuplicationParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDialogLineEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnDialogLineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDialogLineVoParams.cs
+++ b/CP77.CR2W/Types/cp77/scnDialogLineVoParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDummyAlwaysTrueReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnDummyAlwaysTrueReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDummyAlwaysTrueReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnDummyAlwaysTrueReturnCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnDynamicAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnEffectDef.cs
+++ b/CP77.CR2W/Types/cp77/scnEffectDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEffectEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnEffectEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEffectId.cs
+++ b/CP77.CR2W/Types/cp77/scnEffectId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEffectInstance.cs
+++ b/CP77.CR2W/Types/cp77/scnEffectInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEffectInstanceId.cs
+++ b/CP77.CR2W/Types/cp77/scnEffectInstanceId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEndNode.cs
+++ b/CP77.CR2W/Types/cp77/scnEndNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEntityItemsListener.cs
+++ b/CP77.CR2W/Types/cp77/scnEntityItemsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEntityItemsListener.cs
+++ b/CP77.CR2W/Types/cp77/scnEntityItemsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnEntryPoint.cs
+++ b/CP77.CR2W/Types/cp77/scnEntryPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnEventBlendWorkspotSetupParameters.cs
+++ b/CP77.CR2W/Types/cp77/scnEventBlendWorkspotSetupParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnExecutionTag.cs
+++ b/CP77.CR2W/Types/cp77/scnExecutionTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnExecutionTagEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnExecutionTagEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnExitPoint.cs
+++ b/CP77.CR2W/Types/cp77/scnExitPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnFindEntityInContextParams.cs
+++ b/CP77.CR2W/Types/cp77/scnFindEntityInContextParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnFindEntityInEntityParams.cs
+++ b/CP77.CR2W/Types/cp77/scnFindEntityInEntityParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnFindEntityInNodeParams.cs
+++ b/CP77.CR2W/Types/cp77/scnFindEntityInNodeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnFindEntityInWorldParams.cs
+++ b/CP77.CR2W/Types/cp77/scnFindEntityInWorldParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnFindNetworkPlayerParams.cs
+++ b/CP77.CR2W/Types/cp77/scnFindNetworkPlayerParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnGameplayActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnGameplayActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnGameplayActionSetVehicleSuspensionData.cs
+++ b/CP77.CR2W/Types/cp77/scnGameplayActionSetVehicleSuspensionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnGameplayAnimSetSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnGameplayAnimSetSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnGameplayTransitionEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnGameplayTransitionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnGenderMask.cs
+++ b/CP77.CR2W/Types/cp77/scnGenderMask.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnHubNode.cs
+++ b/CP77.CR2W/Types/cp77/scnHubNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnHubNode.cs
+++ b/CP77.CR2W/Types/cp77/scnHubNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIBraindanceConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnIBraindanceConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIBraindanceConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnIBraindanceConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIGameplayActionData.cs
+++ b/CP77.CR2W/Types/cp77/scnIGameplayActionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIGameplayActionData.cs
+++ b/CP77.CR2W/Types/cp77/scnIGameplayActionData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIInterruptCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIInterruptManager_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptManager_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIInterruptManager_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptManager_Operation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIInterruptionOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptionOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIInterruptionOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptionOperation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIInterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptionScenarioOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIInterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnIInterruptionScenarioOperation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIKEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnIKEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIKEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnIKEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnIReturnCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIReturnCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnIReturnCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnIScalingData.cs
+++ b/CP77.CR2W/Types/cp77/scnIScalingData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIScalingData.cs
+++ b/CP77.CR2W/Types/cp77/scnIScalingData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnISceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/scnISceneSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnISceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/scnISceneSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnInputSocketId.cs
+++ b/CP77.CR2W/Types/cp77/scnInputSocketId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInputSocketStamp.cs
+++ b/CP77.CR2W/Types/cp77/scnInputSocketStamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInteractionShapeParams.cs
+++ b/CP77.CR2W/Types/cp77/scnInteractionShapeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterestingConversationData.cs
+++ b/CP77.CR2W/Types/cp77/scnInterestingConversationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterestingConversation_DEPRECATED.cs
+++ b/CP77.CR2W/Types/cp77/scnInterestingConversation_DEPRECATED.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterestingConversationsGroup.cs
+++ b/CP77.CR2W/Types/cp77/scnInterestingConversationsGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterestingConversationsResource.cs
+++ b/CP77.CR2W/Types/cp77/scnInterestingConversationsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterruptAvailability_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptAvailability_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterruptFactConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptFactConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterruptFactConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptFactConditionType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnInterruptManagerNode.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptManagerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterruptionScenario.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptionScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnInterruptionScenarioId.cs
+++ b/CP77.CR2W/Types/cp77/scnInterruptionScenarioId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIsAliveListener.cs
+++ b/CP77.CR2W/Types/cp77/scnIsAliveListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnIsAliveListener.cs
+++ b/CP77.CR2W/Types/cp77/scnIsAliveListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnLipsyncAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnLocalMarker.cs
+++ b/CP77.CR2W/Types/cp77/scnLocalMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtAdvancedEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtAdvancedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtAdvancedEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtAdvancedEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtBasicEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtBasicEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtBodyPartProperties.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtBodyPartProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtBodyPartPropertiesAdvanced.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtBodyPartPropertiesAdvanced.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtChestProperties.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtChestProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtEyesProperties.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtEyesProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtHeadProperties.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtHeadProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnLookAtTwoHandedProperties.cs
+++ b/CP77.CR2W/Types/cp77/scnLookAtTwoHandedProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnMarker.cs
+++ b/CP77.CR2W/Types/cp77/scnMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnNPCStatusEffectsListener.cs
+++ b/CP77.CR2W/Types/cp77/scnNPCStatusEffectsListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnNPCStatusEffectsListener.cs
+++ b/CP77.CR2W/Types/cp77/scnNPCStatusEffectsListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnNodeId.cs
+++ b/CP77.CR2W/Types/cp77/scnNodeId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnNodeSymbol.cs
+++ b/CP77.CR2W/Types/cp77/scnNodeSymbol.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnNotablePoint.cs
+++ b/CP77.CR2W/Types/cp77/scnNotablePoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOutputSocket.cs
+++ b/CP77.CR2W/Types/cp77/scnOutputSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOutputSocketId.cs
+++ b/CP77.CR2W/Types/cp77/scnOutputSocketId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOutputSocketStamp.cs
+++ b/CP77.CR2W/Types/cp77/scnOutputSocketStamp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideInterruptConditions_InterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideInterruptConditions_InterruptionScenarioOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideInterruptConditions_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideInterruptConditions_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideInterruptionScenario_InterruptionOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideInterruptionScenario_InterruptionOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverridePhantomParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnOverridePhantomParamsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverridePhantomParamsEventParams.cs
+++ b/CP77.CR2W/Types/cp77/scnOverridePhantomParamsEventParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideReturnConditions_InterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideReturnConditions_InterruptionScenarioOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideReturnConditions_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideReturnConditions_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnOverrideTalkOnReturn_InterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnOverrideTalkOnReturn_InterruptionScenarioOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPerformerId.cs
+++ b/CP77.CR2W/Types/cp77/scnPerformerId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPerformerSymbol.cs
+++ b/CP77.CR2W/Types/cp77/scnPerformerSymbol.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlacementEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlacementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayAnimEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayAnimEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayDefaultMountedSlotWorkspotEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayDefaultMountedSlotWorkspotEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayFPPControlAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayFPPControlAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayRidAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayRidAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlaySkAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlaySkAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlaySkAnimEventData.cs
+++ b/CP77.CR2W/Types/cp77/scnPlaySkAnimEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlaySkAnimRootMotionData.cs
+++ b/CP77.CR2W/Types/cp77/scnPlaySkAnimRootMotionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayVideoEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayVideoEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayerActorDef.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayerActorDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPlayerAnimData.cs
+++ b/CP77.CR2W/Types/cp77/scnPlayerAnimData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPoseCorrectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnPoseCorrectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPropDef.cs
+++ b/CP77.CR2W/Types/cp77/scnPropDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPropId.cs
+++ b/CP77.CR2W/Types/cp77/scnPropId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnPropOwnershipTransferOptions.cs
+++ b/CP77.CR2W/Types/cp77/scnPropOwnershipTransferOptions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnQuestNode.cs
+++ b/CP77.CR2W/Types/cp77/scnQuestNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRandomizerNode.cs
+++ b/CP77.CR2W/Types/cp77/scnRandomizerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnReferencePointDef.cs
+++ b/CP77.CR2W/Types/cp77/scnReferencePointDef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnReferencePointId.cs
+++ b/CP77.CR2W/Types/cp77/scnReferencePointId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnReminderCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnReminderCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRewindableSectionEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnRewindableSectionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRewindableSectionNode.cs
+++ b/CP77.CR2W/Types/cp77/scnRewindableSectionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRewindableSectionPlaySpeedModifiers.cs
+++ b/CP77.CR2W/Types/cp77/scnRewindableSectionPlaySpeedModifiers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimSetSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimSetSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefAnimContainer.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefAnimContainer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefAnimContainerContext.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefAnimContainerContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationContainerSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidAnimationSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidAnimationSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidAnimationSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRef.cs
+++ b/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidCameraAnimationSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidCyberwareAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidCyberwareAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidCyberwareAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidCyberwareAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidDeformationAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidDeformationAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidDeformationAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidDeformationAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidFacialAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidFacialAnimSetSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidFacialAnimSetSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidFacialAnimSetSRRefId.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnRidResource.cs
+++ b/CP77.CR2W/Types/cp77/scnRidResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidResourceHandler.cs
+++ b/CP77.CR2W/Types/cp77/scnRidResourceHandler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidResourceId.cs
+++ b/CP77.CR2W/Types/cp77/scnRidResourceId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidSerialNumber.cs
+++ b/CP77.CR2W/Types/cp77/scnRidSerialNumber.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnRidTag.cs
+++ b/CP77.CR2W/Types/cp77/scnRidTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSRRefCollection.cs
+++ b/CP77.CR2W/Types/cp77/scnSRRefCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSRRefId.cs
+++ b/CP77.CR2W/Types/cp77/scnSRRefId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScalingData_KeepRelationWithOtherEvents.cs
+++ b/CP77.CR2W/Types/cp77/scnScalingData_KeepRelationWithOtherEvents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneEventId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneEventId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneEventSymbol.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneEventSymbol.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneGraph.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneGraph.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneGraphNode.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneGraphNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneInstanceId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneInstanceId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneInstanceOwnerId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneInstanceOwnerId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneMarker.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneMarker.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsWorkspotEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsWorkspotEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsWorkspotEntrySocket.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneMarkerInternalsWorkspotEntrySocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneResource.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneSharedState.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneSolutionHash.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneSolutionHash.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneSolutionHashHash.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneSolutionHashHash.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneSystem.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnSceneTime.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneTime.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneTimeProvider.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneTimeProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneTimeProvider.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneTimeProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnSceneVOInfo.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneVOInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneWorkspotDataId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneWorkspotDataId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSceneWorkspotInstanceId.cs
+++ b/CP77.CR2W/Types/cp77/scnSceneWorkspotInstanceId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScenesVersions.cs
+++ b/CP77.CR2W/Types/cp77/scnScenesVersions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScenesVersionsChangedRecord.cs
+++ b/CP77.CR2W/Types/cp77/scnScenesVersionsChangedRecord.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScenesVersionsSceneChanges.cs
+++ b/CP77.CR2W/Types/cp77/scnScenesVersionsSceneChanges.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/scnScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/scnScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnSectionInternalsActorBehavior.cs
+++ b/CP77.CR2W/Types/cp77/scnSectionInternalsActorBehavior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSectionNode.cs
+++ b/CP77.CR2W/Types/cp77/scnSectionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSetupSyncWorkspotRelationshipsEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnSetupSyncWorkspotRelationshipsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSpawnDespawnEntityParams.cs
+++ b/CP77.CR2W/Types/cp77/scnSpawnDespawnEntityParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSpawnSetParams.cs
+++ b/CP77.CR2W/Types/cp77/scnSpawnSetParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSpawnerParams.cs
+++ b/CP77.CR2W/Types/cp77/scnSpawnerParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnStartNode.cs
+++ b/CP77.CR2W/Types/cp77/scnStartNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnStartNode.cs
+++ b/CP77.CR2W/Types/cp77/scnStartNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnSyncNodeSignal.cs
+++ b/CP77.CR2W/Types/cp77/scnSyncNodeSignal.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSystemSharedState.cs
+++ b/CP77.CR2W/Types/cp77/scnSystemSharedState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnSystemSharedState.cs
+++ b/CP77.CR2W/Types/cp77/scnSystemSharedState.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnTalkInteractionListener.cs
+++ b/CP77.CR2W/Types/cp77/scnTalkInteractionListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnTalkInteractionListener.cs
+++ b/CP77.CR2W/Types/cp77/scnTalkInteractionListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scnTalkOnReturn_Operation.cs
+++ b/CP77.CR2W/Types/cp77/scnTalkOnReturn_Operation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnTimedCondition.cs
+++ b/CP77.CR2W/Types/cp77/scnTimedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnToggleInterruption_InterruptionOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnToggleInterruption_InterruptionOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnToggleScenario_InterruptionScenarioOperation.cs
+++ b/CP77.CR2W/Types/cp77/scnToggleScenario_InterruptionScenarioOperation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnUnmountEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnUnmountEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnUseSceneWorkspotCommand.cs
+++ b/CP77.CR2W/Types/cp77/scnUseSceneWorkspotCommand.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnUseSceneWorkspotParamsV1.cs
+++ b/CP77.CR2W/Types/cp77/scnUseSceneWorkspotParamsV1.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVarComparison_FactConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnVarComparison_FactConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVarComparison_FactConditionTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/scnVarComparison_FactConditionTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVarVsVarComparison_FactConditionType.cs
+++ b/CP77.CR2W/Types/cp77/scnVarVsVarComparison_FactConditionType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVarVsVarComparison_FactConditionTypeParams.cs
+++ b/CP77.CR2W/Types/cp77/scnVarVsVarComparison_FactConditionTypeParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVehicleMoveOnSpline_Overrides.cs
+++ b/CP77.CR2W/Types/cp77/scnVehicleMoveOnSpline_Overrides.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVoicesetComponent.cs
+++ b/CP77.CR2W/Types/cp77/scnVoicesetComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVoicesetComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/scnVoicesetComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnVoicetagId.cs
+++ b/CP77.CR2W/Types/cp77/scnVoicetagId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWalkToEvent.cs
+++ b/CP77.CR2W/Types/cp77/scnWalkToEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorkspotData.cs
+++ b/CP77.CR2W/Types/cp77/scnWorkspotData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorkspotData_EmbeddedWorkspotTree.cs
+++ b/CP77.CR2W/Types/cp77/scnWorkspotData_EmbeddedWorkspotTree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorkspotData_ExternalWorkspotResource.cs
+++ b/CP77.CR2W/Types/cp77/scnWorkspotData_ExternalWorkspotResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorkspotInstance.cs
+++ b/CP77.CR2W/Types/cp77/scnWorkspotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorkspotSymbol.cs
+++ b/CP77.CR2W/Types/cp77/scnWorkspotSymbol.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnWorldMarker.cs
+++ b/CP77.CR2W/Types/cp77/scnWorldMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnXorNode.cs
+++ b/CP77.CR2W/Types/cp77/scnXorNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnXorNode.cs
+++ b/CP77.CR2W/Types/cp77/scnXorNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/scndevEvent.cs
+++ b/CP77.CR2W/Types/cp77/scndevEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsAttachPropToNode.cs
+++ b/CP77.CR2W/Types/cp77/scneventsAttachPropToNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsAttachPropToPerformer.cs
+++ b/CP77.CR2W/Types/cp77/scneventsAttachPropToPerformer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsAttachPropToWorld.cs
+++ b/CP77.CR2W/Types/cp77/scneventsAttachPropToWorld.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsAttachPropToWorldCachedFallbackBone.cs
+++ b/CP77.CR2W/Types/cp77/scneventsAttachPropToWorldCachedFallbackBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsBraindanceVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsBraindanceVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsCameraEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsCameraEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsCameraOverrideSettings.cs
+++ b/CP77.CR2W/Types/cp77/scneventsCameraOverrideSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsCameraParamsEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsCameraParamsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsCameraPlacementEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsCameraPlacementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsClueEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsClueEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsDespawnEntityEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsDespawnEntityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsDespawnEntityEventParams.cs
+++ b/CP77.CR2W/Types/cp77/scneventsDespawnEntityEventParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsEquipItemToPerformer.cs
+++ b/CP77.CR2W/Types/cp77/scneventsEquipItemToPerformer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsPlayAnimEventData.cs
+++ b/CP77.CR2W/Types/cp77/scneventsPlayAnimEventData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsPlayAnimEventExData.cs
+++ b/CP77.CR2W/Types/cp77/scneventsPlayAnimEventExData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsPlayRidCameraAnimEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsPlayRidCameraAnimEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsPlayerLookAtEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsPlayerLookAtEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsPlayerLookAtEventParams.cs
+++ b/CP77.CR2W/Types/cp77/scneventsPlayerLookAtEventParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsSetAnimFeatureEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsSetAnimFeatureEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsSocket.cs
+++ b/CP77.CR2W/Types/cp77/scneventsSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsSpawnEntityEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsSpawnEntityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsSpawnEntityEventCachedFallbackBone.cs
+++ b/CP77.CR2W/Types/cp77/scneventsSpawnEntityEventCachedFallbackBone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsSpawnEntityEventParams.cs
+++ b/CP77.CR2W/Types/cp77/scneventsSpawnEntityEventParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsUIAnimationBraindanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsUIAnimationBraindanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsUIAnimationEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsUIAnimationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsUnequipItemFromPerformer.cs
+++ b/CP77.CR2W/Types/cp77/scneventsUnequipItemFromPerformer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsUnequipItemFromPerformerByItem.cs
+++ b/CP77.CR2W/Types/cp77/scneventsUnequipItemFromPerformerByItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsVFXBraindanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsVFXBraindanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsVFXDurationEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsVFXDurationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scneventsVFXEvent.cs
+++ b/CP77.CR2W/Types/cp77/scneventsVFXEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnfppGenderSpecificParams.cs
+++ b/CP77.CR2W/Types/cp77/scnfppGenderSpecificParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocLangId.cs
+++ b/CP77.CR2W/Types/cp77/scnlocLangId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocLocStoreEmbedded.cs
+++ b/CP77.CR2W/Types/cp77/scnlocLocStoreEmbedded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocLocStoreEmbeddedVariantDescriptorEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnlocLocStoreEmbeddedVariantDescriptorEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocLocStoreEmbeddedVariantPayloadEntry.cs
+++ b/CP77.CR2W/Types/cp77/scnlocLocStoreEmbeddedVariantPayloadEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocLocstringId.cs
+++ b/CP77.CR2W/Types/cp77/scnlocLocstringId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocSignature.cs
+++ b/CP77.CR2W/Types/cp77/scnlocSignature.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnlocVariantId.cs
+++ b/CP77.CR2W/Types/cp77/scnlocVariantId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnprvSpawnDespawnItem.cs
+++ b/CP77.CR2W/Types/cp77/scnprvSpawnDespawnItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayChoiceOption.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayChoiceOption.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayDialogLine.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayDialogLine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayItemId.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayItemId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayLineUsage.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayLineUsage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayOptionUsage.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayOptionUsage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayStandaloneComment.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayStandaloneComment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnscreenplayStore.cs
+++ b/CP77.CR2W/Types/cp77/scnscreenplayStore.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnsimActionsScenarios.cs
+++ b/CP77.CR2W/Types/cp77/scnsimActionsScenarios.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnsimActionsScenariosNodeScenarios.cs
+++ b/CP77.CR2W/Types/cp77/scnsimActionsScenariosNodeScenarios.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnsimIActionScenario.cs
+++ b/CP77.CR2W/Types/cp77/scnsimIActionScenario.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/scnsimIActionScenario.cs
+++ b/CP77.CR2W/Types/cp77/scnsimIActionScenario.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseAngleRange.cs
+++ b/CP77.CR2W/Types/cp77/senseAngleRange.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseBaseStimuliEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseBaseStimuliEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseBaseStimuliEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseBaseStimuliEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseCSenseManager.cs
+++ b/CP77.CR2W/Types/cp77/senseCSenseManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseCSenseManager.cs
+++ b/CP77.CR2W/Types/cp77/senseCSenseManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseComponent.cs
+++ b/CP77.CR2W/Types/cp77/senseComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseISenseManager.cs
+++ b/CP77.CR2W/Types/cp77/senseISenseManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseISenseManager.cs
+++ b/CP77.CR2W/Types/cp77/senseISenseManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseIShape.cs
+++ b/CP77.CR2W/Types/cp77/senseIShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseInitializeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseInitializeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseInitializeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseOnBeingDetectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnBeingDetectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseOnDetectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnDetectedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseOnDetectedEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnDetectedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseOnEnterShapeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnEnterShapeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseOnEnterShapeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnEnterShapeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseOnExitShapeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnExitShapeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseOnExitShapeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseOnExitShapeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/senseOnRemoveDetection.cs
+++ b/CP77.CR2W/Types/cp77/senseOnRemoveDetection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sensePlayerDetectionChangedEvent.cs
+++ b/CP77.CR2W/Types/cp77/sensePlayerDetectionChangedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseSensorObject.cs
+++ b/CP77.CR2W/Types/cp77/senseSensorObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseSensorObjectComponent.cs
+++ b/CP77.CR2W/Types/cp77/senseSensorObjectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseShapes.cs
+++ b/CP77.CR2W/Types/cp77/senseShapes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseSimpleBox.cs
+++ b/CP77.CR2W/Types/cp77/senseSimpleBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseSimpleCone.cs
+++ b/CP77.CR2W/Types/cp77/senseSimpleCone.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseSimpleSphere.cs
+++ b/CP77.CR2W/Types/cp77/senseSimpleSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseStimuliData.cs
+++ b/CP77.CR2W/Types/cp77/senseStimuliData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseStimuliEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseStimuliEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibilityEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibilityEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObject.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectComponent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectDetectionMultEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectDetectionMultEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectDistanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectDistanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectSecondaryPositionEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectSecondaryPositionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectTypeEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectTypeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/senseVisibleObjectetSecondaryDistanceEvent.cs
+++ b/CP77.CR2W/Types/cp77/senseVisibleObjectetSecondaryDistanceEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/servicesGameServices.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServices.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/servicesGameServices.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServices.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/servicesGameServicesGalaxy.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServicesGalaxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/servicesGameServicesGalaxy.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServicesGalaxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/servicesGameServicesWin.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServicesWin.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/servicesGameServicesWin.cs
+++ b/CP77.CR2W/Types/cp77/servicesGameServicesWin.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/sharedMenuCollection.cs
+++ b/CP77.CR2W/Types/cp77/sharedMenuCollection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sharedMenuItem.cs
+++ b/CP77.CR2W/Types/cp77/sharedMenuItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/sharedResourceCommandOutcome.cs
+++ b/CP77.CR2W/Types/cp77/sharedResourceCommandOutcome.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/speedometerLogicController.cs
+++ b/CP77.CR2W/Types/cp77/speedometerLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/stealthAlertGameController.cs
+++ b/CP77.CR2W/Types/cp77/stealthAlertGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/stimInvestigateData.cs
+++ b/CP77.CR2W/Types/cp77/stimInvestigateData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/subtitleLineMapEntry.cs
+++ b/CP77.CR2W/Types/cp77/subtitleLineMapEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tachometerLogicController.cs
+++ b/CP77.CR2W/Types/cp77/tachometerLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tarotCardLogicController.cs
+++ b/CP77.CR2W/Types/cp77/tarotCardLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tempshitIJournalNodeType.cs
+++ b/CP77.CR2W/Types/cp77/tempshitIJournalNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tempshitIJournalNodeType.cs
+++ b/CP77.CR2W/Types/cp77/tempshitIJournalNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/tempshitJournalEntryNodeType.cs
+++ b/CP77.CR2W/Types/cp77/tempshitJournalEntryNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tempshitJournalEntryNodeType.cs
+++ b/CP77.CR2W/Types/cp77/tempshitJournalEntryNodeType.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/tempshitJournalNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/tempshitJournalNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tempshitJournalNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/tempshitJournalNodeDefinition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/tempshitMapPinManagerNodeDefinition.cs
+++ b/CP77.CR2W/Types/cp77/tempshitMapPinManagerNodeDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/textScrollingAnimController.cs
+++ b/CP77.CR2W/Types/cp77/textScrollingAnimController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/textTextBlockFontStyle.cs
+++ b/CP77.CR2W/Types/cp77/textTextBlockFontStyle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/textTextBlockStyle.cs
+++ b/CP77.CR2W/Types/cp77/textTextBlockStyle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/textTextParameterSet.cs
+++ b/CP77.CR2W/Types/cp77/textTextParameterSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/textTextParameterSet.cs
+++ b/CP77.CR2W/Types/cp77/textTextParameterSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/textWrappingInfo.cs
+++ b/CP77.CR2W/Types/cp77/textWrappingInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tickITimeDilationListener.cs
+++ b/CP77.CR2W/Types/cp77/tickITimeDilationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tickITimeDilationListener.cs
+++ b/CP77.CR2W/Types/cp77/tickITimeDilationListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/tickScriptTimeDilationListener.cs
+++ b/CP77.CR2W/Types/cp77/tickScriptTimeDilationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/tickScriptTimeDilationListener.cs
+++ b/CP77.CR2W/Types/cp77/tickScriptTimeDilationListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/toolsEditorObjectIDPath.cs
+++ b/CP77.CR2W/Types/cp77/toolsEditorObjectIDPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsIMessageLocation.cs
+++ b/CP77.CR2W/Types/cp77/toolsIMessageLocation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsIMessageLocation.cs
+++ b/CP77.CR2W/Types/cp77/toolsIMessageLocation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/toolsIMessageToken.cs
+++ b/CP77.CR2W/Types/cp77/toolsIMessageToken.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsIMessageToken.cs
+++ b/CP77.CR2W/Types/cp77/toolsIMessageToken.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/toolsIResolverUserContext.cs
+++ b/CP77.CR2W/Types/cp77/toolsIResolverUserContext.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsIResolverUserContext.cs
+++ b/CP77.CR2W/Types/cp77/toolsIResolverUserContext.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/toolsLastNodeSelection.cs
+++ b/CP77.CR2W/Types/cp77/toolsLastNodeSelection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessage.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageLocation_BoundingBox.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageLocation_BoundingBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageLocation_EditorObject.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageLocation_EditorObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageLocation_Point.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageLocation_Point.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageLocation_Resource.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageLocation_Resource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageLocation_Webpage.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageLocation_Webpage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageToken_Location.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageToken_Location.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageToken_Name.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageToken_Name.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/toolsMessageToken_Text.cs
+++ b/CP77.CR2W/Types/cp77/toolsMessageToken_Text.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsGroup.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsGroup.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsGroup.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsNotificationListener.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsNotificationListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsNotificationListener.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsNotificationListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsUserSettings.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsUserSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsUserSettings.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsUserSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVar.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVar.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVar.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVar.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarBool.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarBool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarBool.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarBool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarFloat.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarFloat.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarInt.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarInt.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarInt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarListFloat.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListFloat.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarListFloat.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListFloat.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarListInt.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListInt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarListInt.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListInt.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarListName.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarListName.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListName.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarListString.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListString.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarListString.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListString.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarListener.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarListener.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/userSettingsVarName.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/userSettingsVarName.cs
+++ b/CP77.CR2W/Types/cp77/userSettingsVarName.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAIMountedE3Hack.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAIMountedE3Hack.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAIMountedE3Hack.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAIMountedE3Hack.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAVBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAVBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAVBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAVBaseObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAbortSummoningActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAbortSummoningActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAbortSummoningActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAbortSummoningActionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAnimFeature_VehicleProceduralCamera.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAnimFeature_VehicleProceduralCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAssignConvoyEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAssignConvoyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAssignConvoyEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAssignConvoyEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAudio.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAudio.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudio.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAudioEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudioEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAudioPSData.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudioPSData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAudioVehicleCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudioVehicleCurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAudioVehicleCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAudioVehicleCurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAutonomousData.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAutonomousData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAutopilot.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAutopilot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAutopilot.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAutopilot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleAutopilotTransformProvider.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAutopilotTransformProvider.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleAutopilotTransformProvider.cs
+++ b/CP77.CR2W/Types/cp77/vehicleAutopilotTransformProvider.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleBikeBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleBikeBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleBikeBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleBikeBaseObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleBikeCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/vehicleBikeCurveSet.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleBikeCurveSet.cs
+++ b/CP77.CR2W/Types/cp77/vehicleBikeCurveSet.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleCameraManager.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManager.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCameraManager.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManager.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleCameraManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManagerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCameraManagerComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManagerComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleCameraManagerComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManagerComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCameraManagerFT.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManagerFT.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCameraManagerFT.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraManagerFT.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleCameraResetEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraResetEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCameraResetEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraResetEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleCameraSceneEnableEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCameraSceneEnableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCarBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCarBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleCarBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleCarBaseObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeAlarmEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeAlarmEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeAlarmEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeAlarmEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeLightModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeLightModeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeLightModeEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeLightModeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeMovableEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeMovableEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeMovableEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeMovableEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeRadioReceiverStationEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeRadioReceiverStationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeRadioReceiverStationEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeRadioReceiverStationEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeRadioTierEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeRadioTierEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeRadioTierEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeRadioTierEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleChangeStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChangeWindowStateEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChangeWindowStateEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleChassisComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleChassisComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleControllerPS.cs
+++ b/CP77.CR2W/Types/cp77/vehicleControllerPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDebugUIGameController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDebugUIGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDestructionPSData.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDestructionPSData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDetachAllPartsEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDetachAllPartsEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDetachAllPartsEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDetachAllPartsEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleDetachPartEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDetachPartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDoneActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDoneActionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDoneActionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDoneActionEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleDriveFollowEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveFollowEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveFollowSplineEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveFollowSplineEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveJoinTrafficVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveJoinTrafficVehicleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveJoinTrafficVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveJoinTrafficVehicleEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleDriveSplineReverseEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveSplineReverseEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveToGameObjectEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveToGameObjectEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveToNodeRefEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveToNodeRefEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriveToPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriveToPointEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriver.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriver.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleDriver.cs
+++ b/CP77.CR2W/Types/cp77/vehicleDriver.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleFinishedMountingEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFinishedMountingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleFlippedOverEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFlippedOverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleFollowObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFollowObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleFollowObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFollowObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleForbiddenAreaState.cs
+++ b/CP77.CR2W/Types/cp77/vehicleForbiddenAreaState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleFormation.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFormation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleFormation.cs
+++ b/CP77.CR2W/Types/cp77/vehicleFormation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleGarageComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGarageComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleGarageComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGarageComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleGarageComponentPS.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGarageComponentPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleGarageComponentVehicleData.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGarageComponentVehicleData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleGarageVehicleID.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGarageVehicleID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleGlassDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGlassDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleGridDestructionEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleGridDestructionEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleHasVehicleBeenFlippedOverForSomeTimeEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleHasVehicleBeenFlippedOverForSomeTimeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleHasVehicleBeenFlippedOverForSomeTimeEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleHasVehicleBeenFlippedOverForSomeTimeEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleIMoveSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleIMoveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleIMoveSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleIMoveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleIRacingSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleIRacingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleIRacingSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleIRacingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleInteriorUIGameController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleInteriorUIGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleLightComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleLightComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleMoveSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleMoveSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleMoveSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleMoveSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleMoveSystemStopEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleMoveSystemStopEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleMoveSystemStopEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleMoveSystemStopEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleOnPartDetachedEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleOnPartDetachedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleParkedEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleParkedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehiclePersistentData.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehiclePersistentData.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePersistentData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehiclePersistentDataPS.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePersistentDataPS.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehiclePlayerToAIBlendInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePlayerToAIBlendInterpolator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehiclePlayerToAIBlendInterpolator.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePlayerToAIBlendInterpolator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehiclePlayerVehicle.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePlayerVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehiclePortalsList.cs
+++ b/CP77.CR2W/Types/cp77/vehiclePortalsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleRacingSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRacingSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleRacingSystem.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRacingSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleRadioSongChanged.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRadioSongChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleRadioStationChanged.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRadioStationChanged.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleReadyToParkEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleReadyToParkEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleReadyToParkEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleReadyToParkEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleRepairEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRepairEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleRepairEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRepairEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleRequestCameraPerspectiveEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleRequestCameraPerspectiveEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleSplineSlot.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSplineSlot.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleSplineSlot.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSplineSlot.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleSplineSlot_NonAnimSpline.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSplineSlot_NonAnimSpline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleSplineSlot_NonAnimSpline.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSplineSlot_NonAnimSpline.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleStartConvoyEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStartConvoyEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStartConvoyEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStartConvoyEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleStartDynamicMovementEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStartDynamicMovementEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStartedMountingEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStartedMountingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStealEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStealEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStealEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStealEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleStopDriveToPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStopDriveToPointEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStopDriveToPointEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStopDriveToPointEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleStopStunnedVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStopStunnedVehicleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStopStunnedVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStopStunnedVehicleEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleStunnedVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStunnedVehicleEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleStunnedVehicleEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleStunnedVehicleEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleSummonFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSummonFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleSummonLogic.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSummonLogic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleSummonLogic.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSummonLogic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleSummonStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleSummonStartedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleTPPCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTPPCameraComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleTPPCameraComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTPPCameraComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleTankBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTankBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleTankBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTankBaseObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleTeleportEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTeleportEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleTeleportEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleTeleportEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleBrokenTireEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleBrokenTireEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleBrokenTireEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleBrokenTireEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleDoorOpenEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleDoorOpenEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleDoorOpenEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleDoorOpenEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleDoorWrapperEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleDoorWrapperEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleForbiddenVehicleAreaEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleForbiddenVehicleAreaEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleForbiddenVehicleAreaEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleForbiddenVehicleAreaEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestCustomFPPLockOffEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestCustomFPPLockOffEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestCustomFPPLockOffEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestCustomFPPLockOffEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestForceBrakingEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestForceBrakingEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestForceBrakingEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestForceBrakingEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestWeaponEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestWeaponEnabledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleQuestWeaponEnabledEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleQuestWeaponEnabledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleToggleRadioReceiverEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleRadioReceiverEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleToggleRadioReceiverEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleToggleRadioReceiverEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleUIGameController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleUIGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleUnlockedVehicle.cs
+++ b/CP77.CR2W/Types/cp77/vehicleUnlockedVehicle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleUnmountPosition.cs
+++ b/CP77.CR2W/Types/cp77/vehicleUnmountPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVcarGameController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVcarGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVcarRootLogicController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVcarRootLogicController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVcarRootLogicController.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVcarRootLogicController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleVehicleMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVehicleMountableComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVehicleMountableComponent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVehicleMountableComponent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleVehicleProxyBlendCamera.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVehicleProxyBlendCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVehicleProxyBlendCamera.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVehicleProxyBlendCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleVehicleSlotsState.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVehicleSlotsState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVisualPerception.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVisualPerception.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleVisualPerception.cs
+++ b/CP77.CR2W/Types/cp77/vehicleVisualPerception.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vehicleWaterEvent.cs
+++ b/CP77.CR2W/Types/cp77/vehicleWaterEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleWheelRuntimePSData.cs
+++ b/CP77.CR2W/Types/cp77/vehicleWheelRuntimePSData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleWheeledBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleWheeledBaseObject.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vehicleWheeledBaseObject.cs
+++ b/CP77.CR2W/Types/cp77/vehicleWheeledBaseObject.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/vgAttributeTypeValuePair.cs
+++ b/CP77.CR2W/Types/cp77/vgAttributeTypeValuePair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgBaseVectorGraphicShape.cs
+++ b/CP77.CR2W/Types/cp77/vgBaseVectorGraphicShape.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicDefinition.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Circle.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Circle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Group.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Group.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_PolyLine.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_PolyLine.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Polygon.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Polygon.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Rect.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Rect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Text.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicShape_Text.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/vgVectorGraphicStyle.cs
+++ b/CP77.CR2W/Types/cp77/vgVectorGraphicStyle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/visIOccluderResource.cs
+++ b/CP77.CR2W/Types/cp77/visIOccluderResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/visOccluderMeshResource.cs
+++ b/CP77.CR2W/Types/cp77/visOccluderMeshResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/weaponIndicatorController.cs
+++ b/CP77.CR2W/Types/cp77/weaponIndicatorController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/weaponRosterGameController.cs
+++ b/CP77.CR2W/Types/cp77/weaponRosterGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workActorTagCondition.cs
+++ b/CP77.CR2W/Types/cp77/workActorTagCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workAdjustAndPlayCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workAdjustAndPlayCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workAdjustAndPlayCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workAdjustAndPlayCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workAnimClip.cs
+++ b/CP77.CR2W/Types/cp77/workAnimClip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workAnimClipWithItem.cs
+++ b/CP77.CR2W/Types/cp77/workAnimClipWithItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workAnimObjectDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workAnimObjectDebuggerCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workAnimObjectDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workAnimObjectDebuggerCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workBodytypeCondition.cs
+++ b/CP77.CR2W/Types/cp77/workBodytypeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workConditionalSequence.cs
+++ b/CP77.CR2W/Types/cp77/workConditionalSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workConnectedWorkspotNotificationEvent.cs
+++ b/CP77.CR2W/Types/cp77/workConnectedWorkspotNotificationEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workCoverTypeCondition.cs
+++ b/CP77.CR2W/Types/cp77/workCoverTypeCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workDebuggerCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workDebuggerCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workDebuggingTool.cs
+++ b/CP77.CR2W/Types/cp77/workDebuggingTool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workDebuggingTool.cs
+++ b/CP77.CR2W/Types/cp77/workDebuggingTool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workDynamicSyncBindCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workDynamicSyncBindCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEntryAnim.cs
+++ b/CP77.CR2W/Types/cp77/workEntryAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEquipInventoryWeaponAction.cs
+++ b/CP77.CR2W/Types/cp77/workEquipInventoryWeaponAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEquipItemCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workEquipItemCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEquipItemCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workEquipItemCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workEquipItemToSlotAction.cs
+++ b/CP77.CR2W/Types/cp77/workEquipItemToSlotAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEquipPropToSlotAction.cs
+++ b/CP77.CR2W/Types/cp77/workEquipPropToSlotAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEventListenerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workEventListenerCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workEventListenerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workEventListenerCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workExcludedGesturesData.cs
+++ b/CP77.CR2W/Types/cp77/workExcludedGesturesData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workExcludedGesturesData.cs
+++ b/CP77.CR2W/Types/cp77/workExcludedGesturesData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workExitAnim.cs
+++ b/CP77.CR2W/Types/cp77/workExitAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workFastExit.cs
+++ b/CP77.CR2W/Types/cp77/workFastExit.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workFastExitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workFastExitCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workFastExitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workFastExitCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workFastForwardData.cs
+++ b/CP77.CR2W/Types/cp77/workFastForwardData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workFastForwardData.cs
+++ b/CP77.CR2W/Types/cp77/workFastForwardData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workFunctionalTestsDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workFunctionalTestsDebuggerCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workFunctionalTestsDebuggerCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workFunctionalTestsDebuggerCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIContainerEntry.cs
+++ b/CP77.CR2W/Types/cp77/workIContainerEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIEntry.cs
+++ b/CP77.CR2W/Types/cp77/workIEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIScriptedCondition.cs
+++ b/CP77.CR2W/Types/cp77/workIScriptedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIScriptedCondition.cs
+++ b/CP77.CR2W/Types/cp77/workIScriptedCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIWorkspotCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIWorkspotCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIWorkspotCondition.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIWorkspotItemAction.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotItemAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIWorkspotItemAction.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotItemAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIWorkspotQuestAction.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotQuestAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIWorkspotQuestAction.cs
+++ b/CP77.CR2W/Types/cp77/workIWorkspotQuestAction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIdleOnlyModeCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIdleOnlyModeCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIdleOnlyModeCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIdleOnlyModeCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIdleTransitionCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIdleTransitionCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIdleTransitionCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workIdleTransitionCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workIsPlayerCondition.cs
+++ b/CP77.CR2W/Types/cp77/workIsPlayerCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workIsPlayerCondition.cs
+++ b/CP77.CR2W/Types/cp77/workIsPlayerCondition.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workItemOverrideCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workItemOverrideCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workItemOverrideCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workItemOverrideCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workJumpToCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workJumpToCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workJumpToCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workJumpToCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workLookAtDrivenTurn.cs
+++ b/CP77.CR2W/Types/cp77/workLookAtDrivenTurn.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workMaxAnimTimeLimitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workMaxAnimTimeLimitCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workMaxAnimTimeLimitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workMaxAnimTimeLimitCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workMotionAnimClip.cs
+++ b/CP77.CR2W/Types/cp77/workMotionAnimClip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workMotionAnimClip.cs
+++ b/CP77.CR2W/Types/cp77/workMotionAnimClip.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workPauseClip.cs
+++ b/CP77.CR2W/Types/cp77/workPauseClip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workRandomList.cs
+++ b/CP77.CR2W/Types/cp77/workRandomList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workReactionFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/workReactionFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workReactionFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/workReactionFinishedEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workReactionSequence.cs
+++ b/CP77.CR2W/Types/cp77/workReactionSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workRegisterCleanupCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workRegisterCleanupCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workRegisterCleanupCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workRegisterCleanupCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workScriptedCondition.cs
+++ b/CP77.CR2W/Types/cp77/workScriptedCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSelector.cs
+++ b/CP77.CR2W/Types/cp77/workSelector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSelector.cs
+++ b/CP77.CR2W/Types/cp77/workSelector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workSequence.cs
+++ b/CP77.CR2W/Types/cp77/workSequence.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSetInfiniteSequenceCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workSetInfiniteSequenceCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSetInfiniteSequenceCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workSetInfiniteSequenceCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workSetSequenceCategoriesCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workSetSequenceCategoriesCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workShadowDebugger.cs
+++ b/CP77.CR2W/Types/cp77/workShadowDebugger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workShadowDebugger.cs
+++ b/CP77.CR2W/Types/cp77/workShadowDebugger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workSlowExitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workSlowExitCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSlowExitCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workSlowExitCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workStopWorkspotQuestAction.cs
+++ b/CP77.CR2W/Types/cp77/workStopWorkspotQuestAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSyncAnimClip.cs
+++ b/CP77.CR2W/Types/cp77/workSyncAnimClip.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSyncMasterEntryAnim.cs
+++ b/CP77.CR2W/Types/cp77/workSyncMasterEntryAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workSyncMasterEntryAnim.cs
+++ b/CP77.CR2W/Types/cp77/workSyncMasterEntryAnim.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workTagNode.cs
+++ b/CP77.CR2W/Types/cp77/workTagNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workTimeOfDayCondition.cs
+++ b/CP77.CR2W/Types/cp77/workTimeOfDayCondition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workTransferItemOwnershipCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workTransferItemOwnershipCommandData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workTransferItemOwnershipCommandData.cs
+++ b/CP77.CR2W/Types/cp77/workTransferItemOwnershipCommandData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workTransitionAnim.cs
+++ b/CP77.CR2W/Types/cp77/workTransitionAnim.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workUnequipFromSlotAction.cs
+++ b/CP77.CR2W/Types/cp77/workUnequipFromSlotAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workUnequipItemAction.cs
+++ b/CP77.CR2W/Types/cp77/workUnequipItemAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workUnequipPropAction.cs
+++ b/CP77.CR2W/Types/cp77/workUnequipPropAction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkEntryId.cs
+++ b/CP77.CR2W/Types/cp77/workWorkEntryId.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotAnimsetEntry.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotAnimsetEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotFinishedEvent.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotFinishedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotFunctionalTestsDebuggingTool.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotFunctionalTestsDebuggingTool.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotFunctionalTestsDebuggingTool.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotFunctionalTestsDebuggingTool.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workWorkspotGlobalProp.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotGlobalProp.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotInstance.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotInstance.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workWorkspotItemOverride.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotItemOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotItemOverrideItemOverride.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotItemOverrideItemOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotItemOverridePropOverride.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotItemOverridePropOverride.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotResource.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotResourceComponent.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotResourceComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotStartedEvent.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotStartedEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotSystem.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workWorkspotSystem.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/workWorkspotTree.cs
+++ b/CP77.CR2W/Types/cp77/workWorkspotTree.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workworkspotAnimObjectDebugger.cs
+++ b/CP77.CR2W/Types/cp77/workworkspotAnimObjectDebugger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/workworkspotAnimObjectDebugger.cs
+++ b/CP77.CR2W/Types/cp77/workworkspotAnimObjectDebugger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAIDirectorSpawnNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAISpotNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAISpotNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAISpotNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAISpotNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAISpotNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAISpotNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAcousticDataCell.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticDataCell.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticDataResource.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticPortalNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticPortalNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticPortalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticPortalNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticPortalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticPortalNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAcousticSectorNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticSectorNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticSectorNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticSectorNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticSectorNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticSectorNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAcousticZoneNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticZoneNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticZoneNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticZoneNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticZoneNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticZoneNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAcousticsOutdoornessAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAdvertisementLightData.cs
+++ b/CP77.CR2W/Types/cp77/worldAdvertisementLightData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAdvertisementNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAdvertisementNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAdvertisementNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAdvertisementNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAdvertisementNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAdvertisementNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAmbientAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAmbientAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAmbientAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAmbientPaletteExclusionAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAnimationSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldAnimationSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAnimationSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldAnimationSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAnimationSystemScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldAnimationSystemScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAnimationSystemScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldAnimationSystemScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAreaProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAreaProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAreaProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAreaProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAreaShapeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAreaShapeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAreaShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAreaShapeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAreaShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAreaShapeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeSettings.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNodeSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioAttractAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioSignpostTriggerNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAudioTagNode.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioTagNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioTagNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioTagNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAudioTagNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldAudioTagNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldAutoFoliageMapping.cs
+++ b/CP77.CR2W/Types/cp77/worldAutoFoliageMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldAutoFoliageMappingItem.cs
+++ b/CP77.CR2W/Types/cp77/worldAutoFoliageMappingItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBakedDestructionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldBakedDestructionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBakedDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldBakedDestructionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBakedDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldBakedDestructionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldBendedMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldBendedMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBendedMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldBendedMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBendedMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldBendedMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldBlockoutArea.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutArea.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBlockoutAreaOutline.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutAreaOutline.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBlockoutData.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBlockoutEdge.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutEdge.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBlockoutPoint.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutPoint.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBlockoutResource.cs
+++ b/CP77.CR2W/Types/cp77/worldBlockoutResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBuildingProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldBuildingProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldBuildingProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldBuildingProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCableMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCableMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCableMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCableMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCableMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCableMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldClothMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldClothMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldClothMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldClothMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldClothMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldClothMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCollisionAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCollisionAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCollisionAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCollisionGroupEntry.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionGroupEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCollisionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCollisionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCollisionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCollisionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCommunityEntryInitialState.cs
+++ b/CP77.CR2W/Types/cp77/worldCommunityEntryInitialState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCommunityRegistryItem.cs
+++ b/CP77.CR2W/Types/cp77/worldCommunityRegistryItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCommunityRegistryNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCommunityRegistryNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCommunityRegistryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCommunityRegistryNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCommunityRegistryNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCommunityRegistryNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNode_Streamable.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCommunityAreaNode_Streamable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledCrowdParkingSpaceNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledEffectEventInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledEffectEventInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledEffectInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledEffectInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledEffectPlacementInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledEffectPlacementInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfoBuffer.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfoBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfoBuffer.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledNodeInstanceSetupInfoBuffer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledSector.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledSector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledSector.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledSector.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCompiledSmartObjectsNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldConversationData.cs
+++ b/CP77.CR2W/Types/cp77/worldConversationData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldConversationGroupData.cs
+++ b/CP77.CR2W/Types/cp77/worldConversationGroupData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCorpseSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldCorpseSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCorpseSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldCorpseSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCrowdNullAreaCollisionData.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdNullAreaCollisionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdNullAreaCollisionHeader.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdNullAreaCollisionHeader.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdNullAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdNullAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdNullAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdNullAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdNullAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdNullAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCrowdPortalNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdPortalNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdPortalNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdPortalNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCrowdPortalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdPortalNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCrowdPortalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCrowdPortalNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldCurvePathNode.cs
+++ b/CP77.CR2W/Types/cp77/worldCurvePathNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCurvePathNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCurvePathNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldCurvePathNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldCurvePathNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDbgOverlapBox.cs
+++ b/CP77.CR2W/Types/cp77/worldDbgOverlapBox.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_BoostedPrefabProxy.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_BoostedPrefabProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_BoostedPrefabProxy.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_BoostedPrefabProxy.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_Climbable.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_Climbable.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_CollisionMeshes.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_CollisionMeshes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_Device.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_Device.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_Discarded.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_Discarded.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_DistanceAbstractBase.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_DistanceAbstractBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_Duplicates.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_Duplicates.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_GIDebug.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_GIDebug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_GPUMemoryUsage.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_GPUMemoryUsage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_GPUMemoryUsage.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_GPUMemoryUsage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_GameVisualFluff.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_GameVisualFluff.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_GameVisualFluff.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_GameVisualFluff.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_InteriorExterior.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_InteriorExterior.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_MergedMeshes.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_MergedMeshes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_MeshLod.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_MeshLod.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_MeshLod.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_MeshLod.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_MetricsUsageAbstractBase.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_MetricsUsageAbstractBase.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_NavigationImpact.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_NavigationImpact.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ObjectTag.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ObjectTag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ObjectTagExt.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ObjectTagExt.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_PrefabProxy.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_PrefabProxy.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ProxyMeshDependency.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ProxyMeshDependency.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceName.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceReadiness.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceReadiness.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceReadiness.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_ResourceReadiness.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_SameResourceName.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_SameResourceName.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_SecondaryRefPointDistance.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_SecondaryRefPointDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_SecondaryRefPointDistance.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_SecondaryRefPointDistance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingCullingFlag.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingCullingFlag.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingDistance.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingDistance.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingDistance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingPriority.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingPriority.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingPriority.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_StreamingPriority.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_TrianglesPerMesh.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_TrianglesPerMesh.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueInstanceMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueInstanceMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueInstanceMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueInstanceMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueMeshColors.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugColoring_UniqueMeshColors.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDebugFilterSetting_MeshResource.cs
+++ b/CP77.CR2W/Types/cp77/worldDebugFilterSetting_MeshResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDecorationMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDecorationMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDecorationMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDecorationMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDecorationMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDecorationMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDecorationProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDecorationProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDecorationProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDecorationProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDesiredSlotsCountInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldDesiredSlotsCountInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleEntityProxyMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDestructibleProxyMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDeviceConnections.cs
+++ b/CP77.CR2W/Types/cp77/worldDeviceConnections.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDeviceNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDeviceNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDeviceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDeviceNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDeviceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDeviceNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDeviceRef.cs
+++ b/CP77.CR2W/Types/cp77/worldDeviceRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDistantGINode.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantGINode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDistantGINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantGINodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDistantGINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantGINodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDistantLightsNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantLightsNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDistantLightsNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantLightsNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDistantLightsNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDistantLightsNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldDynamicMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldDynamicMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDynamicMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDynamicMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldDynamicMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldDynamicMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEditorDebugColoringSettings.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorDebugColoringSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEditorDebugColoringSettings.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorDebugColoringSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings_NodeConditional.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorDebugFilterSettings_NodeConditional.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEditorForceAutoHideDistance.cs
+++ b/CP77.CR2W/Types/cp77/worldEditorForceAutoHideDistance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEffect.cs
+++ b/CP77.CR2W/Types/cp77/worldEffect.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEffectBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/worldEffectBlackboard.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEffectBlackboard.cs
+++ b/CP77.CR2W/Types/cp77/worldEffectBlackboard.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEffectNode.cs
+++ b/CP77.CR2W/Types/cp77/worldEffectNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEffectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEffectNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEffectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEffectNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEntityNode.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEntityNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEntityNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEntityProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEntityProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityProxyMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEntityProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEntityProxyMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEnvAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldEnvAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEnvAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEnvAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEnvAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldEnvAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldEnvironmentAreaParameters.cs
+++ b/CP77.CR2W/Types/cp77/worldEnvironmentAreaParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldEnvironmentDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldEnvironmentDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldExtractedNodeSocket.cs
+++ b/CP77.CR2W/Types/cp77/worldExtractedNodeSocket.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageBakedDestructionMapping.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageBakedDestructionMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageBrush.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageBrush.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageBrushItem.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageBrushItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageBrushParams.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageBrushParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageCompiledResource.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageCompiledResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageDestructionMapping.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageDestructionMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageDestructionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageDestructionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageDestructionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageDestructionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldFoliageDestructionResource.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageDestructionResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageNode.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldFoliagePhysicalDestructionMapping.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliagePhysicalDestructionMapping.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliagePopulationSpanInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliagePopulationSpanInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageRawData.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageRawData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldFoliageRawItem.cs
+++ b/CP77.CR2W/Types/cp77/worldFoliageRawItem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldForbiddenAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldForbiddenAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldForbiddenAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldForbiddenAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGINode.cs
+++ b/CP77.CR2W/Types/cp77/worldGINode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGINodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGINodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGIShapeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGIShapeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGIShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGIShapeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGIShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGIShapeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGISpaceNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGISpaceNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGISpaceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGISpaceNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGISpaceNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGISpaceNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGenericProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGenericProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGenericProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGenericProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGeometryShapeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGeometryShapeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGeometryShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGeometryShapeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGeometryShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGeometryShapeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGlobalNodeID.cs
+++ b/CP77.CR2W/Types/cp77/worldGlobalNodeID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGlobalNodeRef.cs
+++ b/CP77.CR2W/Types/cp77/worldGlobalNodeRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGroupProxyMeshBuildParams.cs
+++ b/CP77.CR2W/Types/cp77/worldGroupProxyMeshBuildParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGroupProxyMeshBuildParams.cs
+++ b/CP77.CR2W/Types/cp77/worldGroupProxyMeshBuildParams.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldGuardAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldGuardAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGuardAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGuardAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldGuardAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldGuardAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldHeatmapLayer.cs
+++ b/CP77.CR2W/Types/cp77/worldHeatmapLayer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldHeatmapResource.cs
+++ b/CP77.CR2W/Types/cp77/worldHeatmapResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldHeatmapSetup.cs
+++ b/CP77.CR2W/Types/cp77/worldHeatmapSetup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIDestructibleSpotsSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIDestructibleSpotsSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIDestructibleSpotsSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIDestructibleSpotsSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldIMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldIMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldIMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldINodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldINodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldINodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldINodeInstanceRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldINodeInstanceRegistry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldINodeInstanceRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldINodeInstanceRegistry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldIQuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/worldIQuestPrefabStateListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIQuestPrefabStateListener.cs
+++ b/CP77.CR2W/Types/cp77/worldIQuestPrefabStateListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldIRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIRuntimeSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIRuntimeSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIRuntimeSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldITriggerAreaNotifer.cs
+++ b/CP77.CR2W/Types/cp77/worldITriggerAreaNotifer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldITriggerAreaNotiferInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldITriggerAreaNotiferInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldITriggerAreaNotiferInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldITriggerAreaNotiferInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldIWorkspotSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIWorkspotSystem.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldIWorkspotSystem.cs
+++ b/CP77.CR2W/Types/cp77/worldIWorkspotSystem.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInspectorNodeInstanceProperties.cs
+++ b/CP77.CR2W/Types/cp77/worldInspectorNodeInstanceProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedDestructibleMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInstancedMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInstancedOccluderNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedOccluderNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedOccluderNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedOccluderNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInstancedOccluderNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInstancedOccluderNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInterestingConversationsAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInteriorMapNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorMapNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorMapNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorMapNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInteriorMapNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldInteriorMapNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldInvalidProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInvalidProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldInvalidProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldInvalidProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldLightChannelShapeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelShapeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLightChannelShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelShapeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLightChannelShapeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelShapeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldLightChannelVolumeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelVolumeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLightChannelVolumeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelVolumeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLightChannelVolumeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLightChannelVolumeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldLocationAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldLocationAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldMaraudersMapDevicesSink.cs
+++ b/CP77.CR2W/Types/cp77/worldMaraudersMapDevicesSink.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldMaraudersMapDevicesSink.cs
+++ b/CP77.CR2W/Types/cp77/worldMaraudersMapDevicesSink.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldMirrorNode.cs
+++ b/CP77.CR2W/Types/cp77/worldMirrorNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldMirrorNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldMirrorNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldMirrorNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldMirrorNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldNameColorPair.cs
+++ b/CP77.CR2W/Types/cp77/worldNameColorPair.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationDeniedAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationDeniedAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationNode.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptCostModCircle.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptCostModCircle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptFindPointResult.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptFindPointResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptFindWallResult.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptFindWallResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptObstacle.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptObstacle.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptObstacle.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptObstacle.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldNavigationScriptPath.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationScriptPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationTileData.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationTileData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNavigationTileResource.cs
+++ b/CP77.CR2W/Types/cp77/worldNavigationTileResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNodeEditorData.cs
+++ b/CP77.CR2W/Types/cp77/worldNodeEditorData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNodeInstanceRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldNodeInstanceRegistry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNodeInstanceRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldNodeInstanceRegistry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldNodeTransform.cs
+++ b/CP77.CR2W/Types/cp77/worldNodeTransform.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNode_.cs
+++ b/CP77.CR2W/Types/cp77/worldNode_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNodesGroup.cs
+++ b/CP77.CR2W/Types/cp77/worldNodesGroup.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNodesGroupPath.cs
+++ b/CP77.CR2W/Types/cp77/worldNodesGroupPath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNullMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldNullMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldNullMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldNullMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionPayload.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionPayload.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionPayload.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionPayload.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldOffMeshConnectionsData.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshConnectionsData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNode.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectUserData.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshSmartObjectUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshUserData.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshUserData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOffMeshUserData.cs
+++ b/CP77.CR2W/Types/cp77/worldOffMeshUserData.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldOnAreaShapeCompiledEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldOnAreaShapeCompiledEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldOnAreaShapeCompiledEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldOnAreaShapeCompiledEvent.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPackageNodeRefSerializer.cs
+++ b/CP77.CR2W/Types/cp77/worldPackageNodeRefSerializer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPackageNodeRefSerializer.cs
+++ b/CP77.CR2W/Types/cp77/worldPackageNodeRefSerializer.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPatrolSplineNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPatrolSplineNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPatrolSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPatrolSplineNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPatrolSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPatrolSplineNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPatrolSplinePointDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldPatrolSplinePointDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPerformanceAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPersistentSnapData.cs
+++ b/CP77.CR2W/Types/cp77/worldPersistentSnapData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalDestructionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalDestructionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalDestructionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalDestructionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalDestructionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalImpulseAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPhysicalTriggerAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPlayerProximityStartEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldPlayerProximityStartEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPlayerProximityStopEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldPlayerProximityStopEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPopulationSpawnerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPopulationSpawnerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPopulationSpawnerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPopulationSpawnerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPopulationSpawnerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPopulationSpawnerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPrefab.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefab.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabInstanceData.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabInstanceData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabMetadata.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabMetadata.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabMetadata.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabMetadata.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPrefabNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabProxyMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldPrefabVariantsList.cs
+++ b/CP77.CR2W/Types/cp77/worldPrefabVariantsList.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyBoundingBoxSyncParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyBoundingBoxSyncParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyCustomGeometryParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyCustomGeometryParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyMeshAdvancedBuildParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyMeshAdvancedBuildParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyMeshBuildParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyMeshBuildParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyMeshGroupBuildParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyMeshGroupBuildParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyMiscAdvancedParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyMiscAdvancedParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxySurfaceFlattenParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxySurfaceFlattenParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyTextureParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyTextureParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldProxyWindowsParams.cs
+++ b/CP77.CR2W/Types/cp77/worldProxyWindowsParams.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldQualitySetting.cs
+++ b/CP77.CR2W/Types/cp77/worldQualitySetting.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldQuestMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldQuestMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldQuestMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldQuestMarker.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldQuestProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldQuestProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldQuestProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldQuestProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRaceSplineNode.cs
+++ b/CP77.CR2W/Types/cp77/worldRaceSplineNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRaceSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldRaceSplineNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRaceSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldRaceSplineNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRaceSplineNodeOffset.cs
+++ b/CP77.CR2W/Types/cp77/worldRaceSplineNodeOffset.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRainEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldRainEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldReflectionProbeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldReflectionProbeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldReflectionProbeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldReflectionProbeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldReflectionProbeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldReflectionProbeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRelativeNodePath.cs
+++ b/CP77.CR2W/Types/cp77/worldRelativeNodePath.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRelativeNodePathElement.cs
+++ b/CP77.CR2W/Types/cp77/worldRelativeNodePathElement.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRenderProxyTransformBuffer.cs
+++ b/CP77.CR2W/Types/cp77/worldRenderProxyTransformBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRoadMaterialInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldRoadMaterialInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRoadProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldRoadProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRoadProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldRoadProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRotatingMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldRotatingMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRotatingMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldRotatingMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRotatingMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldRotatingMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeEntityRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeEntityRegistry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeEntityRegistry.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeEntityRegistry.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeInfo.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeScene.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeScene.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeScene.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeScene.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemAudio.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemAudio.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemAudio.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemAudio.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemBinkUpdate.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemBinkUpdate.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemBinkUpdate.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemBinkUpdate.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemCamera.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemCamera.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemCamera.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemCamera.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemCompiledTerrain.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemCompiledTerrain.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemCompiledTerrain.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemCompiledTerrain.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDebugRendering.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDebugRendering.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDebugRendering.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDebugRendering.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDestruction.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDestruction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDestruction.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDestruction.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDismemberment.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDismemberment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemDismemberment.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemDismemberment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEffectAttachments.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEffectAttachments.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEffectAttachments.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEffectAttachments.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEffects.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEffects.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEffects.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEffects.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntity.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntity.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntity.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntity.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityAppearanceChanger.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityAppearanceChanger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityAppearanceChanger.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityAppearanceChanger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransactor.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransactor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransactor.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransactor.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransforms.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransforms.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransforms.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityTransforms.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityVisualController.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityVisualController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityVisualController.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEntityVisualController.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEnvironment.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEnvironment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemEnvironment.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemEnvironment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemFoliage.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemFoliage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemFoliage.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemFoliage.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemMarkers.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemMarkers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemMarkers.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemMarkers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemMoverComponents.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemMoverComponents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemMoverComponents.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemMoverComponents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemNavigation.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemNavigation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemNavigation.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemNavigation.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemNodeStreaming.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemNodeStreaming.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemNodeStreaming.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemNodeStreaming.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemPhysics.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemPhysics.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemPhysics.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemPhysics.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemPrefabInstancing.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemPrefabInstancing.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemPrefabInstancing.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemPrefabInstancing.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRemoteViews.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRemoteViews.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRemoteViews.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRemoteViews.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRendering.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRendering.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRendering.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRendering.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRepellerComponents.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRepellerComponents.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemRepellerComponents.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemRepellerComponents.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemScenes.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemScenes.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemScenes.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemScenes.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemSmartObjects.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemSmartObjects.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemSmartObjects.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemSmartObjects.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemSnapSovler.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemSnapSovler.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemSnapSovler.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemSnapSovler.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemStreamingQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemStreamingQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemStreamingQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemStreamingQuery.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTraffic.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTraffic.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTraffic.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTraffic.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTransformAnimator.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTransformAnimator.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTransformAnimator.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTransformAnimator.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTriggers.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTriggers.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemTriggers.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemTriggers.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemVisibility.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemVisibility.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemVisibility.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemVisibility.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemWeather.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemWeather.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemWeather.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemWeather.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemWorldStreaming.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemWorldStreaming.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldRuntimeSystemWorldStreaming.cs
+++ b/CP77.CR2W/Types/cp77/worldRuntimeSystemWorldStreaming.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldSaveSanitizationForbiddenAreaNotifier.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSceneRecordingContentObserverNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSceneRecordingNodeFilter.cs
+++ b/CP77.CR2W/Types/cp77/worldSceneRecordingNodeFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSceneRecordingNodeMeshResourceFilter.cs
+++ b/CP77.CR2W/Types/cp77/worldSceneRecordingNodeMeshResourceFilter.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldScriptedAudioSignpostTrigger.cs
+++ b/CP77.CR2W/Types/cp77/worldScriptedAudioSignpostTrigger.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldScriptedAudioSignpostTrigger.cs
+++ b/CP77.CR2W/Types/cp77/worldScriptedAudioSignpostTrigger.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSharedDataBuffer.cs
+++ b/CP77.CR2W/Types/cp77/worldSharedDataBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSmartObjectNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSmartObjectNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSmartObjectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSmartObjectNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSmartObjectNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSmartObjectNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSnapTags.cs
+++ b/CP77.CR2W/Types/cp77/worldSnapTags.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSnappableNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSnappableNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSnappableNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSnappableNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSocketNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSocketNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSocketNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSocketNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSocketNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSocketNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSocketNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSocketNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSpawnPointMarker.cs
+++ b/CP77.CR2W/Types/cp77/worldSpawnPointMarker.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeOrientationChangeSection.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeOrientationChangeSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeRoadAdjustmentFactorChangeSection.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeRoadAdjustmentFactorChangeSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeSpeedChangeSection.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeSpeedChangeSection.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSpeedSplineNodeSpeedRestriction.cs
+++ b/CP77.CR2W/Types/cp77/worldSpeedSplineNodeSpeedRestriction.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSplineNode.cs
+++ b/CP77.CR2W/Types/cp77/worldSplineNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSplineNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldSplineNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticDecalNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticDecalNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticDecalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticDecalNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticDecalNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticDecalNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticFogVolumeNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticFogVolumeNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticFogVolumeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticFogVolumeNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticFogVolumeNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticFogVolumeNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticGpsLocationEntranceMarkerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticLaneCollisions.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticLaneCollisions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticLightNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticLightNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticLightNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticLightNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticLightNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticLightNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMarkerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMarkerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMarkerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticOccluderMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticParticleNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticParticleNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticParticleNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticParticleNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticQuestMarkerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticSoundEmitterNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticStickerNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticStickerNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticStickerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticStickerNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticStickerNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticStickerNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStaticVectorFieldNode.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticVectorFieldNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticVectorFieldNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticVectorFieldNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStaticVectorFieldNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldStaticVectorFieldNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldStreamingQueryDataResource.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingQueryDataResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingQueryRoadData.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingQueryRoadData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingSector.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingSector.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingSectorDescriptor.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingSectorDescriptor.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingSectorInplaceContent.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingSectorInplaceContent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingSectorVariant.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingSectorVariant.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingTestSummary.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingTestSummary.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldStreamingWorld.cs
+++ b/CP77.CR2W/Types/cp77/worldStreamingWorld.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainCollisionNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainCollisionNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainCollisionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainCollisionNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainCollisionNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainCollisionNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTerrainMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainMeshNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainMeshNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainMeshNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTerrainProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTerrainProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTerrainProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionDebug.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionDebug.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionDebugResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionDebugResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionGroupNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCollisionSphere.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCollisionSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCompiledNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCompiledNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCompiledNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCompiledNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficCompiledNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficCompiledNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficConnectivityInLane.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficConnectivityInLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficConnectivityInLane.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficConnectivityInLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficConnectivityOutLane.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficConnectivityOutLane.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficConnectivityOutLane.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficConnectivityOutLane.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficGlobalPathPosition.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficGlobalPathPosition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneCrowdCreationInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneCrowdCreationInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneCrowdFragment.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneCrowdFragment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneExitDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneExitDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLanePersistent.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLanePersistent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLanePlayerGPSInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLanePlayerGPSInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLanePolygonRepresentation.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLanePolygonRepresentation.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneRef.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneRef.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneStreamed.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneStreamed.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneStreamed.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneStreamed.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficLaneUID.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLaneUID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLanesSpotsResource_.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLanesSpotsResource_.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLanesSpotsResource_.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLanesSpotsResource_.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficLightChangeEvent.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLightChangeEvent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLightDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLightDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLightListenerComponent.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLightListenerComponent.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficLightStage.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficLightStage.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficNullAreaCollisionData.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficNullAreaCollisionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficNullAreaCollisionResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficNullAreaCollisionResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficNullAreaDynamicBlockade.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficNullAreaDynamicBlockade.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficNullAreaDynamicBlockadeData.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficNullAreaDynamicBlockadeData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentData.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentDebugResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentDebugResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnections.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnections.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnectionsResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnectionsResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnectionsResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneConnectionsResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLanePolygonResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLanePolygonResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLanePolygonResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLanePolygonResource.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneSpots.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentLaneSpots.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficPersistentSpatialResource.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficPersistentSpatialResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficSourceNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSourceNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSourceNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSourceNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficSplineNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSplineNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSplineNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSplineNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSplineNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotCompiled.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotCompiled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotCompiled.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotCompiled.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSpotNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSpotNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldTrafficStaticCollisionData.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficStaticCollisionData.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficStaticCollisionSphere.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficStaticCollisionSphere.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSyncPointCompiled.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSyncPointCompiled.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTrafficSyncPointDefinition.cs
+++ b/CP77.CR2W/Types/cp77/worldTrafficSyncPointDefinition.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTransformBuffer.cs
+++ b/CP77.CR2W/Types/cp77/worldTransformBuffer.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTriggerAreaEventInfo.cs
+++ b/CP77.CR2W/Types/cp77/worldTriggerAreaEventInfo.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTriggerAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldTriggerAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTriggerAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTriggerAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldTriggerAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldTriggerAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldVehicleForbiddenAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWaterNullAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterNullAreaNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterNullAreaNode.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterNullAreaNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWaterNullAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterNullAreaNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterNullAreaNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterNullAreaNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWaterPatchNode.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterPatchNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchNodeInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterPatchNodeInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchNodeInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWaterPatchNodeType.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchNodeType.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterPatchProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchProxyMeshNode.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWaterPatchProxyMeshNode.cs
+++ b/CP77.CR2W/Types/cp77/worldWaterPatchProxyMeshNode.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWeatherAreaNotifier.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherAreaNotifier.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWeatherAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherAreaNotifierInstance.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWeatherAreaNotifierInstance.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherAreaNotifierInstance.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWeatherScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherScriptInterface.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWeatherScriptInterface.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherScriptInterface.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWeatherScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherScriptListener.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWeatherScriptListener.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherScriptListener.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWeatherState.cs
+++ b/CP77.CR2W/Types/cp77/worldWeatherState.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorld.cs
+++ b/CP77.CR2W/Types/cp77/worldWorld.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorld.cs
+++ b/CP77.CR2W/Types/cp77/worldWorld.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWorldEnvironmentAreaParameters.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldEnvironmentAreaParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldEnvironmentParameters.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldEnvironmentParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldGlobalLightOverrideWithColorParameters.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldGlobalLightOverrideWithColorParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldGlobalLightParameters.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldGlobalLightParameters.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldID.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldID.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldID.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldID.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldWorldListResource.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldListResource.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldWorldListResourceEntry.cs
+++ b/CP77.CR2W/Types/cp77/worldWorldListResourceEntry.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionQuery.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryCoverDescriptionResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldgeometryDescriptionQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryDescriptionQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryDescriptionResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryDescriptionResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryHandIKDescriptionResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryHandIKDescriptionResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryRuntimeSystemGeomDescription.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryRuntimeSystemGeomDescription.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryRuntimeSystemGeomDescription.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryRuntimeSystemGeomDescription.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperQuery.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperQuery.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperQuery.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperResult.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperResult.cs
+++ b/CP77.CR2W/Types/cp77/worldgeometryaverageNormalDetectionHelperResult.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetNodeInstanceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetNodeInstanceWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetNodeInstanceWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiAdvertisementWidgetNodeInstanceWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiDebugPage_GameUI.cs
+++ b/CP77.CR2W/Types/cp77/worlduiDebugPage_GameUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiDebugPage_GameUI.cs
+++ b/CP77.CR2W/Types/cp77/worlduiDebugPage_GameUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiIWidgetGameController.cs
+++ b/CP77.CR2W/Types/cp77/worlduiIWidgetGameController.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiMeshTargetAttachment.cs
+++ b/CP77.CR2W/Types/cp77/worlduiMeshTargetAttachment.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiMeshTargetAttachment.cs
+++ b/CP77.CR2W/Types/cp77/worlduiMeshTargetAttachment.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiMeshTargetBinding.cs
+++ b/CP77.CR2W/Types/cp77/worlduiMeshTargetBinding.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiMeshTargetBinding.cs
+++ b/CP77.CR2W/Types/cp77/worlduiMeshTargetBinding.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiRuntimeSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/worlduiRuntimeSystemUI.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiRuntimeSystemUI.cs
+++ b/CP77.CR2W/Types/cp77/worlduiRuntimeSystemUI.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiSceneWidgetProperties.cs
+++ b/CP77.CR2W/Types/cp77/worlduiSceneWidgetProperties.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiStreetSignWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiStreetSignWidgetComponentWrapper.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiStreetSignWidgetComponentWrapper.cs
+++ b/CP77.CR2W/Types/cp77/worlduiStreetSignWidgetComponentWrapper.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiViewportWidget.cs
+++ b/CP77.CR2W/Types/cp77/worlduiViewportWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiViewportWidget.cs
+++ b/CP77.CR2W/Types/cp77/worlduiViewportWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiWorldInteractionChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/worlduiWorldInteractionChangeCallback.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiWorldInteractionChangeCallback.cs
+++ b/CP77.CR2W/Types/cp77/worlduiWorldInteractionChangeCallback.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {

--- a/CP77.CR2W/Types/cp77/worlduiWorldLayerWidget.cs
+++ b/CP77.CR2W/Types/cp77/worlduiWorldLayerWidget.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using CP77.CR2W.Reflection;
 using FastMember;
 using static CP77.CR2W.Types.Enums;

--- a/CP77.CR2W/Types/cp77/worlduiWorldLayerWidget.cs
+++ b/CP77.CR2W/Types/cp77/worlduiWorldLayerWidget.cs
@@ -1,6 +1,4 @@
 using CP77.CR2W.Reflection;
-using FastMember;
-using static CP77.CR2W.Types.Enums;
 
 namespace CP77.CR2W.Types
 {


### PR DESCRIPTION
The first iteration of the dumper mimic the dump of the already existing files 1:1 (for better comparison), thus generated types had this artifact after a clean up, but they do not use anything from `System.IO` and since these should not have any custom change in their files it is not necessary.

It could have been done when the next game patch is released, but that would make a mess of that pull request and it would be nice to only track what really changed and not useless changes like this.