### PR TITLE
Serilog Enhancements

### DIFF
--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ProtoBuf.Meta;
@@ -11,17 +10,13 @@ using ReactiveUI;
 using Serilog;
 using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
-using WolvenKit.Common.Services;
 using WolvenKit.Core.Compression;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Services;
 using WolvenKit.Functionality.WKitGlobal.Helpers;
 using WolvenKit.Interaction;
 using WolvenKit.RED4.Archive;
-using WolvenKit.ViewModels.Wizards;
-using WolvenKit.Views.Dialogs;
 using WolvenKit.Views.Dialogs.Windows;
-using WolvenKit.Views.Wizards;
 
 namespace WolvenKit
 {
@@ -96,6 +91,13 @@ namespace WolvenKit
             //NNViewRegistrar.RegisterSplat();
         }
 
+        protected override void OnExit(ExitEventArgs e)
+        {
+            Log.CloseAndFlush();
+
+            base.OnExit(e);
+        }
+
         private IServiceProvider Container { get; set; }
 
         private IHost _host;
@@ -130,9 +132,9 @@ namespace WolvenKit
                         path,
                         outputTemplate: outputTemplate,
                         rollingInterval: RollingInterval.Day,
-                        fileSizeLimitBytes: 100 * 1000 * 1024, // 100 MB
+                        fileSizeLimitBytes: 100 * 1000 * 1024, // MaxFileSize: 100 MB
                         retainedFileCountLimit: 10,
-                        buffered: true)) // Max File Size
+                        buffered: true)) // Allow internal buffering.
                 .CreateLogger();
         }
 

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="protobuf-net" Version="3.1.17" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="SharpVectors.Wpf" Version="1.8.0" />
     <PackageReference Include="Splat" Version="14.4.1" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" Version="14.4.1" />


### PR DESCRIPTION
# Serilog Enhancements
For #930
 * Better Serilog WriteTo.File default options.
 * Introduce Serilog Async for performance.
 * Customize Logging visibility level based on `#if DEBUG`.

## New Feature
Introducing [Serilog.Sinks.Async](https://github.com/serilog/serilog-sinks-async). This allows logging to be buffered and performed on background threads, thus freeing up the MAIN/UI thread when possible. I have seen some non-zero CPU utilization when logging was involved.

## Fixes
Added some healthy defaults for Serilog File sinks and introduced them as async.
`Log.CloseAndFlush()` missing on Application Exit();

## Additional Notes
Users - unless using a debug build - will no longer get the verbose logging by default. I feel this should be configurable as it could potentially interfere with troubleshooting. Unless of course its mainly just warning/error logs that are used today for triage. In which case, I recommend leaving Prod/Release builds with `Warning` level. `Information` could also be relevant happy to go either defaulting to less chatty for now. I suppose it really all depends on the quality of the logging to date of which I don't know.

* Writing log to file is now `async` and `buffered`.
* Writing log to Console is now also `async` and `buffered`.
* New logs are started every `day`.
* New logs are started every `100 MB`.
* We keep only `10` files at any given time.
* Default log level Prod/Release builds would be `Warning`.
* Console included sink is only enabled when `#if DEBUG`.
* Buffering enabled will prevent many writes to disk but achieve the same amount of logs... eventually.
* Serilog.CloseAndFlush() on Application Exit so that the application can log shutdowns gracefully.

This change will not cleanup any currently large directories.