### PR TITLE
🐛 Asset Search Requires Type Prefix For Hash Search

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -478,11 +478,13 @@ namespace WolvenKit.ViewModels.Tools
 
         private readonly record struct CyberSearch(Func<IGameFile, bool> Match, SearchRefinement SourceRefinement);
 
+        // Term to refinement pattern conversion regexps
+
         private static readonly RegexOptions RegexpOpts = RegexOptions.Compiled | RegexOptions.IgnoreCase;
         private static readonly TimeSpan RegexpSafetyTimeout = TimeSpan.FromSeconds(60);
 
         private static readonly Regex RefinementSeparator = new("\\s+>\\s+", RegexpOpts, RegexpSafetyTimeout);
-        private static readonly Regex Hash = new("^(hash:)?(?<num>\\d+)$", RegexpOpts, RegexpSafetyTimeout);
+        private static readonly Regex Hash = new("^hash:(?<num>\\d+)$", RegexpOpts, RegexpSafetyTimeout);
         private static readonly Regex Whitespace = new("\\s+", RegexpOpts, RegexpSafetyTimeout);
         private static readonly Regex Or = new("\\|", RegexpOpts, RegexpSafetyTimeout);
         private static readonly Regex Negation = new("^(?'Open'\\(\\?:)*\\!(?<term>.+?)(?'Close-Open'\\))*$", RegexpOpts, RegexpSafetyTimeout);


### PR DESCRIPTION
Hash search requires `hash:` prefix like `hash:123455633`. Otherwise numbers are handled like any other substring.

Closes #804 
