### PR TITLE
export .gradient files to .gradient.json

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -542,6 +542,38 @@ namespace WolvenKit.Modkit.RED4
                         }
                     }
                 }
+
+                if (Path.GetExtension(primaryDependencies[i]) == ".gradient")
+                {
+                    if (!TexturesList.Contains(primaryDependencies[i]))
+                    {
+                        var hash = FNV1A64HashAlgorithm.HashString(primaryDependencies[i]);
+                        foreach (var ar in archives)
+                        {
+                            if (ar.Files.ContainsKey(hash))
+                            {
+                                var ms = new MemoryStream();
+                                ExtractSingleToStream(ar, hash, ms);
+                                ms.Seek(0, SeekOrigin.Begin);
+
+                                TexturesList.Add(primaryDependencies[i]);
+                                var path = Path.Combine(matRepo, Path.ChangeExtension(primaryDependencies[i], ".gradient.json"));
+                                if (!File.Exists(path))
+                                {
+                                    if (!new FileInfo(path).Directory.Exists)
+                                    {
+                                        Directory.CreateDirectory(new FileInfo(path).Directory.FullName);
+                                    }
+                                    var hp = _wolvenkitFileService.ReadRed4File(ms);
+                                    var dto = new RedFileDto(hp);
+                                    var doc = RedJsonSerializer.Serialize(dto);
+                                    File.WriteAllText(path, doc);
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
             }
 
 


### PR DESCRIPTION
First part of enabling gradient texture imports in Blender. These are used in the gradient eye textures, for example.

See here for the plug-in pull request (PR#14): https://github.com/HitmanHimself/cp77research/pull/14