### PR TITLE
Added function/button to launch CP77 via Steam

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -139,6 +139,7 @@ namespace WolvenKit.ViewModels.Shell
             ShowSettingsCommand = new RelayCommand(ExecuteShowSettings, CanShowSettings);
 
             LaunchGameCommand = new RelayCommand(ExecuteLaunchGame, CanLaunchGame);
+            LaunchSteamGameCommand = new RelayCommand(ExecuteLaunchSteamGame, CanLaunchSteamGame);
 
             CloseModalCommand = new RelayCommand(ExecuteCloseModal, CanCloseModal);
             CloseOverlayCommand = new RelayCommand(ExecuteCloseOverlay, CanCloseOverlay);
@@ -505,6 +506,29 @@ namespace WolvenKit.ViewModels.Shell
             catch (Exception ex)
             {
                 _loggerService.Error("Launch: error launching game! Please check your executable path in Settings.");
+                _loggerService.Info($"Launch: error debug info: {ex.Message}");
+            }
+
+            _loggerService.Success("Game launching.");
+        }
+        public ICommand LaunchSteamGameCommand { get; private set; }
+        private bool CanLaunchSteamGame() => true;
+        private void ExecuteLaunchSteamGame()
+        {
+            try
+            {
+                var steamrunid = "steam://rungameid/1091500";
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = steamrunid,
+                    ErrorDialog = true,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                _loggerService.Error("Launch: Error! Please check if you have Steam installed, and a valid Steam installation of Cyberpunk 2077");
                 _loggerService.Info($"Launch: error debug info: {ex.Message}");
             }
 

--- a/WolvenKit/Views/Shell/RibbonView.xaml
+++ b/WolvenKit/Views/Shell/RibbonView.xaml
@@ -449,6 +449,18 @@
                             <TextBlock Text="Launch Game" Padding="5,0,0,0" />
                         </StackPanel>
                     </Button>
+                    <Separator Margin="6" />
+                    <Button x:Name="ToolbarLaunchSteamGameButton" Command="{Binding LaunchSteamGameCommand}" ToolTip="Launch Game - Did You Remember To Pack &amp; Install?">
+                        <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <iconPacks:PackIconCodicons Style="{StaticResource WolvenKitToolBarButtonIcon}"
+                                Foreground="{StaticResource WolvenKitYellow}"
+                                Padding="0,0,2,2"
+                                Kind="RunAll" />
+                            </Grid>
+                            <TextBlock Text="Launch Game (Steam)" Padding="5,0,0,0" />
+                        </StackPanel>
+                    </Button>
                     <Separator Margin="3" />
                     <TextBlock
                         Height="30"

--- a/WolvenKit/Views/Shell/RibbonView.xaml.cs
+++ b/WolvenKit/Views/Shell/RibbonView.xaml.cs
@@ -228,6 +228,10 @@ namespace WolvenKit.Views.Shell
                         view => view.ToolbarLaunchGameButton)
                     .DisposeWith(disposables);
                 this.BindCommand(ViewModel,
+                    viewModel => viewModel._mainViewModel.LaunchSteamGameCommand,
+                    view => view.ToolbarLaunchSteamGameButton)
+                    .DisposeWith(disposables);
+                this.BindCommand(ViewModel,
                         viewModel => viewModel._mainViewModel.ShowSettingsCommand,
                         view => view.ToolbarSettingsButton)
                     .DisposeWith(disposables);


### PR DESCRIPTION
Adds a function and a button to the shell next to the existing "Launch Game" button that runs the default steam id for Cyberpunk 2077. Not fully added to the ribbon view however as i don't know how to do that. Seemingly "RibbonView.g.i.cs" would have to be generated again.
I hardly know what I'm doing so please be careful with this (and someone would have to add it to the ribbon view properly)
