### PR TITLE
Add libs to main directory and reference them by name and not path

### DIFF
--- a/WolvenKit.Core/Compression/KrakenNative.cs
+++ b/WolvenKit.Core/Compression/KrakenNative.cs
@@ -10,14 +10,7 @@ public static class KrakenNative
     public static int Compress(byte[] buffer, byte[] outputBuffer, int level)
         => Kraken_Compress(buffer, buffer.Length, outputBuffer, level);
 
-
-#if _WINDOWS
-    private const string dllName = "lib/kraken.dll";
-#elif _OSX
-    private const string dllName = "lib/libkraken.dylib";
-#elif _LINUX
-    private const string dllName = "lib/libkraken.so";
-#endif
+    private const string dllName = "kraken";
 
     // EXPORT int Kraken_Decompress(const byte* src, size_t src_len, byte* dst, size_t dst_len);
     [DllImport(dllName, CallingConvention = CallingConvention.StdCall)]

--- a/WolvenKit.Core/Compression/OozNative.cs
+++ b/WolvenKit.Core/Compression/OozNative.cs
@@ -10,8 +10,10 @@ namespace WolvenKit.Core.Compression
         public static int Kraken_Compress(byte[] buffer, byte[] outputBuffer, long level)
             => Kraken_Compress_Raw(buffer, buffer.Length, outputBuffer, level);
 
-        #region Linux
-        [DllImport("ooz", EntryPoint = "_Z17Kraken_DecompressPKhmPhm")]
+        private const string dllName = "ooz";
+
+        #region DLLImports
+        [DllImport(dllName, EntryPoint = "_Z17Kraken_DecompressPKhmPhm")]
         public static extern int Kraken_Decompress_Raw(
             byte[] buffer,
             long bufferSize,
@@ -19,7 +21,7 @@ namespace WolvenKit.Core.Compression
             long outputBufferSize);
 
 
-        [DllImport("ooz", EntryPoint = "_Z15Kraken_CompressPhmS_i")]
+        [DllImport(dllName, EntryPoint = "_Z15Kraken_CompressPhmS_i")]
         public static extern int Kraken_Compress_Raw(
             byte[] buffer,
             long bufferSize,

--- a/WolvenKit.Core/Compression/OozNative.cs
+++ b/WolvenKit.Core/Compression/OozNative.cs
@@ -11,7 +11,7 @@ namespace WolvenKit.Core.Compression
             => Kraken_Compress_Raw(buffer, buffer.Length, outputBuffer, level);
 
         #region Linux
-        [DllImport("lib/libooz.so", EntryPoint = "_Z17Kraken_DecompressPKhmPhm")]
+        [DllImport("ooz", EntryPoint = "_Z17Kraken_DecompressPKhmPhm")]
         public static extern int Kraken_Decompress_Raw(
             byte[] buffer,
             long bufferSize,
@@ -19,7 +19,7 @@ namespace WolvenKit.Core.Compression
             long outputBufferSize);
 
 
-        [DllImport("lib/libooz.so", EntryPoint = "_Z15Kraken_CompressPhmS_i")]
+        [DllImport("ooz", EntryPoint = "_Z15Kraken_CompressPhmS_i")]
         public static extern int Kraken_Compress_Raw(
             byte[] buffer,
             long bufferSize,

--- a/WolvenKit.Core/WolvenKit.Core.csproj
+++ b/WolvenKit.Core/WolvenKit.Core.csproj
@@ -19,7 +19,6 @@
       <Platforms>x64</Platforms>
       <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
   </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
@@ -31,25 +30,26 @@
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
         <DefineConstants>_OSX</DefineConstants>
     </PropertyGroup>
-    
+
   <ItemGroup>
     <None Remove="lib\kraken.dll" />
     <None Remove="lib\libooz.so" />
+    <None Remove="lib\libkraken.dylib" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="lib\kraken.dll">
-      <PackagePath>lib\net5.0</PackagePath>
+    <ContentWithTargetPath Include="lib\kraken.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Pack>true</Pack>
-    </Content>
-    <None Remove="lib\libkraken.dylib" />
-    <Content Include="lib\libkraken.dylib">
+      <TargetPath>libkraken.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\libooz.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="lib\libooz.so">
+      <TargetPath>libooz.so</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\libkraken.dylib">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+      <TargetPath>libkraken.dylib</TargetPath>
+    </ContentWithTargetPath>
   </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The whole lib subdirectoy was a problematic so I think it's better to reference them by name in the main directory as it's not platform-specific.

Also fixes the issue where it tries to load a Linux lib on Windows.