### PR TITLE
Updated Pack.cs removing "basegame_" from output filename

### DIFF
--- a/WolvenKit.Modkit/Modkit/Pack.cs
+++ b/WolvenKit.Modkit/Modkit/Pack.cs
@@ -80,7 +80,7 @@ namespace CP77.CR2W
             if (!outpath.Exists)
                 return null;
 
-            var outfile = Path.Combine(outpath.FullName, $"basegame_{infolder.Name}.archive");
+            var outfile = Path.Combine(outpath.FullName, $"{infolder.Name}.archive");
             var ar = new Archive
             {
                 ArchiveAbsolutePath = outfile,


### PR DESCRIPTION
Updated to remove the "basegame_" part of output file naming as it is no longer necessary for loading archives as of game version 1.2 (and it was annoying me)
