### PR TITLE
Fix issue #812: Material exports which reference material templates from external materials

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -90,9 +90,24 @@ namespace WolvenKit.Modkit.RED4
                         }
 
                         using var reader = new CR2WReader(ms);
-                        _ = reader.ReadFile(out var mi, false);
+                        _ = reader.ReadFile(out var matFile, false);
 
-                        ExternalMaterial.Add(mi.RootChunk as CMaterialInstance);
+                        var mi = matFile.RootChunk as CMaterialInstance;
+                        if (mi != null)
+                        {
+                            ExternalMaterial.Add(mi);
+                        } else
+                        {
+                            // The external materials can also directly reference MaterialTemplates. To keep it easier for the exporter we can expose these as material instances
+                            var fakeMaterialInstance = new CMaterialInstance()
+                            {
+                                BaseMaterial = new CResourceReference<IMaterial> { DepotPath = path },
+                                Values = new CArray<CKeyValuePair>()
+                            };
+
+                            ExternalMaterial.Add(fakeMaterialInstance);
+                        }
+
 
                         foreach (var import in reader.ImportsList)
                         {


### PR DESCRIPTION
# Description

Support material exports for meshes which in their ExternalMaterial array reference, directly link Material Templates instead of Material Instances.
The investigation for the bug is in the issue ticket.

I also investigated if the externalMaterials type could be changed as a list of IMaterial, but there's code later on working on properties specific to material instances, and we would loose the data for the material overrides. Instead, the easier solution implemented here transforms the material template into a "dummy material instance".

We might need the same fix for preloaded external materials. If I realize that it's needed there too, I'll make a follow-up PR.

Fixes:
- #812 
