### PR TITLE
LaunchCommand/LaunchOptions In Settings, Used By Launch Button (Plus Versioned Settings Support..)

### DIFF
--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -10,45 +10,46 @@ namespace WolvenKit.Functionality.Services
     {
         #region Properties
 
-        bool CheckForUpdates { get; set; }
+        // I wish there was a better way to inject deps
+        // than creating unnecessary interfaces.
+        public string SettingsVersion { get; }
+        public bool CheckForUpdates { get; set; }
+        public EUpdateChannel UpdateChannel { get; set; }
+        public bool ShowGuidedTour { get; set; }
+        public string ThemeAccentString { get; set; }
+        public string CP77GameDirPath { get; set; }
+        public string CP77ExecutablePath { get; set; }
+        public string CP77LaunchCommand { get; set; }
+        public string CP77LaunchOptions { get; set; }
+        public bool ShowFilePreview { get; set; }
+        public string ReddbHash { get; set; }
+        public string MaterialRepositoryPath { get; set; }
+        public string W3ExecutablePath { get; set; }
+        public string WccLitePath { get; set; }
 
-        string ThemeAccentString { get; set; }
-
-        // red 4
-
-        string ReddbHash { get; set; }
-
-        string CP77ExecutablePath { get; set; }
-
-        bool ShowFilePreview { get; set; }
-
-        // red 3
-
-        string W3ExecutablePath { get; set; }
-
-        string WccLitePath { get; set; }
-
-        // TreeView
-
-        bool TreeViewGroups { get; set; }
-
-        uint TreeViewGroupSize { get; set; }
+        public bool TreeViewGroups { get; set; }
+        public uint TreeViewGroupSize { get; set; }
 
         #endregion Properties
     }
 
     public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
     {
+        #region lifecyclestuff
 
-        public EUpdateChannel UpdateChannel { get; set; }
+        void Save();
+        void Bounce();
+
+        bool IsHealthy();
+
+
+        #endregion lifecyclestuff
+
+        #region settingspropertystuff
+
         public bool IsUpdateAvailable { get; set; }
 
-        bool ShowGuidedTour { get; set; }
-
-        string MaterialRepositoryPath { get; set; }
-
         string GetRED4OodleDll();
-
 
         string GetW3GameContentDir();
 
@@ -58,9 +59,13 @@ namespace WolvenKit.Functionality.Services
 
         string GetW3GameRootDir();
 
-        public string GetRED4GameExecutablePath();
-
         string GetRED4GameRootDir();
+
+        string GetRED4GameExecutablePath();
+
+        string GetRED4GameLaunchCommand();
+
+        string GetRED4GameLaunchOptions();
 
         public string GetRED4GameModDir();
 
@@ -167,7 +172,6 @@ namespace WolvenKit.Functionality.Services
             return dir;
         }
 
-        void Save();
 
         Color GetThemeAccent();
 
@@ -175,7 +179,6 @@ namespace WolvenKit.Functionality.Services
 
         string GetVersionNumber();
 
-        bool IsHealthy();
-
+        #endregion settingspropertystuff
     }
 }

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -3,11 +3,14 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Windows.Media;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using Splat;
 using WolvenKit.Common;
+using WolvenKit.Common.Services;
 using WolvenKit.Core;
 
 namespace WolvenKit.Functionality.Services
@@ -18,6 +21,8 @@ namespace WolvenKit.Functionality.Services
     public class SettingsManager : ReactiveObject, ISettingsManager
     {
         #region fields
+
+        private readonly ILoggerService _loggerService;
 
         private bool _isLoaded;
 
@@ -32,6 +37,7 @@ namespace WolvenKit.Functionality.Services
         /// </summary>
         public SettingsManager()
         {
+            _loggerService = Locator.Current.GetService<ILoggerService>();
             _assemblyVersion = CommonFunctions.GetAssemblyVersion(Constants.AssemblyName).ToString();
 
             _ = this.WhenAnyPropertyChanged(
@@ -40,7 +46,10 @@ namespace WolvenKit.Functionality.Services
                 nameof(MaterialRepositoryPath),
                 nameof(ThemeAccentString),
                 nameof(CheckForUpdates),
+                nameof(CP77GameDirPath),
                 nameof(CP77ExecutablePath),
+                nameof(CP77LaunchCommand),
+                nameof(CP77LaunchOptions),
                 nameof(ShowFilePreview),
                 nameof(ReddbHash),
                 nameof(TreeViewGroups),
@@ -57,9 +66,75 @@ namespace WolvenKit.Functionality.Services
 
         #endregion constructors
 
+        #region lifecycle
+
+        public static SettingsManager Load()
+        {
+            var dto = LoadFromFile();
+
+            var settings =
+                dto != null
+                ? dto.ToSettingsManager()
+                : new SettingsManager();
+
+            settings._isLoaded = true;
+            return settings;
+        }
+
+        public void Save()
+        {
+            if (!_isLoaded)
+            {
+                return;
+            }
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+            };
+            var json = JsonSerializer.Serialize(new SettingsDto(this), options);
+            File.WriteAllText(GetConfigurationPath(), json);
+            // _loggerService.Info("Settings saved.");
+        }
+
+        public void Bounce()
+        {
+            Save();
+            var bouncedSettings = SettingsManager.LoadFromFile();
+            bouncedSettings.ReconfigureSettingsManager(this);
+        }
+
+        private static SettingsDto LoadFromFile()
+        {
+            try
+            {
+                if (File.Exists(GetConfigurationPath()))
+                {
+                    var jsonString = File.ReadAllText(GetConfigurationPath());
+                    var dto = JsonSerializer.Deserialize<SettingsDto>(jsonString);
+
+                    return dto;
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            return null;
+        }
+
+        #endregion lifecycle
+
         #region properties
 
         #region general
+
+        [Category("General")]
+        [Display(Name = "Settings Version")]
+        [Reactive]
+        [Browsable(false)]
+        public string SettingsVersion { get; set; }
 
         [Category("General")]
         [Display(Name = "Show Guided Tour")]
@@ -90,9 +165,25 @@ namespace WolvenKit.Functionality.Services
         #region red4
 
         [Category("Cyberpunk")]
+        [Display(Name = "Game Directory Path")]
+        [Reactive]
+        public string CP77GameDirPath { get; set; }
+
+        [Category("Cyberpunk")]
         [Display(Name = "Game Executable Path (.exe)")]
         [Reactive]
         public string CP77ExecutablePath { get; set; }
+
+        // This should be conditionally updated by CP77ExecutablePath, but not implemented..
+        [Category("Cyberpunk")]
+        [Display(Name = "Launch Command (executable or other command (e.g. steam:// uri)")]
+        [Reactive]
+        public string CP77LaunchCommand { get; set; }
+
+        [Category("Cyberpunk")]
+        [Display(Name = "Launch Options or Command-Line Parameters To Launch Command")]
+        [Reactive]
+        public string CP77LaunchOptions { get; set; }
 
         [Category("Cyberpunk")]
         [Display(Name = "Depot Path")]
@@ -158,18 +249,13 @@ namespace WolvenKit.Functionality.Services
 
         #region red4
 
-        public string GetRED4GameRootDir()
-        {
-            if (string.IsNullOrEmpty(CP77ExecutablePath))
-            {
-                return null;
-            }
-
-            var fi = new FileInfo(CP77ExecutablePath);
-            return fi.Directory is { Parent: { Parent: { } } } ? Path.Combine(fi.Directory.Parent.Parent.FullName) : null;
-        }
+        public string GetRED4GameRootDir() => CP77GameDirPath;
 
         public string GetRED4GameExecutablePath() => CP77ExecutablePath;
+
+        public string GetRED4GameLaunchCommand() => CP77LaunchCommand;
+
+        public string GetRED4GameLaunchOptions() => CP77LaunchOptions;
 
         public string GetRED4GameModDir()
         {
@@ -205,49 +291,6 @@ namespace WolvenKit.Functionality.Services
 
         public bool IsHealthy() => File.Exists(CP77ExecutablePath) && File.Exists(GetRED4OodleDll());
 
-        public static SettingsManager Load()
-        {
-            SettingsManager config = null;
-            try
-            {
-                if (File.Exists(GetConfigurationPath()))
-                {
-                    var jsonString = File.ReadAllText(GetConfigurationPath());
-                    var dto = JsonSerializer.Deserialize<SettingsDto>(jsonString);
-                    if (dto != null)
-                    {
-                        config = dto.FromDto();
-                    }
-                }
-            }
-            catch (Exception)
-            {
-            }
-
-            // Defaults
-            config ??= new SettingsManager
-            {
-
-            };
-
-            config._isLoaded = true;
-            return config;
-        }
-
-        public void Save()
-        {
-            if (!_isLoaded)
-            {
-                return;
-            }
-
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            };
-            var json = JsonSerializer.Serialize(new SettingsDto(this), options);
-            File.WriteAllText(GetConfigurationPath(), json);
-        }
 
         #endregion methods
     }
@@ -264,7 +307,10 @@ namespace WolvenKit.Functionality.Services
             UpdateChannel = settings.UpdateChannel;
             ShowGuidedTour = settings.ShowGuidedTour;
             ThemeAccentString = settings.ThemeAccentString;
+            CP77GameDirPath = settings.CP77GameDirPath;
             CP77ExecutablePath = settings.CP77ExecutablePath;
+            CP77LaunchCommand = settings.CP77LaunchCommand;
+            CP77LaunchOptions = settings.CP77LaunchOptions;
             ShowFilePreview = settings.ShowFilePreview;
             ReddbHash = settings.ReddbHash;
             MaterialRepositoryPath = settings.MaterialRepositoryPath;
@@ -273,13 +319,22 @@ namespace WolvenKit.Functionality.Services
 
             TreeViewGroups = settings.TreeViewGroups;
             TreeViewGroupSize = settings.TreeViewGroupSize;
+
+            if (settings.SettingsVersion != "2")
+            {
+                MigrateFromV1ToV2();
+            }
         }
 
+        public string SettingsVersion { get; set;  }
         public bool CheckForUpdates { get; set; }
         public EUpdateChannel UpdateChannel { get; set; }
         public bool ShowGuidedTour { get; set; }
         public string ThemeAccentString { get; set; }
+        public string CP77GameDirPath { get; set; }
         public string CP77ExecutablePath { get; set; }
+        public string CP77LaunchCommand { get; set; }
+        public string CP77LaunchOptions { get; set; }
         public bool ShowFilePreview { get; set; }
         public string ReddbHash { get; set; }
         public string MaterialRepositoryPath { get; set; }
@@ -289,25 +344,60 @@ namespace WolvenKit.Functionality.Services
         public bool TreeViewGroups { get; set; }
         public uint TreeViewGroupSize { get; set; }
 
-        public SettingsManager FromDto()
+        public SettingsManager ReconfigureSettingsManager(SettingsManager settingsManager)
+        {
+            if (SettingsVersion != "2")
+            {
+                MigrateFromV1ToV2();
+            }
+
+            settingsManager.SettingsVersion = SettingsVersion;
+            settingsManager.CheckForUpdates = CheckForUpdates;
+            settingsManager.UpdateChannel = UpdateChannel;
+            settingsManager.ShowGuidedTour = ShowGuidedTour;
+            settingsManager.ThemeAccentString = ThemeAccentString;
+            settingsManager.CP77GameDirPath = CP77GameDirPath;
+            settingsManager.CP77ExecutablePath = CP77ExecutablePath;
+            settingsManager.CP77LaunchCommand = CP77LaunchCommand;
+            settingsManager.CP77LaunchOptions = CP77LaunchOptions;
+            settingsManager.ShowFilePreview = ShowFilePreview;
+            settingsManager.ReddbHash = ReddbHash;
+            settingsManager.MaterialRepositoryPath = MaterialRepositoryPath;
+            settingsManager.W3ExecutablePath = W3ExecutablePath;
+            settingsManager.WccLitePath = WccLitePath;
+
+            settingsManager.TreeViewGroups = TreeViewGroups;
+            settingsManager.TreeViewGroupSize = TreeViewGroupSize;
+
+            return settingsManager;
+        }
+
+        public SettingsManager ToSettingsManager()
         {
             var config = new SettingsManager()
             {
-                CheckForUpdates = CheckForUpdates,
-                UpdateChannel = UpdateChannel,
-                ShowGuidedTour = ShowGuidedTour,
-                ThemeAccentString = ThemeAccentString,
-                CP77ExecutablePath = CP77ExecutablePath,
-                ShowFilePreview = ShowFilePreview,
-                ReddbHash = ReddbHash,
-                MaterialRepositoryPath = MaterialRepositoryPath,
-                W3ExecutablePath = W3ExecutablePath,
-                WccLitePath = WccLitePath,
-
-                TreeViewGroups = TreeViewGroups,
-                TreeViewGroupSize = TreeViewGroupSize,
             };
-            return config;
+
+            return ReconfigureSettingsManager(config);
+        }
+
+        // Rather than create all kinds of new interfaces etc.,
+        // always maintain the DTO as the current, and apply
+        // all migrations in order for a controlled upgrade.
+        private void MigrateFromV1ToV2()
+        {
+            if (!string.IsNullOrWhiteSpace(CP77ExecutablePath))
+            {
+                var fi = new FileInfo(CP77ExecutablePath);
+
+                CP77GameDirPath = fi.Directory is { Parent.Parent: { } }
+                    ? Path.Combine(fi.Directory.Parent.Parent.FullName)
+                    : null;
+
+                CP77LaunchCommand = CP77ExecutablePath;
+            }
+
+            SettingsVersion = "2";
         }
     }
 }

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -493,6 +493,7 @@ namespace WolvenKit.ViewModels.Shell
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = _settingsManager.GetRED4GameLaunchCommand(),
+                    Arguments = _settingsManager.GetRED4GameLaunchOptions() ?? "",
                     ErrorDialog = true,
                     UseShellExecute = true,
                 });

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -490,14 +490,11 @@ namespace WolvenKit.ViewModels.Shell
         {
             try
             {
-                var exe = Path.GetFullPath(_settingsManager.GetRED4GameExecutablePath());
-
                 Process.Start(new ProcessStartInfo
                 {
-                    FileName = exe,
+                    FileName = _settingsManager.GetRED4GameLaunchCommand(),
                     ErrorDialog = true,
                     UseShellExecute = true,
-                    WorkingDirectory = exe
                 });
             }
             catch (Exception ex)

--- a/WolvenKit.App/ViewModels/Wizards/FirstSetupWizardViewModel.cs
+++ b/WolvenKit.App/ViewModels/Wizards/FirstSetupWizardViewModel.cs
@@ -55,35 +55,12 @@ namespace WolvenKit.ViewModels.Wizards
             OpenCP77GamePathCommand = new RelayCommand(ExecuteOpenCP77GamePath, CanOpenGamePath);
             OpenDepotPathCommand = new RelayCommand(ExecuteOpenDepotPath, CanOpenDepotPath);
 
+            TryToFindCP77ExecutableAutomatically();
 
-
-            //OpenW3GamePathCommand = new RelayCommand(ExecuteOpenGamePath, CanOpenGamePath);
-            //OpenWccPathCommand = new RelayCommand(ExecuteOpenWccPath, CanOpenWccPath);
-            //OpenModDirectoryCommand = new RelayCommand(ExecuteOpenMod, CanOpenMod);
-            //OpenDlcDirectoryCommand = new RelayCommand(ExecuteOpenDlc, CanOpenDlc);
-
-
-            CheckForUpdates = _settingsManager.CheckForUpdates;
-            // W3ExePath = _settingsManager.W3ExecutablePath;
-            CP77ExePath = _settingsManager.CP77ExecutablePath;
-            //WccLitePath = _settingsManager.WccLitePath;
-
-            MaterialDepotPath = _settingsManager.MaterialRepositoryPath;
-
-            // automatically scan the registry for exe paths for wcc and tw3
-            // if either text field is empty
-            if (/*string.IsNullOrEmpty(W3ExePath) || string.IsNullOrEmpty(WccLitePath) ||*/ string.IsNullOrEmpty(CP77ExePath))
+            MaterialDepotPath = Path.Combine(ISettingsManager.GetAppData(), "MaterialDepot");
+            if (!Directory.Exists(MaterialDepotPath))
             {
-                exeSearcherSlave_DoWork();
-            }
-
-            if (string.IsNullOrEmpty(MaterialDepotPath))
-            {
-                MaterialDepotPath = Path.Combine(ISettingsManager.GetAppData(), "MaterialDepot");
-                if (!Directory.Exists(MaterialDepotPath))
-                {
-                    Directory.CreateDirectory(MaterialDepotPath);
-                }
+                Directory.CreateDirectory(MaterialDepotPath);
             }
         }
 
@@ -153,20 +130,10 @@ namespace WolvenKit.ViewModels.Wizards
 
         private void ExecuteFinish()
         {
-
-            _settingsManager.CheckForUpdates = CheckForUpdates;
-            // _settingsManager.W3ExecutablePath = W3ExePath;
             _settingsManager.CP77ExecutablePath = CP77ExePath;
-            //_settingsManager.WccLitePath = WccLitePath;
             _settingsManager.MaterialRepositoryPath = MaterialDepotPath;
-
-            _settingsManager.Save();
-
-
+            _settingsManager.Bounce();
         }
-
-
-
 
 
         public ICommand OpenDepotPathCommand { get; private set; }
@@ -278,7 +245,7 @@ namespace WolvenKit.ViewModels.Wizards
 
         private delegate void StrDelegate(string value);
 
-        private void exeSearcherSlave_DoWork()
+        private void TryToFindCP77ExecutableAutomatically()
         {
             const string uninstallkey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\";
             const string uninstallkey2 = "SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\";

--- a/WolvenKit/Views/HomePage/Pages/SettingsPageView.xaml.cs
+++ b/WolvenKit/Views/HomePage/Pages/SettingsPageView.xaml.cs
@@ -65,11 +65,14 @@ namespace WolvenKit.Views.HomePage.Pages
                     e.Cancel = true;
                     break;
             }
-
+            // Generate special editors for the properties for which default is not ok
             if (e.OriginalSource is PropertyItem { } propertyItem)
             {
                 switch (propertyItem.DisplayName)
                 {
+                    case nameof(ISettingsDto.CP77GameDirPath):
+                        propertyItem.Editor = new Controls.SingleFolderPathEditor();
+                        break;
                     case nameof(ISettingsDto.CP77ExecutablePath):
                         propertyItem.Editor = new Controls.SingleFilePathEditor();
                         break;


### PR DESCRIPTION
New stuffs:

- SettingsDto is versioned; the idea is to keep the Dto always on the current version but maintain a set of migrations that are always run on load/save. When eventually there's a v3 settings, then for any v2 settings we should run MigrateV2ToV3 (which does whatever fixes) and for any undefined/v1 settings it's MigrateV1ToV2, then MigrateV2ToV3.
- v2 settings include LaunchCommand and LaunchOptions to support the thing I was ACTUALLY doing, which is enabling using alternative launch stuffs for the Launch Button (as req'd in #735 and was part of #718)

Fixed stuffs:

- TweakDB loading could crash on startup on first run because settings might not exist at that point yet

Pictures:

- Initial setup ![image](https://user-images.githubusercontent.com/13802421/159192117-77c2460e-9732-4e63-9bf4-71ad32cbf5e7.png)

- With options (don't recommend this particular one) ![image](https://user-images.githubusercontent.com/13802421/159194680-d97a50c1-ffd3-45b8-8893-241265c2c632.png)


Closes #741 