### PR TITLE
Added ScrollViewer to prevent overflow in CreateClassDialog

### DIFF
--- a/WolvenKit/Views/Dialogs/CreateClassDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CreateClassDialog.xaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
     Width="600"
-    Height="Auto"
+    Height="800"
     d:DesignHeight="600"
     d:DesignWidth="800"
     x:TypeArguments="dialogs:CreateClassDialogViewModel"
@@ -21,7 +21,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
             <RowDefinition Height="50" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -39,25 +39,29 @@
             VerticalAlignment="Center"
             Text="You'll be able to adjust parameters once the class is created. Below are some available classes:"
             TextWrapping="Wrap" />
-        <ItemsControl
-            Grid.Row="2"
-            Margin="-2,5,-2,5"
-            ItemsSource="{Binding ExistingClasses, Mode=OneWay}">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <WrapPanel />
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <Button
-                        Margin="2"
-                        Padding="5,3"
-                        Click="SetSelectedClass"
-                        Content="{Binding}" />
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <ScrollViewer Grid.Row="2">
+            <ItemsControl
+                Margin="-2,5,-2,5"
+                ItemsSource="{Binding ExistingClasses, Mode=OneWay}">
+                
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <WrapPanel />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Button
+                                Margin="2"
+                                Padding="5,3"
+                                Click="SetSelectedClass"
+                                Content="{Binding}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                
+            </ItemsControl>
+        </ScrollViewer>
+
         <hc:ComboBox
             Grid.Row="3"
             VerticalAlignment="Center"


### PR DESCRIPTION
Added ScrollViewer to prevent overflow in CreateClassDialog

Fixed:
- Fixed an issue where the Create Class dialog would be longer than screen and not allow the user to interact with the panel
- Added a default height of `800` to the panel
- Wrapped the main panel content in a `ScrollViewer` so that a large amount of content would scroll the screen rather than expanding infinitely

Before:
![Capture](https://user-images.githubusercontent.com/7128804/154618169-93f407f2-c065-4ea2-962f-6bfcb2e9b213.PNG)

After:
<img width="311" alt="Screenshot 2022-02-17 232045" src="https://user-images.githubusercontent.com/7128804/154618223-a498ef94-b87c-4367-aa81-f0b49ee4bb18.png">


