### PR TITLE
feat: Add ExportFiles command to WKit Scripting

### DIFF
--- a/WolvenKit.App/Helpers/WKitUIScripting.cs
+++ b/WolvenKit.App/Helpers/WKitUIScripting.cs
@@ -1,11 +1,18 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reactive;
+using MoreLinq;
 using Splat;
+using WolvenKit.Common;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Services;
 using WolvenKit.Modkit.Scripting;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Archive.IO;
+using WolvenKit.ViewModels.Shell;
 
 namespace WolvenKit.App.Helpers;
 
@@ -70,6 +77,84 @@ public class WKitUIScripting : WKitScripting
         {
             File.Delete(diskPathInfo.FullName);
             _loggerService.Error(ex);
+        }
+    }
+
+    public void ExportFiles(dynamic relPaths)
+    {
+        if (relPaths is null)
+        {
+            throw new ArgumentNullException(nameof(relPaths));
+        }
+        else if (relPaths is string)
+        {
+            // since relPaths is dynamic we can support string, or string[]
+            // this converts a single string to an array (thanks JavaScript)
+            relPaths = new string[] { relPaths };
+        }
+        else
+        {
+            try
+            {
+                // this will catch exceptions with the (IList) conversion
+                // Cast<string> is lazy and  will be caught later
+                relPaths = ((IList)relPaths).Cast<string>();
+            }
+            catch (InvalidCastException ice)
+            {
+                _loggerService.Error("Unexpected data type found for argument \"relPaths\" in \"ExportFiles\".");
+                _loggerService.Error(ice.Message);
+            }
+            catch (Exception e)
+            {
+                _loggerService.Error(e);
+            }
+        }
+
+        var watcherService = Locator.Current.GetService<IWatcherService>();
+        var impExpVM = Locator.Current.GetService<AppViewModel>().ImportExportToolVM;
+
+        impExpVM.IsExportsSelected = true;
+        impExpVM.IsImportsSelected = false;
+
+        // unset every item in ExportItems
+        foreach (var expItem in impExpVM.ExportableItems)
+        {
+            expItem.IsChecked = false;
+        }
+
+        try
+        {
+            var uncookExts = Enum.GetNames(typeof(ECookedFileFormat));
+            foreach (var relPath in relPaths)
+            {
+                var filePath = Path.Combine(_projectManager.ActiveProject.ModDirectory, (string)relPath);
+                var ext = Path.GetExtension(filePath).Replace(".", "");
+                if (!File.Exists(filePath))
+                {
+                    _loggerService.Info($"{relPath} could not be found.");
+                    continue;
+                }
+                if (!uncookExts.Any(e => e == ext))
+                {
+                    _loggerService.Info($"{relPath} is not an exportable CR2W file.");
+                    continue;
+                }
+
+                // Set the item to be checked
+                impExpVM.ExportableItems.Where(_ => _.FullName == filePath)
+                    .ForEach(_ => _.IsChecked = true);
+            }
+            impExpVM.ProcessSelectedCommand.Execute(Unit.Default);
+        }
+        catch (InvalidCastException ice)
+        {
+            _loggerService.Error("Unexpected data type found for argument \"relPaths\" in \"ExportFiles\".");
+            _loggerService.Error(ice.Message);
+        }
+        catch (Exception e)
+        {
+            _loggerService.Error(e);
         }
     }
 }

--- a/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
@@ -27,7 +27,7 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
     public WScriptDocumentViewModel(string path) : base(path)
     {
         Document = new TextDocument();
-        Extension = "wsc";
+        Extension = "wscript";
 
         _loggerService = Locator.Current.GetService<ILoggerService>();
         _scriptService = Locator.Current.GetService<ExtendedScriptService>();


### PR DESCRIPTION
Implemented:
- Export files from wkit scripts (requires file to already be added to project)

```js
// export either a single item
wkit.ExportFiles("base\\gameplay\\gui\\world\\arcade_games\\roach_race\\art\\roach_race_sprites_1080p.xbm");

// or an array of items
wkit.ExportFiles(["base\\gameplay\\gui\\world\\arcade_games\\roach_race\\art\\roach_race_sprites_1080p.xbm",
    "base\\gameplay\\gui\\world\\arcade_games\\roach_race\\art\\roach_race_sides.xbm"]);

// function can warn of files that do not exist in the project
wkit.ExportFiles(["base\\gameplay\\gui\\world\\arcade_games\\roach_race\\art\\roach_race_sprites_1080p.xbm",
    "base\\gameplay\\code\\CDPR_bugless_code\\literally_anything.cpp"]);

// function can error on invalid type conversions (e.g. random integer)
wkit.ExportFiles(0);
wkit.ExportFiles(["base\\gameplay\\gui\\world\\arcade_games\\roach_race\\art\\roach_race_sprites_1080p.xbm",
    0]);
```

Please feel free to murder my code and clean it up, or suggest new function names, etc. There's also more nasty type things because of the V8 interpreter.