### PR TITLE
Allow simultaneous reads from a single archive file by multiple WolvenKit.CLI processes

### DIFF
--- a/WolvenKit.Common/Extensions/MemoryMappedFileExtensions.cs
+++ b/WolvenKit.Common/Extensions/MemoryMappedFileExtensions.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.IO.MemoryMappedFiles;
+
+namespace WolvenKit.Common.Extensions
+{
+    public static class MemoryMappedFileExtensions
+    {
+        public static MemoryMappedFile GetMemoryMappedFile(FileStream fs, string mapName)
+        {
+            try
+            {
+#pragma warning disable CA1416 // Validate platform compatibility
+                return MemoryMappedFile.OpenExisting(mapName);
+#pragma warning restore CA1416 // Validate platform compatibility
+            }
+            catch (System.IO.IOException)
+            {
+            }
+
+            return MemoryMappedFile.CreateFromFile(fs, mapName, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
+        }
+    }
+}

--- a/WolvenKit.Modkit/RED4/Unbundle.cs
+++ b/WolvenKit.Modkit/RED4/Unbundle.cs
@@ -31,10 +31,7 @@ namespace WolvenKit.Modkit.RED4
             var extractedList = new ConcurrentBag<string>();
             var failedList = new ConcurrentBag<string>();
 
-            MemoryMappedFile mmf;
-
-            // name of memory mapped file that's derived from the filestream
-            var mapName = "archiveMapFS";
+            var mapName = "ExtractAll_Map";
 
             // check search pattern then regex
             var finalmatches = ar.Files.Values.Cast<FileEntry>();
@@ -63,17 +60,8 @@ namespace WolvenKit.Modkit.RED4
                 return;
             }
 
-            try
-            {
-#pragma warning disable CA1416 // Validate platform compatibility
-                mmf = MemoryMappedFile.OpenExisting(mapName);
-#pragma warning restore CA1416 // Validate platform compatibility
-            }
-            catch (System.IO.IOException)
-            {
-                using var fs = new FileStream(ar.ArchiveAbsolutePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
-                mmf = MemoryMappedFile.CreateFromFile(fs, mapName, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
-            }
+            using var fs = new FileStream(ar.ArchiveAbsolutePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            using var mmf = MemoryMappedFileExtensions.GetMemoryMappedFile(fs, mapName);
 
             var progress = 0;
 
@@ -112,7 +100,6 @@ namespace WolvenKit.Modkit.RED4
             {
                 _loggerService.Info(msg);
             }
-            mmf.Dispose();
         }
 
         /// <summary>

--- a/WolvenKit.Modkit/RED4/Unbundle.cs
+++ b/WolvenKit.Modkit/RED4/Unbundle.cs
@@ -63,7 +63,6 @@ namespace WolvenKit.Modkit.RED4
                 return;
             }
 
-            using var fs = new FileStream(ar.ArchiveAbsolutePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
             try
             {
 #pragma warning disable CA1416 // Validate platform compatibility
@@ -72,6 +71,7 @@ namespace WolvenKit.Modkit.RED4
             }
             catch (System.IO.IOException)
             {
+                using var fs = new FileStream(ar.ArchiveAbsolutePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
                 mmf = MemoryMappedFile.CreateFromFile(fs, mapName, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true);
             }
 


### PR DESCRIPTION
### **Implemented Feature:**

On initial read of an archive file, a memory mapped file (MMF) is checked for existence. If it does not exist, the IOException that's thrown is caught and a MMF is created.  Names are added to MMFs on creation to enable sharing of the mapped files across multiple processes, allowing multiple WolvenKit.CLI processes to simultaneously access the same archive file.  Once MMF handling is completed, the MMF is explicitly disposed.


### **Results:**

Changes allow for  multiple simultaneous unbundling instances on the same archive file, and also allows multiple simultaneous uncooking instances on the same archive file (with each instance writing to its own output location).