### PR TITLE
Sector Editing Tweaks

### DIFF
--- a/WolvenKit.App/Helpers/Utils.cs
+++ b/WolvenKit.App/Helpers/Utils.cs
@@ -338,6 +338,8 @@ namespace WolvenKit.ViewModels.Shell
                 wen.AppearanceName = string.IsNullOrEmpty(line.app) ? "default" : line.app;
                 wen.DebugName = Path.GetFileNameWithoutExtension(line.template_path) + "_" + index.ToString();
 
+                current.QuestPrefabRefHash = Convert.ToUInt64(current.GetHashCode()); // Add hash to make object interactible and persistent
+
                 if (line.isdoor is bool b && b)
                 {
                     var eeid = new entEntityInstanceData();

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
@@ -322,10 +322,8 @@ namespace WolvenKit.ViewModels.Documents
                     SelectedItem = group;
                     e.Handled = true;
                 }
-                if (e.HitTestResult.ModelHit is SubmeshComponent lod)
+                if (e.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
                 {
-                    var instance = lod.Parent as MeshComponent;
-                    var mesh = instance.Parent as MeshComponent;
                     Locator.Current.GetService<ILoggerService>().Info("Mesh Name: " + mesh.Name);
                 }
             }

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
@@ -322,6 +322,12 @@ namespace WolvenKit.ViewModels.Documents
                     SelectedItem = group;
                     e.Handled = true;
                 }
+                if (e.HitTestResult.ModelHit is SubmeshComponent lod)
+                {
+                    var instance = lod.Parent as MeshComponent;
+                    var mesh = instance.Parent as MeshComponent;
+                    Locator.Current.GetService<ILoggerService>().Info("Mesh Name: " + mesh.Name);
+                }
             }
         }
     }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1820,7 +1820,7 @@ namespace WolvenKit.ViewModels.Shell
             }
             else
             {
-                Locator.Current.GetService<ILoggerService>().Warning("could not recognize the format of your JSON");
+                Locator.Current.GetService<ILoggerService>().Warning("Could not recognize the format of your JSON");
                 return false;
             }
 
@@ -1832,13 +1832,12 @@ namespace WolvenKit.ViewModels.Shell
 
             //var ad = Locator.Current.GetService<AppViewModel>().ActiveDocument;
             var currentfile = new FileModel(Tab.File.FilePath,
-                Locator.Current.GetService<AppViewModel>().ActiveProject);
+            Locator.Current.GetService<AppViewModel>().ActiveProject);
 
             Locator.Current.GetService<AppViewModel>().SaveFileCommand.SafeExecute(currentfile);
-            //QuickToJSON(Parent.Parent.Data);
             await Refresh();
 
-            Locator.Current.GetService<ILoggerService>().Success($"might have done the thing maybe, who knows really");
+            Locator.Current.GetService<ILoggerService>().Success($"Successfully imported from JSON");
             return true;
         }
 


### PR DESCRIPTION
- Adds a `QuestPrefabRefHash` to all nodes that get added by importing into a sector from `.json`. The hash is needed to make objects interactable and persistent
- Log a clicked mesh's name to the log in sector preview, makes finding the right node a lot easier
