### PR TITLE
Clean all button--issue 1022. 

### DIFF
--- a/WolvenKit.App/Controllers/IGameController.cs
+++ b/WolvenKit.App/Controllers/IGameController.cs
@@ -18,5 +18,6 @@ namespace WolvenKit.Functionality.Controllers
 
         Task<bool> LaunchProject(LaunchProfile profile);
         bool PackProjectHot();
+        bool CleanAll();
     }
 }

--- a/WolvenKit.App/Controllers/MockGameController.cs
+++ b/WolvenKit.App/Controllers/MockGameController.cs
@@ -18,5 +18,6 @@ namespace WolvenKit.Functionality.Controllers
         public async Task HandleStartup() => await Task.CompletedTask;
         public Task<bool> LaunchProject(LaunchProfile profile) => throw new NotImplementedException();
         public bool PackProjectHot() => throw new NotImplementedException();
+        public bool CleanAll() => throw new NotImplementedException();
     }
 }

--- a/WolvenKit.App/Models/LaunchProfile.cs
+++ b/WolvenKit.App/Models/LaunchProfile.cs
@@ -21,6 +21,10 @@ public class LaunchProfile
     // install tweak files
     // install script files
 
+    [Category("Install")]
+    [Display(Name = "Clean packed directory completely first")]
+    public bool CleanAll { get; set; }
+
     [Category("REDmod")]
     [Display(Name = "Pack as REDmod")]
     public bool IsRedmod { get; set; }
@@ -43,6 +47,7 @@ public class LaunchProfile
         return new LaunchProfile()
         {
             CreateBackup = CreateBackup,
+            CleanAll = CleanAll,
             Install = Install,
             IsRedmod = IsRedmod,
             DeployWithRedmod = DeployWithRedmod,

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -158,6 +158,8 @@ namespace WolvenKit.ViewModels.Shell
                 LaunchGame = true
             }));
 
+            CleanAllCommand = ReactiveCommand.CreateFromTask(CleanAllAsync);
+
             HotInstallModCommand = ReactiveCommand.CreateFromTask(HotInstallModAsync);
 
             LaunchOptionsCommand = ReactiveCommand.Create(LaunchOptions);
@@ -965,6 +967,8 @@ namespace WolvenKit.ViewModels.Shell
 
         public bool HasActiveProject() => ActiveProject is not null;
 
+        // Clean all
+        public ReactiveCommand<Unit, Unit> CleanAllCommand { get; private set; }
 
         // Pack mod
         public ReactiveCommand<Unit, Unit> PackModCommand { get; private set; }
@@ -973,6 +977,8 @@ namespace WolvenKit.ViewModels.Shell
         public ReactiveCommand<Unit, Unit> PackInstallRedModCommand { get; private set; }
         public ReactiveCommand<Unit, Unit> PackInstallRunCommand { get; private set; }
         public ReactiveCommand<Unit, Unit> PackInstallRedModRunCommand { get; private set; }
+
+        private Task CleanAllAsync() => Task.Run(() => _gameControllerFactory.GetController().CleanAll());
 
         private async Task LaunchAsync(LaunchProfile profile)
         {

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -336,7 +336,7 @@
                 Margin="1,0"
                 Padding="12,0"
                 Header="Build">
-
+                
                 <!--  Pack  -->
                 <MenuItem
                     x:Name="MenuItemPack"
@@ -448,6 +448,25 @@
                             Foreground="{StaticResource WolvenKitYellow}"
                             Kind="RunAll"
                             Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <Separator />
+
+                <!--  Clean All  -->
+                <MenuItem
+                    x:Name="MenuItemClean"
+                    Margin="2,1"
+                    Header="Clean All"
+                    ToolTip="Clean project's packed directory completely">
+                    <MenuItem.Icon>
+                        <Grid Margin="6,0">
+                            <iconPacks:PackIconForkAwesome
+                                Padding="0,0,2,2"
+                                Foreground="{StaticResource WolvenKitRed}"
+                                Kind="Trash"
+                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                        </Grid>
                     </MenuItem.Icon>
                 </MenuItem>
 

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -123,6 +123,12 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                        view => view.ToolbarPackInstallRedmodLaunchButton)
                    .DisposeWith(disposables);
 
+            // Clean All
+            this.BindCommand(ViewModel,
+                    viewModel => viewModel.MainViewModel.CleanAllCommand,
+                    view => view.MenuItemClean)
+                .DisposeWith(disposables);
+
             // Hot Reload
             this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.HotInstallModCommand,


### PR DESCRIPTION
Thought this would be a simple UI addition, but it turns out not so:

Prior to this proposed change, the only way for the user to cleanup changes/removals/renames to "other" (e.g. `r6/scripts/myscript.reds` => `r6/scripts/thecorrectnameformyscript.reds`) already-packed files under `resources` is to **manually delete** them from the `packed` directory themselves.

I also added `LaunchProfile` entry and missing code path to `Cleanup()` to completely clean as an option. This allows it to clean misc items added or removed in resources dir, such as scripts. 

Implemented and Added:
- The `Clean All` button
![image](https://user-images.githubusercontent.com/70169069/205173532-548ab191-9f62-4ab8-9c71-f10029493e41.png)

- Added `LaunchProfile` options to do so.
![image](https://user-images.githubusercontent.com/70169069/205173641-2522ca8b-f3f9-494e-bd25-2004a2fec7af.png)

- Added optional code path to `Cleanup()` to handle the rest of the `resources/` dir not covered by it. Options are done thru `LaunchProfile`s. The user now can click `Clean All` or integrate it in their profile.

Testing:
- Ensure `Clean All` does it's purpose, without any UI desync or oddness observed using the current removal method.
- Ensure default behavior persists with the `LaunchProfile` option unchecked
- Ensure intended behavior works with the `LaunchProfile` option checked
- Integration with Install to Game: good integration. It also removes the logged files not found in the current `packed/` directory.
