### PR TITLE
Add Base/Mod Files Toggle to Asset Browser

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -272,6 +272,7 @@ namespace WolvenKit.ViewModels.Tools
         }
 
         public ICommand ToggleModBrowserCommand { get; private set; }
+        public bool IsModBrowserActive() => _archiveManager.IsModBrowserActive;
         private bool CanToggleModBrowser() => true;//_archiveManager.IsManagerLoaded;
         private void ExecuteToggleModBrowser()
         {

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -76,9 +76,10 @@
                         Grid.Column="0"
                         VerticalAlignment="Center"
                         Click="LeftNavigationHomeButton_OnClick"
+                        ToolTip="Back to top level"
                         Style="{StaticResource ButtonDefault}"
                         Visibility="Visible">
-                        <iconPacks:PackIconCodicons Kind="Home" />
+                        <iconPacks:PackIconCodicons Kind="FoldUp" />
                     </Button>
 
                     <ToggleButton

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -38,6 +38,10 @@
                             </MultiDataTrigger>
                         </Style.Triggers>
                     </Style>
+
+                    <iconPacks:PackIconCodicons x:Key="AB_ToggleModButtonIcon_ToMods" Kind="Package" />
+                    <iconPacks:PackIconCodicons x:Key="AB_ToggleModButtonIcon_ToBase" Kind="Archive" />
+
                 </Grid.Resources>
 
                 <Grid.RowDefinitions>
@@ -62,6 +66,7 @@
 
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
@@ -76,9 +81,37 @@
                         <iconPacks:PackIconCodicons Kind="Home" />
                     </Button>
 
+                    <ToggleButton
+                        Grid.Column="1"
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+
+                        IsChecked="{Binding IsModBrowserActive}"
+
+                        Command="{Binding ToggleModBrowserCommand}">
+
+                        <ToggleButton.Style>
+                            <Style BasedOn="{StaticResource {x:Type ToggleButton}}" TargetType="ToggleButton">
+
+                                <Setter Property="ToolTip" Value="Switch to installed mod archives" />
+                                <Setter Property="Content" Value="{StaticResource AB_ToggleModButtonIcon_ToMods}" />
+
+                                <Style.Triggers>
+                                    <Trigger Property="IsChecked" Value="True">
+                                        <Setter Property="ToolTip" Value="Switch to game base archives" />
+                                        <Setter Property="Content" Value="{StaticResource AB_ToggleModButtonIcon_ToBase}" />
+                                        <Setter Property="Foreground" Value="DarkViolet" />
+                                        <Setter Property="BorderBrush" Value="DarkViolet" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ToggleButton.Style>
+
+                    </ToggleButton>
+
                     <hc:SearchBar
                         x:Name="FileSearchBar"
-                        Grid.Column="1"
+                        Grid.Column="2"
                         Margin="5,0,0,0"
                         VerticalAlignment="Top"
                         hc:InfoElement.Placeholder="Search all game files: (e.g. judy kind:mesh,ent)"
@@ -88,7 +121,7 @@
                         Style="{StaticResource SearchBarPlus}" />
 
                     <Viewbox
-                        Grid.Column="2"
+                        Grid.Column="3"
                         Width="30"
                         Height="30"
                         Margin="-35,0,0,0">
@@ -111,7 +144,7 @@
 
                     <hc:SearchBar
                         x:Name="OptionsSearchBar"
-                        Grid.Column="3"
+                        Grid.Column="4"
                         Margin="10,0,0,0"
                         VerticalAlignment="Top"
                         hc:InfoElement.Placeholder="(e.g. *.ent, base/**/judy)"


### PR DESCRIPTION
Implemented:
- Toggle button to switch between the game base archives and installed mod archives. This was previously only available in the ribbon.

Fixed:
- The 'home' button in the Asset Browser was a little confusing, changed it to a FoldUp icon and a 'back to top level' tooltip

Didn't remove the existing toggle from the ribbon view yet.
