### PR TITLE
Adds UInt64 parsing for raRef:CResource in TweakDB compilation

### DIFF
--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -15,17 +15,16 @@ namespace WolvenKit.RED4.TweakDB.Types
         public static implicit operator CResource(string value)
         {
             var cres = new CResource();
-            var rx = new Regex(@"(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            var m = rx.Matches(value);
-            if (m.Count == 1)
+            UInt64 key;
+            if (UInt64.TryParse(value, result: out key))
             {
                 cres.Text = value;
-                cres.Key = Convert.ToUInt64(m[0].Groups[1].Value, 10);
-                return cres;
+                cres.Key = key;
+            } else
+            {
+                cres.Text = value;
+                cres.Key = !string.IsNullOrEmpty(value) ? FNV1A64HashAlgorithm.HashString(value) : 0;
             }
-
-            cres.Text = value;
-            cres.Key = (!string.IsNullOrEmpty(value) && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0;
             return cres;
         }
 

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
-using RED.CRC32;
 using WolvenKit.Common.FNV1A;
-using System.Text.RegularExpressions;
 
 namespace WolvenKit.RED4.TweakDB.Types
 {

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -13,8 +13,7 @@ namespace WolvenKit.RED4.TweakDB.Types
         public static implicit operator CResource(string value)
         {
             var cres = new CResource();
-            UInt64 key;
-            if (UInt64.TryParse(value, result: out key))
+            if (ulong.TryParse(value, out var key))
             {
                 cres.Text = value;
                 cres.Key = key;

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -17,7 +17,8 @@ namespace WolvenKit.RED4.TweakDB.Types
             {
                 cres.Text = value;
                 cres.Key = key;
-            } else
+            } 
+            else
             {
                 cres.Text = value;
                 cres.Key = !string.IsNullOrEmpty(value) ? FNV1A64HashAlgorithm.HashString(value) : 0;

--- a/WolvenKit.RED4.TweakDB/Types/CResource.cs
+++ b/WolvenKit.RED4.TweakDB/Types/CResource.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using RED.CRC32;
 using WolvenKit.Common.FNV1A;
+using System.Text.RegularExpressions;
 
 namespace WolvenKit.RED4.TweakDB.Types
 {
@@ -11,11 +12,22 @@ namespace WolvenKit.RED4.TweakDB.Types
         public string Text { get; set; }
         public ulong Key { get; set; }
 
-        public static implicit operator CResource(string value) => new()
+        public static implicit operator CResource(string value)
         {
-            Text = value,
-            Key = (!string.IsNullOrEmpty(value) && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0 
-        };
+            var cres = new CResource();
+            var rx = new Regex(@"(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            var m = rx.Matches(value);
+            if (m.Count == 1)
+            {
+                cres.Text = value;
+                cres.Key = Convert.ToUInt64(m[0].Groups[1].Value, 10);
+                return cres;
+            }
+
+            cres.Text = value;
+            cres.Key = (!string.IsNullOrEmpty(value) && value != "0") ? FNV1A64HashAlgorithm.HashString(value) : 0;
+            return cres;
+        }
 
         public override string ToString() => $"{Text} <raRef:CResource 0x{Key:X} / {Key}>";
         public void Serialize(BinaryWriter writer) => writer.Write(Key);


### PR DESCRIPTION
Only parses decimal since that's the only format I've ever seen CResources in - please correct me if I'm mistaken!