### PR TITLE
1146: prevent adding folders to themselves by accident

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -496,6 +496,12 @@ namespace WolvenKit.Views.Tools
                                 files.Add(sourceFile.FullName);
                             }
                         }
+                        // 1146: addresses "prevent self-drag-and-drop" 
+                        if (files.Count > 0 && files[0] == targetDirectory)
+                        {
+                            return;
+                        }
+                            
                         await ProcessFileAction(files, targetDirectory, false);
                     }
                 }


### PR DESCRIPTION
# 1146: prevent adding folders to themselves by accident

Implemented:
- Dragging-and-dropping a folder on itself will no longer copy the folder to the folder [(1146)](https://github.com/WolvenKit/WolvenKit/issues/1146)


_yo dawg, we heard you liked folders_

closes #1146