### PR TITLE
TweakDB Compilation Improvements for CLI

### DIFF
--- a/WolvenKit.Modkit/RED4/Serialization/Serialization.cs
+++ b/WolvenKit.Modkit/RED4/Serialization/Serialization.cs
@@ -288,7 +288,7 @@ namespace WolvenKit.Modkit.RED4.Serialization
 
                 // check array type
                 var splits = redtype.Split(':');
-                if (splits[0].Equals("array"))
+                if (splits.Length > 1 && splits[0].Equals("array"))
                 {
                     var innertype = GetTypeFromRedTypeStr(redtype.Replace("array:", ""));
                     var outer = Activator.CreateInstance(

--- a/WolvenKit.Modkit/RED4/Serialization/Serialization.cs
+++ b/WolvenKit.Modkit/RED4/Serialization/Serialization.cs
@@ -234,6 +234,8 @@ namespace WolvenKit.Modkit.RED4.Serialization
             {
                 ETweakType.CName => typeof(CName),
                 ETweakType.CString => typeof(CString),
+                ETweakType.TweakDBID => typeof(TweakDBID),
+                ETweakType.CResource => typeof(CResource),
                 ETweakType.CFloat => typeof(CFloat),
                 ETweakType.CBool => typeof(CBool),
                 ETweakType.CUint8 => typeof(CUint8),
@@ -249,12 +251,13 @@ namespace WolvenKit.Modkit.RED4.Serialization
                 ETweakType.CQuaternion => typeof(CQuaternion),
                 ETweakType.CVector2 => typeof(CVector2),
                 ETweakType.CVector3 => typeof(CVector3),
+                ETweakType.LocKey => typeof(LocKey),
                 _ => throw new ArgumentOutOfRangeException(nameof(enumType))
             };
 
         private static string GetTypeStrFromRedTypeStr(string redtype)
         {
-            if (!Enum.TryParse<ERedType>(redtype, out var type))
+            if (!Enum.TryParse<ERedType>(redtype.Replace(":", ""), out var type))
             {
                 return null;
             }
@@ -285,9 +288,9 @@ namespace WolvenKit.Modkit.RED4.Serialization
 
                 // check array type
                 var splits = redtype.Split(':');
-                if (splits.Length == 2 && splits[0].Equals("array"))
+                if (splits[0].Equals("array"))
                 {
-                    var innertype = GetTypeFromRedTypeStr(splits[1]);
+                    var innertype = GetTypeFromRedTypeStr(redtype.Replace("array:", ""));
                     var outer = Activator.CreateInstance(
                         typeof(CArray<>).MakeGenericType(
                             new Type[] { innertype }),

--- a/WolvenKit.Modkit/RED4/Serialization/yaml/IParserExtensions.cs
+++ b/WolvenKit.Modkit/RED4/Serialization/yaml/IParserExtensions.cs
@@ -16,7 +16,7 @@ namespace WolvenKit.Modkit.RED4.Serialization.yaml
         {
             if (parser.Current != null && parser.Current.GetType() != typeof(MappingStart))
             {
-                throw new InvalidDataException("Invalid YAML content.");
+                throw new InvalidDataException($"Invalid YAML content. Got type: {parser.Current.GetType()} for {parser.Current.Start} to {parser.Current.End}");
             }
             parser.MoveNext();
         }

--- a/WolvenKit.RED4.TweakDB/Enums.cs
+++ b/WolvenKit.RED4.TweakDB/Enums.cs
@@ -11,6 +11,8 @@ namespace WolvenKit.RED4.TweakDB
     {
         CName,
         CString,
+        TweakDBID,
+        CResource,
         CFloat,
         CBool,
         CUint8,
@@ -25,13 +27,16 @@ namespace WolvenKit.RED4.TweakDB
         CEulerAngles,
         CQuaternion,
         CVector2,
-        CVector3
+        CVector3,
+        LocKey
     }
 
     public enum ERedType
     {
         CName,
         String,
+        TweakDBID,
+        raRefCResource,
         Float,
         Bool,
         Uint8,
@@ -46,7 +51,8 @@ namespace WolvenKit.RED4.TweakDB
         EulerAngles,
         Quaternion,
         Vector2,
-        Vector3
+        Vector3,
+        LocKey
     }
 
 

--- a/WolvenKit.RED4.TweakDB/FlatsPool.cs
+++ b/WolvenKit.RED4.TweakDB/FlatsPool.cs
@@ -48,7 +48,6 @@ namespace WolvenKit.RED4.TweakDB
                 }
 
                 _flats.Add(flat, valueHash);
-                Console.WriteLine($"Adding flat: {flat}: {value}");
             }
 
             private static uint GetValueHash(IType value)
@@ -144,12 +143,8 @@ namespace WolvenKit.RED4.TweakDB
                 writer.Write(bucket.Flats.Count);
                 foreach (var (name, valueHash) in bucket.Flats)
                 {
-                    var hash = Crc32Algorithm.Compute(name);
-                    writer.Write(hash);
-                    writer.Write((byte)name.Length);
-                    writer.Write((byte)0); // TBD offset 0.
-                    writer.Write((byte)0); // TBD offset 0.
-                    writer.Write((byte)0); // TBD offset 1.
+                    TweakDBID tdbid = name;
+                    tdbid.Serialize(writer);
 
                     writer.Write(indexes[valueHash]);
                 }

--- a/WolvenKit.RED4.TweakDB/FlatsPool.cs
+++ b/WolvenKit.RED4.TweakDB/FlatsPool.cs
@@ -48,6 +48,7 @@ namespace WolvenKit.RED4.TweakDB
                 }
 
                 _flats.Add(flat, valueHash);
+                Console.WriteLine($"Adding flat: {flat}: {value}");
             }
 
             private static uint GetValueHash(IType value)

--- a/WolvenKit.RED4.TweakDB/TweakDB.cs
+++ b/WolvenKit.RED4.TweakDB/TweakDB.cs
@@ -60,8 +60,7 @@ namespace WolvenKit.RED4.TweakDB
             var recordParent = record.Inherits; //unused
             var recordType = record.Type;
 
-            _records.Add($"{name}", recordType);
-            System.Console.WriteLine($"Adding record: {name}: {recordType}");
+            _records.Add(name, recordType);
         }
 
         /// <summary>
@@ -117,13 +116,8 @@ namespace WolvenKit.RED4.TweakDB
             writer.Write(_records.Count);
             foreach (var (name, type) in _records)
             {
-                // TweakDBID.
-                var hash = Crc32Algorithm.Compute(name);
-                writer.Write(hash);
-                writer.Write((byte)name.Length);
-                writer.Write((byte)0); // TBD offset 0.
-                writer.Write((byte)0); // TBD offset 0.
-                writer.Write((byte)0); // TBD offset 1.
+                TweakDBID tdbid = name;
+                tdbid.Serialize(writer);
 
                 writer.Write(Murmur32.Hash(type, s_recordsSeed));
             }

--- a/WolvenKit.RED4.TweakDB/TweakDB.cs
+++ b/WolvenKit.RED4.TweakDB/TweakDB.cs
@@ -60,7 +60,8 @@ namespace WolvenKit.RED4.TweakDB
             var recordParent = record.Inherits; //unused
             var recordType = record.Type;
 
-            _records.Add(name, recordType);
+            _records.Add($"{name}", recordType);
+            System.Console.WriteLine($"Adding record: {name}: {recordType}");
         }
 
         /// <summary>

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -10,12 +10,14 @@ namespace WolvenKit.RED4.TweakDB.Types
         public string Name => "raRef:CResource";
         public string Text { get; set; }
         public ulong Key { get; set; }
+
         public static implicit operator CResource(string value) => new()
         {
             Text = value,
-            Key = (value != null && value != "" && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0 
+            Key = (!string.IsNullOrEmpty(value) && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0 
         };
-        public override string ToString() => $"{Text} <raRef:CResource 0x{String.Format("{0:X}", Key)} / {Key}>";
+
+        public override string ToString() => $"{Text} <raRef:CResource 0x{Key:X} / {Key}>";
         public void Serialize(BinaryWriter writer) => writer.Write(Key);
     }
 

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using RED.CRC32;
+using WolvenKit.Common.FNV1A;
+
+namespace WolvenKit.RED4.TweakDB.Types
+{
+    public class CResource : IPrimitive
+    {
+        public string Name => "raRef:CResource";
+        public string Text { get; set; }
+        public ulong Key { get; set; }
+        public static implicit operator CResource(string value) => new()
+        {
+            Text = value,
+            Key = (value != null && value != "" && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0 
+        };
+        public override string ToString() => $"{Text} <raRef:CResource 0x{String.Format("{0:X}", Key)} / {Key}>";
+        public void Serialize(BinaryWriter writer) => writer.Write(Key);
+    }
+
+}

--- a/WolvenKit.RED4.TweakDB/Types/LocKey.cs
+++ b/WolvenKit.RED4.TweakDB/Types/LocKey.cs
@@ -4,7 +4,7 @@ namespace WolvenKit.RED4.TweakDB.Types
 {
     public class LocKey : CUint64
     {
-        public static implicit operator LocKey(ulong value) => new() { Value = value };
         public override string Name => "gamedataLocKeyWrapper";
+        public static implicit operator LocKey(ulong value) => new() { Value = value };
     }
 }

--- a/WolvenKit.RED4.TweakDB/Types/LocKey.cs
+++ b/WolvenKit.RED4.TweakDB/Types/LocKey.cs
@@ -1,0 +1,10 @@
+using System.IO;
+
+namespace WolvenKit.RED4.TweakDB.Types
+{
+    public class LocKey : CUint64
+    {
+        public static implicit operator LocKey(ulong value) => new() { Value = value };
+        public override string Name => "gamedataLocKeyWrapper";
+    }
+}

--- a/WolvenKit.RED4.TweakDB/Types/TweakDBID.cs
+++ b/WolvenKit.RED4.TweakDB/Types/TweakDBID.cs
@@ -13,7 +13,9 @@ namespace WolvenKit.RED4.TweakDB.Types
         public string Text { get; set; }
         public int Length { get; set; }
         public uint Key { get; set; }
-        public static implicit operator TweakDBID(string value) {
+
+        public static implicit operator TweakDBID(string value)
+        {
             var t = new TweakDBID();
             var rx = new Regex(@"Tw?e?a?k?DBID\w?:\w?0?x?([0-9A-F]{8})\w?:\w?0?x?([0-9A-F]{2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             var m = rx.Matches(value);
@@ -30,7 +32,9 @@ namespace WolvenKit.RED4.TweakDB.Types
             t.Length = value.Length;
             return t;
         }
-        public override string ToString() => $"{Text} <TweakDBID 0x{String.Format("{0:X8}", Key)}:0x{String.Format("{0:X2}", Length)} / {Key}:{Length}>";
+
+        public override string ToString() => $"{Text} <TweakDBID 0x{String.Format("{0:X8}", Key)}:0x{Length:X2} / {Key}:{Length}>";
+
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(Key);

--- a/WolvenKit.RED4.TweakDB/Types/TweakDBID.cs
+++ b/WolvenKit.RED4.TweakDB/Types/TweakDBID.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using RED.CRC32;
+using System.Text.RegularExpressions;
+using System.Buffers.Binary;
+using WolvenKit.RED4.CR2W.Types;
+
+namespace WolvenKit.RED4.TweakDB.Types
+{
+    public class TweakDBID : IPrimitive
+    {
+        public string Name => "TweakDBID";
+        public string Text { get; set; }
+        public int Length { get; set; }
+        public uint Key { get; set; }
+        public static implicit operator TweakDBID(string value) {
+            var t = new TweakDBID();
+            var rx = new Regex(@"Tw?e?a?k?DBID\w?:\w?0?x?([0-9A-F]{8})\w?:\w?0?x?([0-9A-F]{2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            var m = rx.Matches(value);
+            if (m.Count == 1)
+            {
+                t.Text = value;
+                t.Key = Convert.ToUInt32(m[0].Groups[1].Value, 16);
+                t.Length = Convert.ToUInt16(m[0].Groups[2].Value, 16);
+                return t;
+            }
+
+            t.Text = value;
+            t.Key = Crc32Algorithm.Compute(value);
+            t.Length = value.Length;
+            return t;
+        }
+        public override string ToString() => $"{Text} <TweakDBID 0x{String.Format("{0:X8}", Key)}:0x{String.Format("{0:X2}", Length)} / {Key}:{Length}>";
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.Write(Key);
+            writer.Write((byte)Length);
+            writer.Write((byte)0);
+            writer.Write((byte)0); 
+            writer.Write((byte)0);
+        }
+    }
+
+}


### PR DESCRIPTION
Adds TweakDB compilation for TweakDBIDs, raRef:CResources, and LocKeys, fixes some issues with arrays. Supports the `-` array YAML format now as well.

TweakDBIDs can be the full paths, or IDs in the format `TDBID:12345678:12` (with some variations), where the numbers are hexadecimals. 
