### PR TITLE
Add --mesh-export options to the uncook CLI command

### DIFF
--- a/WolvenKit.CLI/Commands/UncookCommand.cs
+++ b/WolvenKit.CLI/Commands/UncookCommand.cs
@@ -4,6 +4,7 @@ using CP77Tools.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using WolvenKit.Common;
+using WolvenKit.Common.Model.Arguments;
 
 namespace CP77Tools.Commands
 {
@@ -21,7 +22,7 @@ namespace CP77Tools.Commands
         public UncookCommand() : base(Name, Description)
         {
             AddOption(new Option<string[]>(new[] { "--path", "-p" }, "Input path to .archive."));
-            AddOption(new Option<string>(new[] { "--outpath", "-o" }, "Output directpry to extract main files to."));
+            AddOption(new Option<string>(new[] { "--outpath", "-o" }, "Output directory to extract main files to."));
             AddOption(new Option<string>(new[] { "--raw", "-or" }, "Optional seperate directory to extract raw files to."));
             AddOption(new Option<string>(new[] { "--pattern", "-w" }, "Use optional search pattern (e.g. *.ink), if both regex and pattern is defined, pattern will be prioritized."));
             AddOption(new Option<string>(new[] { "--regex", "-r" }, "Use optional regex pattern."));
@@ -31,18 +32,35 @@ namespace CP77Tools.Commands
             AddOption(new Option<bool>(new[] { "--unbundle", "-u" }, "Also unbundle files."));
             AddOption(new Option<ECookedFileFormat[]>(new[] { "--forcebuffers", "-fb" }, "Force uncooking to buffers for given extension. e.g. mesh"));
             AddOption(new Option<bool>(new[] { "--serialize", "-s" }, "Serialize to JSON"));
+            AddOption(new Option<MeshExportType?>(new[] { "--mesh-export-type" }, "Mesh export type (Default, WithMaterials, WithRig, Multimesh)."));
+            AddOption(new Option<string>(new[] { "--mesh-export-material-repo" }, "Location of the material repo, if not specified, it uses the outpath."));
+
 
             Handler = CommandHandler
-                .Create<string[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[], bool?
+                .Create<string[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[], bool?, MeshExportType?, string
                     , IHost>(Action);
         }
 
         private void Action(string[] path, string outpath, string raw, EUncookExtension? uext, bool? flip, ulong hash, string pattern,
-            string regex, bool unbundle, ECookedFileFormat[] forcebuffers, bool? serialize, IHost host)
+            string regex, bool unbundle, ECookedFileFormat[] forcebuffers, bool? serialize, MeshExportType? meshExportType, string meshExportMaterialRepo, IHost host)
         {
             var serviceProvider = host.Services;
             var consoleFunctions = serviceProvider.GetRequiredService<ConsoleFunctions>();
-            consoleFunctions.UncookTask(path, outpath, raw, uext, flip, hash, pattern, regex, unbundle, forcebuffers, serialize);
+            consoleFunctions.UncookTask(path, new UncookTaskOptions
+            {
+                outpath = outpath,
+                rawOutDir = raw,
+                uext = uext,
+                flip = flip,
+                hash = hash,
+                pattern = pattern,
+                regex = regex,
+                unbundle = unbundle,
+                forcebuffers = forcebuffers,
+                serialize = serialize,
+                meshExportType = meshExportType,
+                meshExportMaterialRepo = meshExportMaterialRepo
+            });
         }
 
 

--- a/WolvenKit.Modkit/RED4/Tasks/ConsoleFunctions.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/ConsoleFunctions.cs
@@ -22,9 +22,7 @@ namespace CP77Tools.Tasks
         public Task ImportTask(string[] path, string outDir, bool keep);
         public int OodleTask(string path, string outpath, bool decompress, bool compress);
         public void PackTask(string[] path, string outpath);
-        public void UncookTask(string[] path, string outpath, string rawOutDir,
-            EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers, bool? serialize);
+        public void UncookTask(string[] path, UncookTaskOptions options);
     }
 
     public partial class ConsoleFunctions : IConsoleFunctions

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -9,13 +9,27 @@ using WolvenKit.RED4.Archive;
 
 namespace CP77Tools.Tasks
 {
+    public record UncookTaskOptions
+    {
+        public string outpath { get; init; }
+        public string rawOutDir { get; init; }
+        public EUncookExtension? uext { get; init; }
+        public  bool? flip { get; init; }
+        public ulong hash { get; init; }
+        public  string pattern { get; init; }
+        public  string regex { get; init; }
+        public  bool unbundle { get; init; }
+        public  ECookedFileFormat[] forcebuffers { get; init; }
+        public  bool? serialize { get; init; }
+        public MeshExportType? meshExportType { get; init; }
+        public string meshExportMaterialRepo { get; init; }
+    }
+
     public partial class ConsoleFunctions
     {
         #region Methods
 
-        public void UncookTask(string[] path, string outpath, string rawOutDir,
-            EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers, bool? serialize)
+        public void UncookTask(string[] path, UncookTaskOptions options)
         {
             if (path == null || path.Length < 1)
             {
@@ -25,13 +39,11 @@ namespace CP77Tools.Tasks
 
             foreach (var file in path)
             {
-                UncookTaskInner(file, outpath, rawOutDir, uext, flip, hash, pattern, regex, unbundle, forcebuffers, serialize);
+                UncookTaskInner(file, options);
             }
         }
 
-        private void UncookTaskInner(string path, string outpath, string rawOutDir,
-            EUncookExtension? uext, bool? flip, ulong hash, string pattern, string regex, bool unbundle,
-            ECookedFileFormat[] forcebuffers, bool? serialize)
+        private void UncookTaskInner(string path, UncookTaskOptions options)
         {
             #region checks
 
@@ -60,6 +72,12 @@ namespace CP77Tools.Tasks
                 _loggerService.Warning("No .archive file to process in the input directory");
                 return;
             }
+            
+            if (options.meshExportType != null && string.IsNullOrEmpty(options.meshExportMaterialRepo) && string.IsNullOrEmpty(options.outpath))
+            {
+                _loggerService.Warning("When using --mesh-export-type, the --outpath or the --mesh-export-material-repo must be specified.");
+                return;
+            }
 
             var isDirectory = !inputFileInfo.Exists;
             var basedir = inputFileInfo.Exists ? new FileInfo(path).Directory : inputDirInfo;
@@ -73,14 +91,23 @@ namespace CP77Tools.Tasks
                 _mlmaskExportArgs.Value,
                 _wemExportArgs.Value
             );
-            if (flip != null)
+            if (options.flip != null)
             {
-                exportArgs.Get<XbmExportArgs>().Flip = flip.Value;
+                exportArgs.Get<XbmExportArgs>().Flip = options.flip.Value;
             }
-            if (uext != null)
+            if (options.uext != null)
             {
-                exportArgs.Get<XbmExportArgs>().UncookExtension = uext.Value;
-                exportArgs.Get<MlmaskExportArgs>().UncookExtension = uext.Value;
+                exportArgs.Get<XbmExportArgs>().UncookExtension = options.uext.Value;
+                exportArgs.Get<MlmaskExportArgs>().UncookExtension = options.uext.Value;
+            }
+            if (options.meshExportType != null)
+            {
+                exportArgs.Get<MeshExportArgs>().meshExportType = options.meshExportType.Value;
+                if (string.IsNullOrEmpty(options.meshExportMaterialRepo))
+                    exportArgs.Get<MeshExportArgs>().MaterialRepo = options.outpath;
+                else
+                    exportArgs.Get<MeshExportArgs>().MaterialRepo = options.meshExportMaterialRepo;
+                exportArgs.Get<MeshExportArgs>().ArchiveDepot = basedir.FullName;
             }
 
             var archiveDepot = exportArgs.Get<MeshExportArgs>().ArchiveDepot;
@@ -129,30 +156,30 @@ namespace CP77Tools.Tasks
             {
                 // get outdirectory
                 DirectoryInfo outDir;
-                if (string.IsNullOrEmpty(outpath))
+                if (string.IsNullOrEmpty(options.outpath))
                 {
                     outDir = new DirectoryInfo(basedir.FullName);
                 }
                 else
                 {
-                    outDir = new DirectoryInfo(outpath);
+                    outDir = new DirectoryInfo(options.outpath);
                     if (!outDir.Exists)
                     {
-                        outDir = new DirectoryInfo(outpath);
+                        outDir = new DirectoryInfo(options.outpath);
                     }
                 }
 
                 DirectoryInfo rawOutDirInfo = null;
-                if (string.IsNullOrEmpty(rawOutDir))
+                if (string.IsNullOrEmpty(options.rawOutDir))
                 {
                     rawOutDirInfo = outDir;
                 }
                 else
                 {
-                    rawOutDirInfo = new DirectoryInfo(rawOutDir);
+                    rawOutDirInfo = new DirectoryInfo(options.rawOutDir);
                     if (!rawOutDirInfo.Exists)
                     {
-                        rawOutDirInfo = new DirectoryInfo(rawOutDir);
+                        rawOutDirInfo = new DirectoryInfo(options.rawOutDir);
                     }
                 }
 
@@ -160,14 +187,14 @@ namespace CP77Tools.Tasks
                 var ar = _wolvenkitFileService.ReadRed4Archive(fileInfo.FullName, _hashService);
 
                 // run
-                if (hash != 0)
+                if (options.hash != 0)
                 {
-                    _modTools.UncookSingle(ar, hash, outDir, exportArgs, rawOutDirInfo, forcebuffers, serialize ?? false);
-                    _loggerService.Success($" {ar.ArchiveAbsolutePath}: Uncooked one file: {hash}");
+                    _modTools.UncookSingle(ar, options.hash, outDir, exportArgs, rawOutDirInfo, options.forcebuffers, options.serialize ?? false);
+                    _loggerService.Success($" {ar.ArchiveAbsolutePath}: Uncooked one file: {options.hash}");
                 }
                 else
                 {
-                    _modTools.UncookAll(ar, outDir, exportArgs, unbundle, pattern, regex, rawOutDirInfo, forcebuffers, serialize ?? false);
+                    _modTools.UncookAll(ar, outDir, exportArgs, options.unbundle, options.pattern, options.regex, rawOutDirInfo, options.forcebuffers, options.serialize ?? false);
                 }
             }
 


### PR DESCRIPTION
# Add mesh export options to the uncook CLI command

Add CLI options to export meshes.
`--mesh-export-type` which matches the export types in the UI
`--mesh-export-material-repo` which optionally allows to have a material repo in a different folder than the output

Added as well a small refactor for the uncook options to make it easier in the future to add more options.

When reviewing, I recommend enabling the hide whitespace changes option, it renders the refactor much easier to read.

Fixed:
- #805 

