### PR TITLE
Add extra nullchecks for the RenderResourceBlob

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -35,7 +35,7 @@ namespace WolvenKit.Modkit.RED4
             }
 
             var cr2w = _wolvenkitFileService.ReadRed4File(meshStream);
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
                 return false;
             }
@@ -1115,7 +1115,7 @@ namespace WolvenKit.Modkit.RED4
 
         public bool WriteMatToMesh(ref CR2WFile cr2w, string _matData, List<ICyberGameArchive> archives)
         {
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob)
             {
                 return false;
             }

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -38,7 +38,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
         public static bool ExportMeshPreviewer(CR2WFile cr2w, FileInfo outFile)
         {
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
                 return false;
             }
@@ -106,7 +106,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
         public static ModelRoot GetModel(CR2WFile cr2w, bool lodFilter = true, bool includeRig = true, ulong chunkMask = ulong.MaxValue)
         {
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
                 return null;
             }
@@ -136,7 +136,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
         public static void AddMeshToModel(CR2WFile cr2w, ModelRoot model, Skin skin, IVisualNodeContainer node, bool lodFilter = true, ulong chunkMask = ulong.MaxValue, Dictionary<string, Material> materials = null)
         {
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
                 return;
             }
@@ -218,7 +218,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             {
                 var cr2w = _red4ParserService.ReadRed4File(meshStream);
 
-                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
                 {
                     continue;
                 }
@@ -258,7 +258,7 @@ namespace WolvenKit.Modkit.RED4.Tools
         {
             var cr2w = _red4ParserService.ReadRed4File(meshStream);
 
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
                 return false;
             }
@@ -319,7 +319,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             foreach (var meshStream in meshStreamS)
             {
                 var cr2w = _red4ParserService.ReadRed4File(meshStream);
-                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null ||  cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
                 {
                     continue;
                 }

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -41,7 +41,7 @@ namespace WolvenKit.Modkit.RED4
                     }
                 }
                 var meshCr2w = _wolvenkitFileService.ReadRed4File(meshStream);
-                if (meshCr2w != null && meshCr2w.RootChunk is CMesh mesh && mesh.RenderResourceBlob.Chunk is rendRenderMeshBlob rendBlob)
+                if (meshCr2w != null && meshCr2w.RootChunk is CMesh mesh && mesh.RenderResourceBlob != null && mesh.RenderResourceBlob.Chunk is rendRenderMeshBlob rendBlob)
                 {
                     newRig = MeshTools.GetOrphanRig(mesh);
                 }

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -41,7 +41,7 @@ namespace WolvenKit.Modkit.RED4
                     }
                 }
                 var meshCr2w = _wolvenkitFileService.ReadRed4File(meshStream);
-                if (meshCr2w != null && meshCr2w.RootChunk is CMesh baseMeshBlob && baseMeshBlob.RenderResourceBlob.Chunk is rendRenderMeshBlob)
+                if (meshCr2w != null && meshCr2w.RootChunk is CMesh baseMeshBlob && baseMeshBlob.RenderResourceBlob != null && baseMeshBlob.RenderResourceBlob.Chunk is rendRenderMeshBlob)
                 {
                     Rig = MeshTools.GetOrphanRig(baseMeshBlob);
                 }


### PR DESCRIPTION
# Add extra nullchecks for the RenderResourceBlob

This nullcheck already exists in a few places, but it seems some of the assertions were forgotten.
Wolvenkit doesn't really support extracting non-rendered meshes. There's a few of them in the base folder of the archives, and right now they trigger NullPointerExceptions.

If we want to support these later, we'll probably want to have different extracting functions altogether, or it would need at least some bigger refactoring.