### PR TITLE
Add Timer to Check Folder Path Validity in ProjectWizard

### DIFF
--- a/WolvenKit/Views/Wizards/ProjectWizardView.xaml.cs
+++ b/WolvenKit/Views/Wizards/ProjectWizardView.xaml.cs
@@ -6,6 +6,7 @@ namespace WolvenKit.Views.Wizards
 {
     public partial class ProjectWizardView : ReactiveUserControl<ProjectWizardViewModel>
     {
+        private System.Windows.Threading.DispatcherTimer timer;
 
         public ProjectWizardView()
         {
@@ -60,10 +61,45 @@ namespace WolvenKit.Views.Wizards
                     vm => vm.OpenProjectPathCommand,
                     v => v.ProjectPathButton).DisposeWith(disposables);
 
+
+
+                Disposable.Create(() => StopTimer()).DisposeWith(disposables);
+
             });
         }
 
         private void TextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            if(timer == null)
+            {
+                StartTimer();
+            }
+            ValidateAllFields();
+        }
+
+        private void StartTimer()
+        {
+            if (timer == null)
+            {
+                timer = new System.Windows.Threading.DispatcherTimer();
+                timer.Tick += new System.EventHandler(OnTimer);
+                timer.Interval = new System.TimeSpan(0, 0, 1);
+                timer.Start();
+            }
+        }
+
+        private void StopTimer()
+        {
+            if (timer != null)
+            {
+                timer.Stop();
+                timer.Tick -= new System.EventHandler(OnTimer);
+                timer = null;
+            }
+        }
+
+
+        private void OnTimer(object sender, System.EventArgs e)
             => ValidateAllFields();
 
         private void ValidateAllFields()


### PR DESCRIPTION
Added a timer that checks whether the folder path is valid every 1s. This is necessary since the project wizard will otherwise not notice when a folder path has been made valid since it last time was checked. 

Example:
appending a (non-existing) sub-folder in the text-field will cause the wizard to correctly note that the folder doesn't exist and mark the path as invalid. When opening the browser through the button and adding that folder, in the browse UI, the path won't change, thus no check will be made, even though the folder now exists and the path should be valid. 


I have no experience with C# so I'd appreciate any feedback on the changes.