### PR TITLE
fix: added logging if can't find xbm on inkatlas export

### DIFF
--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -634,8 +634,15 @@ namespace WolvenKit.Modkit.RED4
             void ExtractParts(CName texturePath, CArray<inkTextureAtlasMapper> parts, string outDir)
             {
                 var xbmFile = _archiveManager.Lookup(texturePath);
-                if (xbmFile.HasValue)
+                
+                if(xbmFile == null)
                 {
+                    _loggerService.Error(String.Format("File: {0} was not found in any archive.", texturePath));
+                    return;
+                }
+
+                if (xbmFile.HasValue)
+                { 
                     Directory.CreateDirectory(outDir);
 
                     using var ms = new MemoryStream();


### PR DESCRIPTION
# fix/inkatlas-export-logging

fix:
- inkatlas export will now log if it fails, because it can't find a xbm file in a game archive

Closes #979 
