### PR TITLE
WolvenKit CLI: Remove the unconsistant archive name prefix on unbundle and uncook commands

### DIFF
--- a/WolvenKit.Modkit/RED4/Tasks/UnbundleTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UnbundleTask.cs
@@ -81,9 +81,7 @@ namespace CP77Tools.Tasks
                 DirectoryInfo outDir;
                 if (string.IsNullOrEmpty(outpath))
                 {
-                    outDir = new DirectoryInfo(Path.Combine(
-                        basedir.FullName,
-                        fileInfo.Name.Replace(".archive", "")));
+                    outDir = new DirectoryInfo(basedir.FullName);
                 }
                 else
                 {
@@ -91,13 +89,6 @@ namespace CP77Tools.Tasks
                     if (!outDir.Exists)
                     {
                         outDir = new DirectoryInfo(outpath);
-                    }
-
-                    if (inputDirInfo.Exists)
-                    {
-                        outDir = new DirectoryInfo(Path.Combine(
-                            outDir.FullName,
-                            fileInfo.Name.Replace(".archive", "")));
                     }
                 }
 

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -131,9 +131,7 @@ namespace CP77Tools.Tasks
                 DirectoryInfo outDir;
                 if (string.IsNullOrEmpty(outpath))
                 {
-                    outDir = new DirectoryInfo(Path.Combine(
-                        basedir.FullName,
-                        fileInfo.Name.Replace(".archive", "")));
+                    outDir = new DirectoryInfo(basedir.FullName);
                 }
                 else
                 {


### PR DESCRIPTION
# Description

The unbundle command would add a directory as prefix to the output path containing the name of the archive the file would come out from.
The uncook command doesn't have this behavior, which makes sense because it would make it complicated when files have depenendencies accross multiple archives.

I mentioned this issue a few days ago on Discord, and decided to take a look at it.
It seems to be the only place where the archive name is prefixed before exporting assets. So I also removed the other case where the archive name is added to the root folder when no output folder is specified.
