### PR TITLE
AB file sort alphabetically, size suffixes

### DIFF
--- a/WolvenKit.Common/Model/AssetBrowserData.cs
+++ b/WolvenKit.Common/Model/AssetBrowserData.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.IO;
 using ReactiveUI;
 using WolvenKit.RED4.CR2W.Archive;
+using System;
 
 namespace WolvenKit.Common.Model
 {
@@ -33,8 +34,20 @@ namespace WolvenKit.Common.Model
         [Browsable(false)] public ulong Key => _fileEntry.Key;
 
 
-        public uint Size => _fileEntry.Size;
+        public string Size => FormatSize(_fileEntry.Size);
+        string FormatSize(uint size)
+        {
+            string[] suffixes = { "Bytes", "KB", "MB", "GB", "TB", "PB" };
 
+            var counter = 0;
+            var number = (decimal)size;
+            while (Math.Round(number / 1024) >= 1)
+            {
+                number = number / 1024;
+                counter++;
+            }
+            return $"{number:n1} {suffixes[counter]}";
+        }
 
         public IGameFile GetGameFile() => _fileEntry;
 

--- a/WolvenKit/Views/Editor/Basic/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Editor/Basic/AssetBrowserView.xaml.cs
@@ -25,6 +25,7 @@ using WolvenKit.Models.Docking;
 using WolvenKit.Modkit.RED4;
 using WolvenKit.RED4.CR2W.Archive;
 using WolvenKit.ViewModels.Editor;
+using System.Text.RegularExpressions;
 
 namespace WolvenKit.Views.Editor
 {
@@ -219,7 +220,7 @@ namespace WolvenKit.Views.Editor
             if (e.AddedItems.First() is TreeGridRowInfo { RowData: GameFileTreeNode model })
             {
                 vm.RightItems = model.Files.Values.SelectMany(_ => _)
-                    .Select(_ => new FileEntryViewModel(_ as FileEntry));
+                    .Select(_ => new FileEntryViewModel(_ as FileEntry)).OrderBy(_=>Regex.Replace(_.Name, @"\d+", n => n.Value.PadLeft(16, '0')));
             }
         }
 


### PR DESCRIPTION
Fixed:
- <Fixes>
sort file names in asset browser alphanumerically and adding suffixes to the file sizes