### PR TITLE
Improve Rename in Project File Explorer and add Key Shortcuts

### DIFF
--- a/WolvenKit/Views/Dialogs/Windows/RenameDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/RenameDialog.xaml.cs
@@ -31,8 +31,13 @@ namespace WolvenKit.Views.Dialogs.Windows
 
                 if (!string.IsNullOrEmpty(TextBox.Text))
                 {
-                    var ext = Path.GetExtension(TextBox.Text);
-                    TextBox.CaretIndex = Math.Max(TextBox.Text.Length - ext.Length, 0);
+                    var fileNameStart = TextBox.Text.LastIndexOf(@"\");
+                    fileNameStart = (fileNameStart < 0) ? 0 : fileNameStart+1;
+
+                    var fileNameEnd = TextBox.Text.IndexOf(@".", fileNameStart);
+                    fileNameEnd = (fileNameEnd < 0) ? ViewModel.Text.Length - 1 : fileNameEnd;
+
+                    TextBox.Select(fileNameStart, fileNameEnd - fileNameStart);
                     TextBox.Focus();
                 }
 

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -108,7 +108,7 @@
 
                 <Separator />
 
-                <MenuItem Command="{Binding DeleteFileCommand}" Header="Delete">
+                <MenuItem Command="{Binding DeleteFileCommand}" Header="Delete" InputGestureText="Del">
                     <MenuItem.Icon>
                         <iconPacks:PackIconForkAwesome
                             Width="13"
@@ -118,7 +118,7 @@
                             Kind="Trash" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Command="{Binding RenameFileCommand}" Header="Rename">
+                <MenuItem Command="{Binding RenameFileCommand}" Header="Rename" InputGestureText="F2">
                     <MenuItem.Icon>
                         <iconPacks:PackIconForkAwesome
                             Width="13"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -128,6 +128,9 @@ namespace WolvenKit.Views.Tools
                     viewModel => viewModel.RefreshCommand,
                     view => view.RefreshButton);
 
+                // register to KeyUp because KeyDown doesn't forward "F2"
+                this.KeyUp += OnKeyUp;
+
 
             });
 
@@ -141,6 +144,19 @@ namespace WolvenKit.Views.Tools
             }
         }
 
+        private void OnKeyUp(object sender, KeyEventArgs e)
+        {
+            if(e.Key == Key.F2 && ViewModel.RenameFileCommand.CanExecute(null))
+            {
+                ViewModel.RenameFileCommand.Execute(null);
+
+            }
+            else if (e.Key == Key.Delete && ViewModel.DeleteFileCommand.CanExecute(null))
+            {
+                ViewModel.DeleteFileCommand.Execute(null);
+
+            }
+        }
         private bool _isfirsttime { get; set; } = true;
 
         private void TreeGrid_ItemsSourceChanged(object sender, TreeGridItemsSourceChangedEventArgs e)


### PR DESCRIPTION
Improve Rename in Project File Explorer and add Key Shortcuts

Implemented:
- Rename Dialog now selects the filename of the file to be renamed
- Add keyboard shortcut (F2) for rename dialog
- Add keyboard shortcut (Del) for delete dialog

I had to attach the keyboard shortcuts to KeyUp rather than KeyDown because F2 wouldn't work with KeyDown. Not sure why that is. 