### PR TITLE
Fix submesh order being determined by mesh name (MeshData in Blender) instead of node name (Object name in Blender)

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -361,8 +361,10 @@ namespace WolvenKit.Modkit.RED4
             var Meshes = new List<RawMeshContainer>();
             foreach (var node in model.LogicalNodes)
             {
+                _loggerService.Info(node.Name);
                 if (node.Mesh != null)
                 {
+                    _loggerService.Info("belongs to " + node.Mesh.Name);
                     Meshes.Add(GltfMeshToRawContainer(node));
                 }
                 else if (args.FillEmpty)
@@ -519,7 +521,7 @@ namespace WolvenKit.Modkit.RED4
 
             var meshContainer = new RawMeshContainer
             {
-                name = mesh.Name,
+                name = node.Name,
 
                 // Copying PNT w/ RHS to LHS Y+ to Z+
                 positions = mesh.Primitives[0].GetVertices("POSITION").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -361,10 +361,8 @@ namespace WolvenKit.Modkit.RED4
             var Meshes = new List<RawMeshContainer>();
             foreach (var node in model.LogicalNodes)
             {
-                _loggerService.Info(node.Name);
                 if (node.Mesh != null)
                 {
-                    _loggerService.Info("belongs to " + node.Mesh.Name);
                     Meshes.Add(GltfMeshToRawContainer(node));
                 }
                 else if (args.FillEmpty)


### PR DESCRIPTION
# fix/submesh-order

This fixes the submesh order not being determined by object name in Blender, but rather the mesh name that is connected to the object. Those occasionally get mixed up when joining and separating.

Closes #1036 
