### PR TITLE
Continued Fix For ImportSettings Code

### DIFF
--- a/WolvenKit.App/Services/IProjectManager.cs
+++ b/WolvenKit.App/Services/IProjectManager.cs
@@ -1,11 +1,13 @@
 using System.Threading.Tasks;
+using ReactiveUI.Fody.Helpers;
 using WolvenKit.ProjectManagement.Project;
 
 namespace WolvenKit.Functionality.Services
 {
     public interface IProjectManager
     {
-        public bool IsProjectLoaded { get; set; }
+        [Reactive]
+        bool IsProjectLoaded { get; set; }
 
         EditorProject ActiveProject { get; set; }
 

--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -218,6 +218,15 @@ namespace WolvenKit.ViewModels.Tools
 
                     SelectedObject = IsImportsSelected ? SelectedImport : IsExportsSelected ? SelectedExport : SelectedConvert;
                 });
+
+            this
+                .WhenAnyValue(x => x._projectManager.IsProjectLoaded)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(
+                    _ =>
+                    {
+                        ImportSettingsCommand.NotifyCanExecuteChanged();
+                    });
         }
 
         private static bool CheckForMultiImport(Models.FileModel file)
@@ -304,7 +313,7 @@ namespace WolvenKit.ViewModels.Tools
         #endregion properties
 
         public ICommand AddItemsCommand { get; private set; }
-        
+
         public ICommand RemoveItemsCommand { get; private set; }
 
         private bool CanAddItems(ObservableCollection<object> items) => true;
@@ -976,8 +985,7 @@ namespace WolvenKit.ViewModels.Tools
         private void SetupToolDefaults() => ContentId = ToolContentId;
 
         public bool HasActiveProject => _projectManager != null
-            && _projectManager.ActiveProject != null
-            && string.IsNullOrWhiteSpace(_projectManager.ActiveProject.ProjectDirectory);
+            && _projectManager.IsProjectLoaded;
 
         #region Commands
 

--- a/WolvenKit/Views/Tools/ImportExportView.xaml.cs
+++ b/WolvenKit/Views/Tools/ImportExportView.xaml.cs
@@ -56,6 +56,7 @@ namespace WolvenKit.Views.Tools
                         x => x.ExportableItems,
                         x => x.ExportGrid.ItemsSource)
                     .DisposeWith(disposables);
+
                 this.Bind(ViewModel,
                        x => x.SelectedExport,
                        x => x.ExportGrid.SelectedItem)
@@ -65,6 +66,7 @@ namespace WolvenKit.Views.Tools
                         x => x.ImportableItems,
                         x => x.ImportGrid.ItemsSource)
                     .DisposeWith(disposables);
+
                 this.Bind(ViewModel,
                        x => x.SelectedImport,
                        x => x.ImportGrid.SelectedItem)
@@ -74,11 +76,11 @@ namespace WolvenKit.Views.Tools
                         x => x.ConvertableItems,
                         x => x.ConvertGrid.ItemsSource)
                     .DisposeWith(disposables);
+
                 this.Bind(ViewModel,
                        x => x.SelectedConvert,
                        x => x.ConvertGrid.SelectedItem)
                    .DisposeWith(disposables);
-
             });
 
             this.WhenAnyValue(x => x.ViewModel.SelectedObject)


### PR DESCRIPTION
# Continued Fix For ImportSettings Code

## Implemented
 * Re-enable button after Projects are loaded into memory.

## Fixed
 * Just the correct amount of wiring for Observable to trigger and updating the Interface to allow React Observability on the target property.
 
 ## Relates To
 #934 
 
 ## Who Broke It
 @houseofcat 