### PR TITLE
RDTMeshViewModel: fix for meshes that start with a number

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -398,7 +398,7 @@ namespace WolvenKit.ViewModels.Documents
         {
             var group = new MeshComponent()
             {
-                Name = $"{model.Name}",
+                Name = char.IsDigit(model.Name[0]) ? $"_{model.Name}" : $"{model.Name}",
                 AppearanceName = model.AppearanceName,
                 Transform = model.Transform,
                 IsRendering = model.IsEnabled,


### PR DESCRIPTION
If a mesh starts with a number, WolvenKit will crash when previewed. XAML names have restrictions "[m]ost notably, a Name must start with a letter or the underscore character (_), and must contain only letters, digits, or underscores"

Source: https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.name?view=windowsdesktop-6.0

Example of mesh that crashes: "base\entities\cameras\3dmap\3dmap_roads.mesh"

Fixed:
- prepend an underscore character (_) to the name of a mesh that begins with a number (occurs in preview only)
