### PR TITLE
Escape backslashes in ink atlas redscript example.

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTInkTextureAtlasViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTInkTextureAtlasViewModel.cs
@@ -117,7 +117,7 @@ namespace WolvenKit.ViewModels.Documents
             public string RedscriptExample
             {
                 get => $@"let image = new inkImage();
-image.SetAtlasResource(r""{AtlasPath}"");
+image.SetAtlasResource(r""{AtlasPath.Replace("\\", "\\\\")}"");
 image.SetTexturePart(n""{PartName}"");";
                 set
                 {


### PR DESCRIPTION
Escape backslashes in ink atlas redscript example.

Fixed:
- escapes the backslashes in the example because redscript requires that. 
- Currently in main the example would look like: `image.SetAtlasResource(r"base\gameplay\gui\common\icons\atlas_cash.inkatlas");`
- With this change: 
![redscript_example](https://user-images.githubusercontent.com/15858718/179642789-6e48758b-b846-4e84-be34-d0e3ec96cf2f.PNG)

Notes:
- I made the change here instead of where `AtlasPath` is set because it gets used for an `AtlasPath` field displayed above the redscript example, which I think should not be escaped.