### PR TITLE
General fixes

### DIFF
--- a/WolvenKit.App/Models/SlotSet.cs
+++ b/WolvenKit.App/Models/SlotSet.cs
@@ -4,7 +4,7 @@ namespace WolvenKit.App.Models;
 
 public class SlotSet : IBindable
 {
-    public SlotSet(string name, string bindname)
+    public SlotSet(string name, string? bindname)
     {
         Name = name;
         BindName = bindname;

--- a/WolvenKit.App/Models/TweakXL.cs
+++ b/WolvenKit.App/Models/TweakXL.cs
@@ -259,7 +259,14 @@ public class TweakXLYamlTypeConverter : IYamlTypeConverter
                 emitter.Emit(new Scalar(property));
             }
 
-            emitter.Emit(new Scalar(tweakDBID.GetResolvedText().NotNull()));
+            if (tweakDBID.IsResolvable)
+            {
+                emitter.Emit(new Scalar(tweakDBID.GetResolvedText().NotNull()));
+            }
+            else
+            {
+                emitter.Emit(new Scalar($"<TDBID:{(tweakDBID & 0xFFFFFFFF):X8}:{tweakDBID.Length:X2}>"));
+            }
         }
     }
     private void WriteREDRaRef(IEmitter emitter, IRedResourceAsyncReference raRef, string property = "")

--- a/WolvenKit.App/ViewModels/Documents/RDTGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTGraphViewModel.cs
@@ -16,20 +16,11 @@ namespace WolvenKit.App.ViewModels.Documents;
 
 public partial class RDTGraphViewModel : RedDocumentTabViewModel
 {
+    private bool _isLoaded;
+
     public RDTGraphViewModel(IRedType data, RedDocumentViewModel file) : base(file, "Graph Editor")
     {
         _data = data;
-
-        PendingConnection = new PendingConnectionViewModel(this);
-
-        if (data is graphGraphResource ggr)
-        {
-            RenderNodes(ggr.Graph.Chunk.NotNull().Nodes);
-        }
-        else if (data is scnSceneResource ssr)
-        {
-            RenderNodes(ssr.SceneGraph.Chunk.NotNull().Graph);
-        }
 
         //SelectedNodes.CollectionChanged += (object? sender, NotifyCollectionChangedEventArgs e) =>
         //{
@@ -54,8 +45,28 @@ public partial class RDTGraphViewModel : RedDocumentTabViewModel
 
     public List<SocketViewModel> Sockets => SocketLookup.Values.ToList();
 
-    public PendingConnectionViewModel PendingConnection { get; }
+    public PendingConnectionViewModel? PendingConnection { get; private set; }
 
+    public void Load()
+    {
+        if (_isLoaded)
+        {
+            return;
+        }
+
+        PendingConnection = new PendingConnectionViewModel(this);
+
+        if (_data is graphGraphResource ggr)
+        {
+            RenderNodes(ggr.Graph.Chunk.NotNull().Nodes);
+        }
+        else if (_data is scnSceneResource ssr)
+        {
+            RenderNodes(ssr.SceneGraph.Chunk.NotNull().Graph);
+        }
+
+        _isLoaded = true;
+    }
    
     public GeometryGraph RenderNodes(CArray<CHandle<scnSceneGraphNode>> nodes)
     {

--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -2910,7 +2910,7 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
                     var slotSetName = slotset.Name.ToString().NotNull();
                     if (!_slotSets.ContainsKey(slotSetName))
                     {
-                        _slotSets.Add(slotSetName, new SlotSet(slotSetName, bindName.NotNull())
+                        _slotSets.Add(slotSetName, new SlotSet(slotSetName, bindName)
                         {
                             Matrix = ToSeparateMatrix(slotset.LocalTransform),
                             Slots = slots,

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -2111,7 +2111,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             if (epi is not null)
             {
                 //IsDefault = IsDefault(Parent.ResolvedPropertyType, epi, Data);
-                IsDefault = IsDefault(Parent.ResolvedPropertyType.NotNull(), epi, ResolvedData);
+                IsDefault = epi.IsDefault(ResolvedData);
             }
         }
     }

--- a/WolvenKit.Common/Conversion/inkWidgetSerializer.cs
+++ b/WolvenKit.Common/Conversion/inkWidgetSerializer.cs
@@ -66,7 +66,7 @@ namespace WolvenKit.Common.Conversion
                 var name = !string.IsNullOrEmpty(pi.RedName) ? pi.RedName : pi.Name;
                 var propertyValue = ((RedBaseClass)value).GetProperty(name);
 
-                if (!RedReflection.IsDefault(value.GetType(), pi, propertyValue))
+                if (!pi.IsDefault(propertyValue))
                 {
                     var propertyName = pi.RedName;
                     switch (propertyName)

--- a/WolvenKit.RED4/Archive/IO/CR2WWriter.cs
+++ b/WolvenKit.RED4/Archive/IO/CR2WWriter.cs
@@ -41,7 +41,7 @@ public partial class CR2WWriter : Red4Writer
             var value = cls.GetProperty(propertyInfo.RedName);
             if (!propertyInfo.IsDynamic)
             {
-                if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && RedReflection.IsDefault(cls.GetType(), propertyInfo, value))
+                if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && propertyInfo.IsDefault(value))
                 {
                     continue;
                 }

--- a/WolvenKit.RED4/Archive/IO/RedPackageWriter.cs
+++ b/WolvenKit.RED4/Archive/IO/RedPackageWriter.cs
@@ -52,7 +52,7 @@ public partial class RedPackageWriter : Red4Writer
             var value = cls.GetProperty(propertyInfo.RedName);
             if (!propertyInfo.IsDynamic)
             {
-                if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && RedReflection.IsDefault(cls.GetType(), propertyInfo, value))
+                if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && propertyInfo.IsDefault(value))
                 {
                     continue;
                 }

--- a/WolvenKit.RED4/Save/Parser/PersistencySystem2Parser.cs
+++ b/WolvenKit.RED4/Save/Parser/PersistencySystem2Parser.cs
@@ -157,7 +157,7 @@ public class PersistencySystem2Writer : Red4Writer
             ArgumentNullException.ThrowIfNull(propertyInfo.RedName);
 
             var value = instance.GetProperty(propertyInfo.RedName);
-            if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && RedReflection.IsDefault(instance.GetType(), propertyInfo, value))
+            if (!typeInfo.SerializeDefault && !propertyInfo.SerializeDefault && propertyInfo.IsDefault(value))
             {
                 continue;
             }

--- a/WolvenKit.RED4/TweakDB/TweakDB.cs
+++ b/WolvenKit.RED4/TweakDB/TweakDB.cs
@@ -64,7 +64,7 @@ public class TweakDB
             ArgumentNullException.ThrowIfNull(propertyInfo.RedName);
 
             var value = record.GetProperty(propertyInfo.RedName);
-            if (!typeInfo.SerializeDefault && RedReflection.IsDefault(record.GetType(), propertyInfo, value))
+            if (!typeInfo.SerializeDefault && propertyInfo.IsDefault(value))
             {
                 continue;
             }

--- a/WolvenKit.RED4/Types/Classes/worldBenchmarkSummary.cs
+++ b/WolvenKit.RED4/Types/Classes/worldBenchmarkSummary.cs
@@ -189,6 +189,14 @@ namespace WolvenKit.RED4.Types
 		}
 
 		[Ordinal(23)] 
+		[RED("DLSSFrameGenEnabled")] 
+		public CBool DLSSFrameGenEnabled
+		{
+			get => GetPropertyValue<CBool>();
+			set => SetPropertyValue<CBool>(value);
+		}
+
+		[Ordinal(24)] 
 		[RED("FSR2Enabled")] 
 		public CBool FSR2Enabled
 		{
@@ -196,7 +204,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CBool>(value);
 		}
 
-		[Ordinal(24)] 
+		[Ordinal(25)] 
 		[RED("FSR2Quality")] 
 		public CInt32 FSR2Quality
 		{
@@ -204,7 +212,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CInt32>(value);
 		}
 
-		[Ordinal(25)] 
+		[Ordinal(26)] 
 		[RED("FSR2Sharpness")] 
 		public CFloat FSR2Sharpness
 		{
@@ -212,7 +220,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CFloat>(value);
 		}
 
-		[Ordinal(26)] 
+		[Ordinal(27)] 
 		[RED("DRSEnabled")] 
 		public CBool DRSEnabled
 		{
@@ -220,7 +228,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CBool>(value);
 		}
 
-		[Ordinal(27)] 
+		[Ordinal(28)] 
 		[RED("DRSTargetFPS")] 
 		public CUInt32 DRSTargetFPS
 		{
@@ -228,7 +236,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CUInt32>(value);
 		}
 
-		[Ordinal(28)] 
+		[Ordinal(29)] 
 		[RED("DRSMinimalResolutionPercentage")] 
 		public CUInt32 DRSMinimalResolutionPercentage
 		{
@@ -236,7 +244,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CUInt32>(value);
 		}
 
-		[Ordinal(29)] 
+		[Ordinal(30)] 
 		[RED("DRSMaximalResolutionPercentage")] 
 		public CUInt32 DRSMaximalResolutionPercentage
 		{
@@ -244,7 +252,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CUInt32>(value);
 		}
 
-		[Ordinal(30)] 
+		[Ordinal(31)] 
 		[RED("CASSharpeningEnabled")] 
 		public CBool CASSharpeningEnabled
 		{
@@ -252,7 +260,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CBool>(value);
 		}
 
-		[Ordinal(31)] 
+		[Ordinal(32)] 
 		[RED("FSREnabled")] 
 		public CBool FSREnabled
 		{
@@ -260,7 +268,7 @@ namespace WolvenKit.RED4.Types
 			set => SetPropertyValue<CBool>(value);
 		}
 
-		[Ordinal(32)] 
+		[Ordinal(33)] 
 		[RED("FSRQuality")] 
 		public CInt32 FSRQuality
 		{

--- a/WolvenKit.RED4/Types/RedBaseClass.cs
+++ b/WolvenKit.RED4/Types/RedBaseClass.cs
@@ -20,9 +20,19 @@ public partial class RedBaseClass : IRedClass, IRedCloneable, IEquatable<RedBase
                 continue;
             }
 
-            var propTypeInfo = RedReflection.GetTypeInfo(propertyInfo.Type);
             if (propertyInfo.Type.IsValueType)
             {
+                if (propertyInfo.Type.IsAssignableTo(typeof(IRedEnum)))
+                {
+                    var innerType = propertyInfo.Type.GetGenericArguments()[0];
+                    var innerTypeInfo = RedReflection.GetEnumTypeInfo(innerType);
+                    if (innerTypeInfo.DefaultValue != null)
+                    {
+                        InternalSetPropertyValue(propertyInfo.RedName, CEnum.Parse(innerType, innerTypeInfo.DefaultValue));
+                        continue;
+                    }
+                }
+
                 if (propertyInfo.Flags.Equals(Flags.Empty))
                 {
                     if (System.Activator.CreateInstance(propertyInfo.Type) is not IRedType result)

--- a/WolvenKit.RED4/Types/Reflection/ExtendedEnumInfo.cs
+++ b/WolvenKit.RED4/Types/Reflection/ExtendedEnumInfo.cs
@@ -9,10 +9,24 @@ public class ExtendedEnumInfo
         Type = type;
         IsBitfield = type.GetCustomAttribute<FlagsAttribute>() != null;
 
+        if (!IsBitfield)
+        {
+            var val = (Enum)System.Activator.CreateInstance(Type);
+            if (val!.ToString() != "0")
+            {
+                DefaultValue = val.ToString();
+            }
+        }
+
         var valueNames = Enum.GetNames(Type);
         foreach (var valueName in valueNames)
         {
             Names.Add(valueName);
+
+            if (!IsBitfield && DefaultValue == null && valueName == "None")
+            {
+                DefaultValue = "None";
+            }
 
             var member = Type.GetMember(valueName);
             var redAttr = member[0].GetCustomAttribute<REDAttribute>();
@@ -21,6 +35,11 @@ public class ExtendedEnumInfo
                 RedNames.Add(redAttr.Name, valueName);
             }
         }
+
+        if (!IsBitfield && DefaultValue == null)
+        {
+            // TODO
+        }
     }
 
     public Type Type { get; set; }
@@ -28,6 +47,8 @@ public class ExtendedEnumInfo
 
     public List<string> Names { get; set; } = new();
     public Dictionary<string, string> RedNames { get; set; } = new();
+
+    public string? DefaultValue { get; set; }
 
     public string? GetCSNameFromRedName(string valueName)
     {

--- a/WolvenKit.RED4/Types/Reflection/ExtendedTypeInfo.cs
+++ b/WolvenKit.RED4/Types/Reflection/ExtendedTypeInfo.cs
@@ -7,12 +7,18 @@ public class ExtendedTypeInfo
     private readonly Dictionary<string, int> _nameIndex = new();
     private readonly Dictionary<string, int> _redNameIndex = new();
 
-    public ExtendedTypeInfo() => IsDynamicType = true;
+    public ExtendedTypeInfo()
+    {
+        IsDynamicType = true;
+
+        Type = typeof(DynamicBaseClass);
+    }
 
     public ExtendedTypeInfo(Type type)
     {
         IsDynamicType = false;
 
+        Type = type;
         BaseType = type.BaseType;
 
         var attrs = type.GetCustomAttributes(false);
@@ -29,7 +35,7 @@ public class ExtendedTypeInfo
         var cusProps = new List<ExtendedPropertyInfo>();
         foreach (var propertyInfo in type.GetProperties())
         {
-            var extendedInfo = new ExtendedPropertyInfo(type, propertyInfo);
+            var extendedInfo = new ExtendedPropertyInfo(this, propertyInfo);
 
             if (typeof(IRedAppendix).IsAssignableFrom(type) && propertyInfo.Name == "Appendix")
             {
@@ -79,6 +85,7 @@ public class ExtendedTypeInfo
         }
     }
 
+    public Type Type { get; }
     public Type? BaseType { get; }
     public bool SerializeDefault { get; }
     public int ChildLevel { get; }
@@ -218,7 +225,7 @@ public class ExtendedTypeInfo
             }
         }
 
-        var propertyInfo = new ExtendedPropertyInfo(varName, typeName);
+        var propertyInfo = new ExtendedPropertyInfo(this, varName, typeName);
 
         DynamicPropertyInfos.Add(propertyInfo);
 

--- a/WolvenKit.RED4/Types/Reflection/RedReflection.cs
+++ b/WolvenKit.RED4/Types/Reflection/RedReflection.cs
@@ -116,18 +116,7 @@ public static class RedReflection
             throw new MissingRTTIException(redPropertyName, "???", clsType.Name);
         }
 
-        return IsDefault(clsType, extendedPropertyInfo, value);
-    }
-
-    public static bool IsDefault(Type clsType, ExtendedPropertyInfo extendedPropertyInfo, object? value)
-    {
-        if (!extendedPropertyInfo._isDefaultSet)
-        {
-            extendedPropertyInfo.DefaultValue = GetClassDefaultValue(clsType, extendedPropertyInfo);
-            extendedPropertyInfo._isDefaultSet = true;
-        }
-
-        return Equals(extendedPropertyInfo.DefaultValue, value);
+        return extendedPropertyInfo.IsDefault(value);
     }
 
     public static string? GetTypeRedName(Type type)

--- a/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
@@ -1,15 +1,16 @@
 using ReactiveUI;
+using Syncfusion.Windows.Tools.Controls;
 using WolvenKit.App.ViewModels.Documents;
 
 namespace WolvenKit.Views.Documents
 {
     public partial class RedDocumentView : ReactiveUserControl<RedDocumentViewModel>
     {
-
         public RedDocumentView()
         {
-
             InitializeComponent();
+
+            TabControl.SelectedItemChangedEvent += TabControl_OnSelectedItemChangedEvent;
 
             this.WhenActivated(disposables =>
             {
@@ -20,5 +21,17 @@ namespace WolvenKit.Views.Documents
             });
         }
 
+        private void TabControl_OnSelectedItemChangedEvent(object sender, SelectedItemChangedEventArgs e)
+        {
+            if (e.NewSelectedItem.DataContext is RDTMeshViewModel meshViewModel)
+            {
+                meshViewModel.Load();
+            }
+
+            if (e.NewSelectedItem.DataContext is RDTGraphViewModel graphViewModel)
+            {
+                graphViewModel.Load();
+            }
+        }
     }
 }


### PR DESCRIPTION
General fixes

Implemented:
- Mesh/Graph Preview: Load preview only after the tab is selected (speeds up CR2W loading time)

Fixed:
- Streamingsector Preview: Fixed an ArgumentNullException
- CEnum: Fixed wrong value if the default value is != 0
- Tweak to YAML: Fixed crash if a TweakDBID is unresolveable

Refactor:
- Moved default check from `RedReflection` to `ExtendedPropertyInfo`

Added missing property for 1.61_DLSS3
Updated `tweakdbstr.kark`
