### PR TITLE
Update "Open in Asset Browser" to full expand Browser to file path

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -547,7 +547,7 @@ namespace WolvenKit.ViewModels.Tools
         private void MoveToFolder(RedDirectoryViewModel dir) => LeftSelectedItem = dir.GetModel();
 
         /// <summary>
-        /// Navigates the right-side of the browser to the existing file
+        /// Navigates the Asset Browser to the existing file.
         /// </summary>
         /// <param name="file"></param>
         public void ShowFile(FileModel file)
@@ -561,8 +561,30 @@ namespace WolvenKit.ViewModels.Tools
                 .Subscribe()
                 .Dispose();
 
-            RightItems.Clear();
-            RightItems.AddRange(list);
+            if (list.Count > 0)
+            {
+                var fullPath = "";
+                var parentDir = LeftItems.ElementAt(0);
+                parentDir.IsExpanded = true;
+
+                foreach (var dir in file.RelativePath.Split('\\').SkipLast(1))
+                {
+                    fullPath += dir;
+                    parentDir = parentDir.Directories
+                        .Where(x => x.Key == fullPath)
+                        .First()
+                        .Value;
+                    parentDir.IsExpanded = true;
+                    fullPath += '\\';
+                }
+                MoveToFolder(parentDir);
+                RightSelectedItem = RightItems.Where(x => x.FullName == file.RelativePath).FirstOrDefault();
+            }
+            else
+            {
+                _notificationService.Warning("File not found in Asset Browser.");
+            }
+
         }
 
         /// <summary>

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -567,7 +567,7 @@ namespace WolvenKit.ViewModels.Tools
                 var parentDir = LeftItems.ElementAt(0);
                 parentDir.IsExpanded = true;
 
-                foreach (var dir in file.RelativePath.Split('\\').SkipLast(1))
+                foreach (var dir in file.RelativePath.Split(Path.DirectorySeparatorChar).SkipLast(1))
                 {
                     fullPath += dir;
                     parentDir = parentDir.Directories
@@ -575,7 +575,7 @@ namespace WolvenKit.ViewModels.Tools
                         .First()
                         .Value;
                     parentDir.IsExpanded = true;
-                    fullPath += '\\';
+                    fullPath += Path.DirectorySeparatorChar;
                 }
                 MoveToFolder(parentDir);
                 RightSelectedItem = RightItems.Where(x => x.FullName == file.RelativePath).FirstOrDefault();

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -265,7 +265,7 @@
                         </Grid.RowDefinitions>
 
                         <syncfusion:SfDataGrid
-                            x:Name="InnerList"
+                            x:Name="RightFileView"
                             AllowDeleting="False"
                             AllowDraggingColumns="False"
                             AllowDraggingRows="False"
@@ -280,9 +280,9 @@
                             CurrentCellBorderThickness="0"
                             EnableDataVirtualization="True"
                             IsManipulationEnabled="False"
-                            MouseDoubleClick="InnerList_MouseDoubleClick"
+                            MouseDoubleClick="RightFileView_MouseDoubleClick"
                             RowHeight="19"
-                            SelectionChanged="InnerList_SelectionChanged"
+                            SelectionChanged="RightFileView_OnSelectionChanged"
                             SelectionMode="Extended">
 
                             <syncfusion:SfDataGrid.RecordContextMenu>

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -11,6 +11,7 @@ using HandyControl.Data;
 using ReactiveUI;
 using Splat;
 using Syncfusion.UI.Xaml.Grid;
+using Syncfusion.UI.Xaml.ScrollAxis;
 using Syncfusion.UI.Xaml.TreeGrid;
 using WolvenKit.App.Helpers;
 using WolvenKit.Common;
@@ -84,15 +85,15 @@ namespace WolvenKit.Views.Tools
                 // right file list
                 this.OneWayBind(ViewModel,
                         viewModel => viewModel.RightItems,
-                        view => view.InnerList.ItemsSource)
+                        view => view.RightFileView.ItemsSource)
                     .DisposeWith(disposables);
                 this.Bind(ViewModel,
                         viewModel => viewModel.RightSelectedItem,
-                        view => view.InnerList.SelectedItem)
+                        view => view.RightFileView.SelectedItem)
                     .DisposeWith(disposables);
                 //this.Bind(ViewModel,
                 //      viewModel => viewModel.RightSelectedItems,
-                //      view => view.InnerList.SelectedItems)
+                //      view => view.RightFileView.SelectedItems)
                 //  .DisposeWith(disposables);
 
                 this.BindCommand(ViewModel,
@@ -254,6 +255,8 @@ namespace WolvenKit.Views.Tools
                 vm.RightItems.AddRange(model.Files
                     .Select(h => new RedFileViewModel(h))
                     .OrderBy(_ => Regex.Replace(_.Name, @"\d+", n => n.Value.PadLeft(16, '0'))));
+
+                LeftNavigation.ScrollInView(new RowColumnIndex(rowInfo.RowIndex, 0));
             }
         }
 
@@ -307,7 +310,7 @@ namespace WolvenKit.Views.Tools
 
         #region rightFileGrid
 
-        private void InnerList_SelectionChanged(object sender, Syncfusion.UI.Xaml.Grid.GridSelectionChangedEventArgs e)
+        private void RightFileView_OnSelectionChanged(object sender, GridSelectionChangedEventArgs e)
         {
             if (ViewModel is not { } vm)
             {
@@ -319,6 +322,8 @@ namespace WolvenKit.Views.Tools
                 if (item is GridRowInfo info && info.RowData is FileSystemViewModel fsvm)
                 {
                     fsvm.IsChecked = true;
+
+                    RightFileView.ScrollInView(new RowColumnIndex(info.RowIndex, 0));
                 }
             }
 
@@ -377,7 +382,7 @@ namespace WolvenKit.Views.Tools
             */
         }
 
-        private void InnerList_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private void RightFileView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             var selectedIndex = LeftNavigation.SelectedIndex;
             LeftNavigation.ExpandNode(selectedIndex + 1);
@@ -390,11 +395,11 @@ namespace WolvenKit.Views.Tools
                 return;
             }
 
-            if (InnerList.SelectedItem == null)
+            if (RightFileView.SelectedItem == null)
             {
                 return;
             }
-            var selected = InnerList.SelectedItem as RedFileViewModel;
+            var selected = RightFileView.SelectedItem as RedFileViewModel;
 
             if (selected != null && !selected.FullName.ToLower().Contains("bk2"))
             {
@@ -446,7 +451,7 @@ namespace WolvenKit.Views.Tools
 
         private void BKExport_Click(object sender, RoutedEventArgs e)
         {
-            //var q = InnerList.SelectedItems[0] as FileEntryViewModel;
+            //var q = RightFileView.SelectedItems[0] as FileEntryViewModel;
 
             //if (!q.Extension.ToLower().Contains("bk2"))
             //{ return; }


### PR DESCRIPTION
Implemented:
- Asset Browser will open the directory tree to the Depo Path and scroll it into view
- Right side File View will show all files in directory, but select desired file
- Notification system will now warn if the file could not be found in the Asset Browser
