### PR TITLE
Search Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+# VSCode
+.vscode
+
 #macOS
 .DS_Store
 

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -548,21 +548,20 @@ namespace WolvenKit.ViewModels.Tools
                         _ => searchRefinement
                     })
                     .Select(AsMatchFunctions)
-                    .Select(archive =>
-                    archive)
                     .ToArray();
 
-            // Maybe we could avoid reconnecting every time? Dunno if it makes a difference
-            var gameFiles =
-                _archiveManager
-                    .Archives
-                    .Connect()
-                    .Select(archive =>
-                    archive)
+            var gameFilesOrMods =
+                _archiveManager.IsModBrowserActive
+                ? _archiveManager.ModArchives
+                : _archiveManager.Archives;
+
+            var filesToSearch =
+                gameFilesOrMods
+                    .Connect()   // Maybe we could avoid reconnecting every time? Dunno if it makes a difference
                     .TransformMany((archive => archive.Files.Values), (fileInArchive => fileInArchive.Key));
 
             var filesMatchingQuery =
-                gameFiles
+                filesToSearch
                     .Filter((file) =>
                         searchAsSequentialRefinements.All(refinement => refinement.Match(file)));
 

--- a/WolvenKit.App/WolvenKit.App.csproj
+++ b/WolvenKit.App/WolvenKit.App.csproj
@@ -77,6 +77,7 @@
     <PackageReference Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.20.2" />
     <PackageReference Include="gpm.Installer" Version="0.2.4" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+    <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="Syncfusion.SfTreeView.WPF" Version="19.4.0.38" />
     <PackageReference Include="WinCopies.WindowsAPICodePack" Version="2.9.3" />

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -68,8 +68,6 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
                     <Button
@@ -115,46 +113,12 @@
                         Grid.Column="2"
                         Margin="5,0,0,0"
                         VerticalAlignment="Top"
-                        hc:InfoElement.Placeholder="Search all game files: (e.g. judy kind:mesh,ent)"
+                        hc:InfoElement.Placeholder="Search all game or mod files, e.g. game !quest judy .ent|.app|.mesh"
                         FlowDirection="LeftToRight"
                         SearchStarted="FileSearchBar_SearchStarted"
                         ShowClearButton="False"
                         Style="{StaticResource SearchBarPlus}" />
 
-                    <Viewbox
-                        Grid.Column="3"
-                        Width="30"
-                        Height="30"
-                        Margin="-35,0,0,0">
-                        <ToggleButton IsChecked="{Binding IsRegexSearchEnabled}" ToolTip="Toggle Regex">
-
-                            <ToggleButton.Style>
-                                <Style BasedOn="{StaticResource {x:Type ToggleButton}}" TargetType="ToggleButton">
-                                    <Style.Triggers>
-                                        <Trigger Property="IsChecked" Value="True">
-                                            <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
-                                        </Trigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ToggleButton.Style>
-
-                            <iconPacks:PackIconCodicons Kind="Regex" />
-
-                        </ToggleButton>
-                    </Viewbox>
-
-                    <hc:SearchBar
-                        x:Name="OptionsSearchBar"
-                        Grid.Column="4"
-                        Margin="10,0,0,0"
-                        VerticalAlignment="Top"
-                        hc:InfoElement.Placeholder="(e.g. *.ent, base/**/judy)"
-                        hc:InfoElement.Title="Files to include: "
-                        hc:InfoElement.TitlePlacement="Left"
-                        FlowDirection="LeftToRight"
-                        SearchStarted="FileSearchBar_SearchStarted"
-                        ShowClearButton="True"
-                        Style="{StaticResource SearchBarPlus}" />
 
                 </Grid>
 

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -68,10 +68,6 @@ namespace WolvenKit.Views.Tools
                       viewModel => viewModel.SearchBarText,
                       view => view.FileSearchBar.Text)
                   .DisposeWith(disposables);
-                this.Bind(ViewModel,
-                        viewModel => viewModel.OptionsSearchBarText,
-                        view => view.OptionsSearchBar.Text)
-                    .DisposeWith(disposables);
 
                 // left navigation
                 this.OneWayBind(ViewModel,


### PR DESCRIPTION
Generally:

- Search syntax unified a bit, improved (?) syntax and filtering (see below)
- Search game files or mods based on mod toggle in Asset Browser
- Removed secondary search bar, there's just one
- Basic error handling + regexp timeouts

Search syntax:

- Search is a sequential filter split on ` > `, i.e. you can do `judy > quest` to _first_ match `judy` and then in those results `quest`. (Alternative would be `quest judy` because quest is first in the path, but it might be more ergonomic to just tack on further refinements rather than modify the earlier.)
- Spaces to split 'terms', anything allowed to match between terms. I.e. `quest judy` => `quest.*?judy`.
- Partial match anything anywhere. Term `ma` will match a whole lot, e.g. `../market/.../..`, `../machete.xbm` and whatever.
- File extension matching because it's just strings? `.ent` will match, also mid-path, but who does that?
- OR logic like `.app|.ent` (no spaces allowed, currently)
- Exclusion like `judy !shoes .app|.ent|.mesh` or `judy .app|.ent|.mesh > !shoes` if you want to match out of order. Works on extensions too since, again, they're just strings
- You can probably still write most regexps, just don't leave whitespace in them