### PR TITLE
QOL: Discord Issue--Notify and Log items that fail Import/Export. Total count bugfix

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -600,15 +600,23 @@ namespace WolvenKit.ViewModels.Tools
 
             var total = 0;
             var sucessful = 0;
+            
+            //prepare a list of failed items
+            var failedItems = new List<string>();
 
             if (IsImportsSelected)
             {
                 var toBeImported = ImportableItems.Where(x => !x.Extension.Equals(ERawFileFormat.wav.ToString())).ToList();
+                total = toBeImported.Count;
                 foreach (var item in toBeImported)
                 {
                     if (await Task.Run(() => ImportSingleTask(item)))
                     {
                         sucessful++;
+                    }
+                    else // not successful
+                    {
+                        failedItems.Add(item.FullName);
                     }
 
                     Interlocked.Increment(ref progress);
@@ -632,6 +640,10 @@ namespace WolvenKit.ViewModels.Tools
                     {
                         sucessful++;
                     }
+                    else // not successful
+                    {
+                        failedItems.Add(item.FullName);
+                    }
 
                     Interlocked.Increment(ref progress);
                     _progressService.Report(progress / (float)total);
@@ -646,6 +658,15 @@ namespace WolvenKit.ViewModels.Tools
 
             _notificationService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
             _loggerService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
+
+            //We format the list of failed export/import items here
+            if (failedItems.Count > 0)
+            {
+                var failedItemsErrorString = $"The following items failed:\n{String.Join("\n", failedItems)}";
+                _notificationService.Error(failedItemsErrorString); //notify once only 
+                _loggerService.Error(failedItemsErrorString);
+            }
+
             _progressService.Completed();
         }
 
@@ -790,6 +811,9 @@ namespace WolvenKit.ViewModels.Tools
             var total = 0;
             var sucessful = 0;
 
+            //prepare a list of failed items
+            var failedItems = new List<string>();
+
             if (IsImportsSelected)
             {
                 var toBeImported = ImportableItems.Where(_ => _.IsChecked).Where(x => !x.Extension.Equals(ERawFileFormat.wav.ToString())).ToList();
@@ -799,6 +823,10 @@ namespace WolvenKit.ViewModels.Tools
                     if (await Task.Run(() => ImportSingleTask(item)))
                     {
                         sucessful++;
+                    }
+                    else // not successful
+                    {
+                        failedItems.Add(item.FullName);
                     }
 
                     Interlocked.Increment(ref progress);
@@ -822,6 +850,10 @@ namespace WolvenKit.ViewModels.Tools
                     {
                         sucessful++;
                     }
+                    else
+                    {
+                        failedItems.Add(item.FullName);
+                    }
 
                     Interlocked.Increment(ref progress);
                     _progressService.Report(progress / (float)toBeExported.Count);
@@ -835,6 +867,15 @@ namespace WolvenKit.ViewModels.Tools
 
             _notificationService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
             _loggerService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
+
+            //We format the list of failed export/import items here
+            if (failedItems.Count > 0)
+            {
+                var failedItemsErrorString = $"The following items failed:\n{String.Join("\n", failedItems)}";
+                _notificationService.Error(failedItemsErrorString); //notify once only 
+                _loggerService.Error(failedItemsErrorString);
+            }
+
             _progressService.Completed();
         }
 


### PR DESCRIPTION
# Discord Issue: Log/Notify users on items that fail Import/Export. Bonus: Total count bugfix.

**Addresses the following issue:**
(EDIT: correct discord link)
https://discord.com/channels/717692382849663036/1038844130341695538/1038844130341695538


The discord issue mentioned only import. Adding it to export is trivial and may provide useful.

**Implemented:**
- Logged failed items when importing/exporting
- Notify users of failed items when importing/exporting. Coalesced into one notification window only.

**Bug Fixed:**
- Total count is not populated when executing Process All, specifically when Importing. Fix is simple and obvious.

**Testing Done:**
Tests are done on my personal project of 100 files. The following scenarios were successfully tested for both Import/Export:
- All valid files
- Several invalid files
- Clicking Process Selected when there is nothing selected

Test results are satisfactory and meet and/or exceed the requirements.
