### PR TITLE
CLI: Add ability to directly export to JSON from the archives

### DIFF
--- a/WolvenKit.CLI/Commands/UncookCommand.cs
+++ b/WolvenKit.CLI/Commands/UncookCommand.cs
@@ -30,18 +30,19 @@ namespace CP77Tools.Commands
             AddOption(new Option<ulong>(new[] { "--hash" }, "Extract single file with a given hash."));
             AddOption(new Option<bool>(new[] { "--unbundle", "-u" }, "Also unbundle files."));
             AddOption(new Option<ECookedFileFormat[]>(new[] { "--forcebuffers", "-fb" }, "Force uncooking to buffers for given extension. e.g. mesh"));
+            AddOption(new Option<bool>(new[] { "--serialize", "-s" }, "Serialize to JSON"));
 
             Handler = CommandHandler
-                .Create<string[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[]
+                .Create<string[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[], bool?
                     , IHost>(Action);
         }
 
         private void Action(string[] path, string outpath, string raw, EUncookExtension? uext, bool? flip, ulong hash, string pattern,
-            string regex, bool unbundle, ECookedFileFormat[] forcebuffers, IHost host)
+            string regex, bool unbundle, ECookedFileFormat[] forcebuffers, bool? serialize, IHost host)
         {
             var serviceProvider = host.Services;
             var consoleFunctions = serviceProvider.GetRequiredService<ConsoleFunctions>();
-            consoleFunctions.UncookTask(path, outpath, raw, uext, flip, hash, pattern, regex, unbundle, forcebuffers);
+            consoleFunctions.UncookTask(path, outpath, raw, uext, flip, hash, pattern, regex, unbundle, forcebuffers, serialize);
         }
 
 

--- a/WolvenKit.Common/Interfaces/IModTools.cs
+++ b/WolvenKit.Common/Interfaces/IModTools.cs
@@ -34,8 +34,9 @@ namespace WolvenKit.Common.Interfaces
             DirectoryInfo outDir,
             GlobalExportArgs args,
             DirectoryInfo rawOutDir = null,
-            ECookedFileFormat[] forcebuffers = null);
-        void UncookAll(ICyberGameArchive ar, DirectoryInfo outDir, GlobalExportArgs args, bool unbundle = false, string pattern = "", string regex = "", DirectoryInfo rawOutDir = null, ECookedFileFormat[] forcebuffers = null);
+            ECookedFileFormat[] forcebuffers = null,
+            bool serialize = false);
+        void UncookAll(ICyberGameArchive ar, DirectoryInfo outDir, GlobalExportArgs args, bool unbundle = false, string pattern = "", string regex = "", DirectoryInfo rawOutDir = null, ECookedFileFormat[] forcebuffers = null, bool serialize = false);
 
         public bool ConvertToAndWrite(ETextConvertFormat format, string infile, DirectoryInfo outputDirInfo);
 

--- a/WolvenKit.Modkit/RED4/Tasks/ConsoleFunctions.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/ConsoleFunctions.cs
@@ -23,7 +23,7 @@ namespace CP77Tools.Tasks
         public void PackTask(string[] path, string outpath);
         public void UncookTask(string[] path, string outpath, string rawOutDir,
             EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers);
+            ECookedFileFormat[] forcebuffers, bool? serialize);
     }
 
     public partial class ConsoleFunctions : IConsoleFunctions

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -15,7 +15,7 @@ namespace CP77Tools.Tasks
 
         public void UncookTask(string[] path, string outpath, string rawOutDir,
             EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers)
+            ECookedFileFormat[] forcebuffers, bool? serialize)
         {
             if (path == null || path.Length < 1)
             {
@@ -25,13 +25,13 @@ namespace CP77Tools.Tasks
 
             foreach (var file in path)
             {
-                UncookTaskInner(file, outpath, rawOutDir, uext, flip, hash, pattern, regex, unbundle, forcebuffers);
+                UncookTaskInner(file, outpath, rawOutDir, uext, flip, hash, pattern, regex, unbundle, forcebuffers, serialize);
             }
         }
 
         private void UncookTaskInner(string path, string outpath, string rawOutDir,
             EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers)
+            ECookedFileFormat[] forcebuffers, bool? serialize)
         {
             #region checks
 
@@ -162,12 +162,12 @@ namespace CP77Tools.Tasks
                 // run
                 if (hash != 0)
                 {
-                    _modTools.UncookSingle(ar, hash, outDir, exportArgs, rawOutDirInfo, forcebuffers);
+                    _modTools.UncookSingle(ar, hash, outDir, exportArgs, rawOutDirInfo, forcebuffers, serialize ?? false);
                     _loggerService.Success($" {ar.ArchiveAbsolutePath}: Uncooked one file: {hash}");
                 }
                 else
                 {
-                    _modTools.UncookAll(ar, outDir, exportArgs, unbundle, pattern, regex, rawOutDirInfo, forcebuffers);
+                    _modTools.UncookAll(ar, outDir, exportArgs, unbundle, pattern, regex, rawOutDirInfo, forcebuffers, serialize ?? false);
                 }
             }
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WolvenKit.Common;
+using WolvenKit.Common.Conversion;
 using WolvenKit.Common.DDS;
 using WolvenKit.Common.Extensions;
 using WolvenKit.Common.Model.Arguments;
@@ -15,6 +16,7 @@ using WolvenKit.Modkit.Extensions;
 using WolvenKit.Modkit.RED4.Opus;
 using WolvenKit.RED4.Archive;
 using WolvenKit.RED4.CR2W;
+using WolvenKit.RED4.CR2W.JSON;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.Modkit.RED4
@@ -37,7 +39,8 @@ namespace WolvenKit.Modkit.RED4
             DirectoryInfo outDir,
             GlobalExportArgs args,
             DirectoryInfo rawOutDir = null,
-            ECookedFileFormat[] forcebuffers = null)
+            ECookedFileFormat[] forcebuffers = null,
+            bool serialize = false)
         {
             if (!archive.Files.TryGetValue(hash, out var gameFile))
             {
@@ -77,6 +80,27 @@ namespace WolvenKit.Modkit.RED4
                 }
 
                 #endregion unbundle main file
+
+                #region serialize
+
+                if (serialize)
+                {
+                    try
+                    {
+                        var jsonOutput = SerializeMainFile(cr2WStream);
+                        var outpath = Path.Combine(outDir.FullName, $"{relFileFullName.Replace('\\', Path.DirectorySeparatorChar)}.json");
+                        File.WriteAllText(outpath, jsonOutput);
+                        return true;
+                    }
+                    catch (Exception e)
+                    {
+                        _loggerService.Error($"{relFileFullName} And unexpected error occured while converting to json: {e.Message}");
+                        _loggerService.Error(e);
+                        return false;
+                    }
+                }
+
+                #endregion serialize
 
                 #region extract buffers
 
@@ -131,7 +155,8 @@ namespace WolvenKit.Modkit.RED4
             string pattern = "",
             string regex = "",
             DirectoryInfo rawOutDir = null,
-            ECookedFileFormat[] forcebuffers = null)
+            ECookedFileFormat[] forcebuffers = null,
+            bool serialize = false)
         {
             var extractedList = new ConcurrentBag<string>();
             var failedList = new ConcurrentBag<string>();
@@ -181,7 +206,7 @@ namespace WolvenKit.Modkit.RED4
             //foreach (var info in finalMatchesList)
             Parallel.ForEach(finalMatchesList, info =>
             {
-                if (UncookSingle(ar, info.NameHash64, outDir, args, rawOutDir, forcebuffers))
+                if (UncookSingle(ar, info.NameHash64, outDir, args, rawOutDir, forcebuffers, serialize))
                 {
                     extractedList.Add(info.FileName);
                 }
@@ -462,6 +487,15 @@ namespace WolvenKit.Modkit.RED4
             }
 
             return true;
+        }
+
+        private string SerializeMainFile(Stream redstream)
+        {
+            var cr2w = _wolvenkitFileService.ReadRed4File(redstream);
+            var dto = new RedFileDto(cr2w);
+            var json = RedJsonSerializer.Serialize(dto);
+
+            return json;
         }
 
         private bool UncookFont(Stream redstream, Stream outstream)


### PR DESCRIPTION
# Description

There's no direct way to export to json from the CLI. The current flow would be unbundle the file, then use the cr2w command to transform the exported file to json. This is rather cumbersome when doing batch exports. This PR adds a way to directly extract to JSON from the CLI.

# Details

- This PR adds a new exposed CLI flag to the `uncook` command: `-s` or `--serialize`

- Using this flag adds a new step in the uncook process which exports the file to json with the `.json` file extension appended to the end of its path.

- To prevent errors with unsupported files to be uncooked, when the serialize option is used, it does not try to uncook the buffers.

# Notes

For now this argument only serializes the main chunk, but I plan to implement in further PRs serializing the other chunks for embedded resources. But I'm not sure yet on how to expose this to the CLI.