### PR TITLE
Enable TweakXL Subdirectories

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -571,12 +571,16 @@ namespace WolvenKit.Functionality.Controllers
                 .Where(file => file.EndsWith(".yaml") || file.EndsWith(".yml"));
             foreach (var f in tweakFiles)
             {
-                if (!Directory.Exists(cp77Proj.PackedTweakDirectory))
+                var outDir = Path.Combine(cp77Proj.PackedTweakDirectory,
+                    Path.GetRelativePath(cp77Proj.ResourcesDirectory, Path.GetDirectoryName(f)));
+
+                if (!Directory.Exists(outDir))
                 {
-                    Directory.CreateDirectory(cp77Proj.PackedTweakDirectory);
+                    Directory.CreateDirectory(outDir);
                 }
+
                 var filename = Path.GetFileName(f);
-                var outPath = Path.Combine(cp77Proj.PackedTweakDirectory, filename);
+                var outPath = Path.Combine(outDir, filename);
                 File.Copy(f, outPath, true);
             }
             return true;


### PR DESCRIPTION
If a user creates a subdirectory to the Resources folder and it contains TweakXL yaml files, this change will pack the project with those relative paths.

This partially satisfies the custom path request by Apart on Discord.

![image](https://user-images.githubusercontent.com/931177/213943373-22093d77-0e01-482f-988c-a5d5e1beddeb.png)
