### PR TITLE
Buffered Serilog Write Time Improvement

### DIFF
--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -93,6 +93,7 @@ namespace WolvenKit
 
         protected override void OnExit(ExitEventArgs e)
         {
+            Log.Information("Exiting application...");
             Log.CloseAndFlush();
 
             base.OnExit(e);
@@ -134,7 +135,8 @@ namespace WolvenKit
                         rollingInterval: RollingInterval.Day,
                         fileSizeLimitBytes: 100 * 1000 * 1024, // MaxFileSize: 100 MB
                         retainedFileCountLimit: 10,
-                        buffered: true)) // Allow internal buffering.
+                        buffered: true, // Allow internal buffering.
+                        flushToDiskInterval: TimeSpan.FromMinutes(1))) // Write once per minute.
                 .CreateLogger();
         }
 


### PR DESCRIPTION
# Buffered Serilog Write Time Improvement

 * Adding a shutdown log, this helps make sure Flush on Close is working as intended.
 * Unsatisfied with the delay in writing to Disk, forcing the a write from buffer every a minute.

## Implemented
I was unsatisfied with the delay of writing to disk when adding a buffer. Rather than rolling back buffered logging as it does improve performance and cut down on disk writes, I researched how to trigger forced write on time interval. It is configured to every minute now.

## Fixed
 * New log on application exit, no real value other than knowing Serilog Close/Flush is working.
 * Regardless of whether the Serilog LogFile write buffer is full or not, it will write every minute and still write on close.
 
 ## Related To
 #930 

## Who Broke It
@houseofcat 