### PR TITLE
Fix Importer losing files saved by PS or paint.net

### DIFF
--- a/WolvenKit.App/Services/WatcherService.cs
+++ b/WolvenKit.App/Services/WatcherService.cs
@@ -181,14 +181,8 @@ namespace WolvenKit.Functionality.Services
                 return;
             }
 
-            if (Path.GetExtension(e.Name).ToUpper().Equals(".TMP", StringComparison.Ordinal) ||
-                Path.GetExtension(e.OldName).ToUpper().Equals(".TMP", StringComparison.Ordinal) ||
-                Path.GetExtension(e.Name).ToUpper().Equals(".PDNSAVE", StringComparison.Ordinal) ||
-                Path.GetExtension(e.OldName).ToUpper().Equals(".PDNSAVE", StringComparison.Ordinal)
-                )
-            {
-                return;
-            }
+            bool newIsTempFile = Path.GetExtension(e.Name).ToUpper().Equals(".TMP", StringComparison.Ordinal) ||
+                                 Path.GetExtension(e.Name).ToUpper().Equals(".PDNSAVE", StringComparison.Ordinal);
 
             switch (e.ChangeType)
             {
@@ -196,7 +190,11 @@ namespace WolvenKit.Functionality.Services
                 {
                     var key = FileModel.GenerateKey(e.OldFullPath, _projectManager.ActiveProject);
                     _files.RemoveKey(key);
-                    _files.AddOrUpdate(new FileModel(e.FullPath, _projectManager.ActiveProject));
+
+                    if(!newIsTempFile)
+                    {
+                        _files.AddOrUpdate(new FileModel(e.FullPath, _projectManager.ActiveProject));
+                    }
                     break;
                 }
 


### PR DESCRIPTION
Fix Importer losing files saved by PS or paint.net

Fixed:
- Fixed a bug where files saved by paint.net or PhotoShop may be lost in the Importer list.


This commit fixes an issue where files are ignored after being renamed from some temp name (.tmp) to a valid file name. This can occur when files are being saved in Photoshop or paint.net. The solution here was to always remove files either being renamed from or to a temp name but only start tracking files when they have been renamed to a non-temp file name. Reproduced the original paint.net crash and can confirm that this fixes the bug but still surpesses the crash in paint.net 
