### PR TITLE
Implement Ctrl-C shortcut for the CLI

### DIFF
--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -15,6 +15,8 @@ namespace WolvenKit.CLI
         [STAThread]
         public static void Main(string[] args)
         {
+            Console.CancelKeyPress += new ConsoleCancelEventHandler(CancelHandler);
+
             if (!Oodle.Load())
             {
                 Console.Error.WriteLine("Failed to load any oodle libraries. Aborting");
@@ -52,6 +54,11 @@ namespace WolvenKit.CLI
             ImportExportArgs.IsCLI = true;
 
             parser.Invoke(args);
+        }
+
+        protected static void CancelHandler(object sender, ConsoleCancelEventArgs args)
+        {
+            Environment.FailFast("Ctrl-C was triggered");
         }
     }
 }


### PR DESCRIPTION
# Description

When starting a very slow command with the CLI, there's no currently way to stop the program from running until it reaches completion, except by killing it's process from another terminal or task manager.
Ctrl-C as an "emergency" shortcut, is the current convention on all modern system to cancel a console command.

# Implementation notes

`Environment.Exit` cannot be used because there's many exception handlers which swallow unknown errors which ignores the command to exit, and simply continues to run.
We don't really care about graceful shutdown since it's a cancellation action from the user. It should act as fast as possible.

