### PR TITLE
Feature/material-export

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -197,7 +197,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Display(Name = "Mesh Export Type")]
         [Description("Select between mesh export options. By default materials but no rig are included.")]
         [WkitScriptAccess("ExportType")]
-        public MeshExportType meshExportType { get; set; } = MeshExportType.WithRig;
+        public MeshExportType meshExportType { get; set; } = MeshExportType.MeshOnly;
 
         /// <summary>
         /// If lodfilter = true, only exports the highest quality geometry, if false export all the geometry.
@@ -366,8 +366,8 @@ namespace WolvenKit.Common.Model.Arguments
     /// </summary>
     public enum MeshExportType
     {
-        WithRig,
         MeshOnly,
+        WithRig,
         Multimesh
     }
 

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -197,7 +197,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Display(Name = "Mesh Export Type")]
         [Description("Select between mesh export options. By default materials but no rig are included.")]
         [WkitScriptAccess("ExportType")]
-        public MeshExportType meshExportType { get; set; } = MeshExportType.WithMaterials;
+        public MeshExportType meshExportType { get; set; } = MeshExportType.WithRig;
 
         /// <summary>
         /// If lodfilter = true, only exports the highest quality geometry, if false export all the geometry.
@@ -218,13 +218,23 @@ namespace WolvenKit.Common.Model.Arguments
         public bool isGLBinary { get; set; } = true;
 
         /// <summary>
+        /// Binary Export Bool, Decides if we should export materials
+        /// </summary>
+        [Category("Default Export Settings")]
+        [Display(Name = "Export Materials")]
+        [Description("If selected mesh exports will include materials.")]
+        [WkitScriptAccess("WithMaterials")]
+        public bool withMaterials { get; set; } = true;
+
+
+        /// <summary>
         /// MultiMesh Mesh List.
         /// </summary>
         [Category("MultiMesh Settings")]
         [Display(Name = "Select Additional Meshes")]
         [Description("Select additional meshes to be included within a single export.")]
         public List<FileEntry> MultiMeshMeshes { get; set; } = new();      // meshes?
-
+    
         /// <summary>
         /// MultiMesh Rig List.
         /// </summary>
@@ -356,7 +366,6 @@ namespace WolvenKit.Common.Model.Arguments
     /// </summary>
     public enum MeshExportType
     {
-        WithMaterials,
         WithRig,
         MeshOnly,
         Multimesh

--- a/WolvenKit.Modkit/RED4/ModTools.cs
+++ b/WolvenKit.Modkit/RED4/ModTools.cs
@@ -16,6 +16,7 @@ namespace WolvenKit.Modkit.RED4
         private readonly Red4ParserService _wolvenkitFileService;
         private readonly MeshTools _meshTools;
         private readonly IArchiveManager _archiveManager;
+        private readonly Red4ParserService _red4ParserService;
 
         public ModTools(
             ILoggerService loggerService,
@@ -23,7 +24,8 @@ namespace WolvenKit.Modkit.RED4
             IHashService hashService,
             Red4ParserService wolvenkitFileService,
             MeshTools meshTools,
-            IArchiveManager archiveManager
+            IArchiveManager archiveManager,
+            Red4ParserService red4ParserService
         )
         {
             _loggerService = loggerService;
@@ -32,6 +34,7 @@ namespace WolvenKit.Modkit.RED4
             _wolvenkitFileService = wolvenkitFileService;
             _meshTools = meshTools;
             _archiveManager = archiveManager;
+            _red4ParserService= red4ParserService;
         }
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -75,7 +75,7 @@ namespace WolvenKit.Modkit.RED4
 
             return true;
         }
-        private void GetMateriaEntries(CR2WFile cr2w, Stream meshStream, ref List<string> primaryDependencies, ref List<string> materialEntryNames, ref List<CMaterialInstance> materialEntries, List<ICyberGameArchive> archives)
+        private void GetMaterialEntries(CR2WFile cr2w, Stream meshStream, ref List<string> primaryDependencies, ref List<string> materialEntryNames, ref List<CMaterialInstance> materialEntries, List<ICyberGameArchive> archives)
         {
             var cmesh = cr2w.RootChunk as CMesh;
 
@@ -285,7 +285,7 @@ namespace WolvenKit.Modkit.RED4
             var materialEntryNames = new List<string>();
             var materialEntries = new List<CMaterialInstance>();
 
-            GetMateriaEntries(cr2w, meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries, archives);
+            GetMaterialEntries(cr2w, meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries, archives);
 
             var mlSetupNames = new List<string>();
 
@@ -584,7 +584,7 @@ namespace WolvenKit.Modkit.RED4
             var materialEntryNames = new List<string>();
             var materialEntries = new List<CMaterialInstance>();
 
-            GetMateriaEntries(cr2w, meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries, archives);
+            GetMaterialEntries(cr2w, meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries, archives);
 
             var mlSetupNames = new List<string>();
 

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -19,6 +19,7 @@ using WolvenKit.RED4.Archive.IO;
 using WolvenKit.RED4.CR2W.JSON;
 using WolvenKit.RED4.Types;
 using WolvenKit.RED4.Types.Exceptions;
+using System.Drawing.Drawing2D;
 
 namespace WolvenKit.Modkit.RED4
 {
@@ -275,6 +276,305 @@ namespace WolvenKit.Modkit.RED4
                     }
                 }
             }
+        }
+
+        private MatData SetupMaterial(CR2WFile cr2w, Stream meshStream, List<ICyberGameArchive> archives, string matRepo, MeshesInfo info, EUncookExtension eUncookExtension = EUncookExtension.dds)
+        {
+            var primaryDependencies = new List<string>();
+
+            var materialEntryNames = new List<string>();
+            var materialEntries = new List<CMaterialInstance>();
+
+            GetMateriaEntries(cr2w, meshStream, ref primaryDependencies, ref materialEntryNames, ref materialEntries, archives);
+
+            var mlSetupNames = new List<string>();
+
+            var mlTemplateNames = new List<string>();
+
+            var HairProfileNames = new List<string>();
+
+            var TexturesList = new List<string>();
+
+            var exportArgs =
+                new GlobalExportArgs().Register(
+                    new XbmExportArgs() { UncookExtension = eUncookExtension },
+                    new MlmaskExportArgs() { UncookExtension = eUncookExtension }
+                );
+
+            for (var i = 0; i < primaryDependencies.Count; i++)
+            {
+                ExtractFile(primaryDependencies[i]);
+            }
+
+            var RawMaterials = new List<RawMaterial>();
+            var usedMts = GetEmbeddedMaterialTemplates(ref cr2w);
+            for (var i = 0; i < materialEntries.Count; i++)
+            {
+                RawMaterials.Add(ContainRawMaterial(materialEntries[i], materialEntryNames[i], archives, ref usedMts));
+            }
+
+            var matTemplates = new List<RawMaterial>();
+            {
+                var keys = usedMts.Keys.ToList();
+                for (var i = 0; i < keys.Count; i++)
+                {
+                    var rawMat = new RawMaterial
+                    {
+                        Name = keys[i],
+                        Data = new Dictionary<string, object>()
+                    };
+
+                    foreach (var item in usedMts[keys[i]].Parameters[2])
+                    {
+                        rawMat.Data.Add(item.Chunk.ParameterName, GetSerializableValue(item.Chunk));
+                    }
+
+                    matTemplates.Add(rawMat);
+                }
+            }
+
+            var matData = new MatData
+            {
+                MaterialRepo = matRepo,
+                Materials = RawMaterials,
+                TexturesList = TexturesList,
+                MaterialTemplates = matTemplates,
+                Appearances = info.appearances
+            };
+
+            return matData;
+            void ExtractFile(string path)
+            {
+                var extension = Path.GetExtension(path).ToLower();
+
+                switch (extension)
+                {
+                    case ".xbm":
+                        ExtractXBM(path);
+                        break;
+
+                    case ".mlmask":
+                        ExtractMlMask(path);
+                        break;
+
+                    case ".hp":
+                        ExtractHP(path);
+                        break;
+
+                    case ".mlsetup":
+                        ExtractMlSetup(path);
+                        break;
+
+                    case ".mltemplate":
+                        ExtractMlTemplate(path);
+                        break;
+
+                    case ".gradient":
+                        ExtractGradient(path);
+                        break;
+                }
+
+                void ExtractXBM(string path)
+                {
+                    if (!TexturesList.Contains(path))
+                    {
+                        TexturesList.Add(path);
+                    }
+
+                    var destFileName = Path.Combine(matRepo, Path.ChangeExtension(path, "." + exportArgs.Get<XbmExportArgs>().UncookExtension));
+                    if (!File.Exists(destFileName))
+                    {
+                        UncookFile(archives, path, matRepo, exportArgs);
+                    }
+                }
+
+                void ExtractMlMask(string path)
+                {
+                    if (!TexturesList.Contains(path))
+                    {
+                        TexturesList.Add(path);
+                    }
+
+                    var destFileName = Path.Combine(matRepo, path.Replace(".mlmask", $"_0.{exportArgs.Get<XbmExportArgs>().UncookExtension}"));
+                    if (!File.Exists(destFileName))
+                    {
+                        exportArgs.Get<MlmaskExportArgs>().AsList = false;
+                        UncookFile(archives, path, matRepo, exportArgs);
+                    }
+                }
+
+                void ExtractHP(string path)
+                {
+                    if (HairProfileNames.Contains(path))
+                    {
+                        return;
+                    }
+
+                    HairProfileNames.Add(path);
+
+                    var fi = new FileInfo(Path.Combine(matRepo, Path.ChangeExtension(path, ".hp.json")));
+                    if (!fi.Exists)
+                    {
+                        var findStatus = TryFindFile(archives, path, out var result);
+                        if (findStatus == FindFileResult.NoError)
+                        {
+                            if (!fi.Directory.Exists)
+                            {
+                                fi.Directory.Create();
+                            }
+
+                            var dto = new RedFileDto(result.File);
+                            var doc = RedJsonSerializer.Serialize(dto);
+                            File.WriteAllText(fi.FullName, doc);
+                        }
+                        else if (findStatus == FindFileResult.NoCR2W)
+                        {
+                            throw new InvalidParsingException("Error while parsing a file");
+                        }
+                    }
+                }
+
+                void ExtractMlSetup(string path)
+                {
+                    if (mlSetupNames.Contains(path))
+                    {
+                        return;
+                    }
+
+                    mlSetupNames.Add(path);
+
+                    var fi = new FileInfo(Path.Combine(matRepo, Path.ChangeExtension(path, ".mlsetup.json")));
+                    if (!fi.Exists)
+                    {
+                        var findStatus = TryFindFile(archives, path, out var result);
+                        if (findStatus == FindFileResult.NoError)
+                        {
+                            if (!fi.Directory.Exists)
+                            {
+                                fi.Directory.Create();
+                            }
+
+                            var dto = new RedFileDto(result.File);
+                            var doc = RedJsonSerializer.Serialize(dto);
+                            File.WriteAllText(fi.FullName, doc);
+
+                            foreach (var import in result.Imports)
+                            {
+                                ExtractFile(import.DepotPath);
+                            }
+                        }
+                        else if (findStatus == FindFileResult.NoCR2W)
+                        {
+                            throw new InvalidParsingException("Error while parsing a file");
+                        }
+                    }
+                }
+
+                void ExtractMlTemplate(string path)
+                {
+                    if (mlTemplateNames.Contains(path))
+                    {
+                        return;
+                    }
+
+                    mlTemplateNames.Add(path);
+
+                    var fi = new FileInfo(Path.Combine(matRepo, Path.ChangeExtension(path, ".mltemplate.json")));
+                    if (!fi.Exists)
+                    {
+                        var findStatus = TryFindFile(archives, path, out var result);
+                        if (findStatus == FindFileResult.NoError)
+                        {
+                            if (!fi.Directory.Exists)
+                            {
+                                fi.Directory.Create();
+                            }
+
+                            var dto = new RedFileDto(result.File);
+                            var doc = RedJsonSerializer.Serialize(dto);
+                            File.WriteAllText(fi.FullName, doc);
+
+                            foreach (var import in result.Imports)
+                            {
+                                ExtractFile(import.DepotPath);
+                            }
+
+                            var mlTemplateMats = result.File.RootChunk.FindType(typeof(CResourceReference<CBitmapTexture>));
+                            foreach (var mlTemplateMat in mlTemplateMats)
+                            {
+                                var mat = (CResourceReference<CBitmapTexture>)mlTemplateMat.Value;
+                                ExtractXBM(mat.DepotPath);
+                            }
+                        }
+                        else if (findStatus == FindFileResult.NoCR2W)
+                        {
+                            throw new InvalidParsingException("Error while parsing a file");
+                        }
+                    }
+                }
+
+                void ExtractGradient(string path)
+                {
+                    if (TexturesList.Contains(path))
+                    {
+                        return;
+                    }
+
+                    TexturesList.Add(path);
+
+                    var fi = new FileInfo(Path.Combine(matRepo, Path.ChangeExtension(path, ".gradient.json")));
+                    if (!fi.Exists)
+                    {
+                        var findStatus = TryFindFile(archives, path, out var result);
+                        if (findStatus == FindFileResult.NoError)
+                        {
+                            if (!fi.Directory.Exists)
+                            {
+                                fi.Directory.Create();
+                            }
+
+                            var dto = new RedFileDto(result.File);
+                            var doc = RedJsonSerializer.Serialize(dto);
+                            File.WriteAllText(fi.FullName, doc);
+                        }
+                        else if (findStatus == FindFileResult.NoCR2W)
+                        {
+                            throw new InvalidParsingException("Error while parsing a file");
+                        }
+                    }
+                }
+            }
+        }
+        private void SaveMaterials(FileInfo outfile, List<MatData> mats)
+        {
+            var consMatData = new MatData
+            {
+                MaterialRepo = mats[0].MaterialRepo,
+                Materials = new List<RawMaterial>(),
+                TexturesList = new List<string>(),
+                MaterialTemplates = new List<RawMaterial>(),
+                Appearances = new Dictionary<string, string[]>()
+
+            };
+
+            foreach(var matData in mats)
+            {
+                matData.Materials.ForEach(m => consMatData.Materials.Add(m));
+                matData.TexturesList.ForEach(m => consMatData.TexturesList.Add(m));
+                matData.MaterialTemplates.ForEach(m => consMatData.MaterialTemplates.Add(m));
+                foreach(var app in matData.Appearances)
+                {
+                    if (!consMatData.Appearances.ContainsKey(app.Key))
+                    {
+                        consMatData.Appearances.Add(app.Key, app.Value);
+                    }
+                }
+            }
+
+            var str = RedJsonSerializer.Serialize(consMatData);
+
+            File.WriteAllText(Path.ChangeExtension(outfile.FullName, ".Material.json"), str);
+
         }
 
         private void ParseMaterials(CR2WFile cr2w, Stream meshStream, FileInfo outfile, List<ICyberGameArchive> archives, string matRepo, MeshesInfo info, EUncookExtension eUncookExtension = EUncookExtension.dds)

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -31,12 +31,6 @@ namespace WolvenKit.Modkit.RED4.Tools
             _red4ParserService = red4ParserService;
         }
 
-        public bool ExportMesh(Stream meshStream, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
-        {
-            var cr2w = _red4ParserService.ReadRed4File(meshStream);
-            return ExportMesh(cr2w, outfile, meshExportArgs, vmode);
-        }
-
         public static bool ExportMesh(CR2WFile cr2w, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
             var model = GetModel(cr2w, meshExportArgs.LodFilter, mergeMeshes: meshExportArgs.ExperimentalMergedExport);
@@ -214,111 +208,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             return true;
         }
-        public bool ExportMeshWithRig(Stream meshStream, Stream rigStream, FileInfo outfile, bool lodFilter = true, bool isGLBinary = true, ValidationMode vmode = ValidationMode.TryFix)
-        {
-            var cr2w = _red4ParserService.ReadRed4File(meshStream);
 
-            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
-            {
-                return false;
-            }
-
-            using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
-
-            var meshesinfo = GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
-
-            var expMeshes = ContainRawMesh(ms, meshesinfo, lodFilter);
-            UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
-
-            var meshRig = GetOrphanRig(cMesh);
-
-            var Rig = RIG.ProcessRig(_red4ParserService.ReadRed4File(rigStream));
-
-            UpdateMeshJoints(ref expMeshes, Rig, meshRig);
-
-            var model = RawMeshesToGLTF(expMeshes, Rig);
-
-
-            if (WolvenTesting.IsTesting)
-            {
-                model.WriteGLB(new WriteSettings(vmode));
-                return true;
-            }
-
-            if (isGLBinary)
-            {
-                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
-            }
-            else
-            {
-                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
-            }
-
-            meshStream.Dispose();
-            meshStream.Close();
-            rigStream.Dispose();
-            rigStream.Close();
-
-            return true;
-        }
-        public bool ExportMultiMeshWithRig(Dictionary<Stream, String> meshStreamS, List<Stream> rigStreamS, FileInfo outfile, bool lodFilter = true, bool isGLBinary = true, ValidationMode vmode = ValidationMode.TryFix)
-        {
-            var Rigs = new List<RawArmature>();
-            foreach (var rigStream in rigStreamS)
-            {
-                var Rig = RIG.ProcessRig(_red4ParserService.ReadRed4File(rigStream));
-                Rigs.Add(Rig);
-
-                rigStream.Dispose();
-                rigStream.Close();
-            }
-            var expRig = RIG.CombineRigs(Rigs);
-
-            var expMeshes = new List<RawMeshContainer>();
-
-            foreach (var meshStream in meshStreamS.Keys)
-            {
-                var cr2w = _red4ParserService.ReadRed4File(meshStream);
-                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
-                {
-                    continue;
-                }
-
-                using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
-
-                var meshesinfo = GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
-
-                var Meshes = ContainRawMesh(ms, meshesinfo, lodFilter);
-                UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
-
-                var meshRig = GetOrphanRig(cMesh);
-
-                UpdateMeshJoints(ref Meshes, expRig, meshRig, meshStreamS[meshStream]);
-
-                expMeshes.AddRange(Meshes);
-
-                meshStream.Dispose();
-                meshStream.Close();
-            }
-            var model = RawMeshesToGLTF(expMeshes, expRig);
-
-            if (WolvenTesting.IsTesting)
-            {
-                model.WriteGLB(new WriteSettings(vmode));
-                return true;
-            }
-
-            if (isGLBinary)
-            {
-                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
-            }
-            else
-            {
-                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
-            }
-
-            return true;
-        }
         public static MeshesInfo GetMeshesinfo(rendRenderMeshBlob rendmeshblob, CMesh cMesh = null)
         {
             var meshesInfo = new MeshesInfo(rendmeshblob.Header.RenderChunkInfos.Count);
@@ -742,7 +632,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             }
         }
 
-        public static void AddSubmeshesToModel(List<RawMeshContainer> meshes, Skin skin, ref ModelRoot model, IVisualNodeContainer parent, Dictionary<string, Material> materials = null, bool mergeMeshes = false)
+        public static void AddSubmeshesToModel(List<RawMeshContainer> meshes, Skin skin, ref ModelRoot model, IVisualNodeContainer parent, Dictionary<string, Material> materials = null, bool mergeMeshes = false, bool withMaterials = false)
         {
             var mat = model.CreateMaterial("Default");
             mat.WithPBRMetallicRoughness().WithDefault();
@@ -853,6 +743,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             var BuffViewoffset = 0;
 
             var nodes = new Dictionary<uint, Node>();
+            int meshCounter = 0;
             foreach (var mesh in meshes)
             {
                 Mesh mes = null;
@@ -869,8 +760,9 @@ namespace WolvenKit.Modkit.RED4.Tools
                 }
                 else
                 {
-                    node = parent.CreateNode(mesh.name);
-                    mes = model.CreateMesh(mesh.name);
+                    string name = withMaterials ? $"{meshCounter}_{mesh.name}" : mesh.name;
+                    node = parent.CreateNode(name);
+                    mes = model.CreateMesh(name);
                 }
                 var prim = mes.CreatePrimitive();
                 if (materials != null && materials.ContainsKey(mesh.materialNames[0]))
@@ -1009,11 +901,11 @@ namespace WolvenKit.Modkit.RED4.Tools
                     prim.SetMorphTargetAccessors(0, dict);
                     BuffViewoffset += mesh.garmentMorph.Length * 12;
                 }
-
+                meshCounter++;
             }
         }
 
-        public static ModelRoot RawMeshesToGLTF(List<RawMeshContainer> meshes, RawArmature rig, bool mergeMeshes = false)
+        public static ModelRoot RawMeshesToGLTF(List<RawMeshContainer> meshes, RawArmature rig, bool mergeMeshes = false, bool withMaterials = false)
         {
             var model = ModelRoot.CreateModel();
             model.Extras = SharpGLTF.IO.JsonContent.Serialize(new { ExperimentalMergedMeshes = mergeMeshes });
@@ -1045,7 +937,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                 }
             }
 
-            AddSubmeshesToModel(meshes, skin, ref model, model.UseScene(0), materials, mergeMeshes);
+            AddSubmeshesToModel(meshes, skin, ref model, model.UseScene(0), materials, mergeMeshes, withMaterials);
 
             model.UseScene(0).Name = "Scene";
             model.DefaultScene = model.UseScene(0);

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -145,7 +145,6 @@ namespace WolvenKit.Modkit.RED4
 
             var Names = new string[NumTargets];
             var RegionNames = new string[NumTargets];
-            var OutputNames = new string[NumTargets];
             string BaseMesh = morphBlob.BaseMesh.DepotPath;
             string BaseTexture = morphBlob.BaseTexture.DepotPath;
 

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -4,9 +4,11 @@ using System.IO;
 using System.Linq;
 using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
+using Splat;
 using WolvenKit.Common.DDS;
 using WolvenKit.Common.FNV1A;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.Modkit.RED4.GeneralStructs;
 using WolvenKit.Modkit.RED4.RigFile;
 using WolvenKit.Modkit.RED4.Tools;
@@ -143,12 +145,13 @@ namespace WolvenKit.Modkit.RED4
 
             var Names = new string[NumTargets];
             var RegionNames = new string[NumTargets];
+            var OutputNames = new string[NumTargets];
             string BaseMesh = morphBlob.BaseMesh.DepotPath;
             string BaseTexture = morphBlob.BaseTexture.DepotPath;
 
             for (var i = 0; i < NumTargets; i++)
             {
-                Names[i] = morphBlob.Targets[i].Name;
+                Names[i] = String.Format("{0}_{1}", morphBlob.Targets[i].Name, morphBlob.Targets[i].RegionName);
                 RegionNames[i] = morphBlob.Targets[i].RegionName;
             }
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using SharpGLTF.Schema2;
+using SharpGLTF.Validation;
 using WolvenKit.Common;
 using WolvenKit.Common.Conversion;
 using WolvenKit.Common.DDS;
@@ -14,7 +16,10 @@ using WolvenKit.Common.Extensions;
 using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Common.Services;
 using WolvenKit.Modkit.Extensions;
+using WolvenKit.Modkit.RED4.GeneralStructs;
 using WolvenKit.Modkit.RED4.Opus;
+using WolvenKit.Modkit.RED4.RigFile;
+using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.RED4.Archive;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.CR2W.JSON;
@@ -681,16 +686,157 @@ namespace WolvenKit.Modkit.RED4
 
             return true;
         }
+        public bool ExportMeshWithRig(Stream meshStream, Stream rigStream, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
+        {
+            var cr2w = _red4ParserService.ReadRed4File(meshStream);
+
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            {
+                return false;
+            }
+
+            using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
+
+            var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
+
+            var expMeshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
+            MeshTools.UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
+
+            var meshRig = MeshTools.GetOrphanRig(cMesh);
+
+            var Rig = RIG.ProcessRig(_red4ParserService.ReadRed4File(rigStream));
+
+            MeshTools.UpdateMeshJoints(ref expMeshes, Rig, meshRig);
+
+            if (meshExportArgs.withMaterials)
+            {
+                ParseMaterials(cr2w, meshStream, outfile, meshExportArgs.Archives, meshExportArgs.MaterialRepo, meshesinfo, meshExportArgs.MaterialUncookExtension);
+            }
+
+            var model = MeshTools.RawMeshesToGLTF(expMeshes, Rig);
+
+            if (WolvenTesting.IsTesting)
+            {
+                model.WriteGLB(new WriteSettings(vmode));
+                return true;
+            }
+
+            if (meshExportArgs.isGLBinary)
+            {
+                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
+            }
+            else
+            {
+                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
+            }
+
+            meshStream.Dispose();
+            meshStream.Close();
+            rigStream.Dispose();
+            rigStream.Close();
+
+            return true;
+        }
+        public bool ExportMultiMeshWithRig(Dictionary<Stream, String> meshStreamS, List<Stream> rigStreamS, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
+        {
+            var Rigs = new List<RawArmature>();
+            foreach (var rigStream in rigStreamS)
+            {
+                var Rig = RIG.ProcessRig(_red4ParserService.ReadRed4File(rigStream));
+                Rigs.Add(Rig);
+
+                rigStream.Dispose();
+                rigStream.Close();
+            }
+            var expRig = RIG.CombineRigs(Rigs);
+
+            var expMeshes = new List<RawMeshContainer>();
+            List<MatData> matData = new List<MatData>();
+            foreach (var meshStream in meshStreamS.Keys)
+            {
+                var cr2w = _red4ParserService.ReadRed4File(meshStream);
+                if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+                {
+                    continue;
+                }
+
+                using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
+
+                var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
+
+                var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
+                MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
+
+                var meshRig = MeshTools.GetOrphanRig(cMesh);
+
+                MeshTools.UpdateMeshJoints(ref Meshes, expRig, meshRig, meshStreamS[meshStream]);
+
+                if (meshExportArgs.withMaterials)
+                {
+                    matData.Add(SetupMaterial(cr2w, meshStream, meshExportArgs.Archives, meshExportArgs.MaterialRepo, meshesinfo, meshExportArgs.MaterialUncookExtension));
+                }
+
+                expMeshes.AddRange(Meshes);
+
+                meshStream.Dispose();
+                meshStream.Close();
+            }
+            var model = MeshTools.RawMeshesToGLTF(expMeshes, expRig, withMaterials:meshExportArgs.withMaterials);
+
+            SaveMaterials(outfile, matData);
+
+            if (WolvenTesting.IsTesting)
+            {
+                model.WriteGLB(new WriteSettings(vmode));
+                return true;
+            }
+
+            if (meshExportArgs.isGLBinary)
+            {
+                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
+            }
+            else
+            {
+                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
+            }
+
+            return true;
+        }
+
+        public bool ExportMesh(Stream meshStream, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
+        {
+            var archives = meshExportArgs.Archives;
+            var matRepo = meshExportArgs.MaterialRepo;
+            var eUncookExtension = meshExportArgs.MaterialUncookExtension;
+            var isGLBinary = meshExportArgs.isGLBinary;
+            var LodFilter = meshExportArgs.LodFilter;
+            var mergeMeshes = meshExportArgs.ExperimentalMergedExport;
+
+            var cr2w = _red4ParserService.ReadRed4File(meshStream);
+
+            if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+            {
+                return false;
+            }
+
+            using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
+
+            var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
+
+            if (meshExportArgs.withMaterials)
+            {
+                ParseMaterials(cr2w, meshStream, outfile, archives, matRepo, meshesinfo, eUncookExtension);
+            }
+
+            return MeshTools.ExportMesh(cr2w, outfile, meshExportArgs, vmode);
+        }
 
         private bool HandleMesh(Stream cr2wStream, FileInfo cr2wFileName, MeshExportArgs meshargs)
         {
             switch (meshargs.meshExportType)
             {
                 case MeshExportType.MeshOnly:
-                    return _meshTools.ExportMesh(cr2wStream, cr2wFileName, meshargs);
-
-                case MeshExportType.WithMaterials:
-                    return ExportMeshWithMaterials(cr2wStream, cr2wFileName, meshargs);
+                    return ExportMesh(cr2wStream, cr2wFileName, meshargs);
 
                 case MeshExportType.WithRig:
                 {
@@ -704,7 +850,7 @@ namespace WolvenKit.Modkit.RED4
                     using var ms = new MemoryStream();
                     ar?.CopyFileToStream(ms, entry.NameHash64, false);
 
-                    return _meshTools.ExportMeshWithRig(cr2wStream, ms, cr2wFileName, meshargs.LodFilter, meshargs.isGLBinary);
+                    return ExportMeshWithRig(cr2wStream, ms, cr2wFileName, meshargs);
                 }
                 case MeshExportType.Multimesh:
                 {
@@ -736,7 +882,7 @@ namespace WolvenKit.Modkit.RED4
                               }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
 
-                    return _meshTools.ExportMultiMeshWithRig(meshstreams, rigstreams, cr2wFileName, meshargs.LodFilter, meshargs.isGLBinary);
+                    return ExportMultiMeshWithRig(meshstreams, rigstreams, cr2wFileName, meshargs);
                 }
                 default:
                     return false;


### PR DESCRIPTION
# Feature/material-export

- Removed the "withMaterial" export type and replaced it with a boolean that applies to all mesh export types (WithRig, MeshOnly, Multimesh). 

This works perfectly for WithRig and MeshOnly, but creates a 'problem' with Multimesh:
- The Blender plugin reads the Material.json from top to bottom and applies materials to meshes in that exact order.
- An occurence of two submeshes (submesh_00_LOD_0 and submesh_00_LOD_0.001 (technically last mesh in MultiMesh)) would lead to a incorrect order on import as it'd be imported as the second mesh and thus materials being applied wrong.
- To counteract this I've just added a small prefix, which keeps the order intact on import. That prefix is only applied for Multimeshes and only if "Export materials" is ticked.


![image](https://user-images.githubusercontent.com/25871133/213018658-d2ff2c29-3087-41ae-8221-e1a96c28cee9.png)

If someone was now to reimport this exported multimesh object (to for example replace a part of a jacket with some other part of a different jacket) - he'd need to organize the submeshes correctly and then remove the artifically added prefix. If I am not mistaken.
