### PR TITLE
Implemented import option to handle LOD0 as LOD8 if needed.

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -158,6 +158,14 @@ namespace WolvenKit.Common.Model.Arguments
         public bool SelectBase { get; set; } = false;
 
         /// <summary>
+        /// Uses a selected mesh from archives as base mesh for import instead of mod project archive directory mesh
+        /// </summary>
+        [Category("Import Settings")]
+        [Display(Name = "Contains LOD8 named LOD0")]
+        [Description("If checked the included LOD0 will be assigned to LOD8")]
+        public bool ReplaceLod { get; set; } = false;
+
+        /// <summary>
         /// Selected Rig for Mesh WithRig Export. ALWAYS USE THE FIRST ENTRY IN THE LIST.
         /// </summary>
         [Category("WithRig Settings")]

--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -158,11 +158,11 @@ namespace WolvenKit.Common.Model.Arguments
         public bool SelectBase { get; set; } = false;
 
         /// <summary>
-        /// Uses a selected mesh from archives as base mesh for import instead of mod project archive directory mesh
+        /// Assigns found LOD0 submeshes to LOD8 to allow import of certain meshes that handle LOD0 as LOD8.
         /// </summary>
         [Category("Import Settings")]
         [Display(Name = "Contains LOD8 named LOD0")]
-        [Description("If checked the included LOD0 will be assigned to LOD8")]
+        [Description("If checked the included LOD0 submesh will be handled as LOD8")]
         public bool ReplaceLod { get; set; } = false;
 
         /// <summary>

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -356,7 +356,7 @@ namespace WolvenKit.Modkit.RED4
                 }
             }
 
-            VerifyGLTF(model);
+            VerifyGLTF(model, args);
 
             var Meshes = new List<RawMeshContainer>();
             foreach (var node in model.LogicalNodes)
@@ -426,7 +426,7 @@ namespace WolvenKit.Modkit.RED4
 
             MeshTools.UpdateMeshJoints(ref Meshes, newRig, oldRig);
 
-            UpdateSkinningParamCloth(ref Meshes, ref cr2w);
+            UpdateSkinningParamCloth(ref Meshes, ref cr2w, args);
 
             var expMeshes = Meshes.Select(_ => RawMeshToRE4Mesh(_, QuantScale, QuantTrans)).ToList();
 
@@ -902,7 +902,9 @@ namespace WolvenKit.Modkit.RED4
                     var idx = expMeshes[i].name.IndexOf("LOD_");
                     if (idx < expMeshes[i].name.Length - 1)
                     {
-                        meshesInfo.LODLvl[i] = Convert.ToUInt32(expMeshes[i].name.Substring(idx + 4, 1));
+                        var LOD = Convert.ToUInt32(expMeshes[i].name.Substring(idx + 4, 1));
+                        LOD =  LOD == 0 ? 8 : LOD;
+                        meshesInfo.LODLvl[i] = LOD;
                     }
                 }
                 else
@@ -1251,7 +1253,7 @@ namespace WolvenKit.Modkit.RED4
             return ms;
         }
 
-        private static void VerifyGLTF(ModelRoot model)
+        private static void VerifyGLTF(ModelRoot model, GltfImportArgs args)
         {
             if (model.LogicalMeshes.Count < 1)
             {
@@ -1294,6 +1296,8 @@ namespace WolvenKit.Modkit.RED4
                         if (idx < name.Length - 1)
                         {
                             LOD = Convert.ToUInt32(name.Substring(idx + 4, 1));
+                            LOD = args.ReplaceLod && LOD == 0 ? 8 : LOD;
+                            
                             LODs.Add(LOD);
                         }
                     }
@@ -1316,7 +1320,7 @@ namespace WolvenKit.Modkit.RED4
                 throw new Exception("None of the Geometry/submeshes are of 1 Level of Detail or (LOD 1) in provided GLTF");
             }
         }
-        private static void UpdateSkinningParamCloth(ref List<RawMeshContainer> meshes, ref CR2WFile cr2w)
+        private static void UpdateSkinningParamCloth(ref List<RawMeshContainer> meshes, ref CR2WFile cr2w, GltfImportArgs args)
         {
             var cmesh = (CMesh)cr2w.RootChunk;
 
@@ -1328,7 +1332,10 @@ namespace WolvenKit.Modkit.RED4
                     var idx = meshes[i].name.IndexOf("LOD_");
                     if (idx < meshes[i].name.Length - 1)
                     {
-                        LODLvl[i] = Convert.ToUInt32(meshes[i].name.Substring(idx + 4, 1));
+                        var LOD = Convert.ToUInt32(meshes[i].name.Substring(idx + 4, 1));
+                        LOD = args.ReplaceLod && LOD == 0 ? 8 : LOD;
+
+                        LODLvl[i] = LOD;
                     }
                 }
                 else

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -431,7 +431,7 @@ namespace WolvenKit.Modkit.RED4
             var expMeshes = Meshes.Select(_ => RawMeshToRE4Mesh(_, QuantScale, QuantTrans)).ToList();
 
             var meshBuffer = new MemoryStream();
-            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer);
+            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer, args);
 
             meshesInfo.quantScale = QuantScale;
             meshesInfo.quantTrans = QuantTrans;
@@ -755,7 +755,7 @@ namespace WolvenKit.Modkit.RED4
             return Re4Mesh;
         }
 
-        private static MeshesInfo BufferWriter(List<Re4MeshContainer> expMeshes, ref MemoryStream ms)
+        private static MeshesInfo BufferWriter(List<Re4MeshContainer> expMeshes, ref MemoryStream ms, GltfImportArgs args)
         {
             var meshesInfo = new MeshesInfo(expMeshes.Count);
 
@@ -903,7 +903,7 @@ namespace WolvenKit.Modkit.RED4
                     if (idx < expMeshes[i].name.Length - 1)
                     {
                         var LOD = Convert.ToUInt32(expMeshes[i].name.Substring(idx + 4, 1));
-                        LOD =  LOD == 0 ? 8 : LOD;
+                        LOD = args.ReplaceLod && LOD == 0 ? 8 : LOD;
                         meshesInfo.LODLvl[i] = LOD;
                     }
                 }

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -48,7 +48,7 @@ namespace WolvenKit.Modkit.RED4
             }
 
             var model = ModelRoot.Load(inGltfFile.FullName, new ReadSettings(args.ValidationMode));
-            VerifyGLTF(model);
+            VerifyGLTF(model, args);
 
             var Meshes = new List<RawMeshContainer>();
             foreach (var node in model.LogicalNodes)

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -92,7 +92,7 @@ namespace WolvenKit.Modkit.RED4
             var expMeshes = Meshes.Select(_=> RawMeshToRE4Mesh(_, QuantScale, QuantTrans)).ToList();
 
             var meshBuffer = new MemoryStream();
-            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer);
+            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer, args);
 
             meshesInfo.quantScale = QuantScale;
             meshesInfo.quantTrans = QuantTrans;


### PR DESCRIPTION
# Fix/lod0-handling

- Added toggle in import screen that allows the importer to handle LOD0 submeshes as LOD8, if found.

closes #854 