### PR TITLE
🐛 Tweak Browser: explicitly notify on property change & force refresh…

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/TweakBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/TweakBrowserViewModel.cs
@@ -263,11 +263,14 @@ namespace WolvenKit.ViewModels.Tools
 
             GroupTags = CollectionViewSource.GetDefaultView(_tweakDB.GetGroupTags().Select(x => new TweakEntry(x, _tweakDB)).ToList());
             GroupTags.Filter = Filter;
+
+            Refresh();
         }
 
         private void Refresh()
         {
             Records.Refresh();
+            this.RaisePropertyChanged(nameof(Records));
             this.RaisePropertyChanged(nameof(RecordsHeader));
 
             Flats.Refresh();


### PR DESCRIPTION
Not sure this is the right fix, but the problem is here (since this _does_ fix it).

It's possible this would be better addressed by managing when the load is called (it's called twice on startup if the game path needs to be set), or then there's something funky with how the CollectionViewSource works but this is about 7 levels of bindings too deep for me.