### PR TITLE
Get the full relative path instead of filename for CopyRelPath

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -131,7 +131,7 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand CopyFileCommand { get; private set; }
         private bool CanCopyFile() => _projectManager.ActiveProject != null && SelectedItem != null;
-        private void ExecuteCopyRelPath() => Clipboard.SetText(SelectedItem.Name);
+        private void ExecuteCopyRelPath() => Clipboard.SetText(SelectedItem.GetRelativeName(ActiveMod));
 
         /// <summary>
         /// Copies relative path of node.


### PR DESCRIPTION
Affects the right-click "Copy relative path" option in the Project Explorer,
