### PR TITLE
Tweaks to the pack/build process

### DIFF
--- a/WolvenKit.App/Functionality/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Functionality/Controllers/RED4Controller.cs
@@ -393,8 +393,14 @@ namespace WolvenKit.Functionality.Controllers
             foreach (var f in tweakFiles)
             {
                 var text = File.ReadAllText(f);
+                var folder = Path.GetDirectoryName(Path.GetRelativePath(cp77Proj.TweakDirectory, f));
+                var outDirectory = Path.Combine(cp77Proj.PackedTweakDirectory, folder);
+                if (!Directory.Exists(outDirectory))
+                {
+                    Directory.CreateDirectory(outDirectory);
+                }
                 var filename = Path.GetFileNameWithoutExtension(f) + ".bin";
-                var outPath = Path.Combine(cp77Proj.PackedTweakDirectory, filename);
+                var outPath = Path.Combine(outDirectory, filename);
 
                 try
                 {

--- a/WolvenKit.App/Functionality/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Functionality/Controllers/RED4Controller.cs
@@ -348,7 +348,11 @@ namespace WolvenKit.Functionality.Controllers
 
             try
             {
-                Directory.Delete(cp77Proj.PackedModDirectory, true);
+                var archives = Directory.GetFiles(cp77Proj.PackedModDirectory, "*.archive");
+                foreach (var archive in archives)
+                {
+                    File.Delete(archive);
+                }
             }
             catch (Exception e)
             {
@@ -362,7 +366,7 @@ namespace WolvenKit.Functionality.Controllers
                 _modTools.Pack(
                     new DirectoryInfo(cp77Proj.ModDirectory),
                     new DirectoryInfo(cp77Proj.PackedModDirectory),
-                    $"mod{cp77Proj.Name}");
+                    cp77Proj.Name);
                 _loggerService.Info("Packing archives complete!");
             }
 


### PR DESCRIPTION
* Only delete .archive files in `cp77Proj.PackedModDirectory` (`archive/pc/mod`) instead of the whole directory, allowing other files to be placed here & packed
* Removes `mod` prefix from .archive filenames*
* Preserve folder names from `cp77Proj.TweakDirectory` when compiling to `cp77Proj.PackedTweakDirectory`

\* This will cause duplicate .archive files if you're zipping up the packed folder & dropping it in - do we have a way to notify people of a change like this?