### PR TITLE
Implemented saveAs for wscript files (Issue #1028)

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
@@ -123,6 +123,7 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
 
         ContentId = path;
         FilePath = path;
+        Header = Path.GetFileName(path);
         _isInitialized = true;
 
         return true;
@@ -133,8 +134,10 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
         using var fs = new FileStream(FilePath, FileMode.Create, FileAccess.ReadWrite);
         using var bw = new StreamWriter(fs);
         bw.Write(Document.Text);
+        bw.Close();
 
         SetIsDirty(false);
+        this.OpenFile(FilePath);
 
         return Task.CompletedTask;
     }

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1417,6 +1417,10 @@ namespace WolvenKit.ViewModels.Shell
                         red.FilePath == null ||
                         !Directory.Exists(Path.GetDirectoryName(Path.Combine(_projectManager.ActiveProject.ModDirectory, red.RelativePath)))
                     ,
+                    WScriptDocumentViewModel wScript =>
+                        saveAsDialogRequested ||
+                        wScript.FilePath == null ||
+                        !Directory.Exists(ISettingsManager.GetWScriptDir()),
                     _ => false,
                 };
 


### PR DESCRIPTION
# Fix/wscript-saveas

Fixed:
- SaveAs acting as regular save

It now opens a proper SaveFileDialog and gives the opportunity to save the script with a new name and theoretically in a different folder (might not be good?). I also reopen the saved file on saving to make sure that the UI updates accordingly.

closes #1028 