### PR TITLE
Fix mesh export json serialization exception

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -28,7 +28,7 @@ namespace WolvenKit.Modkit.RED4
             return ExportAnim(animsFile, archives, outfile, isGLBinary,incRootMotion);
         }
 
-        public bool ExportAnim(CR2WFile animsFile, List<Archive> archives, FileInfo outfile, bool isGLBinary = true, bool incRootMotion = true)
+        public bool ExportAnim(CR2WFile animsFile, List<Archive> archives, FileInfo outfile, bool isGLBinary = true, bool incRootMotion = true, ValidationMode vmode = ValidationMode.TryFix)
         {
             if (animsFile == null || animsFile.RootChunk is not animAnimSet anims)
             {
@@ -62,11 +62,11 @@ namespace WolvenKit.Modkit.RED4
 
             if (isGLBinary)
             {
-                model.SaveGLB(outfile.FullName);
+                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
             }
             else
             {
-                model.SaveGLTF(outfile.FullName);
+                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
             }
 
             return true;

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using SharpGLTF.Validation;
+using SharpGLTF.Schema2;
 using WolvenKit.Common;
 using WolvenKit.Common.Conversion;
 using WolvenKit.Common.Extensions;
@@ -24,7 +26,7 @@ namespace WolvenKit.Modkit.RED4
     /// </summary>
     public partial class ModTools
     {
-        public bool ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List<Archive> archives, string matRepo, EUncookExtension eUncookExtension = EUncookExtension.dds, bool isGLBinary = true, bool LodFilter = true)
+        public bool ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List<Archive> archives, string matRepo, EUncookExtension eUncookExtension = EUncookExtension.dds, bool isGLBinary = true, bool LodFilter = true, ValidationMode vmode = ValidationMode.TryFix)
         {
             if (matRepo == null)
             {
@@ -52,11 +54,11 @@ namespace WolvenKit.Modkit.RED4
 
             if (isGLBinary)
             {
-                model.SaveGLB(outfile.FullName);
+                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
             }
             else
             {
-                model.SaveGLTF(outfile.FullName);
+                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
             }
 
             meshStream.Dispose();

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -66,7 +66,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             var model = RawMeshesToMinimalGLTF(expMeshes);
 
-            model.SaveGLB(outFile.FullName);
+            model.SaveGLB(outFile.FullName, new WriteSettings(ValidationMode.TryFix));
 
             return true;
         }

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using SharpGLTF.Schema2;
+using SharpGLTF.Validation;
 using WolvenKit.Common.DDS;
 using WolvenKit.Common.FNV1A;
 using WolvenKit.Common.Services;
@@ -19,7 +20,7 @@ namespace WolvenKit.Modkit.RED4
 {
     public partial class ModTools
     {
-        public bool ExportMorphTargets(Stream targetStream, FileInfo outfile, List<Archive> archives, string modFolder, bool isGLBinary = true)
+        public bool ExportMorphTargets(Stream targetStream, FileInfo outfile, List<Archive> archives, string modFolder, bool isGLBinary = true, ValidationMode vmode = ValidationMode.TryFix)
         {
             var cr2w = _wolvenkitFileService.ReadRed4File(targetStream);
             if (cr2w == null || cr2w.RootChunk is not MorphTargetMesh morphBlob || morphBlob.Blob.Chunk is not rendRenderMorphTargetMeshBlob blob || blob.BaseBlob.Chunk is not rendRenderMeshBlob rendblob)
@@ -82,11 +83,11 @@ namespace WolvenKit.Modkit.RED4
 
             if (isGLBinary)
             {
-                model.SaveGLB(outfile.FullName);
+                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
             }
             else
             {
-                model.SaveGLTF(outfile.FullName);
+                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
             }
 
             var dir = new DirectoryInfo(outfile.FullName.Replace(Path.GetExtension(outfile.FullName), string.Empty) + "_textures");


### PR DESCRIPTION
# Description

The default mesh export GLTF settings for Materials, Morphtargets or Animations do not try to fix invalid values while exporting, leading to an internal error.

## Solution

I went through all the method calls for saving the GLTF models and copied the behavior from the default export mode.
Here a link to the code where it's already implemented as such: https://github.com/WolvenKit/WolvenKit/blob/develop/WolvenKit.Modkit/RED4/Tools/MeshTools.cs#L97

--- 

## Example asset leading to the bug: 
`base\environment\architecture\common\int\int_nkt_jp_corridor_a\_dst\int_nkt_jp_corridor_a_zengarden_a_dst_a_dynamic.mesh`

## Stacktrace:
```
[06/06/2022 22:11:53] base\environment\architecture\common\int\int_nkt_jp_corridor_a\_dst\int_nkt_jp_corridor_a_zengarden_a_dst_a_dynamic.mesh - .NET number values such as positive and negative infinity cannot be written as valid JSON.
[06/06/2022 22:11:53] Message: .NET number values such as positive and negative infinity cannot be written as valid JSON.
Source: System.Text.Json
StackTrace:    at System.Text.Json.ThrowHelper.ThrowArgumentException_ValueNotSupported()
   at System.Text.Json.Utf8JsonWriter.WriteNumberValue(Double value)
   at SharpGLTF.IO._JSonSerializationExtensions.TryWriteValue(Utf8JsonWriter writer, Object value)
   at SharpGLTF.IO.JsonSerializable._SerializeValue(Utf8JsonWriter writer, Object value)
   at SharpGLTF.IO.JsonSerializable.SerializeProperty[T](Utf8JsonWriter writer, String name, IReadOnlyList`1 collection, Nullable`1 minItems)
   at SharpGLTF.Schema2.Accessor.SerializeProperties(Utf8JsonWriter writer)
   at SharpGLTF.IO.JsonSerializable.Serialize(Utf8JsonWriter writer)
   at SharpGLTF.IO.JsonSerializable.SerializeProperty[T](Utf8JsonWriter writer, String name, IReadOnlyList`1 collection, Nullable`1 minItems)
   at SharpGLTF.Schema2.ModelRoot.SerializeProperties(Utf8JsonWriter writer)
   at SharpGLTF.IO.JsonSerializable.Serialize(Utf8JsonWriter writer)
   at SharpGLTF.Schema2.ModelRoot._WriteJSON(Stream sw, JsonWriterOptions options)
   at SharpGLTF.Schema2.ModelRoot.GetJSON(JsonWriterOptions options)
   at SharpGLTF.Schema2._BinarySerialization.WriteBinaryModel(BinaryWriter binaryWriter, ModelRoot model)
   at SharpGLTF.Schema2.WriteContext.WriteBinarySchema2(String baseName, ModelRoot model)
   at SharpGLTF.Schema2.ModelRoot.SaveGLB(String filePath, WriteSettings settings)
   at WolvenKit.Modkit.RED4.ModTools.ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List`1 archives, String matRepo, EUncookExtension eUncookExtension, Boolean isGLBinary, Boolean LodFilter) in D:\a\WolvenKit\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 55
   at WolvenKit.Modkit.RED4.ModTools.HandleMesh(Stream cr2wStream, FileInfo cr2wFileName, MeshExportArgs meshargs) in D:\a\WolvenKit\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 488
   at WolvenKit.Modkit.RED4.ModTools.UncookBuffers(Stream cr2wStream, String relPath, GlobalExportArgs settings, DirectoryInfo rawOutDir, ECookedFileFormat[] forcebuffers) in D:\a\WolvenKit\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 274
```
