### PR TITLE
🐛 InsertChild Checks Item Can Be Assigned To Array, Not The Other Way Around

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -2393,7 +2393,7 @@ namespace WolvenKit.ViewModels.Shell
                 {
                     ira = Data as IRedArray;
                 }
-                if (ira.InnerType.IsAssignableTo(item.GetType()))
+                if (ira.InnerType.IsAssignableFrom(item.GetType()))
                 {
                     var iraType = ira.GetType();
                     if (iraType.IsGenericType)


### PR DESCRIPTION
At a glance looked like the rest of the file was using the correct logic but might be worth a check.

closes #847