### PR TITLE
 Fix for automatic Cyberpunk 2077 FileNamePath lookup.

### DIFF
--- a/WolvenKit.App/Helpers/RegistryHelpers.cs
+++ b/WolvenKit.App/Helpers/RegistryHelpers.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+using System.Threading.Tasks;
+using static Microsoft.Win32.Registry;
+using System;
+
+namespace WolvenKit.App.Helpers;
+
+public static class RegistryHelpers
+{
+    public static string GetFileNamePathFromRegistrySubKey(
+        string subKeyPath,
+        string appName,
+        string fileName)
+    {
+        var subKey = LocalMachine.OpenSubKey(subKeyPath);
+        var programName = (string)subKey?.GetValue("DisplayName");
+        var installLocation = (string)subKey?.GetValue("InstallLocation");
+
+        if (programName?.Contains(appName) ?? false)
+        {
+            if (Directory.Exists(installLocation))
+            {
+                var files = Directory
+                    .GetFiles(
+                        installLocation,
+                        fileName,
+                        SearchOption.AllDirectories);
+
+                return files?.FirstOrDefault();
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/WolvenKit.App/Helpers/RegistryHelpers.cs
+++ b/WolvenKit.App/Helpers/RegistryHelpers.cs
@@ -1,9 +1,6 @@
 using System.IO;
 using System.Linq;
-using Microsoft.Win32;
-using System.Threading.Tasks;
 using static Microsoft.Win32.Registry;
-using System;
 
 namespace WolvenKit.App.Helpers;
 

--- a/WolvenKit.App/ViewModels/Dialogs/FirstSetupViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/FirstSetupViewModel.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reactive;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Win32;

--- a/WolvenKit/Views/Dialogs/Windows/FirstSetupView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/FirstSetupView.xaml.cs
@@ -30,10 +30,12 @@ namespace WolvenKit.Views.Dialogs.Windows
                     vm => vm.CP77ExePath,
                     v => v.cp77ExeTxtb.Text)
                     .DisposeWith(disposables);
+
                 this.Bind(ViewModel,
                         vm => vm.MaterialDepotPath,
                         v => v.matdepotxtb.Text)
                     .DisposeWith(disposables);
+
                 this.Bind(ViewModel,
                         vm => vm.AllFieldsValid,
                         v => v.WizardControl.FinishEnabled)
@@ -42,10 +44,10 @@ namespace WolvenKit.Views.Dialogs.Windows
                 this.BindCommand(ViewModel,
                     vm => vm.OpenCP77GamePathCommand,
                     v => v.cp77ExeButton).DisposeWith(disposables);
+
                 this.BindCommand(ViewModel,
                     vm => vm.OpenDepotPathCommand,
                     v => v.matdepotButton).DisposeWith(disposables);
-
 
                 this.BindCommand(
                     ViewModel,


### PR DESCRIPTION
# Fix for automatic Cyberpunk 2077 FileNamePath lookup.

## Implemented
- No new features.

## Fixed
- Automatic "Cyberpunk2077.exe" install location lookup sometimes did not work on first time run.

### Additional Notes
Made some optimizations.
* Introduced high probability default install location check for Steam first.
* Code duplication reduction.
  * Partially moved from the `FirstSetupViewModel.cs` into a new static `RegistryHelpers.cs` class.
* Parallel Loop state introduced to gracefully exit without finishing the loops (similar to `break;`).
* Skip second parallel loop if we already have the `FileNamePath`.
* Removal of unneeded local `void` method for assignment since assignment.
  * Really shouldn't be parallel assignments occurring other than really weird multi-official installation locations (if that is even possible).
* Removed or added blank lines where appropriate in the areas I was viewing. Any other whitespace changes can be from applying Code Document Formatting (CTRL + K,D , CTRL + K,E)
* Moving exception handling to inside the Parallel Loop as the exceptions are cleaner and not ugly `AggregateExceptions` from Parallel/TPL consolidation.

UnitTest projects were incompatible with `net6.0-windows` in Visual Studio 2022 Pro `v16.3.5`. Possible proper solution is to include unit test project with designation of `net6.0-windows` for any code you wish to be testable in the `WolvenKit.App` project.