### PR TITLE
Adds Mesh selection on Sector Preview

### DIFF
--- a/WolvenKit.App/Helpers/MeshHelpers.cs
+++ b/WolvenKit.App/Helpers/MeshHelpers.cs
@@ -32,6 +32,8 @@ namespace WolvenKit.ViewModels.Documents
         public uint LOD { get; set; }
         public string AppearanceName { get; set; }
         public CName DepotPath { get; set; }
+        public HelixToolkit.Wpf.SharpDX.Material OriginalMaterial { get; set; }
+
     }
 
     public class SmartElement3DCollection : ObservableElement3DCollection

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
@@ -70,7 +70,7 @@ namespace WolvenKit.ViewModels.Documents
         public RDTMeshViewModel(worldStreamingBlock data, RedDocumentViewModel file) : this(file)
         {
             _data = data;
-            Header = "Sector Previews";
+            Header = MeshViewHeaders.AllSectorPreview;
 
             PanelVisibility.ShowSearchPanel = true;
             SearchForPointCommand = new DelegateCommand(ExecuteSearchForPoint);
@@ -299,38 +299,35 @@ namespace WolvenKit.ViewModels.Documents
 
         }
 
-        public void OnMouseDown3DHandler(object sender, MouseDown3DEventArgs e)
+        private void MouseDown3DBlock(object sender, MouseDown3DEventArgs args, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            if (e.HitTestResult is not null && ((MouseButtonEventArgs)e.OriginalInputEventArgs).LeftButton == MouseButtonState.Pressed)
+            if (Header == MeshViewHeaders.AllSectorPreview)
             {
-                if (e.HitTestResult.ModelHit is WKBillboardTextModel3D text)
+                if (mouseButtonEventArgs.LeftButton == MouseButtonState.Pressed)
                 {
-                    var sector = Sectors.Where(x => x.Text == text).FirstOrDefault();
-                    if (sector is not null)
+                    if (args.HitTestResult.ModelHit is WKBillboardTextModel3D text)
                     {
-                        try
+                        var sector = Sectors.Where(x => x.Text == text).FirstOrDefault();
+                        if (sector is not null)
                         {
-                            LoadSector(sector);
+                            try
+                            {
+                                LoadSector(sector);
+                            }
+                            catch (Exception ex)
+                            {
+                                Locator.Current.GetService<ILoggerService>().Error(ex);
+                            }
                         }
-                        catch (Exception ex)
-                        {
-                            Locator.Current.GetService<ILoggerService>().Error(ex);
-                        }
+                        args.Handled = true;
                     }
-                    e.Handled = true;
-                }
-                if (e.HitTestResult.ModelHit is MeshComponent group)
-                {
-                    SelectedItem = group;
-                    e.Handled = true;
-                }
-                if (e.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
-                {
-                    UpdateSelection(mesh);
-                    Locator.Current.GetService<ILoggerService>().Info((mesh.WorldNodeIndex != null ? "worldNodeData[" + mesh.WorldNodeIndex + "] : " : "Mesh Name :") + mesh.Name);
+                    if (args.HitTestResult.ModelHit is MeshComponent group)
+                    {
+                        SelectedItem = group;
+                        args.Handled = true;
+                    }
                 }
             }
         }
-
     }
 }

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewBlock.cs
@@ -326,9 +326,11 @@ namespace WolvenKit.ViewModels.Documents
                 }
                 if (e.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
                 {
+                    UpdateSelection(mesh);
                     Locator.Current.GetService<ILoggerService>().Info((mesh.WorldNodeIndex != null ? "worldNodeData[" + mesh.WorldNodeIndex + "] : " : "Mesh Name :") + mesh.Name);
                 }
             }
         }
+
     }
 }

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewEntity.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewEntity.cs
@@ -22,7 +22,7 @@ namespace WolvenKit.ViewModels.Documents
 
         public RDTMeshViewModel(entEntityTemplate ent, RedDocumentViewModel file) : this(file)
         {
-            Header = "Entity Preview";
+            Header = MeshViewHeaders.EntityPreview;
             _data = ent;
 
             PanelVisibility.ShowExportEntity = true;

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
@@ -25,7 +25,7 @@ namespace WolvenKit.ViewModels.Documents
 
         public RDTMeshViewModel(worldStreamingSector data, RedDocumentViewModel file) : this(file)
         {
-            Header = "Sector Preview";
+            Header = MeshViewHeaders.SectorPreview;
             _data = data;
             var app = new Appearance()
             {
@@ -706,6 +706,20 @@ namespace WolvenKit.ViewModels.Documents
             }
         }
 
+        private void MouseDown3DSector(object sender, MouseDown3DEventArgs args, MouseButtonEventArgs mouseButtonEventArgs)
+        {
+            if (Header == MeshViewHeaders.SectorPreview && args.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
+            {
+                if (mouseButtonEventArgs.RightButton == MouseButtonState.Pressed)
+                {
+                    Locator.Current.GetService<ILoggerService>().Info("RighClick: " + mesh.Name);
+                }
+                else if (mouseButtonEventArgs.LeftButton == MouseButtonState.Pressed)
+                {
+                    UpdateSelection(mesh);
+                }
+            }
+        }
     }
 
     public class SectorGroup : GroupModel3D

--- a/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
+++ b/WolvenKit.App/ViewModels/Documents/MeshPreviewSector.cs
@@ -26,6 +26,8 @@ namespace WolvenKit.ViewModels.Documents
             private const string s_noSelection = "No_Selection";
 
             [Reactive] public string Name { get; private set; } = s_noSelection;
+            [Reactive] public string WorldNodeIndex { get; private set; } = string.Empty;
+            [Reactive] public bool IsValid { get; private set; }
 
             private MeshComponent _meshComponent;
             public MeshComponent SelectedMesh
@@ -34,7 +36,9 @@ namespace WolvenKit.ViewModels.Documents
                 set
                 {
                     _meshComponent = value;
-                    Name = (value == null) ? s_noSelection : value.Name;
+                    Name = (value == null) ? s_noSelection : value.Name.StartsWith("_") ? value.Name[1..] : value.Name;
+                    WorldNodeIndex = (value == null) ? string.Empty : "[" + value.WorldNodeIndex + "]";
+                    IsValid = value != null;
                 }
             }
 
@@ -46,6 +50,7 @@ namespace WolvenKit.ViewModels.Documents
         public RDTMeshViewModel(worldStreamingSector data, RedDocumentViewModel file) : this(file)
         {
             Header = MeshViewHeaders.SectorPreview;
+            PanelVisibility.ShowSelectionPanel = true;
             _data = data;
             var app = new Appearance()
             {
@@ -679,7 +684,6 @@ namespace WolvenKit.ViewModels.Documents
             return new SharpDX.Vector3(v.X, v.Y, v.Z);
         }
 
-
         public void UpdateSelection(MeshComponent mesh)
         {
             RetoreSelectedMeshMaterial();
@@ -726,6 +730,7 @@ namespace WolvenKit.ViewModels.Documents
 
         private void MouseDown3DSector(object sender, MouseDown3DEventArgs args, MouseButtonEventArgs mouseButtonEventArgs)
         {
+            
             if (Header == MeshViewHeaders.SectorPreview && args.HitTestResult.ModelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
             {
                 if (mouseButtonEventArgs.RightButton == MouseButtonState.Pressed)

--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reactive.Disposables;
+using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
@@ -180,6 +181,14 @@ namespace WolvenKit.ViewModels.Documents
 
     }
 
+    public static class MeshViewHeaders
+    {
+        public const string MeshPreview = "Mesh Preview";
+        public const string AllSectorPreview = "All Sector Preview";
+        public const string SectorPreview = "Sector Preview";
+        public const string EntityPreview = "Entity Preview";
+    }
+
 
     public partial class RDTMeshViewModel : RedDocumentTabViewModel, IActivatableViewModel
     {
@@ -215,7 +224,7 @@ namespace WolvenKit.ViewModels.Documents
             {
                 if (Header == null)
                 {
-                    Header = "Mesh Preview";
+                    Header = MeshViewHeaders.MeshPreview;
                 }
 
                 File = file;
@@ -877,6 +886,27 @@ namespace WolvenKit.ViewModels.Documents
                     new Vector3D(0, -s_distanceCameraUnits, -s_distanceCameraUnits),
                     new Vector3D(0, s_cameraUpDirectionFactor, -s_cameraUpDirectionFactor),
                     s_cameraAnimationTime);
+        }
+
+        public void MouseDown3D(object sender, RoutedEventArgs e)
+        {
+            if (e is MouseDown3DEventArgs args && args.HitTestResult != null)
+            {
+                var mouseButtonEventArgs = ((MouseButtonEventArgs)args.OriginalInputEventArgs);
+                MouseDown3DSector(sender, args, mouseButtonEventArgs);
+                MouseDown3DBlock(sender, args, mouseButtonEventArgs);
+
+                CommonMouseDownEvents(args.HitTestResult.ModelHit, mouseButtonEventArgs);
+            }
+        }
+
+        private void CommonMouseDownEvents(object modelHit, MouseButtonEventArgs mouseButtonEventArgs) 
+        {
+            if (mouseButtonEventArgs.LeftButton == MouseButtonState.Pressed && modelHit is SubmeshComponent { Parent: MeshComponent { Parent: MeshComponent mesh } })
+            {
+                Locator.Current.GetService<ILoggerService>().Info((mesh.WorldNodeIndex != null ? "worldNodeData[" + mesh.WorldNodeIndex + "] : " : "Mesh Name :") + mesh.Name);
+            }
+        
         }
     }
 

--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -176,8 +176,8 @@ namespace WolvenKit.ViewModels.Documents
     public class PanelVisibility
     {
         public bool ShowExportEntity { get; set; }
-
         public bool ShowSearchPanel { get; set; }
+        public bool ShowSelectionPanel { get; set; }
 
     }
 
@@ -225,7 +225,7 @@ namespace WolvenKit.ViewModels.Documents
                 if (Header == null)
                 {
                     Header = MeshViewHeaders.MeshPreview;
-                }
+                } 
 
                 File = file;
 

--- a/WolvenKit/Views/Documents/RDTDataView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTDataView.xaml.cs
@@ -132,6 +132,7 @@ namespace WolvenKit.Views.Documents
                 //   .DisposeWith(disposables);
 
             });
+            
 
 
             //PropertyGrid.CustomEditorCollection = CustomEditorCollection;

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -181,8 +181,8 @@
                         <ColumnDefinition SharedSizeGroup="ColumnHeader" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <Border BorderThickness="1,1,1,0" BorderBrush="{StaticResource BorderAlt}" />
-                    <Border BorderThickness="0,1,1,0" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
+                    <Border BorderThickness="1,0,1,1" BorderBrush="{StaticResource BorderAlt}" />
+                    <Border BorderThickness="0,0,1,1" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
                         Grid.Row="0"
                         Grid.Column="0"
@@ -202,8 +202,8 @@
                         <ColumnDefinition SharedSizeGroup="ColumnHeader" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <Border BorderThickness="1,1,1,0" BorderBrush="{StaticResource BorderAlt}" />
-                    <Border BorderThickness="0,1,1,0" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
+                    <Border BorderThickness="1,0,1,1" BorderBrush="{StaticResource BorderAlt}" />
+                    <Border BorderThickness="0,0,1,1" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
                         Grid.Column="0"
                         Margin="5,0"
@@ -217,13 +217,14 @@
                         SelectedItem="{Binding SelectedAppearance.SelectedLOD, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     
                 </Grid>
-                <Grid Grid.Column="2">
+                <Grid Grid.Column="2"
+                      Visibility="{Binding PanelVisibility.ShowSelectionPanel, Converter={StaticResource VisibilityConverter}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition SharedSizeGroup="ColumnHeader" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <Border BorderThickness="1" BorderBrush="{StaticResource BorderAlt}"  />
-                    <Border BorderThickness="0,1,1,1" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
+                    <Border BorderThickness="1,0,1,1" BorderBrush="{StaticResource BorderAlt}" />
+                    <Border BorderThickness="0,0,1,1" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
                         Grid.Column="0"
                         Margin="5,7"
@@ -232,6 +233,7 @@
                     <StackPanel Orientation="Horizontal" 
                         Grid.Column="1"
                         Height="15"
+                        Visibility="{Binding CurrentSelection.IsValid, Converter={StaticResource VisibilityConverter}}"
                         VerticalAlignment="Center"
                         Margin="0,7,0,3">
                         <iconPacks:PackIconCodicons
@@ -241,7 +243,14 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         Kind="SymbolClass" />
- 
+
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            Foreground="{StaticResource WolvenKitTan}"
+                            Text="worldNodeData" />
+                        <TextBlock
+                            Margin="3,0,0,0"
+                            Text="{Binding CurrentSelection.WorldNodeIndex, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             Margin="3,0,0,0"
                             Text="{Binding CurrentSelection.Name, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -219,6 +219,12 @@
                         ItemsSource="{Binding SelectedAppearance.LODLUT.Keys, Mode=OneWay}"
                         SelectedItem="{Binding SelectedAppearance.SelectedLOD, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
+                <StackPanel Orientation="Vertical">
+                    <TextBlock
+                        Margin="5,6,0,3"
+                        VerticalAlignment="Center"
+                        Text="{Binding CurrentSelection.Name}" />
+                </StackPanel>
                 <StackPanel Orientation="Vertical" Visibility="{Binding PanelVisibility.ShowSearchPanel, Converter={StaticResource VisibilityConverter}}" >
                     <TextBlock
                         Margin="5,6,0,3"

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -46,11 +46,6 @@
                 <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="MiddleClick" />
                 <MouseBinding Command="hx:ViewportCommands.Rotate" Gesture="Shift+MiddleClick" />
             </hx:Viewport3DX.InputBindings>
-            <i:Interaction.Triggers>
-                <i:EventTrigger EventName="MouseDown3D">
-                    <i:CallMethodAction MethodName="OnMouseDown3DHandler" TargetObject="{Binding}" />
-                </i:EventTrigger>
-            </i:Interaction.Triggers>
             <hx:DirectionalLight3D Direction="0, -1, 0" Color="White" />
             <hx:DirectionalLight3D Direction="0, 0, 1" Color="White" />
             <hx:DirectionalLight3D Direction="0, 0, -1" Color="White" />

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -169,57 +169,84 @@
                 </StackPanel>
             </Border>
         </syncfusion:DropDownButton-->
+        
         <Grid Grid.Column="2">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <StackPanel Orientation="Vertical" >
+            <StackPanel Orientation="Vertical" Grid.IsSharedSizeScope="True" Width="Auto">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition />
-
+                        <ColumnDefinition SharedSizeGroup="ColumnHeader" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
+                    <Border BorderThickness="1,1,1,0" BorderBrush="{StaticResource BorderAlt}" />
+                    <Border BorderThickness="0,1,1,0" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
                         Text="Appearance: " />
                     <ComboBox
-                        x:Name="appearanceComboBox"
                         Grid.Column="1"
-                        Width="{Binding ElementName=lodComboBox, Path=ActualWidth}"
                         Height="30"
                         Padding="10,0"
-                        HorizontalAlignment="Right"
                         DisplayMemberPath="Name"
                         ItemsSource="{Binding Appearances, Mode=OneWay}"
                         SelectedItem="{Binding SelectedAppearance, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition />
-
+                        <ColumnDefinition SharedSizeGroup="ColumnHeader" />
+                        <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
+                    <Border BorderThickness="1,1,1,0" BorderBrush="{StaticResource BorderAlt}" />
+                    <Border BorderThickness="0,1,1,0" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
-                        Margin="5,0,0,0"
+                        Grid.Column="0"
+                        Margin="5,0"
                         VerticalAlignment="Center"
                         Text="Level of Detail: " />
                     <ComboBox
-                        x:Name="lodComboBox"
                         Grid.Column="1"
                         Height="30"
                         Padding="10,0"
                         ItemsSource="{Binding SelectedAppearance.LODLUT.Keys, Mode=OneWay}"
                         SelectedItem="{Binding SelectedAppearance.SelectedLOD, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    
                 </Grid>
-                <StackPanel Orientation="Vertical">
+                <Grid Grid.Column="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="ColumnHeader" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Border BorderThickness="1" BorderBrush="{StaticResource BorderAlt}"  />
+                    <Border BorderThickness="0,1,1,1" BorderBrush="{StaticResource BorderAlt}" Grid.Column="1" />
                     <TextBlock
-                        Margin="5,6,0,3"
+                        Grid.Column="0"
+                        Margin="5,7"
                         VerticalAlignment="Center"
-                        Text="{Binding CurrentSelection.Name}" />
-                </StackPanel>
+                        Text="Selection: " />
+                    <StackPanel Orientation="Horizontal" 
+                        Grid.Column="1"
+                        Height="15"
+                        VerticalAlignment="Center"
+                        Margin="0,7,0,3">
+                        <iconPacks:PackIconCodicons
+                                        Width="15"
+                                        Height="15"
+                                        Margin="6,0,0,2"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Kind="SymbolClass" />
+ 
+                        <TextBlock
+                            Margin="3,0,0,0"
+                            Text="{Binding CurrentSelection.Name, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
+                </Grid>
                 <StackPanel Orientation="Vertical" Visibility="{Binding PanelVisibility.ShowSearchPanel, Converter={StaticResource VisibilityConverter}}" >
                     <TextBlock
                         Margin="5,6,0,3"
@@ -422,38 +449,38 @@
                 </syncfusion:SfTreeGrid.Columns>
             </syncfusion:SfTreeGrid>
             <!--ItemsControl ItemsSource="{Binding SelectedAppearance.Models, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Vertical" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.Template>
-                            <ControlTemplate>
-                                <ItemsPresenter />
-                            </ControlTemplate>
-                        </ItemsControl.Template>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel Margin="5,0,0,0" Orientation="Vertical">
-                                    <CheckBox
-                                        Margin="0,2"
-                                        Checked="ReloadModels"
-                                        IsChecked="{Binding IsEnabled, Mode=TwoWay}"
-                                        Unchecked="ReloadModels">
-                                        <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
-                                    </CheckBox>
-                                    <TextBlock
-                                        Margin="20,0,0,0"
-                                        VerticalAlignment="Center"
-                                        Text="{Binding BindName, StringFormat='bind: {0}'}" />
-                                    <TextBlock
-                                        Margin="20,0,0,0"
-                                        VerticalAlignment="Center"
-                                        Text="{Binding SlotName, StringFormat='slot: {0}'}" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl-->
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.Template>
+                        <ControlTemplate>
+                            <ItemsPresenter />
+                        </ControlTemplate>
+                    </ItemsControl.Template>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="5,0,0,0" Orientation="Vertical">
+                                <CheckBox
+                                    Margin="0,2"
+                                    Checked="ReloadModels"
+                                    IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+                                    Unchecked="ReloadModels">
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
+                                </CheckBox>
+                                <TextBlock
+                                    Margin="20,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Text="{Binding BindName, StringFormat='bind: {0}'}" />
+                                <TextBlock
+                                    Margin="20,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Text="{Binding SlotName, StringFormat='slot: {0}'}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl-->
         </Grid>
     </Grid>
 </reactiveUi:ReactiveUserControl>

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml.cs
@@ -31,15 +31,18 @@ namespace WolvenKit.Views.Documents
                 if (DataContext is RDTMeshViewModel vm)
                 {
                     SetCurrentValue(ViewModelProperty, vm);
+                    hxViewport.MouseDown3D += vm.MouseDown3D;
                 }
 
                 this.OneWayBind(ViewModel,
                         viewModel => viewModel.SelectedAppearance.ModelGroup,
                         view => view.hxContentVisual.ItemsSource)
                     .DisposeWith(disposables);
+            
             });
         }
 
+        private void HxViewport_MouseDown3D(object sender, RoutedEventArgs e) => throw new System.NotImplementedException();
         private void ReloadModels(object sender, RoutedEventArgs e) => hxViewport.ZoomExtents();//if (ViewModel != null)//    LoadModels(ViewModel.SelectedAppearance);
         private void ComboBoxAdv_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {


### PR DESCRIPTION
Adds a visual and textual feedback when selecting a rendered mesh on `Sector Preview` view. 

https://user-images.githubusercontent.com/4053748/210269985-c1bc9da3-709a-48c0-8f4e-df31941f7abc.mp4

Capturing the click over a mesh will select it and display in blue `#0000FF` to give a visual contrast of current used colors. Also, the worldNode will be displayed on new grid item called "Selection", e.g. : *worldNode [145] instanceMeshNode*

Implemented:
- Mesh selection on Sector Preview view. Highlighting the Mesh in blue and displaying the name in selection field.
- Renames header from `Sector Previews` to `All Sector Preview`, in **MeshPreviewBlock.cs**
- Split mouse events per type of Preview : Mesh, All Sector, Sector and Entity

Fixed:
-  Mouse events on all previews is properly restored when tab focus is restored.
