### PR TITLE
Improves tracebility on MeshPreview to respective worldNodeData

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
@@ -324,7 +324,7 @@ namespace WolvenKit.ViewModels.Documents
                 }
                 if (e.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
                 {
-                    Locator.Current.GetService<ILoggerService>().Info("Mesh Name: " + mesh.Name);
+                    Locator.Current.GetService<ILoggerService>().Info((mesh.WorldNodeIndex != null ? "worldNodeData[" + mesh.WorldNodeIndex + "] : " : "Mesh Name :") + mesh.Name);
                 }
             }
         }

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
@@ -71,6 +71,7 @@ namespace WolvenKit.ViewModels.Documents
                     var group = new MeshComponent()
                     {
                         Name = name,
+                        WorldNodeIndex = $"{handleIndex}",
                         AppearanceName = irmn.MeshAppearance,
                         DepotPath = irmn.Mesh.DepotPath
                     };
@@ -241,6 +242,7 @@ namespace WolvenKit.ViewModels.Documents
 
                     var mesh = new MeshComponent()
                     {
+                        WorldNodeIndex = $"{handleIndex}",
                         Name = "collisionNode_" + wcn.SectorHash
                     };
 
@@ -259,6 +261,7 @@ namespace WolvenKit.ViewModels.Documents
                     {
                         var actorGroup = new MeshComponent()
                         {
+                            WorldNodeIndex = $"{handleIndex}",
                             Name = "actor_" + cb.Actors.IndexOf(actor)
                         };
 

--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -383,6 +383,7 @@ namespace WolvenKit.ViewModels.Documents
         {
             public string AppearanceName { get; set; }
             public string MaterialName { get; set; }
+            public string WorldNodeIndex { get; set; }
             public CName DepotPath { get; set; }
         }
 


### PR DESCRIPTION
Implemented:
-  Add worldNodeData index on the logged message of LeftClick event over Mesh Component in MeshPreview View

---
On "Sector Preview" view, when clicking on a Mesh, prints in the log 
```
[13/12/2022 19:21:24] worldNodeData[205] : _instancedMeshNode
````
instead of 
```
[13/12/2022 19:21:24] Mesh Name  : _instancedMeshNode
```

![improved-log](https://user-images.githubusercontent.com/4053748/207426678-c6467851-abd6-4898-886d-8918b9e5f98a.png)
