### PR TITLE
Fix for ImportExportViewModel Crash

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -304,9 +304,8 @@ namespace WolvenKit.ViewModels.Tools
         #endregion properties
 
         public ICommand AddItemsCommand { get; private set; }
+        
         public ICommand RemoveItemsCommand { get; private set; }
-
-
 
         private bool CanAddItems(ObservableCollection<object> items) => true;
 
@@ -826,7 +825,6 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         public ICommand ProcessSelectedCommand { get; private set; }
 
-
         /// <summary>
         /// Execute Process selected in Import / Export Grid Command
         /// </summary>
@@ -977,6 +975,10 @@ namespace WolvenKit.ViewModels.Tools
         /// </summary>
         private void SetupToolDefaults() => ContentId = ToolContentId;
 
+        public bool HasActiveProject => _projectManager != null
+            && _projectManager.ActiveProject != null
+            && string.IsNullOrWhiteSpace(_projectManager.ActiveProject.ProjectDirectory);
+
         #region Commands
 
         [RelayCommand]
@@ -995,16 +997,9 @@ namespace WolvenKit.ViewModels.Tools
             SaveSettings();
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = "HasActiveProject")]
         private void ImportSettings()
         {
-            // Don't import if there is no active project.
-            if (_projectManager.ActiveProject == null
-                || string.IsNullOrWhiteSpace(_projectManager.ActiveProject.ProjectDirectory))
-            {
-                return;
-            }
-
             var gammaRegex = new Regex(".*_[de][0-9]*$");
 
             foreach (var importableItem in ImportableItems)

--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -96,31 +96,30 @@ namespace WolvenKit.ViewModels.Tools
 
         private static JsonSerializerOptions s_jsonSerializerSettings = new() { Converters = { new JsonFileEntryConverter() }, WriteIndented = true };
 
-#endregion fields
+        #endregion fields
 
-/// <summary>
-/// Import Export ViewModel Constructor
-/// </summary>
-/// <param name="projectManager"></param>
-/// <param name="loggerService"></param>
-/// <param name="messageService"></param>
-/// <param name="watcherService"></param>
-/// <param name="gameController"></param>
-/// <param name="modTools"></param>
-public ImportExportViewModel(
-           IProjectManager projectManager,
-           ILoggerService loggerService,
-           IProgressService<double> progressService,
-           IWatcherService watcherService,
-           INotificationService notificationService,
-           IGameControllerFactory gameController,
-           ISettingsManager settingsManager,
-           IModTools modTools,
-           MeshTools meshTools,
-           IArchiveManager archiveManager,
-           IPluginService pluginService,
-           Red4ParserService parserService
-           ) : base(ToolTitle)
+        /// <summary>
+        /// Import Export ViewModel Constructor
+        /// </summary>
+        /// <param name="projectManager"></param>
+        /// <param name="loggerService"></param>
+        /// <param name="messageService"></param>
+        /// <param name="watcherService"></param>
+        /// <param name="gameController"></param>
+        /// <param name="modTools"></param>
+        public ImportExportViewModel(
+            IProjectManager projectManager,
+            ILoggerService loggerService,
+            IProgressService<double> progressService,
+            IWatcherService watcherService,
+            INotificationService notificationService,
+            IGameControllerFactory gameController,
+            ISettingsManager settingsManager,
+            IModTools modTools,
+            MeshTools meshTools,
+            IArchiveManager archiveManager,
+            IPluginService pluginService,
+            Red4ParserService parserService) : base(ToolTitle)
         {
             _projectManager = projectManager;
             _loggerService = loggerService;
@@ -999,6 +998,13 @@ public ImportExportViewModel(
         [RelayCommand]
         private void ImportSettings()
         {
+            // Don't import if there is no active project.
+            if (_projectManager.ActiveProject == null
+                || string.IsNullOrWhiteSpace(_projectManager.ActiveProject.ProjectDirectory))
+            {
+                return;
+            }
+
             var gammaRegex = new Regex(".*_[de][0-9]*$");
 
             foreach (var importableItem in ImportableItems)


### PR DESCRIPTION
# Fix for ImportExportViewModel Crash
Early exit out of `ImportSettings` with no `ActiveProject`.

## Implemented
Used `RelayCommand` attribute's property `CanExecute` and a new property to determine if we `HasActiveProject`.

## Fixed:
@seberoth mentioned how a user could try importing/load settings without having an `ActiveProject`. This leads to an `NullReferenceException` and crash to desktop. I just short circuit in this scenario and early return out without error.

## Additional Information
The crash was in a method called `SaveSettings()` but it didn't seem like any of this code should execute without the `ActiveProject` so moved the check further up the call stack.