### PR TITLE
Skip packages with empty chunks instead of running into an exception

### DIFF
--- a/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
@@ -81,6 +81,7 @@ namespace WolvenKit.Views.Documents
 
                 foreach (var item in ViewModel.library.LibraryItems)
                 {
+
                     if (item.PackageData == null || item.PackageData.Data is not RedPackage pkg)
                     {
                         if (item.Package.Data is not RedPackage pkg2)
@@ -89,6 +90,11 @@ namespace WolvenKit.Views.Documents
                         }
 
                         pkg = pkg2;
+                    }
+
+                    if (pkg.Chunks.Count == 0)
+                    { 
+                        continue; 
                     }
 
                     if (pkg.Chunks[0] is not inkWidgetLibraryItemInstance inst)

--- a/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
@@ -12,6 +12,8 @@ using System.Windows.Media.Imaging;
 using Microsoft.Win32;
 using Prism.Commands;
 using ReactiveUI;
+using Splat;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Layout.inkWidgets;
 using WolvenKit.RED4.Archive.Buffer;
 using WolvenKit.RED4.Types;
@@ -24,6 +26,7 @@ namespace WolvenKit.Views.Documents
     /// </summary>
     public partial class RDTWidgetView : ReactiveUserControl<RDTWidgetViewModel>
     {
+
         public List<inkControl> Widgets = new();
 
         public List<inkControlAnimation> Animations = new();
@@ -93,7 +96,8 @@ namespace WolvenKit.Views.Documents
                     }
 
                     if (pkg.Chunks.Count == 0)
-                    { 
+                    {
+                        Locator.Current.GetService<ILoggerService>().Warning(String.Format("LibraryItem {0} did not contain any packageData and was skipped.", item.Name));
                         continue; 
                     }
 


### PR DESCRIPTION
# Fix/widget-empty-chunks
There are inkwidget files which contain libraryItems with empty packageData.
An example would be the wardrobe.inkwidget from EquipmentEx which has two libraryItems (Root and OutfitManager which don't seem to contain any packageData) resulting WolvenKit running into an exception and displaying absolutely nothing.

This small change will skip those libraryItems and atleast display the ones that contain packageData.

closes #1075 