### PR TITLE
Restore ExportFiles for Scripting and Add Export Settings

### DIFF
--- a/WolvenKit.App/Helpers/WKitUIScripting.cs
+++ b/WolvenKit.App/Helpers/WKitUIScripting.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive;
 using MoreLinq;
 using Splat;
+using WolvenKit.App.ViewModels.Exporters;
 using WolvenKit.Common;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Services;
 using WolvenKit.Modkit.Scripting;
+using WolvenKit.RED4.Archive;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Archive.IO;
-using WolvenKit.ViewModels.Shell;
 
 namespace WolvenKit.App.Helpers;
 
@@ -20,7 +20,8 @@ public class WKitUIScripting : WKitScripting
 {
     private readonly IProjectManager _projectManager;
 
-    public WKitUIScripting(ILoggerService loggerService) : base(loggerService) => _projectManager = Locator.Current.GetService<IProjectManager>();
+    public WKitUIScripting(ILoggerService loggerService)
+        : base(loggerService) => _projectManager = Locator.Current.GetService<IProjectManager>();
 
     public void SuspendFileWatcher(bool suspend)
     {
@@ -77,84 +78,84 @@ public class WKitUIScripting : WKitScripting
         }
     }
 
-    /*
-     * Todo Refactor
-    public void ExportFiles(dynamic relPaths)
+    public void ExportFiles(dynamic exportList)
     {
-        if (relPaths is null)
+        // dynamic type checking
+        // TODO: mix in hashes (V8 doesn't have a ulong equivalent though)
+        switch (exportList)
         {
-            throw new ArgumentNullException(nameof(relPaths));
-        }
-        else if (relPaths is string)
-        {
-            // since relPaths is dynamic we can support string, or string[]
-            // this converts a single string to an array (thanks JavaScript)
-            relPaths = new string[] { relPaths };
-        }
-        else
-        {
-            try
-            {
-                // this will catch exceptions with the (IList) conversion
-                // Cast<string> is lazy and  will be caught later
-                relPaths = ((IList)relPaths).Cast<string>();
-            }
-            catch (InvalidCastException ice)
-            {
-                _loggerService.Error("Unexpected data type found for argument \"relPaths\" in \"ExportFiles\".");
-                _loggerService.Error(ice.Message);
-            }
-            catch (Exception e)
-            {
-                _loggerService.Error(e);
-            }
-        }
-
-        var watcherService = Locator.Current.GetService<IWatcherService>();
-        var impExpVM = Locator.Current.GetService<AppViewModel>().ImportExportToolVM;
-
-        impExpVM.IsExportsSelected = true;
-        impExpVM.IsImportsSelected = false;
-
-        // unset every item in ExportItems
-        foreach (var expItem in impExpVM.ExportableItems)
-        {
-            expItem.IsChecked = false;
-        }
-
-        try
-        {
-            var uncookExts = Enum.GetNames(typeof(ECookedFileFormat));
-            foreach (var relPath in relPaths)
-            {
-                var filePath = Path.Combine(_projectManager.ActiveProject.ModDirectory, (string)relPath);
-                var ext = Path.GetExtension(filePath).Replace(".", "");
-                if (!File.Exists(filePath))
+            case IList list:
+                foreach(var item in list)
                 {
-                    _loggerService.Info($"{relPath} could not be found.");
+                    if (item is not string)
+                    {
+                        throw new Exception($"Unexpected datatype found for {nameof(exportList)}. Expected string or string[].");
+                    }
+                }
+                break;
+            case string exportString:
+                exportList = new string[] { exportString };
+                break;
+            case FileEntry fileEntry:
+                exportList = new string[] { fileEntry.FileName };
+                break;
+            case null:
+                throw new ArgumentNullException(nameof(exportList));
+            default:
+                throw new Exception($"Unexpected datatype found for {nameof(exportList)}. Expected string or string[].");
+        }
+
+        // get the export view model and clear the items
+        var expVM = Locator.Current.GetService<TextureExportViewModel>();
+        expVM.Items.ForEach(_ => _.IsChecked = false);
+
+        foreach (var exportItem in exportList)
+        {
+            if (exportItem is string exportPath)
+            {
+                if (exportPath.Length == 0)
+                {
                     continue;
                 }
-                if (!uncookExts.Any(e => e == ext))
+
+                // check extension is exportable
+                var uncookExts = Enum.GetNames(typeof(ECookedFileFormat));
+                var ext = Path.GetExtension(exportPath).Replace(".", "");
+                if (!uncookExts.Any(_ => _.Equals(ext, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    _loggerService.Info($"{relPath} is not an exportable CR2W file.");
+                    _loggerService.Warning($"{exportPath} does not contain a valid export extension. Skipping.");
+                    continue;
+                }
+
+                // we possibly have a relative path, so convert it to the project path
+                if (!Path.IsPathFullyQualified(exportPath))
+                {
+                    if (_projectManager.IsProjectLoaded)
+                    {
+                        exportPath = Path.Combine(_projectManager.ActiveProject.ModDirectory, exportPath);
+                    }
+                    else
+                    {
+                        _loggerService.Warning($"{exportPath} is a relative path and therefore cannot be resolved with an unloaded project. Skipping.");
+                        continue;
+                    }
+                }
+
+                if (!Path.Exists(exportPath))
+                {
+                    _loggerService.Warning($"{exportPath} could not be found. Skipping.");
                     continue;
                 }
 
                 // Set the item to be checked
-                impExpVM.ExportableItems.Where(_ => _.FullName == filePath)
+                expVM.Items.Where(_ => _.FullName.EndsWith(exportPath, StringComparison.InvariantCultureIgnoreCase))
                     .ForEach(_ => _.IsChecked = true);
             }
-            impExpVM.ProcessSelectedCommand.Execute(Unit.Default);
         }
-        catch (InvalidCastException ice)
+
+        if (expVM.Items.Any(_ => _.IsChecked))
         {
-            _loggerService.Error("Unexpected data type found for argument \"relPaths\" in \"ExportFiles\".");
-            _loggerService.Error(ice.Message);
-        }
-        catch (Exception e)
-        {
-            _loggerService.Error(e);
+            expVM.ProcessSelectedCommand.Execute(Unit.Default);
         }
     }
-    */
 }

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -1,11 +1,32 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive;
 
 namespace WolvenKit.Common.Model.Arguments
 {
+    /// <summary>
+    /// Tags a property as accessible in a WolvenKit Script
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class WkitScriptAccess : Attribute
+    {
+        private readonly string _scriptName;
+        public string ScriptName
+        {
+            get => _scriptName;
+        }
+
+        // by default the script name is the name of the property or class
+        public WkitScriptAccess([CallerMemberName] string scriptName = null)
+        {
+            _scriptName = scriptName;
+        }
+    }
+
     /// <summary>
     /// Export Arguments
     /// </summary>
@@ -25,6 +46,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Settings")]
         [Display(Name = "Use Modified OpusInfo")]
         [Description("If selected modified OpusInfo and paks within the Mod Project are used. If unchecked the original OpusInfo and paks will be exported.")]
+        [WkitScriptAccess()]
         public bool UseMod { get; set; }
 
         [Category("Export Settings")]
@@ -54,6 +76,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Settings")]
         [Display(Name = "Is Binary")]
         [Description("If selected the mesh will be exported as GLB, if unchecked as GLTF")]
+        [WkitScriptAccess("Binary")]
         public bool IsBinary { get; set; } = true;
 
         /// <summary>
@@ -95,9 +118,11 @@ namespace WolvenKit.Common.Model.Arguments
         /// </summary>
         [Category("Export Type")]
         [Display(Name = "MLmask Export Type")]
+        [WkitScriptAccess("ImageFormat")]
         public EUncookExtension UncookExtension { get; set; } = EUncookExtension.png;
 
         [Browsable(false)]
+        [WkitScriptAccess()]
         public bool AsList { get; set; } = true;
 
         /// <summary>
@@ -122,6 +147,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// </summary>
         [Category("Export Type")]
         [Display(Name = "XBM Export Type")]
+        [WkitScriptAccess("ImageType")]
         public EUncookExtension UncookExtension { get; set; } = EUncookExtension.png;
 
         /// <summary>
@@ -129,6 +155,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// </summary>
         [Category("Export Settings")]
         [Display(Name = "Flip Image")]
+        [WkitScriptAccess()]
         public bool Flip { get; set; }
 
         /// <summary>
@@ -169,6 +196,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Type")]
         [Display(Name = "Mesh Export Type")]
         [Description("Select between mesh export options. By default materials but no rig are included.")]
+        [WkitScriptAccess("ExportType")]
         public MeshExportType meshExportType { get; set; } = MeshExportType.WithMaterials;
 
         /// <summary>
@@ -177,6 +205,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Default Export Settings")]
         [Display(Name = "LOD Filter")]
         [Description("If selected LOD meshes will not be included. May cause complications with clipping decals.")]
+        [WkitScriptAccess()]
         public bool LodFilter { get; set; } = true;
 
         /// <summary>
@@ -185,6 +214,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Default Export Settings")]
         [Display(Name = "Is Binary")]
         [Description("If selected mesh exports will be in binary form as GLB rather than glTF format. (Recommended)")]
+        [WkitScriptAccess("Binary")]
         public bool isGLBinary { get; set; } = true;
 
         /// <summary>
@@ -217,6 +247,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("WithMaterials Settings")]
         [Display(Name = "Select Texture Format")]
         [Description("Select the preferred texture format to be exported within the Depot.")]
+        [WkitScriptAccess("ImageType")]
         public EUncookExtension MaterialUncookExtension { get; set; } = EUncookExtension.png;
 
         /// <summary>
@@ -261,6 +292,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Type")]
         [Display(Name = "Wem Export Type")]
         [Description("Select audio output format")]
+        [WkitScriptAccess("ExportType")]
         public WemExportTypes wemExportType { get; set; } = WemExportTypes.Mp3;
 
         [Browsable(false)]
@@ -281,6 +313,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Settings")]
         [Display(Name = "Is Binary")]
         [Description("If selected the anims will be exported as GLB, if unchecked as GLTF")]
+        [WkitScriptAccess("Binary")]
         public bool IsBinary { get; set; } = true;
 
         /// <summary>
@@ -289,6 +322,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Export Settings")]
         [Display(Name = "Include Root Motion")]
         [Description("If selected the anims will have the root translations")]
+        [WkitScriptAccess()]
         public bool incRootMotion { get; set; } = false;
 
         /// <summary>

--- a/WolvenKit/Resources/SyntaxHighlighting/JavaScript-DarkMode.xshd
+++ b/WolvenKit/Resources/SyntaxHighlighting/JavaScript-DarkMode.xshd
@@ -73,6 +73,7 @@
 			<Word>transient</Word>
 			<Word>try</Word>
 			<Word>volatile</Word>
+			<Word>yield</Word>
 		</Keywords>
 		<Keywords color="JavaScriptIntrinsics">
 			<Word>Array</Word>
@@ -80,10 +81,12 @@
 			<Word>Date</Word>
 			<Word>Function</Word>
 			<Word>Global</Word>
+			<Word>JSON</Word>
 			<Word>Math</Word>
 			<Word>Number</Word>
 			<Word>Object</Word>
 			<Word>RegExp</Word>
+			<Word>Set</Word>
 			<Word>String</Word>
 		</Keywords>
 		<Keywords color="JavaScriptLiterals">


### PR DESCRIPTION
Fixed:
- Refactored `wkit.ExportFiles` for scripting

Currently just a draft PR to track adding in export options. PR could be merged now to restore functionality without the additional feature