### PR TITLE
Fix embedded material template in mesh materials exports

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -1199,7 +1199,11 @@ namespace WolvenKit.Modkit.RED4
             {
                 if (Path.GetExtension(file.FileName).Contains("mt"))
                 {
-                    materialTemplates.Add(file.FileName, file.Content as CMaterialTemplate);
+                    var mt = file.Content as CMaterialTemplate;
+                    if(mt != null)
+                    {
+                        materialTemplates.Add(file.FileName, mt);
+                    }
                 }
             }
 

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -596,7 +596,7 @@ namespace WolvenKit.Modkit.RED4
 
 
             var RawMaterials = new List<RawMaterial>();
-            var usedMts = new Dictionary<string, CMaterialTemplate>();
+            var usedMts = GetEmbeddedMaterialTemplates(ref cr2w);
             for (var i = 0; i < materialEntries.Count; i++)
             {
                 RawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i], archives, ref usedMts));
@@ -1190,6 +1190,20 @@ namespace WolvenKit.Modkit.RED4
             var b = blob.LocalMaterialBuffer.RawData.Buffer;
 
             return new MemoryStream(b.GetBytes());
+        }
+
+        private static Dictionary<string, CMaterialTemplate> GetEmbeddedMaterialTemplates(ref CR2WFile cr2w)
+        {
+            var materialTemplates = new Dictionary<string, CMaterialTemplate>();
+            foreach (var file in cr2w.EmbeddedFiles)
+            {
+                if (Path.GetExtension(file.FileName).Contains("mt"))
+                {
+                    materialTemplates.Add(file.FileName, file.Content as CMaterialTemplate);
+                }
+            }
+
+            return materialTemplates;
         }
 
         public bool WriteMatToMesh(ref CR2WFile cr2w, string _matData, List<Archive> archives)


### PR DESCRIPTION
# Description
Some meshes have local materials which reference MaterialTemplates, which themselves only exists within their own cr2w part of the embeddedFiles. This currently breaks the mesh exports with Material for these meshes. This PR aims to fix this.

## Example asset
`base\gameplay\community\crowd.mesh`

## Stacktrace
```
========================
4%[ 0: Error       ] - base\gameplay\community\crowd.mesh - base\materials\long_distant_crowds.mt
[ 0: Error       ] - ========================
System.IO.FileNotFoundException: base\materials\long_distant_crowds.mt
   at WolvenKit.Modkit.RED4.ModTools.LoadFile(String path, List`1 archives) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 1080
   at WolvenKit.Modkit.RED4.ModTools.GetMaterialChain(CMaterialInstance cMaterialInstance, List`1 archives, Dictionary`2& mts) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 1110
   at WolvenKit.Modkit.RED4.ModTools.ContainRawMaterial(CMaterialInstance cMaterialInstance, String name, List`1 archives, Dictionary`2& mts) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 1162
   at WolvenKit.Modkit.RED4.ModTools.ParseMaterials(CR2WFile cr2w, Stream meshStream, FileInfo outfile, List`1 archives, String matRepo, EUncookExtension eUncookExtension) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 602
   at WolvenKit.Modkit.RED4.ModTools.ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List`1 archives, String matRepo, EUncookExtension eUncookExtension, Boolean isGLBinary, Boolean LodFilter, ValidationMode vmode) in E:\WolvenKit\WolvenKit.Modkit\RED4\Tools\MaterialTools.cs:line 53
   at WolvenKit.Modkit.RED4.ModTools.HandleMesh(Stream cr2wStream, FileInfo cr2wFileName, MeshExportArgs meshargs) in E:\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 492
   at WolvenKit.Modkit.RED4.ModTools.UncookBuffers(Stream cr2wStream, String relPath, GlobalExportArgs settings, DirectoryInfo rawOutDir, ECookedFileFormat[] forcebuffers) in E:\WolvenKit\WolvenKit.Modkit\RED4\Uncook.cs:line 290
========================
```
