### PR TITLE
Fixed raw import stack traces

### DIFF
--- a/WolvenKit.Modkit/RED4/Import.cs
+++ b/WolvenKit.Modkit/RED4/Import.cs
@@ -418,8 +418,16 @@ namespace WolvenKit.Modkit.RED4
                 else
                 {
                     // TODO
-                    var md = DDSUtils.GetMetadataFromTGAFile(infile);
-                    format = md.Format;
+                    if (rawExt == EUncookExtension.tga.ToString())
+                    {
+                        var md = DDSUtils.GetMetadataFromTGAFile(infile);
+                        format = md.Format;
+                    }
+                    else
+                    {
+                        _loggerService.Error($"Direct {rawExt} import is not supported yet.");
+                        return false;
+                    }
                 }
 
 


### PR DESCRIPTION
**Issue:**

Importing PNG, BMP, JPG and TIFF files are not yet supported in WolvenKit and import attempts result in unhandled exceptions/stack traces in the CLI instead of clean error messages:

![ImportPNGError_WkitCLI](https://user-images.githubusercontent.com/575507/138033924-a9c3491b-a1c3-4ec8-b0b2-a1b2e3550ba1.png)

**Fixed:**

Stack traces have been replaced with error messages for direct import of unsupported raw file types:

![FixedImportErrorDisplay](https://user-images.githubusercontent.com/575507/138034919-ad9b0f7d-9b40-4826-9ff5-aea0493177f7.png)
