### PR TITLE
Add the apps list of the mesh to the material.json

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -317,7 +317,7 @@ namespace WolvenKit.Modkit.RED4
                     {
                         defferedBuffer = new MemoryStream(animBuffSimd.InplaceCompressedBuffer.Buffer.GetBytes());
                     }
-                    else if (animBuffSimd.DataAddress != null && animBuffSimd.DataAddress != uint.Max)
+                    else if (animBuffSimd.DataAddress != null)
                     {
                         var dataAddr = animBuffSimd.DataAddress;
                         var bytes = new byte[dataAddr.ZeInBytes];

--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -317,7 +317,7 @@ namespace WolvenKit.Modkit.RED4
                     {
                         defferedBuffer = new MemoryStream(animBuffSimd.InplaceCompressedBuffer.Buffer.GetBytes());
                     }
-                    else if (animBuffSimd.DataAddress != null)
+                    else if ((animBuffSimd.DataAddress != null) && animBuffSimd.DataAddress.UnkIndex != uint.MaxValue)
                     {
                         var dataAddr = animBuffSimd.DataAddress;
                         var bytes = new byte[dataAddr.ZeInBytes];

--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -317,7 +317,7 @@ namespace WolvenKit.Modkit.RED4
                     {
                         defferedBuffer = new MemoryStream(animBuffSimd.InplaceCompressedBuffer.Buffer.GetBytes());
                     }
-                    else if (false) //(animBuffSimd.DataAddress != null)
+                    else if (animBuffSimd.DataAddress != null && animBuffSimd.DataAddress != uint.Max)
                     {
                         var dataAddr = animBuffSimd.DataAddress;
                         var bytes = new byte[dataAddr.ZeInBytes];

--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -317,7 +317,7 @@ namespace WolvenKit.Modkit.RED4
                     {
                         defferedBuffer = new MemoryStream(animBuffSimd.InplaceCompressedBuffer.Buffer.GetBytes());
                     }
-                    else if (animBuffSimd.DataAddress != null)
+                    else if (false) //(animBuffSimd.DataAddress != null)
                     {
                         var dataAddr = animBuffSimd.DataAddress;
                         var bytes = new byte[dataAddr.ZeInBytes];

--- a/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
@@ -168,6 +168,7 @@ namespace WolvenKit.Modkit.RED4.GeneralStructs
         public List<RawMaterial> Materials { get; set; }
         public List<string> TexturesList { get; set; }
         public List<RawMaterial> MaterialTemplates { get; set; }
+        public Dictionary<string, string[]> Appearances { get; set; }
     }
     public class RawMaterial
     {

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -58,7 +58,7 @@ namespace WolvenKit.Modkit.RED4
 
             var model = MeshTools.RawMeshesToGLTF(expMeshes, Rig, mergeMeshes);
 
-            ParseMaterials(cr2w, meshStream, outfile, archives, matRepo, eUncookExtension);
+            ParseMaterials(cr2w, meshStream, outfile, archives, matRepo, meshesinfo, eUncookExtension);
 
             if (isGLBinary)
             {
@@ -277,7 +277,7 @@ namespace WolvenKit.Modkit.RED4
             }
         }
 
-        private void ParseMaterials(CR2WFile cr2w, Stream meshStream, FileInfo outfile, List<ICyberGameArchive> archives, string matRepo, EUncookExtension eUncookExtension = EUncookExtension.dds)
+        private void ParseMaterials(CR2WFile cr2w, Stream meshStream, FileInfo outfile, List<ICyberGameArchive> archives, string matRepo, MeshesInfo info, EUncookExtension eUncookExtension = EUncookExtension.dds)
         {
             var primaryDependencies = new List<string>();
 
@@ -331,13 +331,14 @@ namespace WolvenKit.Modkit.RED4
                     matTemplates.Add(rawMat);
                 }
             }
-
+            
             var matData = new MatData
             {
                 MaterialRepo = matRepo,
                 Materials = RawMaterials,
                 TexturesList = TexturesList,
-                MaterialTemplates = matTemplates
+                MaterialTemplates = matTemplates,
+                Appearances = info.appearances
             };
 
             var str = RedJsonSerializer.Serialize(matData);


### PR DESCRIPTION
Add the apps list of mesh items to the material.json when exporting withMaterial

Implemented:
- Add the apps list of mesh items to the material.json when exporting withMaterial

This will allow the Blender plugin to be modified to only bring in a selected material, currently theres not enough information to go from entity>appearance>mesh and select the right material as the appearance names and material names can be different in the mesh. 
I've done some exports and cant find any problems, and have imported the resulting files to blender with the current plugin without issue. 
