### PR TITLE
Include Garment Support for Custom Garments

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -219,6 +219,14 @@ namespace WolvenKit.Common.Model.Arguments
         [WkitScriptAccess("WithMaterials")]
         public bool withMaterials { get; set; } = true;
 
+        /// <summary>
+        /// Garment Export Bool, Decides if we should export garment support data
+        /// </summary>
+        [Category("Default Export Settings")]
+        [Display(Name = "Export Garment Support (Experimental)")]
+        [Description("If selected mesh exports will include garment support data.")]
+        public bool ExportGarmentSupport { get; set; } = true;
+
 
         /// <summary>
         /// MultiMesh Mesh List.

--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -166,6 +166,14 @@ namespace WolvenKit.Common.Model.Arguments
         public bool ReplaceLod { get; set; } = false;
 
         /// <summary>
+        /// Assigns found LOD0 submeshes to LOD8 to allow import of certain meshes that handle LOD0 as LOD8.
+        /// </summary>
+        [Category("Import Settings")]
+        [Display(Name = "Import Garment Support (Experimental)")]
+        [Description("If checked the Garment Support data will be imported from the mesh")]
+        public bool ImportGarmentSupport { get; set; } = false;
+
+        /// <summary>
         /// Selected Rig for Mesh WithRig Export. ALWAYS USE THE FIRST ENTRY IN THE LIST.
         /// </summary>
         [Category("WithRig Settings")]

--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -166,7 +166,7 @@ namespace WolvenKit.Common.Model.Arguments
         public bool ReplaceLod { get; set; } = false;
 
         /// <summary>
-        /// Assigns found LOD0 submeshes to LOD8 to allow import of certain meshes that handle LOD0 as LOD8.
+        /// Imports garment support data from GLB.
         /// </summary>
         [Category("Import Settings")]
         [Display(Name = "Import Garment Support (Experimental)")]

--- a/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
@@ -86,6 +86,8 @@ namespace WolvenKit.Modkit.RED4.GeneralStructs
         public ushort[,]? boneindices { get; set; }
         public Vector3[]? garmentMorph { get; set; }
         public string? name { get; set; }
+        public Vector4[]? garmentSupportWeight { get; set; }
+        public Vector4[]? garmentSupportCap { get; set; }
         public uint weightCount { get; set; }
         public string[]? materialNames { get; set; }
         public uint lod { get; set; }

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -56,7 +56,7 @@ namespace WolvenKit.Modkit.RED4
 
             var expMeshes = MeshTools.ContainRawMesh(ms, meshesinfo, LodFilter);
             MeshTools.UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
-            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh);
+            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh, meshArgs.ExportGarmentSupport);
 
             var Rig = MeshTools.GetOrphanRig(cMesh);
 

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -56,6 +56,7 @@ namespace WolvenKit.Modkit.RED4
 
             var expMeshes = MeshTools.ContainRawMesh(ms, meshesinfo, LodFilter);
             MeshTools.UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
+            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh);
 
             var Rig = MeshTools.GetOrphanRig(cMesh);
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -448,7 +448,7 @@ namespace WolvenKit.Modkit.RED4
 
             UpdateSkinningParamCloth(ref Meshes, ref cr2w, args);
 
-            UpdateGarmentSupportParameters(Meshes, cr2w);
+            UpdateGarmentSupportParameters(Meshes, cr2w, args.ImportGarmentSupport);
 
             var expMeshes = Meshes.Select(_ => RawMeshToRE4Mesh(_, QuantScale, QuantTrans)).ToList();
 
@@ -1732,9 +1732,9 @@ namespace WolvenKit.Modkit.RED4
             }
         }
 
-        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w)
+        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w, bool importGarmentSupport = false)
         {
-            if (cr2w.RootChunk is CMesh cMesh)
+            if (importGarmentSupport && cr2w.RootChunk is CMesh cMesh)
             {
 
                 if (meshes.All(x => x.garmentMorph?.Length > 0 && x.garmentSupportWeight?.Length > 0))

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -448,6 +448,8 @@ namespace WolvenKit.Modkit.RED4
 
             UpdateSkinningParamCloth(ref Meshes, ref cr2w, args);
 
+            UpdateGarmentSupportParameters(Meshes, ref cr2w);
+
             var expMeshes = Meshes.Select(_ => RawMeshToRE4Mesh(_, QuantScale, QuantTrans)).ToList();
 
             var meshBuffer = new MemoryStream();
@@ -549,7 +551,10 @@ namespace WolvenKit.Modkit.RED4
                 colors0 = accessors.Contains("COLOR_0") ? mesh.Primitives[0].GetVertices("COLOR_0").AsVector4Array().ToArray() : Array.Empty<Vec4>(),
                 colors1 = accessors.Contains("COLOR_1") ? mesh.Primitives[0].GetVertices("COLOR_1").AsVector4Array().ToArray() : Array.Empty<Vec4>(),
                 texCoords0 = accessors.Contains("TEXCOORD_0") ? mesh.Primitives[0].GetVertices("TEXCOORD_0").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
-                texCoords1 = accessors.Contains("TEXCOORD_1") ? mesh.Primitives[0].GetVertices("TEXCOORD_1").AsVector2Array().ToArray() : Array.Empty<Vec2>()
+                texCoords1 = accessors.Contains("TEXCOORD_1") ? mesh.Primitives[0].GetVertices("TEXCOORD_1").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
+
+                garmentSupportWeight = accessors.Contains("_GARMENTSUPPORTWEIGHT") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTWEIGHT").AsVector4Array().ToArray() : Array.Empty<Vec4>(),
+                garmentSupportCap = accessors.Contains("_GARMENTSUPPORTCAP") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTCAP").AsVector4Array().ToArray() : Array.Empty<Vec4>()
             };
 
             var indicesList = mesh.Primitives[0].GetIndices().ToList();
@@ -1724,6 +1729,130 @@ namespace WolvenKit.Modkit.RED4
                         blob.LodChunkIndices[3].Add(i);
                     }
                 }
+            }
+        }
+
+        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, ref CR2WFile cr2w)
+        {
+            var cMesh = (CMesh)cr2w.RootChunk;
+
+            if (meshes.All(x => x.garmentMorph?.Length > 0 && x.garmentSupportWeight?.Length > 0))
+            {
+                var garmentMeshBlobChunk = GetParameter_meshMeshParamGarmentSupport(cMesh);
+
+                var garmentBlobChunk = GetParameter_garmentMeshParamGarment(cMesh);
+
+                for (var i = 0; i < meshes.Count; i++)
+                {
+                    WriteToGarmentSupportParameters(meshes[i], garmentMeshBlobChunk, garmentBlobChunk);
+                }
+            }
+            else
+            {
+                RemoveGarmentSupportParameters(ref cMesh);
+            }
+        }
+
+        private static meshMeshParamGarmentSupport GetParameter_meshMeshParamGarmentSupport(CMesh cMesh)
+        {
+            var garmentMeshBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is meshMeshParamGarmentSupport);
+            if (garmentMeshBlob == null)
+            {
+                garmentMeshBlob = new CHandle<meshMeshParameter> { Chunk = new meshMeshParamGarmentSupport() };
+                cMesh.Parameters.Add(garmentMeshBlob);
+            }
+            var garmentMeshBlobChunk = (meshMeshParamGarmentSupport)garmentMeshBlob.Chunk;
+            garmentMeshBlobChunk.ChunkCapVertices = new CArray<CArray<CUInt32>>();
+            garmentMeshBlobChunk.CustomMorph = true;
+
+            return garmentMeshBlobChunk;
+        }
+
+        private static garmentMeshParamGarment GetParameter_garmentMeshParamGarment(CMesh cMesh)
+        {
+            var garmentBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is garmentMeshParamGarment);
+            if (garmentBlob == null)
+            {
+                garmentBlob = new CHandle<meshMeshParameter> { Chunk = new garmentMeshParamGarment() };
+                cMesh.Parameters.Add(garmentBlob);
+            }
+            var garmentBlobChunk = (garmentMeshParamGarment)garmentBlob.Chunk;
+            garmentBlobChunk.Chunks = new CArray<garmentMeshParamGarmentChunkData>();
+
+            return garmentBlobChunk;
+        }
+
+        private static void WriteToGarmentSupportParameters(RawMeshContainer mesh, meshMeshParamGarmentSupport garmentMeshBlobChunk, garmentMeshParamGarment garmentBlobChunk)
+        {
+            ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.indices, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.garmentMorph, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.garmentSupportWeight, nameof(mesh));
+
+            var vertBuffer = new MemoryStream();
+            var vertBW = new BinaryWriter(vertBuffer);
+
+            var indBuffer = new MemoryStream();
+            var indBW = new BinaryWriter(indBuffer);
+
+            var morphBuffer = new MemoryStream();
+            var morphBW = new BinaryWriter(morphBuffer);
+
+            var flagBuffer = new MemoryStream();
+            var flagBW = new BinaryWriter(flagBuffer);
+
+            var capVertices = new CArray<CUInt32>();
+
+            for (var v = 0; v < mesh.positions.Length; v++)
+            {
+                vertBW.Write(mesh.positions[v].X);
+                vertBW.Write(mesh.positions[v].Y);
+                vertBW.Write(mesh.positions[v].Z);
+
+                morphBW.Write(mesh.garmentMorph[v].X);
+                morphBW.Write(mesh.garmentMorph[v].Y);
+                morphBW.Write(mesh.garmentMorph[v].Z);
+
+                var vertexHasValidCap = mesh.garmentSupportCap?.Length > v ? mesh.garmentSupportCap[v].X >= .5f : false;
+                flagBW.Write(Convert.ToByte(mesh.garmentSupportWeight.Length > v ? mesh.garmentSupportWeight[v].X * 255 : 0));
+                flagBW.Write(Convert.ToByte(vertexHasValidCap ? 1 : 0));
+                flagBW.Write((byte)0);
+                flagBW.Write((byte)0);
+                if (vertexHasValidCap)
+                {
+                    capVertices.Add(v);
+                }
+            }
+
+            for (var n = 0; n < mesh.indices.Length; n++)
+            {
+                indBW.Write(Convert.ToUInt16(mesh.indices[n]));
+            }
+
+            garmentMeshBlobChunk.ChunkCapVertices.Add(capVertices);
+
+            garmentBlobChunk.Chunks.Add(new garmentMeshParamGarmentChunkData
+            {
+                GarmentFlags = new DataBuffer(flagBuffer.ToArray()),
+                Indices = new DataBuffer(indBuffer.ToArray()),
+                MorphOffsets = new DataBuffer(morphBuffer.ToArray()),
+                Vertices = new DataBuffer(vertBuffer.ToArray()),
+                NumVertices = Convert.ToUInt32(mesh.positions.Length),
+                LodMask = 1
+            });
+        }
+
+        private static void RemoveGarmentSupportParameters(ref CMesh cMesh)
+        {
+            var garmentMeshBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is meshMeshParamGarmentSupport);
+            if (garmentMeshBlob != null)
+            {
+                cMesh.Parameters.Remove(garmentMeshBlob);
+            }
+            var garmentBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is garmentMeshParamGarment);
+            if (garmentBlob != null)
+            {
+                cMesh.Parameters.Remove(garmentBlob);
             }
         }
     }

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -31,7 +31,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
         public static bool ExportMesh(CR2WFile cr2w, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
-            var model = GetModel(cr2w, meshExportArgs.LodFilter, mergeMeshes: meshExportArgs.ExperimentalMergedExport);
+            var model = GetModel(cr2w, meshExportArgs.LodFilter, mergeMeshes: meshExportArgs.ExperimentalMergedExport, exportGarmentSupport: meshExportArgs.ExportGarmentSupport);
 
             if (model == null)
             {
@@ -56,7 +56,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             return true;
         }
 
-        public static ModelRoot? GetModel(CR2WFile cr2w, bool lodFilter = true, bool includeRig = true, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false)
+        public static ModelRoot? GetModel(CR2WFile cr2w, bool lodFilter = true, bool includeRig = true, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false, bool exportGarmentSupport = false)
         {
             if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
@@ -81,7 +81,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                 UpdateSkinningParamCloth(ref expMeshes, cr2w);
             }
 
-            WriteGarmentParametersToMesh(ref expMeshes, cMesh);
+            WriteGarmentParametersToMesh(ref expMeshes, cMesh, exportGarmentSupport);
 
             var model = RawMeshesToGLTF(expMeshes, rig, mergeMeshes);
 
@@ -1401,10 +1401,10 @@ namespace WolvenKit.Modkit.RED4.Tools
         /// </summary>
         /// <param name="meshes"></param>
         /// <param name="cMesh"></param>
-        public static void WriteGarmentParametersToMesh(ref List<RawMeshContainer> meshes, CMesh cMesh)
+        public static void WriteGarmentParametersToMesh(ref List<RawMeshContainer> meshes, CMesh cMesh, bool exportGarmentSupport = false)
         {
             var garmentBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is garmentMeshParamGarment);
-            if (garmentBlob != null)
+            if (garmentBlob != null && exportGarmentSupport)
             {
                 var garmentBlobChunk = (garmentMeshParamGarment)garmentBlob.Chunk;
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -81,6 +81,8 @@ namespace WolvenKit.Modkit.RED4.Tools
                 UpdateSkinningParamCloth(ref expMeshes, cr2w);
             }
 
+            WriteGarmentParametersToMesh(ref expMeshes, cMesh);
+
             var model = RawMeshesToGLTF(expMeshes, rig, mergeMeshes);
 
             return model;
@@ -186,6 +188,8 @@ namespace WolvenKit.Modkit.RED4.Tools
                 var meshesinfo = GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
 
                 var Meshes = ContainRawMesh(ms, meshesinfo, lodFilter);
+
+                WriteGarmentParametersToMesh(ref Meshes, cMesh);
 
                 expMeshes.AddRange(Meshes);
 
@@ -703,6 +707,26 @@ namespace WolvenKit.Modkit.RED4.Tools
                     bw.Write(mesh.colors1[i].Z);
                     bw.Write(mesh.colors1[i].W);
                 }
+                if (mesh.garmentSupportWeight != null)
+                {
+                    for (var i = 0; i < mesh.garmentSupportWeight.Length; i++)
+                    {
+                        bw.Write(mesh.garmentSupportWeight[i].X);
+                        bw.Write(mesh.garmentSupportWeight[i].Y);
+                        bw.Write(mesh.garmentSupportWeight[i].Z);
+                        bw.Write(mesh.garmentSupportWeight[i].W);
+                    }
+                }
+                if (mesh.garmentSupportCap != null)
+                {
+                    for (var i = 0; i < mesh.garmentSupportCap.Length; i++)
+                    {
+                        bw.Write(mesh.garmentSupportCap[i].X);
+                        bw.Write(mesh.garmentSupportCap[i].Y);
+                        bw.Write(mesh.garmentSupportCap[i].Z);
+                        bw.Write(mesh.garmentSupportCap[i].W);
+                    }
+                }
                 for (var i = 0; i < mesh.texCoords0.Length; i++)
                 {
                     bw.Write(mesh.texCoords0[i].X);
@@ -855,6 +879,30 @@ namespace WolvenKit.Modkit.RED4.Tools
                     prim.SetVertexAccessor("COLOR_1", acc);
                     BuffViewoffset += mesh.colors1.Length * 16;
                 }
+
+                if (mesh.garmentSupportWeight != null)
+                {
+                    if (mesh.garmentSupportWeight.Length > 0)
+                    {
+                        var acc = model.CreateAccessor();
+                        var buff = model.UseBufferView(buffer, BuffViewoffset, mesh.garmentSupportWeight.Length * 16);
+                        acc.SetData(buff, 0, mesh.garmentSupportWeight.Length, DimensionType.VEC4, EncodingType.FLOAT, false);
+                        prim.SetVertexAccessor("_GARMENTSUPPORTWEIGHT", acc);
+                        BuffViewoffset += mesh.garmentSupportWeight.Length * 16;
+                    }
+                }
+                if (mesh.garmentSupportCap != null)
+                {
+                    if (mesh.garmentSupportCap.Length > 0)
+                    {
+                        var acc = model.CreateAccessor();
+                        var buff = model.UseBufferView(buffer, BuffViewoffset, mesh.garmentSupportCap.Length * 16);
+                        acc.SetData(buff, 0, mesh.garmentSupportCap.Length, DimensionType.VEC4, EncodingType.FLOAT, false);
+                        prim.SetVertexAccessor("_GARMENTSUPPORTCAP", acc);
+                        BuffViewoffset += mesh.garmentSupportCap.Length * 16;
+                    }
+                }
+
                 if (mesh.texCoords0.Length > 0)
                 {
                     var acc = model.CreateAccessor();
@@ -1346,5 +1394,56 @@ namespace WolvenKit.Modkit.RED4.Tools
                 }
             }
         }
+
+        /// <summary>
+        /// Check if cMesh has a garmentMeshParamGarment parameter; if it does then for each submesh in the mesh with a garmentFlags buffer of size greater than 0, then write to the GarmentSupport attributes.
+        /// These attributes will be imported into Blender as color attributes, with the values stored in the red channel.
+        /// </summary>
+        /// <param name="meshes"></param>
+        /// <param name="cMesh"></param>
+        public static void WriteGarmentParametersToMesh(ref List<RawMeshContainer> meshes, CMesh cMesh)
+        {
+            var garmentBlob = cMesh.Parameters.FirstOrDefault(x => x.Chunk is garmentMeshParamGarment);
+            if (garmentBlob != null)
+            {
+                var garmentBlobChunk = (garmentMeshParamGarment)garmentBlob.Chunk;
+
+                for (var i = 0; i < garmentBlobChunk.Chunks.Count && i < meshes.Count; i++)
+                {
+                    var mesh = meshes[i];
+
+                    ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
+
+                    if (garmentBlobChunk.Chunks[i]?.GarmentFlags is { Buffer.MemSize: > 0 })
+                    {
+                        meshes[i].garmentSupportWeight = new Vec4[mesh.positions.Length];
+                        meshes[i].garmentSupportCap = new Vec4[mesh.positions.Length];
+
+                        var stream = new MemoryStream(garmentBlobChunk.Chunks[i].GarmentFlags.Buffer.GetBytes());
+                        var br = new BinaryReader(stream);
+                        stream.Seek(0, SeekOrigin.Begin);
+
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            if (mesh.garmentSupportWeight != null)
+                            {
+                                mesh.garmentSupportWeight[e] = PrepareGarmentVertexWeight(br.ReadByte());
+                            }
+
+                            if (mesh.garmentSupportCap != null)
+                            {
+                                mesh.garmentSupportCap[e] = PrepareGarmentVertexCap(br.ReadByte());
+                            }
+
+                            br.ReadByte();
+                            br.ReadByte();
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Vec4 PrepareGarmentVertexWeight(byte vertexWeightData) => new() { X = vertexWeightData / 255f, Y = 0f, Z = 0f, W = 1f };
+        private static Vec4 PrepareGarmentVertexCap(byte vertexCapData) => new() { X = vertexCapData * 1f, Y = 0f, Z = 0f, W = 1f };
     }
 }

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -712,7 +712,7 @@ namespace WolvenKit.Modkit.RED4
             var expMeshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
             MeshTools.UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
 
-            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh);
+            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh, meshExportArgs.ExportGarmentSupport);
 
             var meshRig = MeshTools.GetOrphanRig(cMesh);
 
@@ -785,7 +785,7 @@ namespace WolvenKit.Modkit.RED4
                 var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
                 MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
 
-                MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh);
+                MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh, meshExportArgs.ExportGarmentSupport);
 
                 var meshRig = MeshTools.GetOrphanRig(cMesh);
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -712,6 +712,8 @@ namespace WolvenKit.Modkit.RED4
             var expMeshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
             MeshTools.UpdateSkinningParamCloth(ref expMeshes, meshStream, cr2w);
 
+            MeshTools.WriteGarmentParametersToMesh(ref expMeshes, cMesh);
+
             var meshRig = MeshTools.GetOrphanRig(cMesh);
 
             var Rig = RIG.ProcessRig(_red4ParserService.ReadRed4File(rigStream));
@@ -782,6 +784,8 @@ namespace WolvenKit.Modkit.RED4
 
                 var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
                 MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
+
+                MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh);
 
                 var meshRig = MeshTools.GetOrphanRig(cMesh);
 


### PR DESCRIPTION
Include Garment Support for Custom Garments

Implemented:
- Write to custom accessors in glb when exporting garment mesh
- Write to Garment Support parameters when importing mesh with garment support data

