### PR TITLE
Fix file path separator for Linux during uncook

### DIFF
--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -57,7 +57,7 @@ namespace WolvenKit.Modkit.RED4
                     relFileFullName += ".bin";
                 }
 
-                var mainFileInfo = new FileInfo(Path.Combine(outDir.FullName, $"{relFileFullName}"));
+                var mainFileInfo = new FileInfo(Path.Combine(outDir.FullName, $"{relFileFullName.Replace('\\', Path.DirectorySeparatorChar)}"));
 
                 // write mainFile
                 if (!WolvenTesting.IsTesting)
@@ -211,7 +211,7 @@ namespace WolvenKit.Modkit.RED4
         /// <returns></returns>
         private bool UncookBuffers(Stream cr2wStream, string relPath, GlobalExportArgs settings, DirectoryInfo rawOutDir, ECookedFileFormat[] forcebuffers = null)
         {
-            var outfile = new FileInfo(Path.Combine(rawOutDir.FullName, relPath));
+            var outfile = new FileInfo(Path.Combine(rawOutDir.FullName, $"{relPath.Replace('\\', Path.DirectorySeparatorChar)}"));
             if (outfile.Directory == null)
             {
                 return false;


### PR DESCRIPTION
Fixes the path separators for Linux when performing an uncook operation with WolvenKit.CLI. Without the change, single files are created with the literal name of the relative path in the archives, rather than creating a directory structure.

Confirmed to still work on Windows as well.