### PR TITLE
Issue 993--Add a textbox to the settings to add ignored extensions

### DIFF
--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -22,6 +22,7 @@ namespace WolvenKit.Functionality.Services
         public string MaterialRepositoryPath { get; set; }
         public bool TreeViewGroups { get; set; }
         public uint TreeViewGroupSize { get; set; }
+        public string TreeViewIgnoredExtensions { get; set; }
         public bool ShowAdvancedOptions { get; set; }
         public bool ShowCNameAsHex { get; set; }
         public bool ShowNodeRefAsHex { get; set; }

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -24,6 +24,7 @@ namespace WolvenKit.Functionality.Services
             MaterialRepositoryPath = settings.MaterialRepositoryPath;
             TreeViewGroups = settings.TreeViewGroups;
             TreeViewGroupSize = settings.TreeViewGroupSize;
+            TreeViewIgnoredExtensions = settings.TreeViewIgnoredExtensions;
             ShowAdvancedOptions = settings.ShowAdvancedOptions;
             ShowCNameAsHex = settings.ShowCNameAsHex;
             ShowNodeRefAsHex = settings.ShowNodeRefAsHex;
@@ -51,6 +52,7 @@ namespace WolvenKit.Functionality.Services
         public string MaterialRepositoryPath { get; set; }
         public bool TreeViewGroups { get; set; }
         public uint TreeViewGroupSize { get; set; }
+        public string TreeViewIgnoredExtensions { get; set; }
         public bool ShowAdvancedOptions { get; set; }
         public bool ShowCNameAsHex { get; set; }
         public bool ShowNodeRefAsHex { get; set; }
@@ -79,6 +81,7 @@ namespace WolvenKit.Functionality.Services
             settingsManager.MaterialRepositoryPath = MaterialRepositoryPath;
             settingsManager.TreeViewGroups = TreeViewGroups;
             settingsManager.TreeViewGroupSize = TreeViewGroupSize;
+            settingsManager.TreeViewIgnoredExtensions = TreeViewIgnoredExtensions;
             settingsManager.ShowAdvancedOptions = ShowAdvancedOptions;
             settingsManager.ShowCNameAsHex = ShowCNameAsHex;
             settingsManager.ShowNodeRefAsHex = ShowNodeRefAsHex;

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -44,6 +44,7 @@ namespace WolvenKit.Functionality.Services
                 nameof(ReddbHash),
                 nameof(TreeViewGroups),
                 nameof(TreeViewGroupSize),
+                nameof(TreeViewIgnoredExtensions),
                 nameof(ShowAdvancedOptions),
                 nameof(ShowCNameAsHex),
                 nameof(ShowNodeRefAsHex),
@@ -191,6 +192,11 @@ namespace WolvenKit.Functionality.Services
         [Display(Name = "Group Size")]
         [Reactive]
         public uint TreeViewGroupSize { get; set; } = 100;
+
+        [Category("File Editor")]
+        [Display(Name = "Ignored Extensions (Open using System Editor. Syntax: .ext1|.ext2)")]
+        [Reactive]
+        public string TreeViewIgnoredExtensions { get; set; } = "";
 
         [Category("Import / Export")]
         [Display(Name = "Show advanced Options")]

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1255,80 +1255,92 @@ namespace WolvenKit.ViewModels.Shell
         {
             var ext = Path.GetExtension(fullpath).ToLower();
 
-            // double click
-            switch (ext)
+            // everything in ignoredExtensions is delegated to the System viewer
+            string delimiter = "|";
+            //string[] ignoredExtensions = _settingsManager.TreeViewIgnoredExtensions.ToLower().Split(delimiter);
+            //bool isAnIgnoredExtension = Array.Exists(ignoredExtensions, extension => extension.Equals(ext));
+            bool isAnIgnoredExtension = _settingsManager.TreeViewIgnoredExtensions.Split(delimiter).Any(entry => entry.ToLower().Trim().Equals(ext));
+            if (isAnIgnoredExtension)
             {
-                // custom raw file extensions
-                case $".{nameof(ERawFileFormat.masklist)}":
-
-                // images
-                case ".png":
-                case ".jpg":
-                case ".tga":
-                case ".bmp":
-                case ".jpeg":
-                case ".dds":
-
-                //text
-                case ".xml":
-                case ".txt":
-                case ".ws":
-
-                // other
-                case ".mp3":
-                case ".wav":
-                case ".glb":
-                case ".gltf":
-                case ".fbx":
-                case ".xcf":
-                case ".psd":
-                case ".apb":
-                case ".apx":
-                case ".ctw":
-                case ".blend":
-                case ".zip":
-                case ".rar":
-                case ".bat":
-                case ".yml":
-                case ".log":
-                case ".ini":
-                case ".xl":
-                case ".reds":
-                    //case ".yaml":
-                    ShellExecute();
-                    break;
-
-                // double file formats
-                case ".csv":
-                case ".json":
-                    return IsInRawFolder(fullpath) ? Task.Run(() => ShellExecute()) : Task.Run(() => OpenRedengineFile());
-
-                // VIDEO
-                case ".bk2":
-                    break;
-
-                // AUDIO
-
-                case ".wem":
-                    return Task.Run(() => OpenAudioFile());
-
-                case ".subs":
-                    return Task.Run(() => PolymorphExecute(fullpath, ".txt"));
-
-                case ".usm":
+                ShellExecute();
+            }
+            // double click
+            else
+            {
+                switch (ext)
                 {
-                    // TODO: port winforms
-                    //if (!File.Exists(fullpath) || Path.GetExtension(fullpath) != ".usm")
-                    //    return;
-                    //var usmplayer = new frmUsmPlayer(fullpath);
-                    //usmplayer.Show(dockPanel, DockState.Document);
-                    break;
+                    // custom raw file extensions
+                    case $".{nameof(ERawFileFormat.masklist)}":
+
+                    // images
+                    case ".png":
+                    case ".jpg":
+                    case ".tga":
+                    case ".bmp":
+                    case ".jpeg":
+                    case ".dds":
+
+                    //text
+                    case ".xml":
+                    case ".txt":
+                    case ".ws":
+
+                    // other
+                    case ".mp3":
+                    case ".wav":
+                    case ".glb":
+                    case ".gltf":
+                    case ".fbx":
+                    case ".xcf":
+                    case ".psd":
+                    case ".apb":
+                    case ".apx":
+                    case ".ctw":
+                    case ".blend":
+                    case ".zip":
+                    case ".rar":
+                    case ".bat":
+                    case ".yml":
+                    case ".log":
+                    case ".ini":
+                    case ".xl":
+                    case ".reds":
+                        //case ".yaml":
+                        ShellExecute();
+                        break;
+
+                    // double file formats
+                    case ".csv":
+                    case ".json":
+                        return IsInRawFolder(fullpath) ? Task.Run(() => ShellExecute()) : Task.Run(() => OpenRedengineFile());
+
+                    // VIDEO
+                    case ".bk2":
+                        break;
+
+                    // AUDIO
+
+                    case ".wem":
+                        return Task.Run(() => OpenAudioFile());
+
+                    case ".subs":
+                        return Task.Run(() => PolymorphExecute(fullpath, ".txt"));
+
+                    case ".usm":
+                    {
+                        // TODO: port winforms
+                        //if (!File.Exists(fullpath) || Path.GetExtension(fullpath) != ".usm")
+                        //    return;
+                        //var usmplayer = new frmUsmPlayer(fullpath);
+                        //usmplayer.Show(dockPanel, DockState.Document);
+                        break;
+                    }
+                    //case ".BNK":
+                    // TODO SPLIT WEMS TO PLAYLIST FROM BNK
+                    case "":
+                    default:
+                        return Task.Run(() => OpenRedengineFile());
                 }
-                //case ".BNK":
-                // TODO SPLIT WEMS TO PLAYLIST FROM BNK
-                case "":
-                default:
-                    return Task.Run(() => OpenRedengineFile());
             }
 
             return Task.Run(() => true);


### PR DESCRIPTION
# Addressing [Issue 993](https://github.com/WolvenKit/WolvenKit/issues/993) by adding an "ignored extensions" Textbox to settings.



**Implemented:**
@rfuzzo 's suggestion: to use a textbox in WolvenKit Settings that delegates _all_ listed extensions to the default System Editor.

How it looks in the Settings Dialog:
![image](https://user-images.githubusercontent.com/70169069/200404500-300af70d-acef-4980-b619-445890e25367.png)



**Notes**
Delimiter is currently set to pipe/vertical bar "|".  Comparisons are all lowercase, following existing code. I did a simple Trim() for a bit more robust user entry handling.

**Testing done:**
Limited functional testing w.r.t the change, such as entering multiple extensions and seeing how the double clicking responds. Results satisfies the requirements.
