### PR TITLE
Random fixes

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -464,7 +464,12 @@ namespace WolvenKit.ViewModels.Tools
             CollectionAvailableItems.Clear();
             if (_archiveManager != null)
             {
-                CollectionAvailableItems.AddRange(_archiveManager.GetGroupedFiles()[$".{fetchExtension}"].Select(_ => new CollectionItemViewModel(_)));
+                CollectionAvailableItems.AddRange(_archiveManager
+                    .GetGroupedFiles()[$".{fetchExtension}"]
+                    .Select(_ => new CollectionItemViewModel(_))
+                    .GroupBy(x => x.Name)
+                    .Select(x => x.First())
+                );
             }
         }
 

--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -614,7 +614,11 @@ namespace WolvenKit.ViewModels.Tools
                         success = await ImportSingle(item);
                     }
                 }
-                success = await ImportWavs(wavs);
+
+                if (wavs.Count > 0)
+                {
+                    success = await ImportWavs(wavs);
+                }
             }
             if (IsExportsSelected)
             {

--- a/WolvenKit.Core/FNV1A/FNV1A64HashAlgorithm.cs
+++ b/WolvenKit.Core/FNV1A/FNV1A64HashAlgorithm.cs
@@ -78,7 +78,7 @@ namespace WolvenKit.Common.FNV1A
             {
                 unchecked
                 {
-                    hash = (hash ^ (uint)b) * FnvHashPrime;
+                    hash = (hash ^ (ulong)b) * FnvHashPrime;
                 }
             }
 

--- a/WolvenKit.RED4.Archive/Buffer/RedPackageStructs.cs
+++ b/WolvenKit.RED4.Archive/Buffer/RedPackageStructs.cs
@@ -88,29 +88,29 @@ namespace WolvenKit.RED4.Archive.Buffer
     public struct RedPackageNameHeader
     {
         [FieldOffset(0)]
-        public uint bitfield;
+        private uint bitfield;
 
-        private const int sizeShift = 24;
-        private const uint offsetMask = (1U << sizeShift) - 1U;
-        private const uint sizeMask = 0xFF << (sizeShift - 1);
+        private const int s_sizeShift = 24;
+        private const uint s_offsetMask = 0x00FFFFFF;
+        private const uint s_sizeMask   = 0xFF000000;
 
         public uint offset
         {
-            get => bitfield & offsetMask;
+            get => bitfield & s_offsetMask;
             set
             {
-                bitfield &= ~offsetMask;
-                bitfield |= value & offsetMask;
+                bitfield &= ~s_offsetMask;
+                bitfield |= value & s_offsetMask;
             }
         }
 
         public byte size
         {
-            get => (byte)((bitfield & sizeMask) >> sizeShift);
+            get => (byte)((bitfield & s_sizeMask) >> s_sizeShift);
             set
             {
-                bitfield &= ~sizeMask;
-                bitfield |= ((uint)value << sizeShift) & sizeMask;
+                bitfield &= ~s_sizeMask;
+                bitfield |= ((uint)value << s_sizeShift) & s_sizeMask;
             }
         }
     }

--- a/WolvenKit.RED4.Archive/IO/CR2WWriter.File.cs
+++ b/WolvenKit.RED4.Archive/IO/CR2WWriter.File.cs
@@ -456,6 +456,8 @@ namespace WolvenKit.RED4.Archive.IO
             public byte[] BufferData { get; set; }
         }
 
+        protected override void GenerateBufferBytes(RedBuffer buffer) => WriteBufferData(buffer);
+
         private DataCollection GenerateData()
         {
             var result = new DataCollection();
@@ -527,11 +529,6 @@ namespace WolvenKit.RED4.Archive.IO
 
                     chunkCounter++;
                 }
-            }
-
-            foreach (var kvp in file.BufferRef)
-            {
-                WriteBufferData(kvp.Value);
             }
 
             file.GenerateStringDictionary();

--- a/WolvenKit.RED4.Archive/IO/CR2WWriter.File.cs
+++ b/WolvenKit.RED4.Archive/IO/CR2WWriter.File.cs
@@ -543,8 +543,8 @@ namespace WolvenKit.RED4.Archive.IO
                 var typeInfo = RedReflection.GetTypeInfo(embeddedFile.Content);
                 SetParent(_chunkInfos[embeddedFile.Content].Id, maxDepth: typeInfo.ChildLevel);
 
-                var tuple = new ImportEntry("", (CName)embeddedFile.FileName, (ushort)8);
-                if (!result.ImportList.Contains(tuple))
+                var tuple = new ImportEntry("", embeddedFile.FileName, 8);
+                if (result.ImportList.All(x => x.DepotPath != tuple.DepotPath))
                 {
                     result.ImportList.Add(tuple);
                 }

--- a/WolvenKit.RED4.Archive/IO/RedPackageWriter.cs
+++ b/WolvenKit.RED4.Archive/IO/RedPackageWriter.cs
@@ -102,6 +102,15 @@ namespace WolvenKit.RED4.Archive.IO
             }
         }
 
+        public override void Write(IRedEnum instance)
+        {
+            var typeInfo = RedReflection.GetEnumTypeInfo(instance.GetInnerType());
+            var valueName = typeInfo.GetRedNameFromCSName(instance.ToEnumString());
+
+            CNameRef.Add(_writer.BaseStream.Position, valueName);
+            _writer.Write(GetStringIndex(valueName));
+        }
+
         public override void Write(IRedBitField instance)
         {
             var enumString = instance.ToBitFieldString();

--- a/WolvenKit.RED4.Types/IO/Red4Writer.cs
+++ b/WolvenKit.RED4.Types/IO/Red4Writer.cs
@@ -269,8 +269,15 @@ namespace WolvenKit.RED4.IO
 
         public List<RedBuffer> BufferStack = new();
 
+        protected virtual void GenerateBufferBytes(RedBuffer buffer)
+        {
+
+        }
+
         public virtual void Write(DataBuffer val)
         {
+            GenerateBufferBytes(val.Buffer);
+
             if (val.Buffer.IsEmpty)
             {
                 _writer.Write(0x80000000);
@@ -299,11 +306,19 @@ namespace WolvenKit.RED4.IO
         public virtual void Write(NodeRef val) => _writer.WriteLengthPrefixedString(val);
         public virtual void Write(SerializationDeferredDataBuffer val)
         {
+            GenerateBufferBytes(val.Buffer);
+
             BufferRef.Add(_writer.BaseStream.Position, val.Buffer);
             _writer.Write((ushort)(GetRedBufferIndex(val.Buffer) + 1));
         }
 
-        public virtual void Write(SharedDataBuffer val) => _writer.Write(val.Buffer.GetBytes());
+        public virtual void Write(SharedDataBuffer val)
+        {
+            GenerateBufferBytes(val.Buffer);
+
+            _writer.Write(val.Buffer.GetBytes());
+        }
+
         public virtual void Write(TweakDBID val) => _writer.Write((ulong)val);
         public virtual void Write(gamedataLocKeyWrapper val) => _writer.Write((ulong)val);
 

--- a/WolvenKit.RED4.Types/IO/Red4Writer.cs
+++ b/WolvenKit.RED4.Types/IO/Red4Writer.cs
@@ -480,6 +480,11 @@ namespace WolvenKit.RED4.IO
         {
             var typeInfo = RedReflection.GetEnumTypeInfo(instance.GetInnerType());
             var valueName = typeInfo.GetRedNameFromCSName(instance.ToEnumString());
+
+            if (valueName == "None")
+            {
+                valueName = "";
+            }
             
             CNameRef.Add(_writer.BaseStream.Position, valueName);
             _writer.Write(GetStringIndex(valueName));

--- a/WolvenKit.RED4.Types/Primitives/Simples/CName.cs
+++ b/WolvenKit.RED4.Types/Primitives/Simples/CName.cs
@@ -40,9 +40,7 @@ namespace WolvenKit.RED4.Types
 
             if (!s_cNameCache.ContainsKey(_value))
             {
-                var buffer = Encoding.UTF8.GetBytes(_value);
-                var sBuffer = Array.ConvertAll(buffer, b => b != 0x80 ? (byte)Math.Abs((sbyte)b) : (byte)0x80);
-                s_cNameCache.TryAdd(_value, FNV1A64HashAlgorithm.HashReadOnlySpan(sBuffer));
+                s_cNameCache.TryAdd(_value, FNV1A64HashAlgorithm.HashString(_value, Encoding.UTF8, false, true));
             }
 
             return s_cNameCache[_value];

--- a/WolvenKit.RED4.Types/Primitives/Simples/NodeRef.cs
+++ b/WolvenKit.RED4.Types/Primitives/Simples/NodeRef.cs
@@ -56,9 +56,8 @@ namespace WolvenKit.RED4.Types
 
             if (!s_NodeRefStringCache.ContainsKey(_value))
             {
-                var buffer = Encoding.UTF8.GetBytes(_value);
-                var sBuffer = Array.ConvertAll(buffer, b => b != 0x80 ? (byte)Math.Abs((sbyte)b) : (byte)0x80);
-                var hash = FNV1A64HashAlgorithm.HashReadOnlySpan(sBuffer);
+                var hash = FNV1A64HashAlgorithm.HashString(_value, Encoding.UTF8, false, true);
+
                 s_NodeRefStringCache.TryAdd(_value, hash);
                 s_NodeRefHashCache.TryAdd(hash, _value);
             }

--- a/WolvenKit.RED4.Types/Reflection/RedReflection.cs
+++ b/WolvenKit.RED4.Types/Reflection/RedReflection.cs
@@ -535,8 +535,8 @@ namespace WolvenKit.RED4.Types
                 {
                     return PropertyInfos[i2];
                 }
-                throw new ArgumentNullException();
-                //return null;
+
+                return null;
             }
 
             public ExtendedPropertyInfo GetPropertyInfoByName(string name)


### PR DESCRIPTION
Fixed:
- Hashing for CName and NodeRefs (again...)
- Duplicated fileName writing in CR2W
- Wrongly shifted size field in RedPackageNameHeader
- Enum writing for enums where value is "None"
- A bug introduced while merging #799 
- Moved buffer generation, so the newly generated bytes are written
- Removed showing success message on import/export when the action failed
- Prevent empty soundbank creation while processing all imports/exports
- Filter out "old" files from rig selection
