### PR TITLE
mlsetup, mltemplate dump support and fixes/improvements

### DIFF
--- a/WolvenKit.Modkit/Modkit/Helper/Common/MaterialSetup.cs
+++ b/WolvenKit.Modkit/Modkit/Helper/Common/MaterialSetup.cs
@@ -1,0 +1,302 @@
+﻿using WolvenKit.RED4.CR2W.Types;
+using System;
+
+namespace WolvenKit.RED4.MaterialSetupFile
+{
+    public class Setup
+    {
+        public string Name { get; set; }
+        public int LayerCount { get; set; }
+        public SetupLayer[] Layers { get; set; }
+
+        public Setup(Multilayer_Setup setup, string name)
+        {
+            Name = name;
+            LayerCount = setup.Layers.Count;
+            Layers = new SetupLayer[LayerCount];
+
+            for (int i = 0; i < LayerCount; i++)
+            {
+                Layers[i] = new SetupLayer();
+
+                try
+                {
+                    Layers[i].MatTile = setup.Layers[i].MatTile.Value;
+                    Layers[i].MbTile = setup.Layers[i].MbTile.Value;
+                    Layers[i].Microblend = setup.Layers[i].Microblend.DepotPath;
+                    Layers[i].MicroblendContrast = setup.Layers[i].MicroblendContrast.Value;
+                    Layers[i].MicroblendNormalStrength = setup.Layers[i].MicroblendNormalStrength.Value;
+                    Layers[i].MicroblendOffsetU = setup.Layers[i].MicroblendOffsetU.Value;
+                    Layers[i].MicroblendOffsetV = setup.Layers[i].MicroblendOffsetV.Value;
+                    Layers[i].Opacity = setup.Layers[i].Opacity.Value;
+                    Layers[i].OffsetU = setup.Layers[i].OffsetU.Value;
+                    Layers[i].OffsetV = setup.Layers[i].OffsetV.Value;
+                    Layers[i].Material = setup.Layers[i].Material.DepotPath;
+                    Layers[i].ColorScale = setup.Layers[i].ColorScale.Value;
+                    Layers[i].NormalStrength = setup.Layers[i].NormalStrength.Value;
+                    Layers[i].RoughLevelsIn = setup.Layers[i].RoughLevelsIn.Value;
+                    Layers[i].RoughLevelsOut = setup.Layers[i].RoughLevelsOut.Value;
+                    Layers[i].MetalLevelsIn = setup.Layers[i].MetalLevelsIn.Value;
+                    Layers[i].MetalLevelsOut = setup.Layers[i].MetalLevelsOut.Value;
+                    Layers[i].Overrides = setup.Layers[i].Overrides.Value;
+                }
+                catch{ }
+            }
+        }
+    }
+    public class SetupLayer
+    {
+        public Nullable<float> MatTile { get; set; } = null;
+        public Nullable<float> MbTile { get; set; } = null;
+        public string Microblend { get; set; } = null;
+        public Nullable<float> MicroblendContrast { get; set; } = null;
+        public Nullable<float> MicroblendNormalStrength { get; set; } = null;
+        public Nullable<float> MicroblendOffsetU { get; set; } = null;
+        public Nullable<float> MicroblendOffsetV { get; set; } = null;
+        public Nullable<float> Opacity { get; set; } = null;
+        public Nullable<float> OffsetU { get; set; } = null;
+        public Nullable<float> OffsetV { get; set; } = null;
+        public string Material { get; set; } = null;
+        public string ColorScale { get; set; } = null;
+        public string NormalStrength { get; set; } = null;
+        public string RoughLevelsIn { get; set; } = null;
+        public string RoughLevelsOut { get; set; } = null;
+        public string MetalLevelsIn { get; set; } = null;
+        public string MetalLevelsOut { get; set; } = null;
+        public string Overrides { get; set; } = null;
+    }
+    public class Template
+    {
+        public string Name { get; set; }
+        public string ColorTexture { get; set; }
+        public string NormalTexture { get; set; }
+        public string RoughnessTexture { get; set; }
+        public string MetalnessTexture { get; set; }
+        public float TilingMultiplier { get; set; }
+        public float[] ColorMaskLevelsIn { get; set; }
+        public float[] ColorMaskLevelsOut { get; set; }
+        public TemplateDefaultOverrides DefaultOverrides { get; set; }
+        public TemplateOverrides Overrides { get; set; }
+        public Template(Multilayer_LayerTemplate template, string name)
+        {
+            int Count = 0;
+            bool Zeroed = false;
+            try
+            {
+
+                Name = name;
+                ColorTexture = template.ColorTexture.DepotPath;
+                NormalTexture = template.NormalTexture.DepotPath;
+                RoughnessTexture = template.RoughnessTexture.DepotPath;
+                MetalnessTexture = template.MetalnessTexture.DepotPath;
+                TilingMultiplier = template.TilingMultiplier.Value;
+
+                Count = template.ColorMaskLevelsIn.Count;
+
+                if (Count == 0)
+                {
+                    Zeroed = true;
+                    Count = 1;
+                }
+
+                ColorMaskLevelsIn = new float[Count];
+                if (Zeroed)
+                    ColorMaskLevelsIn[0] = 9999;
+
+                for (int i = 0; i < template.ColorMaskLevelsIn.Count; i++)
+                    ColorMaskLevelsIn[i] = template.ColorMaskLevelsIn[i].Value;
+
+                Zeroed = false;
+
+                Count = template.ColorMaskLevelsOut.Count;
+
+                if (Count == 0)
+                {
+                    Zeroed = true;
+                    Count = 1;
+                }
+
+                ColorMaskLevelsOut = new float[Count];
+                if (Zeroed)
+                    ColorMaskLevelsOut[0] = 9999;
+                Zeroed = false;
+
+                for (int i = 0; i < template.ColorMaskLevelsOut.Count; i++)
+                    ColorMaskLevelsOut[i] = template.ColorMaskLevelsOut[i].Value;
+
+
+                DefaultOverrides = new TemplateDefaultOverrides();
+                DefaultOverrides.ColorScale = template.DefaultOverrides.ColorScale.Value;
+                DefaultOverrides.NormalStrength = template.DefaultOverrides.NormalStrength.Value;
+                DefaultOverrides.RoughLevelsIn = template.DefaultOverrides.RoughLevelsIn.Value;
+                DefaultOverrides.RoughLevelsOut = template.DefaultOverrides.RoughLevelsOut.Value;
+                DefaultOverrides.MetalLevelsIn = template.DefaultOverrides.MetalLevelsIn.Value;
+                DefaultOverrides.MetalLevelsOut = template.DefaultOverrides.MetalLevelsOut.Value;
+
+                Overrides = new TemplateOverrides();
+
+                Overrides.ColorScale = new OverrideValue[template.Overrides.ColorScale.Count];
+                for (int i = 0; i < template.Overrides.ColorScale.Count; i++)
+                {
+                    Overrides.ColorScale[i] = new OverrideValue();
+                    Overrides.ColorScale[i].N = template.Overrides.ColorScale[i].N.Value;
+
+                    Count = template.Overrides.ColorScale[i].V.Count;
+
+                    if (Count == 0)
+                    {
+                        Zeroed = true;
+                        Count = 1;
+                    }
+                    Overrides.ColorScale[i].V = new float[Count];
+
+                    if (Zeroed)
+                        Overrides.ColorScale[i].V[0] = 9999;
+                    Zeroed = false;
+
+                    for (int e = 0; e < template.Overrides.ColorScale[i].V.Count; e++)
+                    {
+                        Overrides.ColorScale[i].V[e] = template.Overrides.ColorScale[i].V[e].Value;
+                    }
+                }
+
+                Overrides.RoughLevelsIn = new OverrideValue[template.Overrides.RoughLevelsIn.Count];
+                for (int i = 0; i < template.Overrides.RoughLevelsIn.Count; i++)
+                {
+                    Overrides.RoughLevelsIn[i] = new OverrideValue();
+                    Overrides.RoughLevelsIn[i].N = template.Overrides.RoughLevelsIn[i].N.Value;
+
+                    Count = template.Overrides.RoughLevelsIn[i].V.Count;
+
+                    if (Count == 0)
+                    {
+                        Zeroed = true;
+                        Count = 1;
+
+                    }
+                    Overrides.RoughLevelsIn[i].V = new float[Count];
+
+                    if (Zeroed)
+                        Overrides.RoughLevelsIn[i].V[0] = 9999;
+                    Zeroed = false;
+
+                    for (int e = 0; e < template.Overrides.RoughLevelsIn[i].V.Count; e++)
+                    {
+                        Overrides.RoughLevelsIn[i].V[e] = template.Overrides.RoughLevelsIn[i].V[e].Value;
+                    }
+                }
+
+                Overrides.RoughLevelsOut = new OverrideValue[template.Overrides.RoughLevelsOut.Count];
+                for (int i = 0; i < template.Overrides.RoughLevelsOut.Count; i++)
+                {
+                    Overrides.RoughLevelsOut[i] = new OverrideValue();
+                    Overrides.RoughLevelsOut[i].N = template.Overrides.RoughLevelsOut[i].N.Value;
+
+                    Count = template.Overrides.RoughLevelsOut[i].V.Count;
+
+                    if (Count == 0)
+                    {
+                        Zeroed = true;
+                        Count = 1;
+
+                    }
+                    Overrides.RoughLevelsOut[i].V = new float[Count];
+
+                    if (Zeroed)
+                        Overrides.RoughLevelsOut[i].V[0] = 9999;
+                    Zeroed = false;
+
+                    for (int e = 0; e < template.Overrides.RoughLevelsOut[i].V.Count; e++)
+                    {
+                        Overrides.RoughLevelsOut[i].V[e] = template.Overrides.RoughLevelsOut[i].V[e].Value;
+                    }
+                }
+
+                Overrides.MetalLevelsIn = new OverrideValue[template.Overrides.MetalLevelsIn.Count];
+                for (int i = 0; i < template.Overrides.MetalLevelsIn.Count; i++)
+                {
+                    Overrides.MetalLevelsIn[i] = new OverrideValue();
+                    Overrides.MetalLevelsIn[i].N = template.Overrides.MetalLevelsIn[i].N.Value;
+
+                    Count = template.Overrides.MetalLevelsIn[i].V.Count;
+
+                    if (Count == 0)
+                    {
+                        Zeroed = true;
+                        Count = 1;
+
+                    }
+                    Overrides.MetalLevelsIn[i].V = new float[Count];
+
+                    if (Zeroed)
+                        Overrides.MetalLevelsIn[i].V[0] = 9999;
+                    Zeroed = false;
+
+                    for (int e = 0; e < template.Overrides.MetalLevelsIn[i].V.Count; e++)
+                    {
+                        Overrides.MetalLevelsIn[i].V[e] = template.Overrides.MetalLevelsIn[i].V[e].Value;
+                    }
+                }
+
+                Overrides.MetalLevelsOut = new OverrideValue[template.Overrides.MetalLevelsOut.Count];
+                for (int i = 0; i < template.Overrides.MetalLevelsOut.Count; i++)
+                {
+                    Overrides.MetalLevelsOut[i] = new OverrideValue();
+                    Overrides.MetalLevelsOut[i].N = template.Overrides.MetalLevelsOut[i].N.Value;
+
+                    Count = template.Overrides.MetalLevelsOut[i].V.Count;
+
+                    if (Count == 0)
+                    {
+                        Zeroed = true;
+                        Count = 1;
+
+                    }
+                    Overrides.MetalLevelsOut[i].V = new float[Count];
+
+                    if (Zeroed)
+                        Overrides.MetalLevelsOut[i].V[0] = 9999;
+                    Zeroed = false;
+
+                    for (int e = 0; e < template.Overrides.MetalLevelsOut[i].V.Count; e++)
+                    {
+                        Overrides.MetalLevelsOut[i].V[e] = template.Overrides.MetalLevelsOut[i].V[e].Value;
+                    }
+                }
+
+                Overrides.NormalStrength = new OverrideValue[template.Overrides.NormalStrength.Count];
+                for (int i = 0; i < template.Overrides.NormalStrength.Count; i++)
+                {
+                    Overrides.NormalStrength[i] = new OverrideValue();
+                    Overrides.NormalStrength[i].N = template.Overrides.NormalStrength[i].N.Value;
+                    Overrides.NormalStrength[i].V = new float[1];
+                    Overrides.NormalStrength[i].V[0] = template.Overrides.NormalStrength[i].V.Value;
+                }
+            }
+            catch {  }
+        }
+    }
+    public class TemplateDefaultOverrides
+    {
+        public string ColorScale { get; set; }
+        public string NormalStrength { get; set; }
+        public string RoughLevelsIn { get; set; }
+        public string RoughLevelsOut { get; set; }
+        public string MetalLevelsIn { get; set; }
+        public string MetalLevelsOut { get; set; }
+    }
+    public class TemplateOverrides
+    {
+        public OverrideValue[] ColorScale { get; set; }
+        public OverrideValue[] RoughLevelsIn { get; set; }
+        public OverrideValue[] RoughLevelsOut { get; set; }
+        public OverrideValue[] MetalLevelsIn { get; set; }
+        public OverrideValue[] MetalLevelsOut { get; set; }
+        public OverrideValue[] NormalStrength { get; set; }
+    }
+    public class OverrideValue
+    {
+        public string N { get; set; }
+        public float[] V { get; set; }
+    }
+}

--- a/WolvenKit.Modkit/Modkit/Helper/Common/MaterialTypes.cs
+++ b/WolvenKit.Modkit/Modkit/Helper/Common/MaterialTypes.cs
@@ -1,5 +1,5 @@
-using WolvenKit.RED4.CR2W.Types;
-
+﻿using WolvenKit.RED4.CR2W.Types;
+using System;
 namespace WolvenKit.RED4.MeshFile.Materials.MaterialTypes
 {
     public enum MaterialType
@@ -8,52 +8,52 @@ namespace WolvenKit.RED4.MeshFile.Materials.MaterialTypes
     }
     public class MultiLayered
     {
-        public string multilayerSetup { get; set; } = null;
-        public string multilayerMask { get; set; } = null;
-        public string globalNormal { get; set; } = null;
+        public string MultilayerSetup { get; set; } = null;
+        public string MultilayerMask { get; set; } = null;
+        public string GlobalNormal { get; set; } = null;
         public MultiLayered(CMaterialInstance cMaterialInstance)
         {
             for (int i = 0; i < cMaterialInstance.CMaterialInstanceData.Count; i++)
             {
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MultilayerSetup")
-                    multilayerSetup = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<Multilayer_Setup>).DepotPath;
+                    MultilayerSetup = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<Multilayer_Setup>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MultilayerMask")
-                    multilayerMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<Multilayer_Mask>).DepotPath;
+                    MultilayerMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<Multilayer_Mask>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "GlobalNormal")
-                    globalNormal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    GlobalNormal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
             }
         }
     }
     public class MeshDecal
     {
-        public string diffuseTexture { get; set; } = null;
-        public Color diffuseColor { get; set; }
-        public float diffuseAlpha { get; set; } = 9999;
-        public Struct2D uVOffset { get; set; }
-        public float uVRotation { get; set; } = 9999;
-        public Struct2D uVScale { get; set; }
-        public string secondaryMask { get; set; } = null;
-        public float secondaryMaskUVScale { get; set; } = 9999;
-        public float secondaryMaskInfluence { get; set; } = 9999;
-        public string normalTexture { get; set; } = null;
-        public float normalAlpha { get; set; } = 9999;
-        public string normalAlphaTex { get; set; } = null;
-        public float normalsBlendingMode { get; set; } = 9999;
-        public string roughnessTexture { get; set; } = null;
-        public string metalnessTexture { get; set; } = null;
-        public float alphaMaskContrast { get; set; } = 9999;
-        public float roughnessMetalnessAlpha { get; set; } = 9999;
-        public float animationSpeed { get; set; } = 9999;
-        public float animationFramesWidth { get; set; } = 9999;
-        public float animationFramesHeight { get; set; } = 9999;
-        public float depthThreshold { get; set; } = 9999;
+        public string DiffuseTexture { get; set; } = null;
+        public Color DiffuseColor { get; set; }
+        public Nullable<float> DiffuseAlpha { get; set; } = null;
+        public Struct2D UVOffset { get; set; }
+        public Nullable<float> UVRotation { get; set; } = null;
+        public Struct2D UVScale { get; set; }
+        public string SecondaryMask { get; set; } = null;
+        public Nullable<float> SecondaryMaskUVScale { get; set; } = null;
+        public Nullable<float> SecondaryMaskInfluence { get; set; } = null;
+        public string NormalTexture { get; set; } = null;
+        public Nullable<float> NormalAlpha { get; set; } = null;
+        public string NormalAlphaTex { get; set; } = null;
+        public Nullable<float> NormalsBlendingMode { get; set; } = null;
+        public string RoughnessTexture { get; set; } = null;
+        public string MetalnessTexture { get; set; } = null;
+        public Nullable<float> AlphaMaskContrast { get; set; } = null;
+        public Nullable<float> RoughnessMetalnessAlpha { get; set; } = null;
+        public Nullable<float> AnimationSpeed { get; set; } = null;
+        public Nullable<float> AnimationFramesWidth { get; set; } = null;
+        public Nullable<float> AnimationFramesHeight { get; set; } = null;
+        public Nullable<float> DepthThreshold { get; set; } = null;
 
         public MeshDecal(CMaterialInstance cMaterialInstance)
         {
             for (int i = 0; i < cMaterialInstance.CMaterialInstanceData.Count; i++)
             {
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DiffuseTexture")
-                    diffuseTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    DiffuseTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DiffuseColor")
                 {
                     float x = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Red.Value / 255f;
@@ -61,103 +61,102 @@ namespace WolvenKit.RED4.MeshFile.Materials.MaterialTypes
                     float z = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Blue.Value / 255f;
                     float w = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Alpha.Value / 255f;
 
-                    diffuseColor = new Color(x, y, z, w);
+                    DiffuseColor = new Color(x, y, z, w);
                 }
                 System.Numerics.Vector2 uvOff = new System.Numerics.Vector2();
                 System.Numerics.Vector2 uvSca = new System.Numerics.Vector2();
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DiffuseAlpha")
-                    diffuseAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    DiffuseAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "UVOffsetX")
                     uvOff.X = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "UVOffsetY")
                     uvOff.Y = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "UVRotation")
-                    uVRotation = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    UVRotation = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "UVScaleX")
                     uvSca.X = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "UVScaleY")
                     uvSca.Y = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "SecondaryMask")
-                    secondaryMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    SecondaryMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "SecondaryMaskUVScale")
-                    secondaryMaskUVScale = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    SecondaryMaskUVScale = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "SecondaryMaskInfluence")
-                    secondaryMaskInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    SecondaryMaskInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "NormalTexture")
-                    normalTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    NormalTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "NormalAlpha")
-                    normalAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    NormalAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "NormalAlphaTex")
-                    normalAlphaTex = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    NormalAlphaTex = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "NormalsBlendingMode")
-                    normalsBlendingMode = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    NormalsBlendingMode = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "RoughnessTexture")
-                    roughnessTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    RoughnessTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MetalnessTexture")
-                    metalnessTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    MetalnessTexture = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "AlphaMaskContrast")
-                    alphaMaskContrast = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    AlphaMaskContrast = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "RoughnessMetalnessAlpha")
-                    roughnessMetalnessAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    RoughnessMetalnessAlpha = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "AnimationSpeed")
-                    animationSpeed = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    AnimationSpeed = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "AnimationFramesWidth")
-                    animationFramesWidth = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    AnimationFramesWidth = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "AnimationFramesHeight")
-                    animationFramesHeight = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    AnimationFramesHeight = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DepthThreshold")
-                    depthThreshold = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    DepthThreshold = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
-                uVScale = new Struct2D(uvSca.X, uvSca.Y);
-                uVOffset = new Struct2D(uvSca.X, uvSca.Y);
+                UVScale = new Struct2D(uvSca.X, uvSca.Y);
+                UVOffset = new Struct2D(uvSca.X, uvSca.Y);
             }
         }
     }
-    
     public class HumanSkin
     {
-        public string roughness { get; set; } = null;
-        public string detailNormal { get; set; } = null;
-        public float detailNormalInfluence { get; set; } = 9999;
-        public string normal { get; set; } = null;
-        public string albedo { get; set; } = null;
-        public string detailmap_Squash { get; set; } = null;
-        public string detailmap_Stretch { get; set; } = null;
-        public float detailRoughnessBiasMin { get; set; } = 9999;
-        public float detailRoughnessBiasMax { get; set; } = 9999;
-        public Color tintColor { get; set; }
-        public float tintScale { get; set; } = 9999;
-        public string skinProfile { get; set; } = null;
-        public string bloodflow { get; set; } = null;
-        public Color bloodColor { get; set; }
-        public float microDetailUVScale01 { get; set; } = 9999;
-        public float microDetailUVScale02 { get; set; } = 9999;
-        public string tintColorMask { get; set; } = null;
-        public float microDetailInfluence { get; set; } = 9999;
-        public float cavityIntensity { get; set; } = 9999;
+        public string Roughness { get; set; } = null;
+        public string DetailNormal { get; set; } = null;
+        public Nullable<float> DetailNormalInfluence { get; set; } = null;
+        public string Normal { get; set; } = null;
+        public string Albedo { get; set; } = null;
+        public string Detailmap_Squash { get; set; } = null;
+        public string Detailmap_Stretch { get; set; } = null;
+        public Nullable<float> DetailRoughnessBiasMin { get; set; } = null;
+        public Nullable<float> DetailRoughnessBiasMax { get; set; } = null;
+        public Color TintColor { get; set; }
+        public Nullable<float> TintScale { get; set; } = null;
+        public string SkinProfile { get; set; } = null;
+        public string Bloodflow { get; set; } = null;
+        public Color BloodColor { get; set; }
+        public Nullable<float> MicroDetailUVScale01 { get; set; } = null;
+        public Nullable<float> MicroDetailUVScale02 { get; set; } = null;
+        public string TintColorMask { get; set; } = null;
+        public Nullable<float> MicroDetailInfluence { get; set; } = null;
+        public Nullable<float> CavityIntensity { get; set; } = null;
 
         public HumanSkin(CMaterialInstance cMaterialInstance)
         {
             for (int i = 0; i < cMaterialInstance.CMaterialInstanceData.Count; i++)
             {
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Roughness")
-                    roughness = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Roughness = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DetailNormal")
-                    detailNormal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    DetailNormal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DetailNormalInfluence")
-                    detailNormalInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    DetailNormalInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Normal")
-                    normal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Normal = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Albedo")
-                    albedo = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Albedo = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Detailmap_Squash")
-                    detailmap_Squash = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Detailmap_Squash = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Detailmap_Stretch")
-                    detailmap_Stretch = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Detailmap_Stretch = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DetailRoughnessBiasMin")
-                    detailRoughnessBiasMin = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    DetailRoughnessBiasMin = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "DetailRoughnessBiasMax")
-                    detailRoughnessBiasMax = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    DetailRoughnessBiasMax = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "TintColor")
                 {
                     float x = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Red.Value / 255f;
@@ -165,15 +164,15 @@ namespace WolvenKit.RED4.MeshFile.Materials.MaterialTypes
                     float z = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Blue.Value / 255f;
                     float w = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Alpha.Value / 255f;
 
-                    tintColor = new Color(x, y, z, w);
+                    TintColor = new Color(x, y, z, w);
                 }
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "TintScale")
-                    tintScale = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    TintScale = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "SkinProfile")
-                    skinProfile = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<CSkinProfile>).DepotPath;
+                    SkinProfile = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<CSkinProfile>).DepotPath;
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "Bloodflow")
-                    bloodflow = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    Bloodflow = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "BloodColor")
                 {
@@ -182,23 +181,23 @@ namespace WolvenKit.RED4.MeshFile.Materials.MaterialTypes
                     float z = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Blue.Value / 255f;
                     float w = (cMaterialInstance.CMaterialInstanceData[i].Variant as CColor).Alpha.Value / 255f;
 
-                    bloodColor = new Color(x, y, z, w);
+                    BloodColor = new Color(x, y, z, w);
                 }
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MicroDetailUVScale01")
-                    microDetailUVScale01 = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    MicroDetailUVScale01 = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MicroDetailUVScale02")
-                    microDetailUVScale02 = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    MicroDetailUVScale02 = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "TintColorMask")
-                    tintColorMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
+                    TintColorMask = (cMaterialInstance.CMaterialInstanceData[i].Variant as rRef<ITexture>).DepotPath;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "MicroDetailInfluence")
-                    microDetailInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    MicroDetailInfluence = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
                 if (cMaterialInstance.CMaterialInstanceData[i].REDName == "CavityIntensity")
-                    cavityIntensity = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
+                    CavityIntensity = (cMaterialInstance.CMaterialInstanceData[i].Variant as CFloat).Value;
 
             }
         }

--- a/WolvenKit.Modkit/Modkit/Helper/Common/Structs.cs
+++ b/WolvenKit.Modkit/Modkit/Helper/Common/Structs.cs
@@ -115,10 +115,10 @@ namespace WolvenKit.RED4.GeneralStructs
     public class RawMaterial
     {
         public string Name { get; set; }
-        public MaterialType materialType { get; set; }
-        public bool extInstanced { get; set; } = false;
-        public HumanSkin humanSkin { get; set; }
-        public MeshDecal meshDecal { get; set; }
-        public MultiLayered multiLayered { get; set; }
+        public string BaseMaterial { get; set; }
+        public MaterialType MaterialType { get; set; }
+        public HumanSkin HumanSkin { get; set; }
+        public MeshDecal MeshDecal { get; set; }
+        public MultiLayered MultiLayered { get; set; }
     }
 }

--- a/WolvenKit.Modkit/Modkit/Helper/Functions/MaterialFunctions.cs
+++ b/WolvenKit.Modkit/Modkit/Helper/Functions/MaterialFunctions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using CP77.CR2W;
 using WolvenKit.RED4.GeneralStructs;
@@ -12,13 +12,19 @@ using WolvenKit.RED4.MeshFile.Materials.MaterialTypes;
 using WolvenKit.Common.DDS;
 using WolvenKit.RED4.CR2W.Archive;
 using WolvenKit.Common.FNV1A;
+using WolvenKit.RED4.MaterialSetupFile;
+using SharpGLTF.IO;
 
 namespace WolvenKit.RED4.MeshFile.Materials
 {
     public class MATERIAL
     {
-        public static void ExporMeshWithMaterials(Stream meshStream, string depotDir, string _meshName, string outfile, bool isGLBinary = true, bool useAssetLib = true,bool copyTextures = false,EUncookExtension eUncookExtension = EUncookExtension.dds , bool LodFilter = true)
+        static string cacheDir = Path.GetTempPath() + "WolvenKit\\Material\\Temp\\";
+        public static List<Archive> archives;
+        public void ExportMeshWithMaterialsUsingAssetLib(Stream meshStream, DirectoryInfo assetLib, string _meshName, FileInfo outfile, bool isGLBinary = true,bool copyTextures = false,EUncookExtension eUncookExtension = EUncookExtension.dds , bool LodFilter = true)
         {
+            Directory.CreateDirectory(cacheDir);
+
             List<RawMeshContainer> expMeshes = new List<RawMeshContainer>();
             var mesh_cr2w = CP77.CR2W.ModTools.TryReadCr2WFile(meshStream);
 
@@ -42,20 +48,58 @@ namespace WolvenKit.RED4.MeshFile.Materials
             }
             ModelRoot model = MESH.RawRigidMeshesToGLTF(expMeshes);
 
-            string outDir = Path.GetDirectoryName(outfile) + "\\" + Path.GetFileNameWithoutExtension(outfile) + "_Textures\\";
-            Directory.CreateDirectory(outDir);
+            DirectoryInfo outDir = new DirectoryInfo(outfile.DirectoryName + "\\" + Path.GetFileNameWithoutExtension(outfile.FullName) + "_Textures\\");
+            Directory.CreateDirectory(outDir.FullName);
 
-            if (useAssetLib)
-                ParseMaterialsUsingAssetLib(meshStream, ref model, outDir, depotDir, copyTextures, eUncookExtension);
-            else
-                ParseMaterialsUsingGameDir(meshStream,ref model, outDir, depotDir, eUncookExtension);
+            ParseMaterialsUsingAssetLib(meshStream, ref model, outDir, assetLib, copyTextures, eUncookExtension);
 
             if (isGLBinary)
-                model.SaveGLB(outfile);
+                model.SaveGLB(outfile.FullName);
             else
-                model.SaveGLTF(outfile);
+                model.SaveGLTF(outfile.FullName);
+
+            Directory.Delete(cacheDir, true);
         }
-        static void GetMateriaEntries(Stream meshStream, ref List<string> primaryDependencies,ref List<string> materialEntryNames, ref List<CMaterialInstance> materialEntries)
+        public void ExportMeshWithMaterialsUsingArchives(Stream meshStream, string _meshName, FileInfo outfile, bool isGLBinary = true, EUncookExtension eUncookExtension = EUncookExtension.dds, bool LodFilter = true)
+        {
+            Directory.CreateDirectory(cacheDir);
+
+            List<RawMeshContainer> expMeshes = new List<RawMeshContainer>();
+            var mesh_cr2w = CP77.CR2W.ModTools.TryReadCr2WFile(meshStream);
+
+            MemoryStream ms = MESH.GetMeshBufferStream(meshStream, mesh_cr2w);
+            MeshesInfo meshinfo = MESH.GetMeshesinfo(mesh_cr2w);
+            for (int i = 0; i < meshinfo.meshC; i++)
+            {
+                if (meshinfo.LODLvl[i] != 1 && LodFilter)
+                    continue;
+                RawMeshContainer mesh = MESH.ContainRawMesh(ms, meshinfo.vertCounts[i], meshinfo.indCounts[i], meshinfo.vertOffsets[i], meshinfo.tx0Offsets[i], meshinfo.normalOffsets[i], meshinfo.colorOffsets[i], meshinfo.unknownOffsets[i], meshinfo.indicesOffsets[i], meshinfo.vpStrides[i], meshinfo.qScale, meshinfo.qTrans, meshinfo.weightcounts[i]);
+                mesh.name = _meshName + "_" + i;
+
+                mesh.appNames = new string[meshinfo.appearances.Count];
+                mesh.materialNames = new string[meshinfo.appearances.Count];
+                for (int e = 0; e < meshinfo.appearances.Count; e++)
+                {
+                    mesh.appNames[e] = meshinfo.appearances[e].Name;
+                    mesh.materialNames[e] = meshinfo.appearances[e].MaterialNames[i];
+                }
+                expMeshes.Add(mesh);
+            }
+            ModelRoot model = MESH.RawRigidMeshesToGLTF(expMeshes);
+
+            DirectoryInfo outDir = new DirectoryInfo(outfile.DirectoryName + "\\" + Path.GetFileNameWithoutExtension(outfile.FullName) + "_Textures\\");
+            Directory.CreateDirectory(outDir.FullName);
+
+            ParseMaterialsUsingArchives(meshStream, ref model, outDir, eUncookExtension);
+
+            if (isGLBinary)
+                model.SaveGLB(outfile.FullName);
+            else
+                model.SaveGLTF(outfile.FullName);
+
+            Directory.Delete(cacheDir, true);
+        }
+        static void GetMateriaEntries(Stream meshStream, ref List<string> primaryDependencies,ref List<string> materialEntryNames, ref List<CMaterialInstance> materialEntries, DirectoryInfo assetLib, bool useAssetLib)
         {
             var cr2w = ModTools.TryReadCr2WFile(meshStream);
 
@@ -68,12 +112,66 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 }
             }
 
-            int count = (cr2w.Chunks[index].data as CMesh).MaterialEntries.Count;
-            
-            for (int i = 0; i < count; i++)
+            List<CMaterialInstance> ExternalMaterial = new List<CMaterialInstance>();
+            for (int i = 0; i < (cr2w.Chunks[index].data as CMesh).ExternalMaterials.Count; i++)
             {
-                materialEntryNames.Add((cr2w.Chunks[index].data as CMesh).MaterialEntries[i].Name.Value);
+                if(useAssetLib)
+                {
+                    string path = assetLib.FullName + (cr2w.Chunks[index].data as CMesh).ExternalMaterials[i].DepotPath;
+                    if(File.Exists(path))
+                    {
+                        FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read);
+                        var micr2w = ModTools.TryReadCr2WFile(fs);
+                        ExternalMaterial.Add(micr2w.Chunks[0].data as CMaterialInstance);
+
+                        for (int t = 0; t < micr2w.Imports.Count; t++)
+                        {
+                            bool notFound = true;
+                            for (int e = 0; e < primaryDependencies.Count; e++)
+                            {
+                                if (primaryDependencies[e] == micr2w.Imports[t].DepotPathStr)
+                                    notFound = false;
+                            }
+                            if (notFound)
+                                primaryDependencies.Add(micr2w.Imports[t].DepotPathStr);
+                        }
+                        fs.Dispose();
+                        fs.Close();
+                    }
+                }
+                else
+                {
+                    string path = (cr2w.Chunks[index].data as CMesh).ExternalMaterials[i].DepotPath;
+
+                    ulong hash = FNV1A64HashAlgorithm.HashString(path);
+                    foreach (Archive ar in archives)
+                        ModTools.ExtractSingle(ar, hash, new DirectoryInfo(cacheDir));
+
+                    path = cacheDir + (cr2w.Chunks[index].data as CMesh).ExternalMaterials[i].DepotPath;
+
+                    if (File.Exists(path))
+                    {
+                        FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read);
+                        var micr2w = ModTools.TryReadCr2WFile(fs);
+                        ExternalMaterial.Add(micr2w.Chunks[0].data as CMaterialInstance);
+
+                        for (int t = 0; t < micr2w.Imports.Count; t++)
+                        {
+                            bool notFound = true;
+                            for (int e = 0; e < primaryDependencies.Count; e++)
+                            {
+                                if (primaryDependencies[e] == micr2w.Imports[t].DepotPathStr)
+                                    notFound = false;
+                            }
+                            if (notFound)
+                                primaryDependencies.Add(micr2w.Imports[t].DepotPathStr);
+                        }
+                        fs.Dispose();
+                        fs.Close();
+                    }
+                }
             }
+            List<CMaterialInstance> LocalMaterial = new List<CMaterialInstance>();
 
             bool isbuffered = true;
             if ((cr2w.Chunks[index].data as CMesh).LocalMaterialBuffer.RawDataHeaders.Count == 0)
@@ -83,7 +181,7 @@ namespace WolvenKit.RED4.MeshFile.Materials
             {
                 MemoryStream materialStream = GetMaterialStream(meshStream, cr2w);
                 byte[] bytes = materialStream.ToArray();
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < (cr2w.Chunks[index].data as CMesh).LocalMaterialBuffer.RawDataHeaders.Count; i++)
                 {
                     UInt32 offset = (cr2w.Chunks[index].data as CMesh).LocalMaterialBuffer.RawDataHeaders[i].Offset.Value;
                     UInt32 size = (cr2w.Chunks[index].data as CMesh).LocalMaterialBuffer.RawDataHeaders[i].Size.Value;
@@ -105,7 +203,7 @@ namespace WolvenKit.RED4.MeshFile.Materials
                             primaryDependencies.Add(mtcr2w.Imports[e].DepotPathStr);
                     }
 
-                    materialEntries.Add(mtcr2w.Chunks[0].data as CMaterialInstance);
+                    LocalMaterial.Add(mtcr2w.Chunks[0].data as CMaterialInstance);
                 }
             }
             else
@@ -114,7 +212,7 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 {
                     if (cr2w.Chunks[i].REDType == "CMaterialInstance")
                     {
-                        materialEntries.Add(cr2w.Chunks[i].data as CMaterialInstance);
+                        LocalMaterial.Add(cr2w.Chunks[i].data as CMaterialInstance);
                     }
                 }
                 for(int i = 0; i < cr2w.Imports.Count; i++)
@@ -129,25 +227,32 @@ namespace WolvenKit.RED4.MeshFile.Materials
                         primaryDependencies.Add(cr2w.Imports[i].DepotPathStr);
                 }
             }
-        }
-        static void ParseMaterialsUsingAssetLib(Stream meshStream, ref ModelRoot model,string outDir, string assetLib, bool copyTextures = false, EUncookExtension eUncookExtension = EUncookExtension.dds)
-        {
-            string cacheDir = Path.GetTempPath() + "WolvenKit\\Material\\TempImages\\";
 
+            int Count = (cr2w.Chunks[index].data as CMesh).MaterialEntries.Count;
+            for (int i = 0; i < Count; i++)
+            {
+                var Entry = (cr2w.Chunks[index].data as CMesh).MaterialEntries[i];
+                materialEntryNames.Add(Entry.Name.Value);
+                if (Entry.IsLocalInstance.Value)
+                    materialEntries.Add(LocalMaterial[Entry.Index.Value]);
+                else
+                    materialEntries.Add(ExternalMaterial[Entry.Index.Value]);
+            }
+        }
+        static void ParseMaterialsUsingAssetLib(Stream meshStream, ref ModelRoot model,DirectoryInfo outDir, DirectoryInfo AssetLib, bool CopyTextures = false, EUncookExtension eUncookExtension = EUncookExtension.dds)
+        {
             List<string> primaryDependencies = new List<string>();
 
             List<string> materialEntryNames = new List<string>();
             List<CMaterialInstance> materialEntries = new List<CMaterialInstance>();
 
-            GetMateriaEntries(meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries);
+            GetMateriaEntries(meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries,AssetLib,true);
 
             List<string> mlSetupNames = new List<string>();
             List<Multilayer_Setup> mlSetups = new List<Multilayer_Setup>();
 
             List<string> mlTemplateNames = new List<string>();
             List<Multilayer_LayerTemplate> mlTemplates = new List<Multilayer_LayerTemplate>();
-
-            Directory.CreateDirectory(cacheDir);
 
             List<string> TexturesList = new List<string>();
 
@@ -157,11 +262,11 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 if (Path.GetExtension(primaryDependencies[i]) == ".xbm")
                 {
                     TexturesList.Add(primaryDependencies[i]);
-                    if (File.Exists(assetLib + primaryDependencies[i]))
+                    if (File.Exists(AssetLib.FullName + primaryDependencies[i]))
                     {
-                        if (copyTextures)
+                        if (CopyTextures)
                         {
-                            File.Copy(assetLib + primaryDependencies[i], cacheDir + Path.GetFileName(primaryDependencies[i]), true);
+                            File.Copy(AssetLib.FullName + primaryDependencies[i], cacheDir + Path.GetFileName(primaryDependencies[i]), true);
                             ModTools.Export(new FileInfo(cacheDir + Path.GetFileName(primaryDependencies[i])), eUncookExtension);
                         }
                     }
@@ -169,22 +274,22 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 if (Path.GetExtension(primaryDependencies[i]) == ".mlmask")
                 {
                     TexturesList.Add(primaryDependencies[i]);
-                    if (File.Exists(assetLib + primaryDependencies[i]))
+                    if (File.Exists(AssetLib.FullName + primaryDependencies[i]))
                     {
-                        if (copyTextures)
+                        if (CopyTextures)
                         {
-                            File.Copy(assetLib + primaryDependencies[i], cacheDir + Path.GetFileName(primaryDependencies[i]), true);
+                            File.Copy(AssetLib.FullName + primaryDependencies[i], cacheDir + Path.GetFileName(primaryDependencies[i]), true);
                             ModTools.Export(new FileInfo(cacheDir + Path.GetFileName(primaryDependencies[i])), eUncookExtension);
                         }
                     }
                 }
 
                 if (Path.GetExtension(primaryDependencies[i]) == ".mlsetup")
-                    if (File.Exists(assetLib + primaryDependencies[i]))
+                    if (File.Exists(AssetLib.FullName + primaryDependencies[i]))
                     {
-                        FileStream setupFs = new FileStream((assetLib + primaryDependencies[i]), FileMode.Open, FileAccess.Read);
+                        FileStream setupFs = new FileStream((AssetLib.FullName + primaryDependencies[i]), FileMode.Open, FileAccess.Read);
                         var cr2w = ModTools.TryReadCr2WFile(setupFs);
-                        mlSetupNames.Add(Path.GetFileNameWithoutExtension(primaryDependencies[i]));
+                        mlSetupNames.Add(Path.GetFileName(primaryDependencies[i]));
                         mlSetups.Add(cr2w.Chunks[0].data as Multilayer_Setup);
 
                         setupFs.Dispose();
@@ -194,22 +299,22 @@ namespace WolvenKit.RED4.MeshFile.Materials
                             if (Path.GetExtension(cr2w.Imports[e].DepotPathStr) == ".xbm")
                             {
                                 TexturesList.Add(cr2w.Imports[e].DepotPathStr);
-                                if (File.Exists(assetLib + cr2w.Imports[e].DepotPathStr))
+                                if (File.Exists(AssetLib.FullName + cr2w.Imports[e].DepotPathStr))
                                 {
-                                    if (copyTextures)
+                                    if (CopyTextures)
                                     {
-                                        File.Copy(assetLib + cr2w.Imports[e].DepotPathStr, cacheDir + Path.GetFileName(cr2w.Imports[e].DepotPathStr), true);
+                                        File.Copy(AssetLib.FullName + cr2w.Imports[e].DepotPathStr, cacheDir + Path.GetFileName(cr2w.Imports[e].DepotPathStr), true);
                                         ModTools.Export(new FileInfo(cacheDir + Path.GetFileName(cr2w.Imports[e].DepotPathStr)), eUncookExtension);
                                     }
                                 }
                             }
                             if (Path.GetExtension(cr2w.Imports[e].DepotPathStr) == ".mltemplate")
                             {
-                                if (File.Exists(assetLib + cr2w.Imports[e].DepotPathStr))
+                                if (File.Exists(AssetLib.FullName + cr2w.Imports[e].DepotPathStr))
                                 {
-                                    FileStream templateFs = new FileStream((assetLib + cr2w.Imports[e].DepotPathStr), FileMode.Open, FileAccess.Read);
+                                    FileStream templateFs = new FileStream((AssetLib.FullName + cr2w.Imports[e].DepotPathStr), FileMode.Open, FileAccess.Read);
                                     var mlTempcr2w = ModTools.TryReadCr2WFile(templateFs);
-                                    mlTemplateNames.Add(Path.GetFileNameWithoutExtension(cr2w.Imports[e].DepotPathStr));
+                                    mlTemplateNames.Add(Path.GetFileName(cr2w.Imports[e].DepotPathStr));
                                     mlTemplates.Add(mlTempcr2w.Chunks[0].data as Multilayer_LayerTemplate);
 
                                     templateFs.Dispose();
@@ -217,11 +322,11 @@ namespace WolvenKit.RED4.MeshFile.Materials
                                     for (int eye = 0; eye < mlTempcr2w.Imports.Count; eye++)
                                     {
                                         TexturesList.Add(mlTempcr2w.Imports[eye].DepotPathStr);
-                                        if (File.Exists(assetLib + mlTempcr2w.Imports[eye].DepotPathStr))
+                                        if (File.Exists(AssetLib.FullName + mlTempcr2w.Imports[eye].DepotPathStr))
                                         {
-                                            if (copyTextures)
+                                            if (CopyTextures)
                                             {
-                                                File.Copy(assetLib + mlTempcr2w.Imports[eye].DepotPathStr, cacheDir + Path.GetFileName(mlTempcr2w.Imports[eye].DepotPathStr), true);
+                                                File.Copy(AssetLib.FullName + mlTempcr2w.Imports[eye].DepotPathStr, cacheDir + Path.GetFileName(mlTempcr2w.Imports[eye].DepotPathStr), true);
                                                 ModTools.Export(new FileInfo(cacheDir + Path.GetFileName(mlTempcr2w.Imports[eye].DepotPathStr)), eUncookExtension);
                                             }
                                         }
@@ -233,17 +338,57 @@ namespace WolvenKit.RED4.MeshFile.Materials
                     }
             }
 
-            List<RawMaterial> rawMaterials = new List<RawMaterial>();
-            for (int i = 0; i < materialEntries.Count; i++)
-            { 
-                rawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i]));
+            try
+            {
+
+                List<RawMaterial> RawMaterials = new List<RawMaterial>();
+                for (int i = 0; i < materialEntries.Count; i++)
+                {
+                    RawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i]));
+                }
+
+                List<Setup> MaterialSetups = new List<Setup>();
+                for (int i = 0; i < mlSetups.Count; i++)
+                {
+                    MaterialSetups.Add(new Setup(mlSetups[i], mlSetupNames[i]));
+                }
+
+                List<Template> MaterialTemplates = new List<Template>();
+                for (int i = 0; i < mlTemplates.Count; i++)
+                {
+                    MaterialTemplates.Add(new Template(mlTemplates[i], mlTemplateNames[i]));
+                }
+
+                if(RawMaterials.Count > 0)
+                {
+                    if(MaterialSetups.Count > 0)
+                    {
+                        if(MaterialTemplates.Count > 0)
+                        {
+                            var obj = new { AssetLib = AssetLib.FullName, CopyTextures, ValueToBeIgnored = 9999, RawMaterials, MaterialSetups, MaterialTemplates};
+                            model.Extras = JsonContent.Serialize(obj);
+                            File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                        }
+                        else
+                        {
+                            var obj = new { AssetLib = AssetLib.FullName, CopyTextures, ValueToBeIgnored = 9999, RawMaterials, MaterialSetups};
+                            model.Extras = JsonContent.Serialize(obj);
+                            File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                        }
+                    }
+                    else
+                    {
+                        var obj = new { AssetLib = AssetLib.FullName, CopyTextures, ValueToBeIgnored = 9999, RawMaterials};
+                        model.Extras = JsonContent.Serialize(obj);
+                        File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                    }
+                }
+
             }
+            catch { }
 
-            var obj = new { assetLib, copyTextures , rawMaterials };
-            model.Extras = SharpGLTF.IO.JsonContent.Serialize(obj);
+            File.WriteAllLines(outDir.FullName + "TexturesList.txt", TexturesList);
 
-            File.WriteAllText(outDir + "Material.json", SharpGLTF.IO.JsonContent.Serialize(obj).ToJson());
-            File.WriteAllLines(outDir + "TexturesList.txt", TexturesList);
 
             string ext = "*.dds";
             if (eUncookExtension == EUncookExtension.png)
@@ -259,35 +404,22 @@ namespace WolvenKit.RED4.MeshFile.Materials
 
             string[] files = Directory.GetFiles(cacheDir, ext);
             for (int i = 0; i < files.Length; i++)
-                File.Move(files[i], outDir + Path.GetFileName(files[i]),true);
-
-            Directory.Delete(cacheDir,true);
+                File.Move(files[i], outDir.FullName + Path.GetFileName(files[i]),true);
         }
-        static void ParseMaterialsUsingGameDir(Stream meshStream, ref ModelRoot model, string outDir, string gameDir, EUncookExtension eUncookExtension = EUncookExtension.dds)
+        static void ParseMaterialsUsingArchives(Stream meshStream, ref ModelRoot model, DirectoryInfo outDir, EUncookExtension eUncookExtension = EUncookExtension.dds)
         {
-            gameDir = gameDir.Replace("bin\\x64", "archive\\pc\\content");
-            string[] archiveNames = Directory.GetFiles(gameDir, "*.archive");
-
-            List<Archive> archives = new List<Archive>();
-            for (int i = 0; i < archiveNames.Length; i++)
-                archives.Add(new Archive(archiveNames[i]));
-
-            string cacheDir = Path.GetTempPath() + "WolvenKit\\Material\\TempImages\\";
-
             List<string> primaryDependencies = new List<string>();
 
             List<string> materialEntryNames = new List<string>();
             List<CMaterialInstance> materialEntries = new List<CMaterialInstance>();
 
-            GetMateriaEntries(meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries);
+            GetMateriaEntries(meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries,new DirectoryInfo(cacheDir), false);
 
             List<string> mlSetupNames = new List<string>();
             List<Multilayer_Setup> mlSetups = new List<Multilayer_Setup>();
 
             List<string> mlTemplateNames = new List<string>();
             List<Multilayer_LayerTemplate> mlTemplates = new List<Multilayer_LayerTemplate>();
-
-            Directory.CreateDirectory(cacheDir);
 
             List<string> TexturesList = new List<string>();
 
@@ -369,17 +501,55 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 }
             }
 
-            List<RawMaterial> rawMaterials = new List<RawMaterial>();
-            for (int i = 0; i < materialEntries.Count; i++)
+            try
             {
-                rawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i]));
+
+                List<RawMaterial> RawMaterials = new List<RawMaterial>();
+                for (int i = 0; i < materialEntries.Count; i++)
+                {
+                    RawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i]));
+                }
+
+                List<Setup> MaterialSetups = new List<Setup>();
+                for (int i = 0; i < mlSetups.Count; i++)
+                {
+                    MaterialSetups.Add(new Setup(mlSetups[i], mlSetupNames[i]));
+                }
+
+                List<Template> MaterialTemplates = new List<Template>();
+                for (int i = 0; i < mlTemplates.Count; i++)
+                {
+                    MaterialTemplates.Add(new Template(mlTemplates[i], mlTemplateNames[i]));
+                }
+
+                if (RawMaterials.Count > 0)
+                {
+                    if (MaterialSetups.Count > 0)
+                    {
+                        if (MaterialTemplates.Count > 0)
+                        {
+                            var obj = new { AssetLib = "", CopyTextures = true, ValueToBeIgnored = 9999, RawMaterials, MaterialSetups, MaterialTemplates };
+                            model.Extras = JsonContent.Serialize(obj);
+                            File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                        }
+                        else
+                        {
+                            var obj = new { AssetLib = "", CopyTextures = true, ValueToBeIgnored = 9999, RawMaterials, MaterialSetups };
+                            model.Extras = JsonContent.Serialize(obj);
+                            File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                        }
+                    }
+                    else
+                    {
+                        var obj = new { AssetLib = "", CopyTextures = true, ValueToBeIgnored = 9999, RawMaterials };
+                        model.Extras = JsonContent.Serialize(obj);
+                        File.WriteAllText(outDir.FullName + "Material.json", JsonContent.Serialize(obj).ToJson());
+                    }
+                }
+
             }
-
-            var obj = new { assetLib = "", copyTextures = true, rawMaterials };
-            model.Extras = SharpGLTF.IO.JsonContent.Serialize(obj);
-
-            File.WriteAllText(outDir + "Material.json", SharpGLTF.IO.JsonContent.Serialize(obj).ToJson());
-            File.WriteAllLines(outDir + "TexturesList.txt", TexturesList);
+            catch { }
+            File.WriteAllLines(outDir.FullName + "TexturesList.txt", TexturesList);
 
             string ext = "*.dds";
             if (eUncookExtension == EUncookExtension.png)
@@ -396,42 +566,37 @@ namespace WolvenKit.RED4.MeshFile.Materials
             string[] files = Directory.GetFiles(cacheDir, ext,SearchOption.AllDirectories);
 
             for (int i = 0; i < files.Length; i++)
-                File.Move(files[i], outDir + Path.GetFileName(files[i]), true);
-
-            Directory.Delete(cacheDir, true);
+                File.Move(files[i], outDir.FullName + Path.GetFileName(files[i]), true);
         }
-        static RawMaterial ContainRawMaterial(CMaterialInstance cMaterialInstance, string name)
+        static RawMaterial ContainRawMaterial(CMaterialInstance cMaterialInstance, string Name)
         {
             RawMaterial rawMaterial = new RawMaterial();
 
-            rawMaterial.Name = name;
-
-            if (Path.GetExtension(cMaterialInstance.BaseMaterial.DepotPath) == ".mi")
-                rawMaterial.extInstanced = true;
-
+            rawMaterial.Name = Name;
+            rawMaterial.BaseMaterial = cMaterialInstance.BaseMaterial.DepotPath;
 
             if (Path.GetFileNameWithoutExtension(cMaterialInstance.BaseMaterial.DepotPath) == "mesh_decal")
             {
-                rawMaterial.materialType = MaterialType.MeshDecal;
+                rawMaterial.MaterialType = MaterialType.MeshDecal;
 
-                MeshDecal meshDecal = new MeshDecal(cMaterialInstance);
-                rawMaterial.meshDecal = meshDecal;
+                MeshDecal MeshDecal = new MeshDecal(cMaterialInstance);
+                rawMaterial.MeshDecal = MeshDecal;
 
             }
             if (Path.GetFileNameWithoutExtension(cMaterialInstance.BaseMaterial.DepotPath) == "multilayered")
             {
-                rawMaterial.materialType = MaterialType.MultiLayered;
+                rawMaterial.MaterialType = MaterialType.MultiLayered;
 
                 MultiLayered multiLayered = new MultiLayered(cMaterialInstance);
-                rawMaterial.multiLayered = multiLayered;
+                rawMaterial.MultiLayered = multiLayered;
 
             }
             if (cMaterialInstance.BaseMaterial.DepotPath.Contains("skin"))
             {
-                rawMaterial.materialType = MaterialType.HumanSkin;
+                rawMaterial.MaterialType = MaterialType.HumanSkin;
 
-                HumanSkin humanSkin = new HumanSkin(cMaterialInstance);
-                rawMaterial.humanSkin = humanSkin;
+                HumanSkin HumanSkin = new HumanSkin(cMaterialInstance);
+                rawMaterial.HumanSkin = HumanSkin;
             }
 
             return rawMaterial;
@@ -449,17 +614,23 @@ namespace WolvenKit.RED4.MeshFile.Materials
                 MemoryStream outstream = new MemoryStream();
                 // copy to some outstream
                 ms.DecompressAndCopySegment(outstream, b.DiskSize, b.MemSize);
-
                 BinaryReader outreader = new BinaryReader(outstream);
                 outstream.Position = 161;
-                if (new string(outreader.ReadChars(17)) == "CMaterialInstance")
+                if (new string(BitConverter.ToString(outreader.ReadBytes(17))) == "43-4D-61-74-65-72-69-61-6C-49-6E-73-74-61-6E-63-65") // CMaterialInstance
                 {
                     materialStream = outstream;
                     break;
                 }
             }
-
             return materialStream;
+        }
+        public MATERIAL(List<Archive> Archives)
+        {
+            archives = Archives;
+        }
+        public MATERIAL()
+        {
+
         }
     }
 }

--- a/WolvenKit.Modkit/Modkit/Helper/Functions/MeshFunctions.cs
+++ b/WolvenKit.Modkit/Modkit/Helper/Functions/MeshFunctions.cs
@@ -111,7 +111,7 @@ namespace WolvenKit.RED4.MeshFile
 
 
 
-        public static void ExportMeshWithoutRig(Stream meshStream, string _meshName, string outfile, bool LodFilter = true, bool isGLBinary = true)
+        public static void ExportMeshWithoutRig(Stream meshStream, string _meshName, FileInfo outfile, bool LodFilter = true, bool isGLBinary = true)
         {
             List<RawMeshContainer> expMeshes = new List<RawMeshContainer>();
             var cr2w = CP77.CR2W.ModTools.TryReadCr2WFile(meshStream);
@@ -135,12 +135,12 @@ namespace WolvenKit.RED4.MeshFile
                 expMeshes.Add(mesh);
             }
             ModelRoot model = RawRigidMeshesToGLTF(expMeshes);
-            if (isGLBinary)
-                model.SaveGLB(outfile);
+            if(isGLBinary)
+                model.SaveGLB(outfile.FullName);
             else
-                model.SaveGLTF(outfile);
+                model.SaveGLTF(outfile.FullName);
         }
-        public static void ExportMultiMeshWithoutRig(List<Stream> meshStreamS, List<string> _meshNameS, string outfile, bool LodFilter = true, bool isGLBinary = true)
+        public static void ExportMultiMeshWithoutRig(List<Stream> meshStreamS, List<string> _meshNameS,FileInfo outfile, bool LodFilter = true, bool isGLBinary = true)
         {
             List<RawMeshContainer> expMeshes = new List<RawMeshContainer>();
 
@@ -168,12 +168,12 @@ namespace WolvenKit.RED4.MeshFile
                 }
             }
             ModelRoot model = RawRigidMeshesToGLTF(expMeshes);
-            if (isGLBinary)
-                model.SaveGLB(outfile);
+            if(isGLBinary)
+                model.SaveGLB(outfile.FullName);
             else
-                model.SaveGLTF(outfile);
+                model.SaveGLTF(outfile.FullName);
         }
-        public static void ExportMeshWithRig(Stream meshMstream, Stream rigMStream, string _meshName, string outfile, bool LodFilter = true, bool isGLBinary = true)
+        public static void ExportMeshWithRig(Stream meshMstream, Stream rigMStream, string _meshName,FileInfo outfile, bool LodFilter = true, bool isGLBinary = true)
         {
             RawArmature Rig = RIG.ProcessRig(rigMStream);
 
@@ -219,12 +219,12 @@ namespace WolvenKit.RED4.MeshFile
             }
 
             ModelRoot model = RawSkinnedMeshesToGLTF(expMeshes, Rig);
-            if (isGLBinary)
-                model.SaveGLB(outfile);
+            if(isGLBinary)
+                model.SaveGLB(outfile.FullName);
             else
-                model.SaveGLTF(outfile);
+                model.SaveGLTF(outfile.FullName);
         }
-        public static void ExportMultiMeshWithRig(List<Stream> meshStreamS, List<Stream> rigStreamS, List<string> _meshNameS, string outfile, bool LodFilter = true, bool isGLBinary = true)
+        public static void ExportMultiMeshWithRig(List<Stream> meshStreamS, List<Stream> rigStreamS, List<string> _meshNameS,FileInfo outfile, bool LodFilter = true, bool isGLBinary = true)
         {
             List<RawArmature> Rigs = new List<RawArmature>();
             rigStreamS = rigStreamS.OrderByDescending(r => r.Length).ToList();  // not so smart hacky method to get bodybase rigs on top/ orderby descending
@@ -282,10 +282,10 @@ namespace WolvenKit.RED4.MeshFile
                 }
             }
             ModelRoot model = RawSkinnedMeshesToGLTF(expMeshes, expRig);
-            if (isGLBinary)
-                model.SaveGLB(outfile);
+            if(isGLBinary)
+                model.SaveGLB(outfile.FullName);
             else
-                model.SaveGLTF(outfile);
+                model.SaveGLTF(outfile.FullName);
         }
         static Vec3[] GetMeshBonesPosn(CR2WFile cr2w)
         {


### PR DESCRIPTION
# Pull request template

<PULL REQUEST TITLE>

Implemented:
- <Features implemented>
Material Setup and Template Dump with Material.json, External MaterialEntries parsing aswell, Separate Methods for usingAssetLib and using Archive List.
Fixed:
- <Fixes>
Some Exception Handling, changed method for getting material buffer(to UTF8 error in some cases)
<Additional notes>
using DirectoryInfo and FileInfo instead of strings. one time MATERIAL object initialization with Archives list, so as not to read Archives from GameDir every time mesh is exported, i.e. efficient, fast for multiple exports