### PR TITLE
Hooks up Import Sync Flag to IResource(Async)References

### DIFF
--- a/WolvenKit.RED4.Archive/Buffer/Package04Structs.cs
+++ b/WolvenKit.RED4.Archive/Buffer/Package04Structs.cs
@@ -51,7 +51,7 @@ namespace WolvenKit.RED4.Archive.Buffer
         private const int sizeShift = 23;
         private const uint offsetMask = (1U << sizeShift) - 1U;
         private const uint sizeMask = 0xFF << (sizeShift);
-        private const int unkShift = 31;
+        private const int syncShift = 31;
 
         public uint offset
         {
@@ -73,13 +73,13 @@ namespace WolvenKit.RED4.Archive.Buffer
             }
         }
 
-        public bool unk1
+        public bool sync
         {
-            get => Convert.ToBoolean(bitfield >> unkShift);
+            get => Convert.ToBoolean(bitfield >> syncShift);
             set
             {
-                bitfield &= ~(1U << unkShift);
-                bitfield |= Convert.ToUInt32(value) << unkShift;
+                bitfield &= ~(1U << syncShift);
+                bitfield |= Convert.ToUInt32(value) << syncShift;
             }
         }
     }

--- a/WolvenKit.RED4.Archive/IO/PackageReader.File.cs
+++ b/WolvenKit.RED4.Archive/IO/PackageReader.File.cs
@@ -148,7 +148,7 @@ namespace WolvenKit.RED4.Archive.IO
 
             var import = new PackageImport()
             {
-                Flags = (InternalEnums.EImportFlags)(r.unk1 ? 0b10 : 0b00)
+                Flags = (InternalEnums.EImportFlags)(r.sync ? 0b1 : 0b0)
             };
             if (readAsHash)
             {

--- a/WolvenKit.RED4.Archive/IO/PackageWriter.File.cs
+++ b/WolvenKit.RED4.Archive/IO/PackageWriter.File.cs
@@ -184,7 +184,7 @@ namespace WolvenKit.RED4.Archive.IO
                     {
                         offset = (uint)refData.Count + position,
                         size = 8,
-                        unk1 = (reff.Item3 & 0b10) > 0
+                        sync = reff.Item3 > 0
                     });
                     refData.AddRange(BitConverter.GetBytes(reff.Item2.GetRedHash()));
                 }
@@ -194,7 +194,7 @@ namespace WolvenKit.RED4.Archive.IO
                     {
                         offset = (uint)refData.Count + position,
                         size = (byte)reff.Item2.Length,
-                        unk1 = (reff.Item3 & 0b10) > 0
+                        sync = reff.Item3 > 0
                     });
 
                     if ((string)reff.Item2 != null)

--- a/WolvenKit.RED4.Archive/IO/PackageWriter.cs
+++ b/WolvenKit.RED4.Archive/IO/PackageWriter.cs
@@ -200,7 +200,7 @@ namespace WolvenKit.RED4.Archive.IO
                 return;
             }
 
-            var val = ("", instance.DepotPath, (ushort)instance.Flags);
+            var val = ("", instance.DepotPath, (ushort)1);
 
             ImportRef.Add(_writer.BaseStream.Position, val);
             _writer.Write(GetImportIndex(val));
@@ -215,7 +215,7 @@ namespace WolvenKit.RED4.Archive.IO
                 return;
             }
 
-            var val = ("", instance.DepotPath, (ushort)instance.Flags);
+            var val = ("", instance.DepotPath, (ushort)0);
 
             ImportRef.Add(_writer.BaseStream.Position, val);
             _writer.Write(GetImportIndex(val));

--- a/WolvenKit.RED4.Types/EnumsExt/InternalEnums.cs
+++ b/WolvenKit.RED4.Types/EnumsExt/InternalEnums.cs
@@ -6,7 +6,7 @@ namespace WolvenKit.RED4.Types
         public enum EImportFlags
         {
             Default = 0x0,      // done
-            Obligatory = 0x1,
+            Obligatory = 0x1,   // also sync in packages
             Template = 0x2,     // done
             Soft = 0x4,         // done
             Embedded = 0x8,


### PR DESCRIPTION
It looks the bit in the import header is whether that reference is a `CResourceReference` (`1`) or `CResourceAsyncReference` (`0`). Moves the flag to the second bit (1), but allows for anything besides the first (`> 0`) to set the Sync flag, not that it matters, since the Package flags aren't used anywhere else to my knowledge.

Closes #643 