### PR TITLE
Enhancement--Script deployment support. Issue 926

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -322,11 +322,11 @@ namespace WolvenKit.Functionality.Controllers
             _loggerService.Success($"{cp77Proj.Name} archiveXL files packed into {cp77Proj.GetPackedArchiveDirectory(options.IsRedmod)}");
 
             // pack 'script' files
-            if (!PackScriptFiles(cp77Proj))
+            if (!PackResources(cp77Proj))
             {
                 _progressService.IsIndeterminate = false;
-                _loggerService.Error("Packing script files failed, aborting.");
-                _notificationService.Error("Packing script files failed, aborting.");
+                _loggerService.Error("Packing other resource files failed, aborting.");
+                _notificationService.Error("Packing other resource files failed, aborting.");
                 return false;
             }
 
@@ -477,10 +477,10 @@ namespace WolvenKit.Functionality.Controllers
         }
 
 
-        private static bool PackScriptFiles(Cp77Project cp77Proj)
+        private static bool PackResources(Cp77Project cp77Proj)
         {
             //preliminary approach -- everything under resources, except for *.yaml, *.xl, is a 'script' element
-            //this will cover all potential scripts
+            //this will cover all potential add-ons/mods/redscript
             //All such files goes into the root of the cp77Proj.PackedRootDirectory
             Directory.GetFiles(cp77Proj.ResourcesDirectory, "*.*", SearchOption.AllDirectories)
                 .Where(name => !name.ToLower().EndsWith(".xl") && !name.ToLower().EndsWith(".yaml")) 

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using MoreLinq;
 using ReactiveUI;
 using Splat;
 using WolvenKit.App.Models;
@@ -320,6 +321,17 @@ namespace WolvenKit.Functionality.Controllers
             }
             _loggerService.Success($"{cp77Proj.Name} archiveXL files packed into {cp77Proj.GetPackedArchiveDirectory(options.IsRedmod)}");
 
+            // pack 'script' files
+            if (!PackScriptFiles(cp77Proj))
+            {
+                _progressService.IsIndeterminate = false;
+                _loggerService.Error("Packing script files failed, aborting.");
+                _notificationService.Error("Packing script files failed, aborting.");
+                return false;
+            }
+
+            _loggerService.Success($"{cp77Proj.Name} script files packed into {cp77Proj.PackedRootDirectory}");
+
 
             // pack redmod files
             if (options.IsRedmod)
@@ -463,6 +475,33 @@ namespace WolvenKit.Functionality.Controllers
 
             return true;
         }
+
+
+        private static bool PackScriptFiles(Cp77Project cp77Proj)
+        {
+            //preliminary approach -- everything under resources, except for *.yaml, *.xl, is a 'script' element
+            //this will cover all potential scripts
+            //All such files goes into the root of the cp77Proj.PackedRootDirectory
+            Directory.GetFiles(cp77Proj.ResourcesDirectory, "*.*", SearchOption.AllDirectories)
+                .Where(name => !name.ToLower().EndsWith(".xl") && !name.ToLower().EndsWith(".yaml")) 
+                .ForEach( f => 
+                {
+                    var fileName = Path.GetFileName(f);
+                    var fileRelativeDir = Path.GetRelativePath(cp77Proj.ResourcesDirectory, Path.GetDirectoryName(f));
+                    var fileOutputDir = Path.Combine(cp77Proj.PackedRootDirectory, fileRelativeDir);
+                    var fileOutputPath = Path.Combine(fileOutputDir, fileName);
+                    if (!Directory.Exists(fileOutputDir))
+                    {
+                        Directory.CreateDirectory(fileOutputDir);
+                    }
+                    
+                    // copy files, with overwriting
+                    File.Copy(f, fileOutputPath, true);
+                }
+            );
+            return true;
+        }
+
         private static bool PackTweakXlFiles(Cp77Project cp77Proj)
         {
             var tweakFiles = Directory.GetFiles(cp77Proj.ResourcesDirectory, "*.yaml", SearchOption.AllDirectories);


### PR DESCRIPTION
Addresses https://github.com/WolvenKit/WolvenKit/issues/926

- Specification discussion was done earlier thru discord and can be ref'd if needed.
- Supports all present and future scripting elements--assuming they are deployed under the game directory.  
- The sample testbed I used contain CET, redscript, and red4ext dlls for deployment.

**Implemented**

_Assumptions for the preliminary approach: the user is responsible for structuring their scripts to match the target deployment directory structure._

- The ability to deploy scripting elements user puts under `resource` into `packed`. Please see the testbed below for a sample structure.
- Simple as-is copying, skipping the special `yaml` and `xl` files.


**Notes**
Hot deployment seems to follow a separate path and is not touched by this PR.

**Testing Done**
- Using everything in the test bed below
- With only yaml/xl files
- With blank `resources`
- Both as regular and REDmod 

Testing meets the requirements.

**Test Bed**
Tests are done the following `resources` structure. `.xl` and `.yaml` files are added thru clicking `(+)New File`
![image](https://user-images.githubusercontent.com/70169069/200919466-99b107aa-6132-463b-8f86-669db0f9a04c.png)
