### PR TITLE
Clipboard error fix - Clipboard crash #744

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -340,7 +340,7 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand CopyRelPathCommand { get; private set; }
         private bool CanCopyRelPath() => RightSelectedItem != null; // _projectManager.ActiveProject != null && RightSelectedItem != null;
-        private void ExecuteCopyRelPath() => Clipboard.SetText(RightSelectedItem.FullName);
+        private void ExecuteCopyRelPath() => Clipboard.SetDataObject(RightSelectedItem.FullName);
         public ReactiveCommand<Unit, Unit> ExpandAll { get; set; }
         public ReactiveCommand<Unit, Unit> CollapseAll { get; set; }
         public ReactiveCommand<Unit, Unit> Expand { get; set; }

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -340,7 +340,7 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand CopyRelPathCommand { get; private set; }
         private bool CanCopyRelPath() => RightSelectedItem != null; // _projectManager.ActiveProject != null && RightSelectedItem != null;
-        private void ExecuteCopyRelPath() => Clipboard.SetDataModel(RightSelectedItem.FullName);
+        private void ExecuteCopyRelPath() => Clipboard.SetText(RightSelectedItem.FullName);
         public ReactiveCommand<Unit, Unit> ExpandAll { get; set; }
         public ReactiveCommand<Unit, Unit> CollapseAll { get; set; }
         public ReactiveCommand<Unit, Unit> Expand { get; set; }

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -340,7 +340,7 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand CopyRelPathCommand { get; private set; }
         private bool CanCopyRelPath() => RightSelectedItem != null; // _projectManager.ActiveProject != null && RightSelectedItem != null;
-        private void ExecuteCopyRelPath() => Clipboard.SetText(RightSelectedItem.FullName);
+        private void ExecuteCopyRelPath() => Clipboard.SetDataModel(RightSelectedItem.FullName);
         public ReactiveCommand<Unit, Unit> ExpandAll { get; set; }
         public ReactiveCommand<Unit, Unit> CollapseAll { get; set; }
         public ReactiveCommand<Unit, Unit> Expand { get; set; }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -178,14 +178,14 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand CopyFileCommand { get; private set; }
         private bool CanCopyFile() => _projectManager.ActiveProject != null && SelectedItem != null;
-        private void CopyFile() => Clipboard.SetText(SelectedItem.FullName);
+        private void CopyFile() => Clipboard.SetDataObject(SelectedItem.FullName);
 
         /// <summary>
         /// Copies relative path of node.
         /// </summary>
         public ICommand CopyRelPathCommand { get; private set; }
         private bool CanCopyRelPath() => _projectManager.ActiveProject != null && SelectedItem != null;
-        private void ExecuteCopyRelPath() => Clipboard.SetText(FileModel.GetRelativeName(SelectedItem.FullName, ActiveMod));
+        private void ExecuteCopyRelPath() => Clipboard.SetDataObject(FileModel.GetRelativeName(SelectedItem.FullName, ActiveMod));
 
         /// <summary>
         /// Reimports the game file to replace the current one


### PR DESCRIPTION
# Pull request template

Clipboard crash #744 fix

Implemented:
Clipboard SetText fails whereas SetDataObject does not

Fixed:
Changed Clipboard.SetText to Clipboard.SetDataObject

See https://stackoverflow.com/questions/44538513/clipboard-settext-fails-whereas-setdataobject-does-not#:~:text=From%20MSDN-,Clipboard.,adds%20text%20data%20to%20it.
