### PR TITLE
Add Launch Game button to main toolbar

### DIFF
--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -58,6 +58,8 @@ namespace WolvenKit.Functionality.Services
 
         string GetW3GameRootDir();
 
+        public string GetRED4GameExecutablePath();
+
         string GetRED4GameRootDir();
 
         public string GetRED4GameModDir();

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -169,6 +169,8 @@ namespace WolvenKit.Functionality.Services
             return fi.Directory is { Parent: { Parent: { } } } ? Path.Combine(fi.Directory.Parent.Parent.FullName) : null;
         }
 
+        public string GetRED4GameExecutablePath() => CP77ExecutablePath;
+
         public string GetRED4GameModDir()
         {
             var dir = Path.Combine(GetRED4GameRootDir(), "archive", "pc", "mod");

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -133,6 +133,8 @@ namespace WolvenKit.ViewModels.Shell
             ShowHomePageCommand = new RelayCommand(ExecuteShowHomePage, CanShowHomePage);
             ShowSettingsCommand = new RelayCommand(ExecuteShowSettings, CanShowSettings);
 
+            LaunchGameCommand = new RelayCommand(ExecuteLaunchGame, CanLaunchGame);
+
             CloseModalCommand = new RelayCommand(ExecuteCloseModal, CanCloseModal);
             CloseOverlayCommand = new RelayCommand(ExecuteCloseOverlay, CanCloseOverlay);
             CloseDialogCommand = new RelayCommand(ExecuteCloseDialog, CanCloseDialog);
@@ -471,6 +473,31 @@ namespace WolvenKit.ViewModels.Shell
 
             _homePageViewModel.SelectedIndex = 1;
             SetActiveOverlay(_homePageViewModel);
+        }
+
+        public ICommand LaunchGameCommand { get; private set; }
+        private bool CanLaunchGame() => true;
+        private void ExecuteLaunchGame()
+        {
+            try
+            {
+                var exe = Path.GetFullPath(_settingsManager.GetRED4GameExecutablePath());
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = exe,
+                    ErrorDialog = true,
+                    UseShellExecute = true,
+                    WorkingDirectory = exe
+                });
+            }
+            catch (Exception ex)
+            {
+                _loggerService.Error("Launch: error launching game! Please check your executable path in Settings.");
+                _loggerService.Info($"Launch: error debug info: {ex.Message}");
+            }
+
+            _loggerService.Success("Game launching.");
         }
 
         public ICommand ShowPluginCommand { get; private set; }

--- a/WolvenKit/Views/Shell/RibbonView.xaml
+++ b/WolvenKit/Views/Shell/RibbonView.xaml
@@ -123,7 +123,8 @@
             IsLocked="True"
             >
                 <ToolBarTray.Style>
-                    <Style TargetType="ToolBarTray" BasedOn="{StaticResource ToolBarTrayBaseStyle}">
+                    <Style TargetType="ToolBarTray">
+                        <Setter Property="Background" Value="Transparent" />
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsChecked, ElementName=ribbonEnabled}" Value="False">
@@ -402,6 +403,18 @@
                                 Kind="ArrowRight" />
                             </Grid>
                             <TextBlock Text="Pack &amp; Install" Padding="5,0,0,0" />
+                        </StackPanel>
+                    </Button>
+                    <Separator Margin="6" />
+                    <Button x:Name="ToolbarLaunchGameButton" Command="{Binding LaunchGameCommand}" ToolTip="Launch Game - Did You Remember To Pack &amp; Install?">
+                        <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <iconPacks:PackIconCodicons Style="{StaticResource WolvenKitToolBarButtonIcon}"
+                                Foreground="{StaticResource WolvenKitYellow}"
+                                Padding="0,0,2,2"
+                                Kind="RunAll" />
+                            </Grid>
+                            <TextBlock Text="Launch Game" Padding="5,0,0,0" />
                         </StackPanel>
                     </Button>
                     <Separator Margin="3" />

--- a/WolvenKit/Views/Shell/RibbonView.xaml.cs
+++ b/WolvenKit/Views/Shell/RibbonView.xaml.cs
@@ -224,6 +224,10 @@ namespace WolvenKit.Views.Shell
                         view => view.ToolbarPackInstallButton)
                     .DisposeWith(disposables);
                 this.BindCommand(ViewModel,
+                        viewModel => viewModel._mainViewModel.LaunchGameCommand,
+                        view => view.ToolbarLaunchGameButton)
+                    .DisposeWith(disposables);
+                this.BindCommand(ViewModel,
                         viewModel => viewModel._mainViewModel.ShowSettingsCommand,
                         view => view.ToolbarSettingsButton)
                     .DisposeWith(disposables);


### PR DESCRIPTION
Implemented:
- Launch Game button in the main toolbar (Closes #702)

Notes:
- Just launches the game. Could have it pack & install automatically, but I suspect quite often folks will want to do or simply do that separately. So it's two clicks rather than possibly rebuilding the mod when you don't want to.
- No implementation for the Ribbon (which is to be retired)