### PR TITLE
WolvenKIT.CLI: Fix System.IO.IOException when batch export meshes with materials

### DIFF
--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -67,9 +67,13 @@ namespace WolvenKit.Modkit.RED4
                         Directory.CreateDirectory(mainFileInfo.Directory.FullName);
                     }
 
-                    using var fs = new FileStream(mainFileInfo.FullName, FileMode.Create, FileAccess.Write);
-                    cr2WStream.Seek(0, SeekOrigin.Begin);
-                    cr2WStream.CopyTo(fs);
+                    // prevents batch extract to create write conflicts when a single file is referrenced by multiple items
+                    if (!File.Exists(mainFileInfo.FullName))
+                    {
+                        using var fs = new FileStream(mainFileInfo.FullName, FileMode.Create, FileAccess.Write);
+                        cr2WStream.Seek(0, SeekOrigin.Begin);
+                        cr2WStream.CopyTo(fs);
+                    }
                 }
 
                 #endregion unbundle main file


### PR DESCRIPTION
# Description

This PR is fixing an issue with the Wolvenkit CLI.
When doing a batch export of meshes with materials, any meshes which references the same material than another mesh has a high chance of failing to be correctly extracted.
Here is the stacktrace that this PR is fixing:

```
[ 0: Error       ] - base\environment\decoration\unique\quest\q114\q114_blockade_a_dst\q114_blockade_a_dst_dynamic.mesh - The process cannot access the file 'G:\MaterialDepot\base\surfaces\materials\concrete\concrete_new\concrete_new_clean_01_300.mltemplate' because it is being used by another process.
[ 0: Error       ] - ========================
System.IO.IOException: The process cannot access the file 'G:\MaterialDepot\base\surfaces\materials\concrete\concrete_new\concrete_new_clean_01_300.mltemplate' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
   at WolvenKit.Modkit.RED4.ModTools.UncookSingle(Archive archive, UInt64 hash, DirectoryInfo outDir, GlobalExportArgs args, DirectoryInfo rawOutDir, ECookedFileFormat[] forcebuffers) in E:\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 70
   at WolvenKit.Modkit.RED4.ModTools.ParseMaterials(CR2WFile cr2w, Stream meshStream, FileInfo outfile, List`1 archives, String matRepo, EUncookExtension eUncookExtension) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 526
   at WolvenKit.Modkit.RED4.ModTools.ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List`1 archives, String matRepo, EUncookExtension eUncookExtension, Boolean isGLBinary, Boolean LodFilter) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 51
   at WolvenKit.Modkit.RED4.ModTools.HandleMesh(Stream cr2wStream, FileInfo cr2wFileName, MeshExportArgs meshargs) in E:\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 489
   at WolvenKit.Modkit.RED4.ModTools.UncookBuffers(Stream cr2wStream, String relPath, GlobalExportArgs settings, DirectoryInfo rawOutDir, ECookedFileFormat[] forcebuffers) in E:\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 287
========================
```

# Implemented solution

As suggested by @dragonzkiller, I added a check to skip the extraction of the files, if they already have been extracted.