### PR TITLE
TreeView Drag & Drop, Copy & Paste Enhancements

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -26,7 +26,7 @@ namespace WolvenKit.ViewModels.Documents
 
         [Reactive] public RedDocumentViewModel File { get; set; }
 
-        public IRedType CopiedChunk;
+        public static IRedType CopiedChunk;
 
         public RDTDataViewModel(IRedType data, RedDocumentViewModel file)
         {

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1524,11 +1524,11 @@ namespace WolvenKit.ViewModels.Shell
         {
             if (Data is IRedCloneable irc)
             {
-                Tab.CopiedChunk = (IRedType)irc.DeepCopy();
+                RDTDataViewModel.CopiedChunk = (IRedType)irc.DeepCopy();
             }
             else
             {
-                Tab.CopiedChunk = Data;
+                RDTDataViewModel.CopiedChunk = Data;
             }
         }
 
@@ -1538,34 +1538,50 @@ namespace WolvenKit.ViewModels.Shell
         {
             if (Data is IRedCloneable irc)
             {
-                Parent.InsertChild(-1, (IRedType)irc.DeepCopy());
+                Parent.InsertChild(Parent.GetIndexOf(this) + 1, (IRedType)irc.DeepCopy());
             }
             else
             {
-                Parent.InsertChild(-1, Data);
+                Parent.InsertChild(Parent.GetIndexOf(this) + 1, Data);
+            }
+        }
+
+        public IRedArray ArraySelfOrParent
+        {
+            get
+            {
+                if (Parent.ResolvedData is IRedArray ira)
+                {
+                    return ira;
+                }
+                if (ResolvedData is IRedArray ira2)
+                {
+                    return ira2;
+                }
+                return null;
             }
         }
 
         public ICommand PasteChunkCommand { get; private set; }
-        private bool CanPasteChunk() => (IsArray || IsInArray) && Tab.CopiedChunk != null;
+        private bool CanPasteChunk() => (IsArray || IsInArray) && RDTDataViewModel.CopiedChunk != null && (ArraySelfOrParent?.InnerType.IsAssignableTo(RDTDataViewModel.CopiedChunk.GetType()) ?? true);
         private void ExecutePasteChunk()
         {
-            if (Tab.CopiedChunk == null)
+            if (RDTDataViewModel.CopiedChunk == null)
             {
                 return;
             }
             if (Parent.ResolvedData is IRedArray)
             {
-                if (Parent.InsertChild(-1, Tab.CopiedChunk))
+                if (Parent.InsertChild(Parent.GetIndexOf(this) + 1, RDTDataViewModel.CopiedChunk))
                 {
-                    Tab.CopiedChunk = null;
+                    RDTDataViewModel.CopiedChunk = null;
                 }
             }
             if (ResolvedData is IRedArray)
             {
-                if (InsertChild(-1, Tab.CopiedChunk))
+                if (InsertChild(-1, RDTDataViewModel.CopiedChunk))
                 {
-                    Tab.CopiedChunk = null;
+                    RDTDataViewModel.CopiedChunk = null;
                 }
             }
         }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1645,7 +1645,7 @@ namespace WolvenKit.ViewModels.Shell
                         {
                             index = pkg.Chunks.Count;
                         }
-                        pkg.Chunks.Add(rbc);
+                        pkg.Chunks.Insert(index, rbc);
                     }
                     else if (db.GetValue().Data is CR2WList list)
                     {
@@ -1707,5 +1707,7 @@ namespace WolvenKit.ViewModels.Shell
                 }
             }
         }
+
+        public static bool IsControlBeingHeld => Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl);
     }
 }

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -557,24 +557,31 @@
                         <Grid.RowDefinitions>
                             <RowDefinition />
                             <RowDefinition />
-                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <TextBlock
                             Grid.Row="0"
                             Margin="5,2,5,0"
                             VerticalAlignment="Center"
-                            Text="Duplicate item here:" />
+                            Text="Duplicate item to this index (release control to move)"
+                            Visibility="{Binding Data[0].Content.IsControlBeingHeld, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         <TextBlock
-                            Grid.Row="1"
-                            Margin="5,0,5,2"
+                            Grid.Row="0"
+                            Margin="5,2,5,0"
                             VerticalAlignment="Center"
-                            Foreground="{StaticResource WolvenKitTan}"
-                            Text="{Binding Data[0].Content.Type}" />
-                        <TextBlock
-                            Grid.Row="2"
-                            Margin="5,0,5,2"
-                            VerticalAlignment="Center"
-                            Text="{Binding Data[0].Content.Descriptor}" />
+                            Text="Move item to this index (hold control to duplicate)"
+                            Visibility="{Binding Data[0].Content.IsControlBeingHeld, Converter={StaticResource InvertBooleanVisibilityConverter}}" />
+                        <StackPanel Grid.Row="1" Orientation="Horizontal">
+                            <TextBlock
+                                Margin="5,0,5,2"
+                                VerticalAlignment="Center"
+                                Foreground="{StaticResource WolvenKitTan}"
+                                Text="{Binding Data[0].Content.Type}" />
+                            <TextBlock
+                                Margin="0,0,5,2"
+                                VerticalAlignment="Center"
+                                Text="{Binding Data[0].Content.Descriptor}" />
+
+                        </StackPanel>
                     </Grid>
                 </Border>
             </DataTemplate>

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -167,7 +167,7 @@ namespace WolvenKit.Views.Tools
                     }
                     else
                     {
-                        target.Parent.MoveChild(target.Parent.Properties.IndexOf(target) + (e.DropPosition == DropPosition.DropBelow ? 1 : 0), source.Data);
+                        target.Parent.MoveChild(target.Parent.Properties.IndexOf(target) + (e.DropPosition == DropPosition.DropBelow ? 1 : 0), source);
                     }
                         //if (target.Parent.Data is DataBuffer or SerializationDeferredDataBuffer)
                         //{

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -66,7 +66,7 @@ namespace WolvenKit.Views.Tools
 
         private void SfTreeView_ItemDragOver(object sender, TreeViewItemDragOverEventArgs e)
         {
-            e.DropPosition = DropPosition.None;
+            var allowDrop = false;
             if (sender is SfTreeView tv)
             {
                 if (e.DraggingNodes != null && e.DraggingNodes[0].Content is ChunkViewModel source)
@@ -75,7 +75,7 @@ namespace WolvenKit.Views.Tools
                     {
                         if (source == target)
                         {
-                            e.DropPosition = DropPosition.None;
+                            allowDrop = false;
                         }
                         //else if (source.CanBeDroppedOn(target))
                         //{
@@ -83,11 +83,11 @@ namespace WolvenKit.Views.Tools
                         //}
                         else if (source.Data is IRedType)
                         {
-                            if (IsControlBeingHeld)
+                            if (IsControlBeingHeld && !target.Parent.IsReadOnly)
                             {
                                 if (target.Parent.Data is IRedBufferPointer)
                                 {
-                                    e.DropPosition = DropPosition.DropBelow;
+                                    allowDrop = true;
                                 }
 
                                 if (target.Parent.Data is IRedArray arr)
@@ -96,22 +96,27 @@ namespace WolvenKit.Views.Tools
 
                                     if (arrayType == typeof(CArray<>))
                                     {
-                                        e.DropPosition = DropPosition.DropBelow;
+                                        allowDrop = true;
                                     }
 
                                     if (arrayType == typeof(CStatic<>) && arr.Count < arr.MaxSize)
                                     {
-                                        e.DropPosition = DropPosition.DropBelow;
+                                        allowDrop = true;
                                     }
                                 }
                             }
-                            else if (target.IsInArray)
+                            else if (target.IsInArray && !target.Parent.IsReadOnly)
                             {
-                                e.DropPosition = DropPosition.DropBelow;
+                                allowDrop = true;
                             }
                         }
                     }
                 }
+                if (e.DropPosition == DropPosition.DropAsChild || e.DropPosition == DropPosition.DropHere)
+                {
+                    e.DropPosition = DropPosition.DropBelow;
+                }
+                e.DropPosition = allowDrop ? e.DropPosition : DropPosition.None;
             }
             //if (e.Data.GetDataPresent(DataFormats.FileDrop))
             //{
@@ -156,13 +161,13 @@ namespace WolvenKit.Views.Tools
                             MessageBoxResult messageBoxResult = MessageBox.Show($"Duplicate {source.Data.GetType().Name} here?", "Duplicate Confirmation", MessageBoxButton.YesNo);
                             if (messageBoxResult == MessageBoxResult.Yes)
                             {
-                                target.Parent.InsertChild(target.Parent.Properties.IndexOf(target) + 1, (IRedType)irc.DeepCopy());
+                                target.Parent.InsertChild(target.Parent.Properties.IndexOf(target) + (e.DropPosition == DropPosition.DropBelow ? 1 : 0), (IRedType)irc.DeepCopy());
                             }
                         }
                     }
                     else
                     {
-                        target.Parent.MoveChild(target.Parent.Properties.IndexOf(target) + 1, source.Data);
+                        target.Parent.MoveChild(target.Parent.Properties.IndexOf(target) + (e.DropPosition == DropPosition.DropBelow ? 1 : 0), source.Data);
                     }
                         //if (target.Parent.Data is DataBuffer or SerializationDeferredDataBuffer)
                         //{


### PR DESCRIPTION
* Cleans-up the tooltip for dragging, shows the current action (duplicate or move), and note about using control to switch
* Allows copy & pasting and dragging between two open files (move & duplicate)
* Paste/duplicate after the selected item's index (pasting into array row itself puts it at the end)
* Allows items to be dragged above an item, instead of just below
