### PR TITLE
Rework Depot Operations

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
@@ -38,41 +38,13 @@ namespace WolvenKit.ViewModels.Shell
             _modTools = modTools;
             SettingsManager = settingsManager;
 
-            OpenMaterialRepositoryCommand = ReactiveCommand.Create(() => Commonfunctions.ShowFolderInExplorer(SettingsManager.MaterialRepositoryPath));
-
-            UnbundleGameCommand = ReactiveCommand.CreateFromTask(UnbundleGame);
+            OpenGameFolderCommand = ReactiveCommand.Create(() => Commonfunctions.ShowFolderInExplorer(SettingsManager.GetRED4GameRootDir()));
         }
 
         public ISettingsManager SettingsManager { get; }
         public AppViewModel MainViewModel { get; }
 
-        public ReactiveCommand<Unit, Unit> OpenMaterialRepositoryCommand { get; }
-        public ReactiveCommand<Unit, Unit> UnbundleGameCommand { get; }
+        public ReactiveCommand<Unit, Unit> OpenGameFolderCommand { get; }
 
-        private async Task UnbundleGame()
-        {
-            var depotPath = new DirectoryInfo(SettingsManager.MaterialRepositoryPath);
-            if (depotPath.Exists)
-            {
-                await Task.Run(() =>
-                {
-                    var archives = _archiveManager.Archives.KeyValues.Select(x => x.Value).ToList();
-
-                    var total = archives.Count;
-                    var progress = 0;
-                    _progressService.Report(0);
-
-                    for (var i = 0; i < archives.Count; i++)
-                    {
-                        var archive = archives[i];
-                        _modTools.ExtractAll(archive as Archive, depotPath);
-
-                        progress++;
-                        _progressService.Report(i / (float)total);
-                    }
-                    _progressService.Report(1.0);
-                });
-            }
-        }
     }
 }

--- a/WolvenKit.Common/Interfaces/IModTools.cs
+++ b/WolvenKit.Common/Interfaces/IModTools.cs
@@ -36,6 +36,16 @@ namespace WolvenKit.Common.Interfaces
             DirectoryInfo rawOutDir = null,
             ECookedFileFormat[] forcebuffers = null,
             bool serialize = false);
+
+        public Task<bool> UncookSingleAsync(
+            ICyberGameArchive archive,
+            ulong hash,
+            DirectoryInfo outDir,
+            GlobalExportArgs args,
+            DirectoryInfo rawOutDir = null,
+            ECookedFileFormat[] forcebuffers = null,
+            bool serialize = false);
+
         void UncookAll(ICyberGameArchive ar, DirectoryInfo outDir, GlobalExportArgs args, bool unbundle = false, string pattern = "", string regex = "", DirectoryInfo rawOutDir = null, ECookedFileFormat[] forcebuffers = null, bool serialize = false);
 
         public bool ConvertToAndWrite(ETextConvertFormat format, string infile, DirectoryInfo outputDirInfo);

--- a/WolvenKit.Core/Extensions/IEnumerableExtensions.cs
+++ b/WolvenKit.Core/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WolvenKit.Core.Extensions;
+
+public static class IEnumerableExtensions
+{
+    public static Task ParallelForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> funcBody, int maxDoP = 4)
+    {
+        async Task AwaitPartition(IEnumerator<T> partition)
+        {
+            using (partition)
+            {
+                while (partition.MoveNext())
+                {
+                    await Task.Yield();
+                    await funcBody(partition.Current)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+
+        return Task.WhenAll(
+            Partitioner
+                .Create(source)
+                .GetPartitions(maxDoP)
+                .AsParallel()
+                .Select(AwaitPartition));
+    }
+
+    public static Task ParallelForEachAsync<T1, T2>(this IEnumerable<T1> source, Func<T1, T2, Task> funcBody, T2 secondInput, int maxDoP = 4)
+    {
+        async Task AwaitPartition(IEnumerator<T1> partition)
+        {
+            using (partition)
+            {
+                while (partition.MoveNext())
+                {
+                    await Task.Yield();
+                    await funcBody(partition.Current, secondInput).ConfigureAwait(false);
+                }
+            }
+        }
+
+        return Task.WhenAll(
+            Partitioner
+                .Create(source)
+                .GetPartitions(maxDoP)
+                .AsParallel()
+                .Select(AwaitPartition));
+    }
+
+    public static Task ParallelForEachAsync<T1, T2, T3>(this IEnumerable<T1> source, Func<T1, T2, T3, Task> funcBody, T2 secondInput, T3 thirdInput, int maxDoP = 4)
+    {
+        async Task AwaitPartition(IEnumerator<T1> partition)
+        {
+            using (partition)
+            {
+                while (partition.MoveNext())
+                {
+                    await Task.Yield();
+                    await funcBody(partition.Current, secondInput, thirdInput).ConfigureAwait(false);
+                }
+            }
+        }
+
+        return Task.WhenAll(
+            Partitioner
+                .Create(source)
+                .GetPartitions(maxDoP)
+                .AsParallel()
+                .Select(AwaitPartition));
+    }
+}

--- a/WolvenKit.Core/Interfaces/IGameFile.cs
+++ b/WolvenKit.Core/Interfaces/IGameFile.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 
 namespace WolvenKit.Core.Interfaces;
 
@@ -32,4 +33,6 @@ public interface IGameFile
     #endregion Properties
 
     public void Extract(Stream output);
+
+    public Task ExtractAsync(Stream output);
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -340,7 +340,13 @@ namespace WolvenKit.Modkit.RED4
             var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
             var smallOffset = widthInTiles0 * heightInTiles0;
 
-            var smallScale = maskWidth / mWidthLow;
+            // DivideByZero preventions.
+            // maskWidthLow == 0
+            // maskWidth < mWidthLow => maskWidth / mWidthLow = 0 because (int) Math
+            var smallScale =
+                mWidthLow == 0 || mWidthLow !< maskWidth
+                ? 1
+                : maskWidth / mWidthLow;
 
             for (uint x = 0; x < maskWidth; x++)
             {
@@ -362,7 +368,11 @@ namespace WolvenKit.Modkit.RED4
             var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
 
             var paramOffset = tilesData[tileIndex * 2];
-            var paramBits = tilesData[(tileIndex * 2) + 1];
+
+            // IndexOutOfRange Prevention
+            var paramBits = tilesData.Length > (tileIndex * 2) + 1
+                ? tilesData[(tileIndex * 2) + 1]
+                : 0;
 
             if ((uint)(paramBits & (1 << maskIndex)) == 0U)
             {

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -139,6 +139,118 @@ namespace WolvenKit.Modkit.RED4
         }
 
         /// <summary>
+        /// Uncooks a single file by hash. This will both extract and uncook the redengine file
+        /// </summary>
+        /// <param name="archive"></param>
+        /// <param name="hash"></param>
+        /// <param name="outDir"></param>
+        /// <param name="rawOutDir"></param>
+        /// <param name="args"></param>
+        /// <param name="forcebuffers"></param>
+        /// <returns></returns>
+        public async Task<bool> UncookSingleAsync(
+            ICyberGameArchive archive,
+            ulong hash,
+            DirectoryInfo outDir,
+            GlobalExportArgs args,
+            DirectoryInfo rawOutDir = null,
+            ECookedFileFormat[] forcebuffers = null,
+            bool serialize = false)
+        {
+            if (!archive.Files.TryGetValue(hash, out var gameFile))
+            {
+                return false;
+            }
+
+            #region unbundle main file
+
+            using var cr2WStream = new MemoryStream();
+            await gameFile.ExtractAsync(cr2WStream);
+
+            if (archive.Files[hash] is not FileEntry entry)
+            {
+                return false;
+            }
+
+            var relFileFullName = entry.FileName;
+            if (string.IsNullOrEmpty(Path.GetExtension(relFileFullName)))
+            {
+                relFileFullName += ".bin";
+            }
+
+            var mainFileInfo = new FileInfo(Path.Combine(outDir.FullName, $"{relFileFullName.Replace('\\', Path.DirectorySeparatorChar)}"));
+
+            // write mainFile
+            if (!WolvenTesting.IsTesting)
+            {
+                if (mainFileInfo.Directory != null)
+                {
+                    Directory.CreateDirectory(mainFileInfo.Directory.FullName);
+                }
+
+                // prevents batch extract to create write conflicts when a single file is referrenced by multiple items
+                if (!File.Exists(mainFileInfo.FullName))
+                {
+                    using var fs = new FileStream(mainFileInfo.FullName, FileMode.Create, FileAccess.Write);
+                    cr2WStream.Seek(0, SeekOrigin.Begin);
+                    await cr2WStream.CopyToAsync(fs);
+                }
+            }
+
+            #endregion unbundle main file
+
+            #region serialize
+
+            if (serialize)
+            {
+                try
+                {
+                    var jsonOutput = SerializeMainFile(cr2WStream);
+                    var outpath = Path.Combine(outDir.FullName, $"{relFileFullName.Replace('\\', Path.DirectorySeparatorChar)}.json");
+                    await File.WriteAllTextAsync(outpath, jsonOutput);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    _loggerService.Error($"{relFileFullName} And unexpected error occured while converting to json: {e.Message}");
+                    _loggerService.Error(e);
+                    return false;
+                }
+            }
+
+            #endregion serialize
+
+            #region extract buffers
+
+            var hasBuffers = (entry.SegmentsEnd - entry.SegmentsStart) > 1;
+            if (!hasBuffers)
+            {
+                return true;
+            }
+
+            // uncook main file buffers to raw out dir
+            if (rawOutDir is null or { Exists: false })
+            {
+                rawOutDir = outDir;
+            }
+
+            try
+            {
+                // wems need the physical infile path
+                args.Get<WemExportArgs>().FileName = mainFileInfo.FullName;
+                return UncookBuffers(cr2WStream, relFileFullName, args, rawOutDir, forcebuffers);
+            }
+            catch (Exception e)
+            {
+                _loggerService.Error($"{relFileFullName} And unexpected error occured while uncooking: {e.Message}");
+                _loggerService.Error(e);
+                return false;
+            }
+
+            #endregion extract buffers
+        }
+
+        /// <summary>
         /// Uncooks all Files to the specified directory.
         /// </summary>
         /// <param name="ar"></param>

--- a/WolvenKit.RED4.Archive/Base/FileEntry.cs
+++ b/WolvenKit.RED4.Archive/Base/FileEntry.cs
@@ -106,6 +106,8 @@ namespace WolvenKit.RED4.Archive
 
         public void Extract(Stream output) => Extract(output, false);
 
+        public Task ExtractAsync(Stream output) => ExtractAsync(output, false);
+
         public void Extract(Stream output, bool decompressBuffers)
         {
             if (Archive is not ICyberGameArchive ar)

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -138,8 +138,8 @@ namespace WolvenKit
                         fileSizeLimitBytes: 100 * 1000 * 1024, // MaxFileSize: 100 MB
                         retainedFileCountLimit: 10,
                         buffered: true, // Allow internal buffering.
-                        flushToDiskInterval: TimeSpan.FromMinutes(1)),
-                    bufferSize: 1000) // Write once per minute.
+                        flushToDiskInterval: TimeSpan.FromMinutes(1)), // Write once per minute.
+                    bufferSize: 1000)
                 .CreateLogger();
         }
 

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -127,7 +127,7 @@ namespace WolvenKit
                 .MinimumLevel.Debug()
                 .WriteTo.Async(a => a.Console(), bufferSize: 1000)
 #else
-                .MinimumLevel.Warning()
+                .MinimumLevel.Information()
 #endif
                 .WriteTo.MySink(_host.Services.GetService<MySink>())
                 .WriteTo.Async(

--- a/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml
@@ -6,13 +6,16 @@
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:local="clr-namespace:WolvenKit.Views.Dialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="Materials Generator"
-    Width="650"
+    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    Title="Depot Generator"
+    Width="800"
     Height="450"
     Closed="Window_Closed"
     ResizeMode="NoResize"
+
     SizeToContent="Height"
     mc:Ignorable="d"
+    ShowInTaskbar="False"
     WindowStartupLocation="CenterOwner">
 
     <hc:Window.Resources>
@@ -25,61 +28,126 @@
     </hc:Window.Resources>
 
     <Grid Background="{DynamicResource RegionBrush}" DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type hc:Window}}}">
-        <StackPanel>
-            <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical">
-                <Border
-                    Margin="15,15,15,15"
-                    VerticalAlignment="Stretch"
-                    Style="{StaticResource BorderTipWarning}">
-                    <TextBlock Text="Generation requires 32GB of space and is extremely resource intensive. Full generation not necessary for material exports." />
-                </Border>
-            </StackPanel>
-            <StackPanel
-                HorizontalAlignment="Center"
-                IsEnabled="False"
-                Orientation="Horizontal">
+
+        <StackPanel HorizontalAlignment="Stretch">
+            <Grid Margin="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
                 <TextBlock
-                    Width="150"
-                    HorizontalAlignment="Stretch"
-                    Text="Game Executable Path" />
-                <TextBox
-                    x:Name="ArchivesTextBox"
-                    Width="390"
-                    HorizontalAlignment="Stretch"
-                    IsEnabled="False"
-                    Text="{Binding ArchivesFolderPath, Mode=OneWay}" />
-                <Button
-                    x:Name="ArchivesButton"
-                    Margin="5,0,0,0"
-                    Click="ArchivesButton_Click"
-                    Content="Find" />
-            </StackPanel>
-            <StackPanel
-                Margin="0,15,0,0"
-                HorizontalAlignment="Center"
-                Orientation="Horizontal">
-                <TextBlock
-                    Width="150"
-                    HorizontalAlignment="Stretch"
+                    Grid.Column="0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
                     Text="Depot Path" />
                 <TextBox
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
                     x:Name="MaterialsTextBox"
-                    Width="390"
-                    HorizontalAlignment="Stretch"
-                    hc:InfoElement.Necessary="True"
-                    IsEnabled="False"
-                    Text="{Binding MaterialsDepotPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <Button
-                    x:Name="MaterialsButton"
-                    Margin="5,0,0,0"
-                    Click="MaterialsButton_Click"
-                    Content="Find" />
-            </StackPanel>
+                    ToolTip="The Depot Path is the output folder for extracted files"
+                    PreviewMouseDown="MaterialsButton_Click"
+                    IsReadOnly="True"
+                    Text="{Binding MaterialsDepotPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </Grid>
             <Button
-                Margin="15"
                 HorizontalAlignment="Stretch"
-                Click="GenerateButton_Click"
-                Content="Generate" />
+                Margin="16,0"
+                Command="{Binding OpenMaterialRepositoryCommand}"
+                Content="Open Depot Folder" />
+
+            <Grid Margin="16,48,16,16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="200"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button
+                    Grid.Column="0"
+                    Height="48"
+                    Width="190"
+                    HorizontalAlignment="Left"
+                    Click="GenerateButton_Click"
+                    ToolTip="Extracts all material files from archives and exports textures to PNG">
+                    <Button.Content>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="24"/>
+                                <ColumnDefinition Width="100"/>
+                            </Grid.ColumnDefinitions>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="0,0,2,2"
+                                Foreground="{StaticResource WolvenKitTan}"
+                                Kind="PictureOutline"/>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="6,6,-3,-3"
+                                Foreground="{StaticResource ContentBackgroundAlt2}"
+                                Kind="Circle"/>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="8,8,-1,-1"
+                                Kind="Cog"/>
+                            <TextBlock
+                                Grid.Column="1"
+                                Text="Generate Materials"/>
+                        </Grid>
+                    </Button.Content>
+                </Button>
+
+                <StackPanel Grid.Column="1">
+                    <Border
+                        Height="48"
+                        VerticalAlignment="Stretch"
+                        Style="{StaticResource BorderTipWarning}">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="Requires xxGB of space and is extremely resource intensive. Not necessary for material exports." />
+                    </Border>
+                </StackPanel>
+            </Grid>
+
+            <Grid Margin="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="200"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="0"
+                    Height="48"
+                    Width="190"
+                    HorizontalAlignment="Left"
+                    Command="{Binding UnbundleGameCommand}"
+                    ToolTip="Extracts all game files from archives">
+                    <Button.Content>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="24"/>
+                                <ColumnDefinition Width="100"/>
+                            </Grid.ColumnDefinitions>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="0,0,2,2"
+                                Foreground="{StaticResource WolvenKitTan}"
+                                Kind="Archive"/>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="6,6,-3,-3"
+                                Foreground="{StaticResource ContentBackgroundAlt2}"
+                                Kind="Circle"/>
+                            <iconPacks:PackIconForkAwesome
+                                Padding="8,8,-1,-1"
+                                Kind="Cog"/>
+                            <TextBlock
+                                Grid.Column="1"
+                                Text="Unbundle Game"/>
+                        </Grid>
+                    </Button.Content>
+                </Button>
+                <StackPanel Grid.Column="1">
+                    <Border
+                        Height="48"
+                        VerticalAlignment="Stretch"
+                        Style="{StaticResource BorderTipWarning}">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="Requires xxGB of space and is extremely resource intensive. Not necessary for most modding workflows." />
+                    </Border>
+                </StackPanel>
+            </Grid>
         </StackPanel>
     </Grid>
 </hc:Window>

--- a/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml.cs
@@ -153,7 +153,25 @@ namespace WolvenKit.Views.Dialogs.Windows
                         _parallelOptions,
                         entry =>
                         {
+                            var endPath = Path.Combine(materialRepoDir.FullName, entry.Name);
+                            var dirpath = Path.GetDirectoryName(endPath);
+                            var dirInfo = Directory.CreateDirectory(dirpath);
 
+                            try
+                            {
+                                if (dirInfo.Exists) // CreateDirectory sometimes is false even on success.
+                                {
+                                    using var fs = new FileStream(endPath, FileMode.Create, FileAccess.Write);
+                                    entry.Extract(fs);
+                                }
+                                Interlocked.Increment(ref progress);
+                                _progress.Report(progress / (float)filesList.Count);
+                            }
+                            catch (Exception ex)
+                            {
+                                _loggerService.Error($"Error extracting [File: {entry.Name}] [Key: {entry.Key}]");
+                                _loggerService.Error(ex);
+                            }
                         }
                     );
                 }

--- a/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/MaterialsRepositoryDialog.xaml.cs
@@ -115,13 +115,13 @@ namespace WolvenKit.Views.Dialogs.Windows
 
                 var filesList = groupedFiles[key].GroupBy(x => x.Key).Select(x => x.First()).ToList();
                 var fileCount = filesList.Count;
-                _loggerService.Info($"{key}: Found {fileCount} entries to uncook");
+                _loggerService.Info($"{key}: Found {fileCount} entries to unbundle");
                 var progress = 0;
                 _progress.Report(0);
 
                 if (UseNewParallelism)
                 {
-                    async Task ExtractAsync(FileEntry entry)
+                    async Task UnbundleAsync(FileEntry entry)
                     {
                         var endPath = Path.Combine(materialRepoDir.FullName, entry.Name);
                         var dirpath = Path.GetDirectoryName(endPath);
@@ -139,12 +139,12 @@ namespace WolvenKit.Views.Dialogs.Windows
                         }
                         catch (Exception ex)
                         {
-                            _loggerService.Error($"Error extracting [File: {endPath}] [Entry: {entry.Name}]");
+                            _loggerService.Error($"Error unbundling [File: {endPath}] [Entry: {entry.Name}]");
                             _loggerService.Error(ex);
                         }
                     }
 
-                    await filesList.ParallelForEachAsync(ExtractAsync, _maxDoP);
+                    await filesList.ParallelForEachAsync(UnbundleAsync, _maxDoP);
                 }
                 else
                 {
@@ -169,7 +169,7 @@ namespace WolvenKit.Views.Dialogs.Windows
                             }
                             catch (Exception ex)
                             {
-                                _loggerService.Error($"Error extracting [File: {entry.Name}] [Key: {entry.Key}]");
+                                _loggerService.Error($"Error unbundling [File: {endPath}] [Key: {entry.Key}]");
                                 _loggerService.Error(ex);
                             }
                         }

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -490,7 +490,22 @@
                 Margin="1,0"
                 Padding="12,0"
                 Header="Tools">
-                <MenuItem x:Name="MenuItemShowSoundModdingTool" Header="Sound Modding Tool">
+                <MenuItem
+                    Header="Depot Generator"
+                    Margin="2,1"
+                    Click="GenerateMaterialRepoButton_Click">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconForkAwesome
+                            Margin="6,0"
+                            Foreground="{StaticResource WolvenKitTan}"
+                            Kind="List"
+                            Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem
+                    x:Name="MenuItemShowSoundModdingTool"
+                    Header="Sound Modding Tool"
+                    Margin="2,1">
                     <MenuItem.Icon>
                         <iconPacks:PackIconForkAwesome
                             Margin="6,0"
@@ -499,7 +514,6 @@
                             Kind="VolumeUp" />
                     </MenuItem.Icon>
                 </MenuItem>
-
             </MenuItem>
 
             <!--  Game  -->
@@ -509,20 +523,19 @@
                 Header="Game">
 
                 <MenuItem Margin="2,1" Header="Launch Game">
-
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconCodicons
+                            Margin="6,0"
+                            Foreground="{StaticResource WolvenKitYellow}"
+                            Kind="RunAll"
+                            Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                    </MenuItem.Icon>
 
                     <MenuItem
                         x:Name="ToolbarLaunchButton"
                         Margin="2,1"
                         CommandParameter="0"
                         Header="Launch Game">
-                        <MenuItem.Icon>
-                            <iconPacks:PackIconCodicons
-                                Margin="5,0,5,0"
-                                Foreground="{StaticResource WolvenKitYellow}"
-                                Kind="RunAll"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                        </MenuItem.Icon>
                     </MenuItem>
 
                     <MenuItem
@@ -537,59 +550,15 @@
                         CommandParameter="2"
                         Header="Pack, Install and Launch Game" />
 
-
                 </MenuItem>
 
-                <Separator Margin="0,10" />
-
-                <MenuItem x:Name="MenuItemUnbundleGame" Header="Unbundle Game to Depot">
+                <MenuItem Margin="2,1" x:Name="MenuItemOpenGameFolder" Header="Open Game Folder">
                     <MenuItem.Icon>
-                        <Grid Width="18" Margin="0,0,-8,0">
-                            <iconPacks:PackIconForkAwesome
-                                Padding="0,0,2,2"
-                                Foreground="{StaticResource WolvenKitTan}"
-                                Kind="Archive"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            <iconPacks:PackIconForkAwesome
-                                Padding="6,6,-3,-3"
-                                Foreground="{StaticResource ContentBackgroundAlt2}"
-                                Kind="Circle"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            <iconPacks:PackIconForkAwesome
-                                Padding="8,8,-1,-1"
-                                Kind="Cog"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                        </Grid>
-                    </MenuItem.Icon>
-                </MenuItem>
-                <MenuItem Click="GenerateMaterialRepoButton_Click" Header="Extract Materials to Depot">
-                    <MenuItem.Icon>
-                        <Grid Width="18" Margin="0,0,-8,0">
-                            <iconPacks:PackIconForkAwesome
-                                Padding="0,0,2,2"
-                                Foreground="{StaticResource WolvenKitTan}"
-                                Kind="PictureOutline"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            <iconPacks:PackIconForkAwesome
-                                Padding="6,6,-3,-3"
-                                Foreground="{StaticResource ContentBackgroundAlt2}"
-                                Kind="Circle"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            <iconPacks:PackIconForkAwesome
-                                Padding="8,8,-1,-1"
-                                Kind="Cog"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                        </Grid>
-                    </MenuItem.Icon>
-                </MenuItem>
-                <MenuItem x:Name="MenuItemOpenMaterialRepository" Header="Browse Game Depot">
-                    <MenuItem.Icon>
-                        <Grid Width="18" Margin="0,0,-8,0">
-                            <iconPacks:PackIconForkAwesome
-                                Foreground="{StaticResource WolvenKitTan}"
-                                Kind="List"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                        </Grid>
+                        <iconPacks:PackIconForkAwesome
+                            Margin="6,0"
+                            Foreground="{StaticResource WolvenKitTan}"
+                            Kind="FolderOpen"
+                            Style="{StaticResource WolvenKitToolBarButtonIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
             </MenuItem>

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -109,6 +109,10 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                     viewModel => viewModel.MainViewModel.ShowSoundModdingToolCommand,
                     view => view.MenuItemShowSoundModdingTool)
                 .DisposeWith(disposables);
+            this.BindCommand(ViewModel,
+                        viewModel => viewModel.OpenGameFolderCommand,
+                        view => view.MenuItemOpenGameFolder)
+                    .DisposeWith(disposables);
 
             // Game
             this.BindCommand(ViewModel,
@@ -132,15 +136,6 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
             //        viewModel => viewModel.MainViewModel.SelectedGameCommands,
             //        view => view.ToolbarLaunchCombobox.ItemsSource)
             //    .DisposeWith(disposables);
-
-            this.BindCommand(ViewModel,
-                        viewModel => viewModel.UnbundleGameCommand,
-                        view => view.MenuItemUnbundleGame)
-                    .DisposeWith(disposables);
-            this.BindCommand(ViewModel,
-                        viewModel => viewModel.OpenMaterialRepositoryCommand,
-                        view => view.MenuItemOpenMaterialRepository)
-                    .DisposeWith(disposables);
 
             // Extensions
             this.BindCommand(ViewModel,
@@ -194,7 +189,8 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
         {
             var x = new MaterialsRepositoryDialog();
             MaterialsRepositoryDia = x;
-            x.Show();
+            x.Owner = Application.Current.MainWindow;
+            x.ShowDialog();
         }
     }
 


### PR DESCRIPTION
# Rework Depot Operations

## Implemented
- Ja-to's command improvements.
- Added new parallelism style that should be more responsive to the entire system and UI.
- Added ability to feature flag revert to legacy parallelism.
  - Enhance legacy parallelism with options.

## Fixed
- Some arithmetic bug fixes on range / division operations. Relates to #939
- Better logging on Uncook exceptions that were getting lost in the ether.

## Preliminary Benchmark
```ini
i9 12900K @ 5.0 GHz, 32 GB of DDR4 4000 MHz

// DEBUG
12:37:29 pm - tweaked parallel foreach starttime
12:40:17 pm - endtime
2 minutes 48 seconds

// expected to be slower but better system responsiveness
// DEBUG
12:59:35 pm - new parallelforeach async starttime
13:01:54 pm - endtime
2 minutes 19 seconds
```

While the results showed it was faster, I would caution that the results are dependent on the system and level activity of the system. I would expect it to be slightly slower than the previous path forward. It should be assumed to be about 3 minutes on a comparable system and faster when in `Release` mode.