### PR TITLE
Experimental merged mesh export option

### DIFF
--- a/WolvenKit.CLI/Commands/UncookCommand.cs
+++ b/WolvenKit.CLI/Commands/UncookCommand.cs
@@ -38,12 +38,16 @@ internal class UncookCommand : CommandBase
         AddOption(new Option<bool>(new[] { "--serialize", "-s" }, "Serialize to JSON"));
         AddOption(new Option<MeshExportType?>(new[] { "--mesh-export-type" }, "Mesh export type (Default, WithMaterials, WithRig, Multimesh)."));
         AddOption(new Option<string>(new[] { "--mesh-export-material-repo" }, "Location of the material repo, if not specified, it uses the outpath."));
+        AddOption(new Option<bool>(new[] { "--mesh-export-lod-filter" }, "Filter out lod models."));
+        AddOption(new Option<bool>(new[] { "--mesh-export-experimental-merged-export" }, "[EXPERIMENTAL] Merged mesh export. (Only supports Default or WithMaterials, re-import not supported)"));
 
-        SetInternalHandler(CommandHandler.Create<FileSystemInfo[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[], bool?, MeshExportType?, string, IHost>(Action));
+        SetInternalHandler(CommandHandler.Create<FileSystemInfo[], string, string, EUncookExtension?, bool?, ulong, string, string, bool, ECookedFileFormat[], 
+        bool?, MeshExportType?, string, bool?, bool?, IHost>(Action));
     }
 
     private int Action(FileSystemInfo[] path, string outpath, string raw, EUncookExtension? uext, bool? flip, ulong hash, string pattern,
-        string regex, bool unbundle, ECookedFileFormat[] forcebuffers, bool? serialize, MeshExportType? meshExportType, string meshExportMaterialRepo, IHost host)
+        string regex, bool unbundle, ECookedFileFormat[] forcebuffers, bool? serialize, MeshExportType? meshExportType, string meshExportMaterialRepo, 
+        bool? meshExportLodFilter, bool? meshExportExperimentalMergedExport, IHost host)
     {
         var serviceProvider = host.Services;
         var logger = serviceProvider.GetRequiredService<ILoggerService>();
@@ -68,7 +72,9 @@ internal class UncookCommand : CommandBase
             forcebuffers = forcebuffers,
             serialize = serialize,
             meshExportType = meshExportType,
-            meshExportMaterialRepo = meshExportMaterialRepo
+            meshExportMaterialRepo = meshExportMaterialRepo,
+            meshExportLodFilter = meshExportLodFilter,
+            meshExportExperimentalMergedExport = meshExportExperimentalMergedExport
         });
     }
 }

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -241,6 +241,12 @@ namespace WolvenKit.Common.Model.Arguments
         public string MaterialRepo { get; set; }
 
         /// <summary>
+        /// Experimental merged export
+        /// </summary>
+        [Browsable(false)]
+        public bool ExperimentalMergedExport { get; set; } = false;
+
+        /// <summary>
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -25,6 +25,8 @@ public record UncookTaskOptions
     public bool? serialize { get; init; }
     public MeshExportType? meshExportType { get; init; }
     public string meshExportMaterialRepo { get; init; }
+    public bool? meshExportLodFilter { get; init; }
+    public bool? meshExportExperimentalMergedExport { get; init; }
 }
 
 public partial class ConsoleFunctions
@@ -145,6 +147,14 @@ public partial class ConsoleFunctions
             exportArgs.Get<MeshExportArgs>().meshExportType = options.meshExportType.Value;
             exportArgs.Get<MeshExportArgs>().MaterialRepo = string.IsNullOrEmpty(options.meshExportMaterialRepo) ? outDir.FullName : options.meshExportMaterialRepo;
             exportArgs.Get<MeshExportArgs>().ArchiveDepot = basedir.FullName;
+        }
+
+        if(options.meshExportExperimentalMergedExport == true){
+            exportArgs.Get<MeshExportArgs>().ExperimentalMergedExport = true;
+        }
+
+        if(options.meshExportLodFilter == true){
+            exportArgs.Get<MeshExportArgs>().LodFilter = true;
         }
 
         var archiveDepot = exportArgs.Get<MeshExportArgs>().ArchiveDepot;

--- a/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
@@ -88,6 +88,7 @@ namespace WolvenKit.Modkit.RED4.GeneralStructs
         public string name { get; set; }
         public uint weightCount { get; set; }
         public string[] materialNames { get; set; }
+        public uint lod { get; set; }
     }
     public class Re4MeshContainer
     {

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -27,8 +27,15 @@ namespace WolvenKit.Modkit.RED4
     /// </summary>
     public partial class ModTools
     {
-        public bool ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, List<ICyberGameArchive> archives, string matRepo, EUncookExtension eUncookExtension = EUncookExtension.dds, bool isGLBinary = true, bool LodFilter = true, ValidationMode vmode = ValidationMode.TryFix)
+        public bool ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, MeshExportArgs meshArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
+            var archives = meshArgs.Archives;
+            var matRepo = meshArgs.MaterialRepo;
+            var eUncookExtension = meshArgs.MaterialUncookExtension;
+            var isGLBinary = meshArgs.isGLBinary;
+            var LodFilter = meshArgs.LodFilter;
+            var mergeMeshes = meshArgs.ExperimentalMergedExport;
+
             if (matRepo == null)
             {
                 throw new Exception("Depot path is not set: Choose a Depot location within Settings for generating materials.");
@@ -49,7 +56,7 @@ namespace WolvenKit.Modkit.RED4
 
             var Rig = MeshTools.GetOrphanRig(cMesh);
 
-            var model = MeshTools.RawMeshesToGLTF(expMeshes, Rig);
+            var model = MeshTools.RawMeshesToGLTF(expMeshes, Rig, mergeMeshes);
 
             ParseMaterials(cr2w, meshStream, outfile, archives, matRepo, eUncookExtension);
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -9,6 +9,7 @@ using SharpGLTF.Scenes;
 using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
 using WolvenKit.Common.Services;
+using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Modkit.RED4.GeneralStructs;
 using WolvenKit.Modkit.RED4.RigFile;
 using WolvenKit.RED4.Archive.CR2W;
@@ -71,15 +72,15 @@ namespace WolvenKit.Modkit.RED4.Tools
             return true;
         }
 
-        public bool ExportMesh(Stream meshStream, FileInfo outfile, bool lodFilter = true, bool isGLBinary = true, ValidationMode vmode = ValidationMode.TryFix)
+        public bool ExportMesh(Stream meshStream, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
             var cr2w = _red4ParserService.ReadRed4File(meshStream);
-            return ExportMesh(cr2w, outfile, lodFilter, isGLBinary, vmode);
+            return ExportMesh(cr2w, outfile, meshExportArgs, vmode);
         }
 
-        public static bool ExportMesh(CR2WFile cr2w, FileInfo outfile, bool lodFilter = true, bool isGLBinary = true, ValidationMode vmode = ValidationMode.TryFix)
+        public static bool ExportMesh(CR2WFile cr2w, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
-            var model = GetModel(cr2w, lodFilter);
+            var model = GetModel(cr2w, meshExportArgs.LodFilter, mergeMeshes: meshExportArgs.ExperimentalMergedExport);
 
             if (model == null)
             {
@@ -92,7 +93,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                 return true;
             }
 
-            if (isGLBinary)
+            if (meshExportArgs.isGLBinary)
             {
                 model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
             }
@@ -104,7 +105,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             return true;
         }
 
-        public static ModelRoot GetModel(CR2WFile cr2w, bool lodFilter = true, bool includeRig = true, ulong chunkMask = ulong.MaxValue)
+        public static ModelRoot GetModel(CR2WFile cr2w, bool lodFilter = true, bool includeRig = true, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false)
         {
             if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
@@ -122,14 +123,14 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             var meshesinfo = GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
 
-            var expMeshes = ContainRawMesh(ms, meshesinfo, lodFilter, chunkMask);
+            var expMeshes = ContainRawMesh(ms, meshesinfo, lodFilter, chunkMask, mergeMeshes);
 
             if (includeRig)
             {
                 UpdateSkinningParamCloth(ref expMeshes, cr2w);
             }
 
-            var model = RawMeshesToGLTF(expMeshes, rig);
+            var model = RawMeshesToGLTF(expMeshes, rig, mergeMeshes);
 
             return model;
         }
@@ -491,7 +492,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             return meshesInfo;
         }
-        public static List<RawMeshContainer> ContainRawMesh(MemoryStream gfs, MeshesInfo info, bool lodFilter, ulong chunkMask = ulong.MaxValue)
+        public static List<RawMeshContainer> ContainRawMesh(MemoryStream gfs, MeshesInfo info, bool lodFilter, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false)
         {
             var gbr = new BinaryReader(gfs);
 
@@ -506,7 +507,8 @@ namespace WolvenKit.Modkit.RED4.Tools
 
                 var meshContainer = new RawMeshContainer
                 {
-                    positions = new Vec3[info.vertCounts[index]]
+                    positions = new Vec3[info.vertCounts[index]],
+                    lod = info.LODLvl[index]
                 };
 
                 // getting positions
@@ -682,7 +684,10 @@ namespace WolvenKit.Modkit.RED4.Tools
                     meshContainer.indices[i] = gbr.ReadUInt16();
                 }
 
-                meshContainer.name = "submesh_" + Convert.ToString(index).PadLeft(2, '0') + "_LOD_" + info.LODLvl[index];
+                
+                meshContainer.name = mergeMeshes ? 
+                    info.appearances.Keys.FirstOrDefault("default") : 
+                    "submesh_" + Convert.ToString(index).PadLeft(2, '0') + "_LOD_" + info.LODLvl[index];
 
                 meshContainer.materialNames = new string[info.appearances.Count];
                 var apps = info.appearances.Keys.ToList();
@@ -744,7 +749,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             }
         }
 
-        public static void AddSubmeshesToModel(List<RawMeshContainer> meshes, Skin skin, ref ModelRoot model, IVisualNodeContainer parent, Dictionary<string, Material> materials = null)
+        public static void AddSubmeshesToModel(List<RawMeshContainer> meshes, Skin skin, ref ModelRoot model, IVisualNodeContainer parent, Dictionary<string, Material> materials = null, bool mergeMeshes = false)
         {
             var mat = model.CreateMaterial("Default");
             mat.WithPBRMetallicRoughness().WithDefault();
@@ -854,9 +859,26 @@ namespace WolvenKit.Modkit.RED4.Tools
             var buffer = model.UseBuffer(ms.ToArray());
             var BuffViewoffset = 0;
 
+            var nodes = new Dictionary<uint, Node>();
             foreach (var mesh in meshes)
             {
-                var mes = model.CreateMesh(mesh.name);
+                Mesh mes = null;
+                Node node = null;
+                if(mergeMeshes)
+                {
+                    if(!nodes.ContainsKey(mesh.lod))
+                    {
+                        nodes[mesh.lod] = parent.CreateNode();
+                        nodes[mesh.lod].Mesh = model.CreateMesh($"{mesh.name}_LOD{mesh.lod}");
+                    }
+                    node = nodes[mesh.lod];
+                    mes = nodes[mesh.lod].Mesh;
+                } 
+                else 
+                {
+                    node = parent.CreateNode(mesh.name);
+                    mes = model.CreateMesh(mesh.name);
+                }
                 var prim = mes.CreatePrimitive();
                 if (materials != null && materials.ContainsKey(mesh.materialNames[0]))
                 {
@@ -965,7 +987,6 @@ namespace WolvenKit.Modkit.RED4.Tools
                     prim.SetIndexAccessor(acc);
                     BuffViewoffset += mesh.indices.Length * 2;
                 }
-                var node = parent.CreateNode(mesh.name);
                 node.Mesh = mes;
                 if (skin != null && mesh.weightCount > 0)
                 {
@@ -999,9 +1020,10 @@ namespace WolvenKit.Modkit.RED4.Tools
             }
         }
 
-        public static ModelRoot RawMeshesToGLTF(List<RawMeshContainer> meshes, RawArmature rig)
+        public static ModelRoot RawMeshesToGLTF(List<RawMeshContainer> meshes, RawArmature rig, bool mergeMeshes = false)
         {
             var model = ModelRoot.CreateModel();
+            model.Extras = SharpGLTF.IO.JsonContent.Serialize(new { ExperimentalMergedMeshes = mergeMeshes });
 
             Skin skin = null;
             if (rig != null)
@@ -1010,7 +1032,26 @@ namespace WolvenKit.Modkit.RED4.Tools
                 skin.BindJoints(RIG.ExportNodes(ref model, rig).Values.ToArray());
             }
 
-            AddSubmeshesToModel(meshes, skin, ref model, model.UseScene(0));
+            Dictionary<string, Material> materials = null;
+            
+            if(mergeMeshes){
+                materials = new Dictionary<string, Material>();
+
+                foreach (var mesh in meshes)
+                {
+                    foreach (var material in mesh.materialNames)
+                    {
+                        if (!materials.ContainsKey(material))
+                        {
+                            materials[material] = model.CreateMaterial(material);
+                            materials[material].WithPBRMetallicRoughness();
+                            materials[material].DoubleSided = true;
+                        }
+                    }
+                }
+            }
+
+            AddSubmeshesToModel(meshes, skin, ref model, model.UseScene(0), materials, mergeMeshes);
 
             model.UseScene(0).Name = "Scene";
             model.DefaultScene = model.UseScene(0);

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -681,11 +681,10 @@ namespace WolvenKit.Modkit.RED4
             switch (meshargs.meshExportType)
             {
                 case MeshExportType.Default:
-                    return _meshTools.ExportMesh(cr2wStream, cr2wFileName, meshargs.LodFilter, meshargs.isGLBinary);
+                    return _meshTools.ExportMesh(cr2wStream, cr2wFileName, meshargs);
 
                 case MeshExportType.WithMaterials:
-                    return ExportMeshWithMaterials(cr2wStream, cr2wFileName, meshargs.Archives, meshargs.MaterialRepo,
-                        meshargs.MaterialUncookExtension, meshargs.isGLBinary, meshargs.LodFilter);
+                    return ExportMeshWithMaterials(cr2wStream, cr2wFileName, meshargs);
 
                 case MeshExportType.WithRig:
                 {


### PR DESCRIPTION
# Description

This adds a new option for mesh exports, where submeshes are exported as primitives of a mesh inside the GLTF scene, instead of what currently is happening where the submeshes are individual meshes.
This makes it much easier to work with meshes when trying to visualize streaming sectors in third-party programs, because meshes are properly hierarchy organized, instead of all at the root of the scene.
This also will make it simpler in the future if we want to use the GLTF extension for material variants (which I plan to try to add soon).

This is heavily based on the work from @jackhumbert in his [mesh-import-export branch](https://github.com/WolvenKit/WolvenKit/tree/mesh-import-export-cleanup).

# Changes: 
- Added a meshExportArgument to merge submeshes on export
- Added 2 CLI options to try it out as well as exposing the `lodFilter` option
- All changes to the mesh export functions are branched behind this mergeMeshes config. This does not change behavior for current exports.
- Added an Extra key to the GLTF models in order to later be able to differentiate between merged sub meshes models compared to normally exported models. This is required to in the future implement the import, without breaking current workflows.
- I left out the import changes from @jackhumbert branch as they would break the workflows of all mods for now. I'll take a look at implementing it later using the `Extra` key added on the models to differentiate between normal meshes and the meshes exported with merged submeshes.