### PR TITLE
Pin ReactiveUI.WPF to .NET 6.0.0 to allow compiling on < 6.0.102.

### DIFF
--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Platforms>x64</Platforms>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -26,7 +26,12 @@
       <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
-
+  <ItemGroup>
+      <FrameworkReference
+          Update="Microsoft.WindowsDesktop.App;Microsoft.WindowsDesktop.App.WPF;Microsoft.WindowsDesktop.App.WindowsForms"
+          TargetingPackVersion="6.0.0" />
+  </ItemGroup>
+    
   <ItemGroup>
     <ProjectReference Include="..\WolvenKit.App\WolvenKit.App.csproj" />
     <ProjectReference Include="..\WolvenKit.Common\WolvenKit.Common.csproj" />
@@ -48,7 +53,7 @@
     <PackageReference Include="ReactiveUI" Version="17.1.50" />
     <PackageReference Include="ReactiveUI.Events.WPF" Version="15.1.1" />
     <PackageReference Include="ReactiveUI.Fody" Version="17.1.50" />
-    <PackageReference Include="ReactiveUI.WPF" Version="17.1.50" />
+    <PackageReference Include="ReactiveUI.WPF" Version="17.1.50" Condition="'$(TargetFramework)' == 'net600'"  />
     <PackageReference Include="ScottPlot.WPF" Version="4.1.33" />
     <PackageReference Include="Splat" Version="14.1.45" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
@@ -105,8 +110,8 @@
     </PackageReference>
   </ItemGroup>
 
-
-  <ItemGroup>
+    
+    <ItemGroup>
     <Compile Remove="Functionality\Behavior\**" />
     <Compile Remove="lib\**" />
     <Compile Remove="NewFolder1\**" />


### PR DESCRIPTION
Fixed:
- Unable to compile develop on 6.0.0 after the 6.0.102 release that NuGet update pulled in for ReactiveUI. [dotnet core issue](https://github.com/dotnet/core/issues/7176).

Couldn't find a nicer way to do this, please fix if you do :)
