### PR TITLE
fix: Apply meshes uext arg to uncook command

### DIFF
--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -142,6 +142,7 @@ public partial class ConsoleFunctions
         {
             exportArgs.Get<XbmExportArgs>().UncookExtension = options.uext.Value;
             exportArgs.Get<MlmaskExportArgs>().UncookExtension = options.uext.Value;
+            exportArgs.Get<MeshExportArgs>().MaterialUncookExtension = options.uext.Value;
         }
         if (options.meshExportType != null)
         {


### PR DESCRIPTION
Apply meshes uext arg to uncook command

Implemented:
- Applied #1029 also to uncook
