### PR TITLE
AssetBrowserViewModel: Browse to Folder

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -129,7 +129,7 @@ namespace WolvenKit.ViewModels.Tools
             AddSearchKeyCommand = ReactiveCommand.Create<string>(x => SearchBarText += $" {x}:");
             FindUsesCommand = ReactiveCommand.CreateFromTask(FindUses);
             FindUsingCommand = ReactiveCommand.CreateFromTask(FindUsing);
-            BrowseToFolderCommand = new DelegateCommand(BrowseToFolder, CanOpenFileOnly).ObservesProperty(() => RightSelectedItem);
+            BrowseToFolderCommand = new DelegateCommand(BrowseToFolder, CanBrowseToFolder).ObservesProperty(() => RightSelectedItem);
             LoadAssetBrowserCommand = ReactiveCommand.CreateFromTask(LoadAssetBrowser);
 
             OpenWolvenKitSettingsCommand = new DelegateCommand(OpenWolvenKitSettings, CanOpenWolvenKitSettings);
@@ -374,6 +374,7 @@ namespace WolvenKit.ViewModels.Tools
         /// Browse the left side folder tree to the folder containing the selected item. (e.g. for after searching)
         /// </summary>
         public ICommand BrowseToFolderCommand { get; private set; }
+        private bool CanBrowseToFolder() => RightSelectedItem is RedFileViewModel;
         private void BrowseToFolder()
         {
             if (RightSelectedItem is RedFileViewModel file)

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -305,6 +305,7 @@
                                     <Separator />
                                     <MenuItem x:Name="RightContextMenuFindUsesMenuItem" Header="Find used files" />
                                     <MenuItem x:Name="RightContextMenuFindUsingMenuItem" Header="Find files using this" />
+                                    <MenuItem x:Name="RightContextMenuBrowseToFolder" Header="Browse to asset folder" />
                                     <Separator />
                                     <MenuItem x:Name="RightContextMenuCopyPathMenuItem" Header="Copy Relative Path" />
                                 </ContextMenu>

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -106,6 +106,10 @@ namespace WolvenKit.Views.Tools
                       view => view.RightContextMenuFindUsingMenuItem)
                   .DisposeWith(disposables);
                 this.BindCommand(ViewModel,
+                      viewModel => viewModel.BrowseToFolderCommand,
+                      view => view.RightContextMenuBrowseToFolder)
+                  .DisposeWith(disposables);
+                this.BindCommand(ViewModel,
                       viewModel => viewModel.CopyRelPathCommand,
                       view => view.RightContextMenuCopyPathMenuItem)
                   .DisposeWith(disposables);


### PR DESCRIPTION
Enables browse to folder for all files in the right file view. This is most useful for opening the folders to the selected file after a search is performed.

Also a small performance increase by removing ToAsyncEnumerable in "FindUsing" and "FindUses"
