### PR TITLE
Adds the CLI to the installer

### DIFF
--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <ProjectReference Include="..\WolvenKit.App\WolvenKit.App.csproj" />
     <ProjectReference Include="..\WolvenKit.Common\WolvenKit.Common.csproj" />
+    <ProjectReference Include="..\WolvenKit.CLI\WolvenKit.CLI.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds the WolvenKit CLI to the main project, and therefore the installer, so folks installing the app from the .exe will have the CLI available to them once installed.

Github workflow for release was tested here, where you can download the installer to test it out: https://github.com/jackhumbert/WolvenKit/releases/tag/untagged-b429e677e83651d8c4bc