### PR TITLE
Fix UV map for mesh preview

### DIFF
--- a/WolvenKit.App/Extensions/SharpDXExtensions.cs
+++ b/WolvenKit.App/Extensions/SharpDXExtensions.cs
@@ -5,6 +5,7 @@ namespace WolvenKit.Functionality.Extensions
     public static class SharpDXExtensions
     {
         public static SharpDX.Vector2 ToVector2(this System.Numerics.Vector2 v) => new(v.X, v.Y);
+        public static SharpDX.Vector2 ToVector2Flip(this System.Numerics.Vector2 v) => new(v.X, v.Y * -1);
 
         public static SharpDX.Vector3 ToVector3(this System.Numerics.Vector3 v) => new(v.X, v.Y, v.Z);
 

--- a/WolvenKit.App/Helpers/MeshHelpers.cs
+++ b/WolvenKit.App/Helpers/MeshHelpers.cs
@@ -120,7 +120,7 @@ namespace WolvenKit.ViewModels.Documents
                     textureCoordinates = new Vector2Collection(mesh.texCoords0.Length);
                     for (var i = 0; i < mesh.texCoords0.Length; i++)
                     {
-                        textureCoordinates.Add(mesh.texCoords0[i].ToVector2());
+                        textureCoordinates.Add(mesh.texCoords0[i].ToVector2Flip());
                     }
                 }
                 else


### PR DESCRIPTION
Fix UV map for mesh preview

Fixed:
- Flips UV map for the file editor mesh preview. Mesh UV's in the previewer are now aligned with textures after XBM changes.

Closes #962
