### PR TITLE
Array item copy, paste & duplication, array index clean-up

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -26,6 +26,8 @@ namespace WolvenKit.ViewModels.Documents
 
         [Reactive] public RedDocumentViewModel File { get; set; }
 
+        public IRedType CopiedChunk;
+
         public RDTDataViewModel(IRedType data, RedDocumentViewModel file)
         {
             File = file;

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -590,19 +590,26 @@ namespace WolvenKit.ViewModels.Shell
         {
             if (ResolvedData is IList ary)
             {
-                //return ary.IndexOf(child.Data);
-                var index = 0;
-                foreach (var item in ary)
-                {
-                    if (item.GetHashCode() == child.Data.GetHashCode())
+                //if (PropertiesLoaded)
+                //{
+                //    Properties.IndexOf(child);
+                //}
+                //else
+                //{
+                    //return ary.IndexOf(child.Data);
+                    var index = 0;
+                    foreach (var item in ary)
                     {
-                        return index;
-                    }
-                    else
-                    {
+                        if (item.GetHashCode() == child.Data.GetHashCode())
+                        {
+                            if (!PropertiesLoaded || Properties[index].GetHashCode() == child.GetHashCode())
+                            {
+                                return index;
+                            }
+                        }
                         index++;
                     }
-                }
+                //}
             }
             else if (ResolvedData is IRedBufferPointer rbp && rbp.GetValue().Data is Package04 pkg)
             {
@@ -1608,6 +1615,7 @@ namespace WolvenKit.ViewModels.Shell
             if (cvm.ResolvedData is IRedArray ira && ira.InnerType.IsAssignableTo(item.GetType()))
             {
                 ira.Add(item);
+                cvm.CalculateDescriptor();
                 cvm.Name = null;
                 cvm.PropertyCount = -1;
                 cvm.PropertiesLoaded = false;

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -623,7 +623,18 @@ namespace WolvenKit.ViewModels.Shell
             }
             else if (ResolvedData is IRedBufferPointer rbp2 && rbp2.GetValue().Data is CR2WList cl)
             {
-                return cl.Files.IndexOf(cl.Files.Where(x => x.RootChunk == child.Data).FirstOrDefault());
+                var index = 0;
+                foreach (var file in cl.Files)
+                {
+                    if (file.RootChunk.GetHashCode() == child.Data.GetHashCode())
+                    {
+                        if (!PropertiesLoaded || Properties[index].GetHashCode() == child.GetHashCode())
+                        {
+                            return index;
+                        }
+                    }
+                    index++;
+                }
             }
             return 0;
         }
@@ -869,19 +880,19 @@ namespace WolvenKit.ViewModels.Shell
                     //{
                     //    width += 20;
                     //}
-                    if (PropertyCount <= 10)
+                    if (Parent.PropertyCount <= 10)
                     {
                         width += 16;
                     }
-                    else if (PropertyCount <= 100)
+                    else if (Parent.PropertyCount <= 100)
                     {
                         width += 21;
                     }
-                    else if (PropertyCount <= 1000)
+                    else if (Parent.PropertyCount <= 1000)
                     {
                         width += 26;
                     }
-                    else if (PropertyCount <= 10000)
+                    else if (Parent.PropertyCount <= 10000)
                     {
                         width += 31;
                     }

--- a/WolvenKit.RED4.Archive/Buffer/CR2WList.cs
+++ b/WolvenKit.RED4.Archive/Buffer/CR2WList.cs
@@ -5,7 +5,7 @@ using WolvenKit.RED4.Types;
 
 namespace WolvenKit.RED4.Archive.Buffer
 {
-    public class CR2WList : Red4File, IParseableBuffer
+    public class CR2WList : Red4File, IParseableBuffer, IRedCloneable
     {
         public IRedType Data
         {
@@ -22,6 +22,24 @@ namespace WolvenKit.RED4.Archive.Buffer
         public CR2WList()
         {
             Files = new List<CR2WFile>();
+        }
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            var list = new CR2WList();
+            foreach (var file in Files)
+            {
+                list.Files.Add(new CR2WFile()
+                {
+                    RootChunk = (RedBaseClass)file.RootChunk.DeepCopy()
+                });
+            }
+            return list;
         }
     }
 }

--- a/WolvenKit.RED4.Archive/Buffer/Package04.cs
+++ b/WolvenKit.RED4.Archive/Buffer/Package04.cs
@@ -3,7 +3,7 @@ using WolvenKit.RED4.Types;
 
 namespace WolvenKit.RED4.Archive.Buffer
 {
-    public class Package04 : Red4File, IParseableBuffer
+    public class Package04 : Red4File, IParseableBuffer, IRedCloneable
     {
         public ushort Version = 4;
         public ushort Sections = 7;
@@ -19,6 +19,23 @@ namespace WolvenKit.RED4.Archive.Buffer
         public Package04()
         {
             RootCruids = new List<CRUID>();
+        }
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            var pkg = new Package04();
+            pkg.RootCruids = RootCruids;
+            pkg.Chunks = new List<RedBaseClass>();
+            foreach (var chunk in Chunks)
+            {
+                pkg.Chunks.Add((RedBaseClass)chunk.DeepCopy());
+            }
+            return pkg;
         }
     }
 }

--- a/WolvenKit.RED4.Types/Primitives/CHandle.cs
+++ b/WolvenKit.RED4.Types/Primitives/CHandle.cs
@@ -22,7 +22,7 @@ namespace WolvenKit.RED4.Types
     }
 
     [RED("handle")]
-    public class CHandle<T> : IRedHandle<T>, /*IRedNotifyObjectChanged, */IEquatable<CHandle<T>> where T : RedBaseClass
+    public class CHandle<T> : IRedHandle<T>, /*IRedNotifyObjectChanged, */IEquatable<CHandle<T>>, IRedCloneable where T : RedBaseClass
     {
         // public event ObjectChangedEventHandler ObjectChanged;
 
@@ -130,5 +130,15 @@ namespace WolvenKit.RED4.Types
         }
 
         public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode((T)Chunk);
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            return CHandle.Parse(InnerType, (RedBaseClass)_chunk.DeepCopy());
+        }
     }
 }

--- a/WolvenKit.RED4.Types/Primitives/Simples/DataBuffer.cs
+++ b/WolvenKit.RED4.Types/Primitives/Simples/DataBuffer.cs
@@ -4,7 +4,7 @@ using System.ComponentModel;
 
 namespace WolvenKit.RED4.Types
 {
-    public class DataBuffer : IRedBufferWrapper, IRedBufferPointer, IRedPrimitive, IEquatable<DataBuffer>
+    public class DataBuffer : IRedBufferWrapper, IRedBufferPointer, IRedPrimitive, IEquatable<DataBuffer>, IRedCloneable
     {
         [Browsable(false)]
         public RedBuffer Buffer { get; set; }
@@ -71,5 +71,24 @@ namespace WolvenKit.RED4.Types
         }
 
         public override int GetHashCode() => Buffer.GetHashCode();
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            var db = new DataBuffer();
+            if (Data is IRedCloneable irc)
+            {
+                db.Data = (IParseableBuffer)irc.DeepCopy();
+            }
+            else
+            {
+                db.Data = Data;
+            }
+            return db;
+        }
     }
 }

--- a/WolvenKit.RED4.Types/Primitives/Simples/SerializationDeferredDataBuffer.cs
+++ b/WolvenKit.RED4.Types/Primitives/Simples/SerializationDeferredDataBuffer.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 namespace WolvenKit.RED4.Types
 {
     [RED("serializationDeferredDataBuffer")]
-    public class SerializationDeferredDataBuffer : IRedBufferWrapper, IRedBufferPointer, IRedPrimitive, IEquatable<SerializationDeferredDataBuffer>
+    public class SerializationDeferredDataBuffer : IRedBufferWrapper, IRedBufferPointer, IRedPrimitive, IEquatable<SerializationDeferredDataBuffer>, IRedCloneable
     {
         [Browsable(false)]
         public RedBuffer Buffer { get; set; }
@@ -73,5 +73,24 @@ namespace WolvenKit.RED4.Types
         }
 
         public override int GetHashCode() => Buffer.GetHashCode();
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            var db = new SerializationDeferredDataBuffer();
+            if (Data is IRedCloneable irc)
+            {
+                db.Data = (IParseableBuffer)irc.DeepCopy();
+            }
+            else
+            {
+                db.Data = Data;
+            }
+            return db;
+        }
     }
 }

--- a/WolvenKit.RED4.Types/Primitives/Simples/SharedDataBuffer.cs
+++ b/WolvenKit.RED4.Types/Primitives/Simples/SharedDataBuffer.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace WolvenKit.RED4.Types
 {
-    public class SharedDataBuffer : IRedBufferWrapper, IRedPrimitive, IEquatable<SharedDataBuffer>
+    public class SharedDataBuffer : IRedBufferWrapper, IRedPrimitive, IEquatable<SharedDataBuffer>, IRedCloneable
     {
         [Browsable(false)]
         public RedBuffer Buffer { get; set; }
@@ -59,5 +59,24 @@ namespace WolvenKit.RED4.Types
         }
 
         public override int GetHashCode() => (Buffer != null ? Buffer.GetHashCode() : 0);
+
+        public object ShallowCopy()
+        {
+            return MemberwiseClone();
+        }
+
+        public object DeepCopy()
+        {
+            var db = new SharedDataBuffer();
+            if (Data is IRedCloneable irc)
+            {
+                db.Data = (IParseableBuffer)irc.DeepCopy();
+            }
+            else
+            {
+                db.Data = Data;
+            }
+            return db;
+        }
     }
 }

--- a/WolvenKit/Views/Editors/RedTypeView.xaml
+++ b/WolvenKit/Views/Editors/RedTypeView.xaml
@@ -23,6 +23,15 @@
         <Grid.Resources>
             <sys:Double x:Key="RowHeight">26</sys:Double>
             <SolidColorBrush x:Key="RedTypeColor" Color="{StaticResource WolvenKitTanColor}" />
+
+            <Style x:Key="ArrayNameColumnWidth" TargetType="ColumnDefinition">
+                <Setter Property="Width" Value="218" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsInArray}" Value="True">
+                        <Setter Property="Width" Value="{Binding ArrayIndexWidth}" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
             <DataTemplate x:Key="AddHandleButton" DataType="{x:Type shell:ChunkViewModel}">
                 <Button
                     Height="12"
@@ -489,24 +498,15 @@
                     BorderThickness="0,1,0,0">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition>
-                                <ColumnDefinition.Style>
-                                    <Style TargetType="ColumnDefinition">
-                                        <Setter Property="Width" Value="160" />
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsInArray}" Value="True">
-                                                <Setter Property="Width" Value="{Binding ArrayIndexWidth}" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </ColumnDefinition.Style>
-                            </ColumnDefinition>
+                            <ColumnDefinition Width="6" />
+                            <ColumnDefinition Style="{StaticResource ArrayNameColumnWidth}" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="1" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock
-                            Margin="6,5,0,0"
+                            Grid.Column="1"
+                            Margin="0,5,0,0"
                             VerticalAlignment="Top"
                             Style="{StaticResource PGNameStyle}"
                             Text="{Binding Name, Mode=OneTime}"
@@ -514,17 +514,17 @@
                             ToolTip="{Binding XPath, Mode=OneTime}" />
                         <ContentPresenter
                             x:Name="DeleteButtonWrapper"
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Margin="0,6,0,0"
                             VerticalAlignment="Top"
                             ContentTemplate="{StaticResource DeleteButton}"
                             DataContext="{Binding}" />
                         <GridSplitter
-                            Grid.Column="2"
+                            Grid.Column="3"
                             HorizontalAlignment="Stretch"
                             Background="{StaticResource BorderAlt}" />
                         <ContentControl
-                            Grid.Column="3"
+                            Grid.Column="4"
                             Height="27"
                             VerticalAlignment="Top"
                             Content="{Binding}"

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -241,20 +241,48 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem
-                    Command="ApplicationCommands.Copy"
-                    CommandParameter="{Binding}"
-                    CommandTarget="{Binding}"
-                    Header="Copy Value to Clipboard"
+                    Command="{Binding Path=PlacementTarget.Tag.DuplicateChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Duplicate Item in Array"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}">
                     <MenuItem.Icon>
-                        <iconPacks:PackIconCodicons
+                        <iconPacks:PackIconMaterial
                             Width="13"
                             Height="13"
                             Padding="0,0,0,0"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
-                            Kind="Copy" />
+                            Kind="ContentDuplicate" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.CopyChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Copy From Array"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial
+                            Width="13"
+                            Height="13"
+                            Padding="0,0,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Kind="ContentCopy" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.PasteChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Paste Into Array"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial
+                            Width="13"
+                            Height="13"
+                            Padding="0,0,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Kind="ContentPaste" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem
@@ -270,6 +298,23 @@
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
                             Kind="Json" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
+                    Command="ApplicationCommands.Copy"
+                    CommandParameter="{Binding}"
+                    CommandTarget="{Binding}"
+                    Header="Copy Value to Clipboard"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconCodicons
+                            Width="13"
+                            Height="13"
+                            Padding="0,0,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Kind="Copy" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -241,8 +241,24 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.AddItemToCompiledDataCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Create Item In Buffer"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}"
+                    Visibility="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial
+                            Width="13"
+                            Height="13"
+                            Padding="0,0,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Kind="ContentDuplicate" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.DuplicateChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Duplicate Item in Array"
+                    Header="Duplicate Item in Array/Buffer"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}">
                     <MenuItem.Icon>
@@ -257,7 +273,7 @@
                 </MenuItem>
                 <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.CopyChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Copy From Array"
+                    Header="Copy From Array/Buffer"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}">
                     <MenuItem.Icon>
@@ -272,7 +288,7 @@
                 </MenuItem>
                 <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.PasteChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Paste Into Array"
+                    Header="Paste Into Array/Buffer"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}">
                     <MenuItem.Icon>
@@ -319,7 +335,7 @@
                 </MenuItem>
                 <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.DeleteItemCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Delete"
+                    Header="Delete Item in Array/Buffer"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}">
                     <MenuItem.Icon>
@@ -330,6 +346,21 @@
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
                             Kind="Remove" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.DeleteAllCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Delete All Items in Array/Buffer"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial
+                            Width="13"
+                            Height="13"
+                            Padding="0,0,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Kind="NotificationClearAll" />
                     </MenuItem.Icon>
                 </MenuItem>
             </ContextMenu>
@@ -519,6 +550,35 @@
             LoadOnDemandCommand="{Binding OnDemandLoadingCommand}"
             QueryNodeSize="TreeView_QueryNodeSize"
         -->
+        <syncfusion:SfTreeView.DragPreviewTemplate>
+            <DataTemplate DataType="{x:Type syncfusion:TreeViewDragInfo}">
+                <Border BorderBrush="{StaticResource BorderAlt}" BorderThickness="1">
+                    <Grid Background="{StaticResource ContentBackgroundAlt2}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Margin="5,2,5,0"
+                            VerticalAlignment="Center"
+                            Text="Duplicate item here:" />
+                        <TextBlock
+                            Grid.Row="1"
+                            Margin="5,0,5,2"
+                            VerticalAlignment="Center"
+                            Foreground="{StaticResource WolvenKitTan}"
+                            Text="{Binding Data[0].Content.Type}" />
+                        <TextBlock
+                            Grid.Row="2"
+                            Margin="5,0,5,2"
+                            VerticalAlignment="Center"
+                            Text="{Binding Data[0].Content.Descriptor}" />
+                    </Grid>
+                </Border>
+            </DataTemplate>
+        </syncfusion:SfTreeView.DragPreviewTemplate>
         <syncfusion:SfTreeView.HierarchyPropertyDescriptors>
             <treeViewEngine:HierarchyPropertyDescriptor
                 ChildPropertyName="TVProperties"

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -52,8 +52,8 @@ namespace WolvenKit.Views.Tools
 
         // Drag & Drop Functionality
 
-        private string dropFileLocation;
-        private RedTypeDto dropFile;
+        //private string dropFileLocation;
+        //private RedTypeDto dropFile;
 
         private void SfTreeView_ItemDragStarting(object sender, TreeViewItemDragStartingEventArgs e)
         {


### PR DESCRIPTION
Implemented:
* Copy & paste an array item within the same tab (is copy & pasting from different files/tabs desirable?)
* Duplicate array item (handles & value types work too)
* Dragging items rearranges them, holding control duplicates them with confirmation (previously was too easy to accidentally duplicate)

Fixed:
* Array index for identical primitives
* Array index width in the treeview & editor

Fixes #642, fixes #644 (possibly fixed earlier), and fixes #676