### PR TITLE
fix: Sanitize RedRef Depot Path Hashes

### DIFF
--- a/WolvenKit.Common/RED4/CR2W/JSON/PrimitiveConverter.cs
+++ b/WolvenKit.Common/RED4/CR2W/JSON/PrimitiveConverter.cs
@@ -366,10 +366,10 @@ public class ResourceReferenceConverter : JsonConverter<IRedRef>, ICustomRedConv
                 case "DepotPath":
                 {
                     var converter = options.GetConverter(typeof(CName));
-                    if (converter is ICustomRedConverter conv)
+                    if (converter is CNameConverter conv)
                     {
                         reader.Read();
-                        depotPath = (CName)conv.ReadRedType(ref reader, typeof(CName), options)!;
+                        depotPath = (CName)conv.ReadRedTypeSanitized(ref reader, typeof(CName), options)!;
                     }
                     else
                     {

--- a/WolvenKit.Common/RED4/CR2W/JSON/Simples.cs
+++ b/WolvenKit.Common/RED4/CR2W/JSON/Simples.cs
@@ -29,7 +29,15 @@ public class CGuidConverter : JsonConverter<CGuid>, ICustomRedConverter
 
 public class CNameConverter : JsonConverter<CName>, ICustomRedConverter
 {
+    private bool _sanitizedHash = false;
+
     public object ReadRedType(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => Read(ref reader, typeToConvert, options);
+
+    public object ReadRedTypeSanitized(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        _sanitizedHash = true;
+        return Read(ref reader, typeToConvert, options);
+    }
 
     public override CName Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -40,7 +48,14 @@ public class CNameConverter : JsonConverter<CName>, ICustomRedConverter
 
         if (reader.TokenType == JsonTokenType.String)
         {
-            return reader.GetString();
+            if (_sanitizedHash)
+            {
+                return CName.GetHashSanitized(reader.GetString());
+            }
+            else
+            {
+                return reader.GetString();
+            }
         }
         else if (reader.TokenType == JsonTokenType.Number)
         {

--- a/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using WolvenKit.RED4.Types.Pools;
 
 namespace WolvenKit.RED4.Types;
@@ -33,6 +34,53 @@ public readonly struct CName : IRedString, IRedPrimitive<string>, IEquatable<CNa
 
     public static bool operator ==(CName a, CName b) => Equals(a, b);
     public static bool operator !=(CName a, CName b) => !(a == b);
+
+    // used to sanitize resource paths
+    public static CName GetHashSanitized(string text)
+    {
+        if (string.IsNullOrEmpty(text) || text == "None")
+        {
+            return 0;
+        }
+
+        var strResult = new StringBuilder();
+
+        // replace all forward slashes with backslash
+        text = text.Replace('/', '\\');
+
+        // strip all leading and trailing slashes and quotes
+        while ("\"'\\".Contains(text[0]))
+        {
+            text = text.Substring(1, text.Length - 1);
+        }
+
+        while ("\"'\\".Contains(text[text.Length - 1]))
+        {
+            text = text.Substring(0, text.Length - 1);
+        }
+
+        // append all remaining characters except repeated slashes
+        foreach (var element in text.ToCharArray())
+        {
+            if (strResult.Length == 0)
+            {
+                strResult.Append(element);
+                continue;
+            }
+
+            if (element == '\\')
+            {
+                if (strResult[strResult.Length - 1] != '\\')
+                {
+                    strResult.Append('\\');
+                }
+                continue;
+            }
+
+            strResult.Append(element);
+        }
+        return strResult.ToString().ToLowerInvariant();
+    }
 
 
     public int CompareTo(object value)

--- a/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
@@ -53,7 +53,7 @@ public readonly struct CName : IRedString, IRedPrimitive<string>, IEquatable<CNa
     public int CompareTo(CName other)
     {
         var strA = GetResolvedText();
-        var strB = GetResolvedText();
+        var strB = other.GetResolvedText();
 
         if (strA != null && strB != null)
         {

--- a/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Windows;
 using System.Windows.Input;
-using HandyControl.Tools.Extension;
 using Splat;
 using WolvenKit.Functionality.Services;
 using WolvenKit.RED4.Types;
@@ -52,53 +50,6 @@ namespace WolvenKit.Views.Editors
         public static readonly DependencyProperty SanitizeHashProperty = DependencyProperty.Register(
             nameof(SanitizeHash), typeof(bool), typeof(RedCNameEditor), new PropertyMetadata(false));
 
-        private CName GetHashSanitized(string text)
-        {
-            if (text.IsNullOrEmpty() || text == "None")
-            {
-                return 0;
-            }
-
-            var strResult = new StringBuilder();
-
-            // replace all forward slashes with backslash
-            text = text.Replace('/', '\\');
-
-            // strip all leading and trailing slashes and quotes
-            while ("\"'\\".Contains(text[0]))
-            {
-                text = text.Substring(1, text.Length - 1);
-            }
-
-            while ("\"'\\".Contains(text[text.Length - 1]))
-            {
-                text = text.Substring(0, text.Length - 1);
-            }
-
-            // append all remaining characters except repeated slashes
-            foreach (var element in text.ToCharArray())
-            {
-                if (strResult.Length == 0)
-                {
-                    strResult.Append(element);
-                    continue;
-                }
-
-                if (element == '\\')
-                {
-                    if (strResult[strResult.Length - 1] != '\\')
-                    {
-                        strResult.Append('\\');
-                    }
-                    continue;
-                }
-
-                strResult.Append(element);
-            }
-            return strResult.ToString().ToLowerInvariant();
-
-        }
-
         public string Text
         {
             get => RedString;
@@ -109,7 +60,7 @@ namespace WolvenKit.Views.Editors
         {
             get
             {
-                ulong retHash = SanitizeHash ? GetHashSanitized(RedString) : RedString;
+                ulong retHash = SanitizeHash ? CName.GetHashSanitized(RedString) : RedString;
                 if (_settingsManager.ShowCNameAsHex)
                 {
                     return retHash.ToString("X");

--- a/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
@@ -62,15 +62,15 @@ namespace WolvenKit.Views.Editors
             var strResult = new StringBuilder();
 
             // replace all forward slashes with backslash
-            text.Replace('/', '\\');
+            text = text.Replace('/', '\\');
 
             // strip all leading and trailing slashes and quotes
-            while ("\"'\\/".Contains(text[0]))
+            while ("\"'\\".Contains(text[0]))
             {
                 text = text.Substring(1, text.Length - 1);
             }
 
-            while ("\"'\\/".Contains(text[text.Length - 1]))
+            while ("\"'\\".Contains(text[text.Length - 1]))
             {
                 text = text.Substring(0, text.Length - 1);
             }
@@ -84,7 +84,7 @@ namespace WolvenKit.Views.Editors
                     continue;
                 }
 
-                if ("\\/".Contains(element))
+                if (element == '\\')
                 {
                     if (strResult[strResult.Length - 1] != '\\')
                     {

--- a/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
@@ -1,8 +1,10 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Windows;
 using System.Windows.Input;
+using HandyControl.Tools.Extension;
 using Splat;
 using WolvenKit.Functionality.Services;
 using WolvenKit.RED4.Types;
@@ -40,6 +42,63 @@ namespace WolvenKit.Views.Editors
             }
         }
 
+        // sanitize hashes when control is used for ResourcePath
+        public bool SanitizeHash
+        {
+            get => (bool)GetValue(SanitizeHashProperty);
+            set => SetValue(SanitizeHashProperty, value);
+        }
+
+        public static readonly DependencyProperty SanitizeHashProperty = DependencyProperty.Register(
+            nameof(SanitizeHash), typeof(bool), typeof(RedCNameEditor), new PropertyMetadata(false));
+
+        private CName GetHashSanitized(string text)
+        {
+            if (text.IsNullOrEmpty() || text == "None")
+            {
+                return 0;
+            }
+
+            var strResult = new StringBuilder();
+
+            // replace all forward slashes with backslash
+            text.Replace('/', '\\');
+
+            // strip all leading and trailing slashes and quotes
+            while ("\"'\\/".Contains(text[0]))
+            {
+                text = text.Substring(1, text.Length - 1);
+            }
+
+            while ("\"'\\/".Contains(text[text.Length - 1]))
+            {
+                text = text.Substring(0, text.Length - 1);
+            }
+
+            // append all remaining characters except repeated slashes
+            foreach (var element in text.ToCharArray())
+            {
+                if (strResult.Length == 0)
+                {
+                    strResult.Append(element);
+                    continue;
+                }
+
+                if ("\\/".Contains(element))
+                {
+                    if (strResult[strResult.Length - 1] != '\\')
+                    {
+                        strResult.Append('\\');
+                    }
+                    continue;
+                }
+
+                strResult.Append(element);
+            }
+            return strResult.ToString().ToLowerInvariant();
+
+        }
+
         public string Text
         {
             get => RedString;
@@ -50,13 +109,14 @@ namespace WolvenKit.Views.Editors
         {
             get
             {
+                ulong retHash = SanitizeHash ? GetHashSanitized(RedString) : RedString;
                 if (_settingsManager.ShowCNameAsHex)
                 {
-                    return ((ulong)RedString).ToString("X");
+                    return retHash.ToString("X");
                 }
                 else
                 {
-                    return ((ulong)RedString).ToString();
+                    return retHash.ToString();
                 }
             }
             set

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml
@@ -30,7 +30,8 @@
             x:Name="DepotPathEditor"
             Grid.Row="0"
             Grid.Column="1"
-            RedString="{Binding RedRef.DepotPath, Mode=OneWay}" />
+            RedString="{Binding RedRef.DepotPath, Mode=OneWay}"
+            SanitizeHash="True"/>
 
         <TextBlock
             Grid.Row="1"

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
@@ -1,18 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using ReactiveUI;
 using WolvenKit.RED4.Types;
-using WolvenKit.Views.Templates;
-using YamlDotNet.Core.Tokens;
 
 namespace WolvenKit.Views.Editors
 {


### PR DESCRIPTION
Implemented:
- `RedRefEditor` (via the embedded `RedCNameEditor`) now sanitizes the hashes of the resource paths before hashing

Fixed:
- Fixes #1062, but more "correctly" than just handling uppercase letters as the entire path is sanitized

This adds the option `SanitizeHash="True"` to the `RedCNameEditor` in the XAML which will remove all leading and trailing characters that are one of `" ' \ /` as well as replacing any repeated slashes (forwards and backwards) to be a single backslash. Final path is then made all lowercase before being fed into the hashing algorithm.
