### PR TITLE
📛 Export/Import Type Tagged `.morphtarget` GLTF

### DIFF
--- a/WolvenKit.App/ViewModels/Exporters/TextureExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Exporters/TextureExportViewModel.cs
@@ -201,6 +201,7 @@ public partial class TextureExportViewModel : ExportViewModel
 
                 meshExportArgs.Archives.Insert(0, proj.AsArchive());
 
+                // Should check for depo here instead of dtl
                 meshExportArgs.MaterialRepo = _settingsManager.MaterialRepositoryPath;
             }
             if (item.Properties is MorphTargetExportArgs morphTargetExportArgs)

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -184,6 +184,15 @@ namespace WolvenKit.Common.Model.Arguments
     public class MeshExportArgs : ExportArgs
     {
         /// <summary>
+        /// Experimental New Mesh Exporter Logic.
+        /// </summary>
+        [Category("Experimental")]
+        [Display(Name = "Use New Mesh Exporter")]
+        [Description("Use New Mesh Exporter Logic. Turn off if you run into issues.")]
+        [WkitScriptAccess("ExperimentalNewMeshExporter")]
+        public bool ExperimentUseNewMeshExporter { get; set; } = false; // TODO: Remove this when the new exporter is stable.
+
+        /// <summary>
         /// Export type for the selected Mesh.
         /// </summary>
         [Category("Export Type")]

--- a/WolvenKit.Modkit/RED4/ModTools.Types.cs
+++ b/WolvenKit.Modkit/RED4/ModTools.Types.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DynamicData.Kernel;
+using WolvenKit.Common;
+using WolvenKit.Common.FNV1A;
+using WolvenKit.Common.Model.Arguments;
+using WolvenKit.Core.Extensions;
+using WolvenKit.RED4.Archive;
+using WolvenKit.RED4.Archive.CR2W;
+using WolvenKit.RED4.Archive.IO;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.Modkit.RED4;
+
+public partial class ModTools
+{
+	private static readonly Regex TypeExtensionMatcher = new(
+		$"\\w+\\.(?<typeExtension>{ string.Join("|", Enum.GetNames<GltfImportAsFormat>().Select((n) => n.ToLower())) })\\.(glb|gltf)$",
+		RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.NonBacktracking
+	);
+
+    private static readonly Func<string, string> InternalExtForType = (internalType) =>
+		internalType switch {
+			"meshwithrig" => ".mesh",
+			_ => $".{internalType}"
+		};
+
+    private static readonly Func<string, Optional<string>> TypeFromFileExt = (path) =>
+		TypeExtensionMatcher.Match(path).Groups["typeExtension"].Value switch {
+			string matched when !string.IsNullOrWhiteSpace(matched) => Optional.Some(matched.ToLower()),
+			_ => Optional.None<string>()
+		};
+
+	private static readonly Func<string, GltfImportAsFormat> ImportFormatFor = (type) =>
+		type switch {
+			"anims" => GltfImportAsFormat.Anims,
+			"mesh" => GltfImportAsFormat.Mesh,
+			"morphtarget" => GltfImportAsFormat.Morphtarget,
+			"rig" => GltfImportAsFormat.Rig,
+			"meshwithrig" => GltfImportAsFormat.MeshWithRig,
+			_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown extension, probably shouldn't be calling this function")
+		};
+}

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -26,6 +26,8 @@ namespace WolvenKit.Modkit.RED4
     /// </summary>
     public partial class ModTools
     {
+        // Unused?
+        /*
         public bool ExportMeshWithMaterials(Stream meshStream, FileInfo outfile, MeshExportArgs meshArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
             var archives = meshArgs.Archives;
@@ -74,6 +76,7 @@ namespace WolvenKit.Modkit.RED4
 
             return true;
         }
+        */
         private void GetMaterialEntries(CR2WFile cr2w, Stream meshStream, ref List<string> primaryDependencies, ref List<string> materialEntryNames, ref List<CMaterialInstance> materialEntries, List<ICyberGameArchive> archives)
         {
             if (cr2w.RootChunk is not CMesh cmesh)
@@ -286,7 +289,7 @@ namespace WolvenKit.Modkit.RED4
             }
         }
 
-        private MatData SetupMaterial(CR2WFile cr2w, Stream meshStream, List<ICyberGameArchive> archives, string matRepo, MeshesInfo info, EUncookExtension eUncookExtension = EUncookExtension.dds)
+        private MatData SetupMaterial(CR2WFile cr2w, Stream meshStream, List<ICyberGameArchive> archives, string matRepo, MeshesInfo info, EUncookExtension eUncookExtension = EUncookExtension.dds, bool experimentUseNewMeshExporter = false)
         {
             var primaryDependencies = new List<string>();
 
@@ -308,6 +311,11 @@ namespace WolvenKit.Modkit.RED4
                     new XbmExportArgs() { UncookExtension = eUncookExtension },
                     new MlmaskExportArgs() { UncookExtension = eUncookExtension }
                 );
+
+            if (experimentUseNewMeshExporter)
+            {
+                _loggerService.Info($"SetupMaterial: skipping all .mi or .mt material entries");
+            }
 
             for (var i = 0; i < primaryDependencies.Count; i++)
             {
@@ -379,8 +387,13 @@ namespace WolvenKit.Modkit.RED4
                     case ".gradient":
                         ExtractGradient(path);
                         break;
+
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        if (!experimentUseNewMeshExporter)
+                        {
+                            throw new ArgumentOutOfRangeException();
+                        }
+                        break;
                 }
 
                 void ExtractXBM(string path)

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -1021,7 +1021,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             model.Extras = SharpGLTF.IO.JsonContent.Serialize(new { ExperimentalMergedMeshes = mergeMeshes });
 
             Skin? skin = null;
-            if (rig != null)
+            if (rig != null && rig.BoneCount > 0)
             {
                 skin = model.CreateSkin();
                 skin.BindJoints(RIG.ExportNodes(ref model, rig).Values.ToArray());

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -28,6 +28,7 @@ namespace WolvenKit.Modkit.RED4
             var cr2w = _parserService.ReadRed4File(targetStream);
             if (cr2w == null || cr2w.RootChunk is not MorphTargetMesh morphBlob || morphBlob.Blob.Chunk is not rendRenderMorphTargetMeshBlob blob || blob.BaseBlob.Chunk is not rendRenderMeshBlob rendblob)
             {
+                _loggerService.Error("Morphtarget: does not look like a valid morphtarget");
                 return false;
             }
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -445,7 +445,14 @@ namespace WolvenKit.Modkit.RED4
                     // (i.e. -o argument) can be used to provide the correct absolute pathname.
                     var modFolderPath = settings.Get<MorphTargetExportArgs>().ModFolderPath;
                     modFolderPath ??= rawOutDir.FullName;
-                    return ExportMorphTargets(cr2wStream, outfile, settings.Get<MorphTargetExportArgs>().Archives, modFolderPath, settings.Get<MorphTargetExportArgs>().IsBinary);
+
+                    // We're tacking on an extra file ext because ***SharpGLTF*** cuts off the ext
+                    // when actually writing to disk way down the line. This way it'll save the
+                    // actual type extension we want it to...
+                    var typePreservingOutfile = new FileInfo($"{outfile.FullName}.dummyextguardthatwillberemoved");
+
+                    return ExportMorphTargets(cr2wStream, typePreservingOutfile, settings.Get<MorphTargetExportArgs>().Archives, modFolderPath, settings.Get<MorphTargetExportArgs>().IsBinary);
+                
                 case ECookedFileFormat.anims:
                     try
                     {
@@ -868,6 +875,7 @@ namespace WolvenKit.Modkit.RED4
                     var entry = meshargs.Rig?.FirstOrDefault();
                     if (entry is null)
                     {
+                        _loggerService.Error("WithRig: No rig specified, add one to the export");
                         return false;
                     }
 
@@ -883,6 +891,7 @@ namespace WolvenKit.Modkit.RED4
                     var rigs = meshargs.MultiMeshRigs;
                     if (!meshes.Any() || !rigs.Any())
                     {
+                        _loggerService.Error("WithRig: No rig specified, add one to the export");
                         return false;
                     }
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -429,7 +430,16 @@ namespace WolvenKit.Modkit.RED4
                 case ECookedFileFormat.mesh:
                     try
                     {
-                        return HandleMesh(cr2wStream, outfile, settings.Get<MeshExportArgs>());
+                        if (settings.Get<MeshExportArgs>().ExperimentUseNewMeshExporter)
+                        {
+                            _loggerService.Info("Using new mesh exporter.");
+                            return HandleMeshesAndRigs(cr2wStream, outfile, settings.Get<MeshExportArgs>());
+                        }
+                        else
+                        {
+                            _loggerService.Info("Using classic mesh exporter.");
+                            return HandleMesh(cr2wStream, outfile, settings.Get<MeshExportArgs>());
+                        }
                     }
                     catch (Exception e)
                     {
@@ -760,6 +770,8 @@ namespace WolvenKit.Modkit.RED4
 
             return true;
         }
+
+
         public bool ExportMultiMeshWithRig(Dictionary<Stream, string> meshStreamS, List<Stream> rigStreamS, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
         {
             var Rigs = new List<RawArmature>();
@@ -891,7 +903,7 @@ namespace WolvenKit.Modkit.RED4
                     var rigs = meshargs.MultiMeshRigs;
                     if (!meshes.Any() || !rigs.Any())
                     {
-                        _loggerService.Error("WithRig: No rig specified, add one to the export");
+                        _loggerService.Error($"MultiMesh: need at least 1 extra mesh ({meshes.Count}) or rig ({rigs.Count})");
                         return false;
                     }
 
@@ -922,6 +934,151 @@ namespace WolvenKit.Modkit.RED4
                     return false;
             }
         }
+
+#region NewMeshExporter
+
+        // Unified Mesh exporter
+
+        public bool ExportMeshesAndRigs(Dictionary<Stream, string> meshStreamS, List<Stream> rigStreamS, FileInfo outfile, MeshExportArgs meshExportArgs, ValidationMode vmode = ValidationMode.TryFix)
+        {
+            if (meshExportArgs.withMaterials && meshExportArgs.MaterialRepo is null)
+            {
+                _loggerService.Error("Materials requested but Depot path is not set: choose a Depot location within Settings for generating materials.");
+                return false;
+            }
+
+            var rigsCombinedToExport = _ProcessRigs(rigStreamS);
+            var (meshesToExport, materialDataToExport) = _ProcessMeshesAndMaterials(meshStreamS, rigsCombinedToExport);
+
+            var modelsAndRigsCombinedToExport = MeshTools.RawMeshesToGLTF(meshesToExport, rigsCombinedToExport, withMaterials: meshExportArgs.withMaterials);
+
+            SaveMaterials(outfile, materialDataToExport);
+            _SaveMeshes(outfile, modelsAndRigsCombinedToExport);
+
+            _loggerService.Info($"Mesh export completed, {meshesToExport.Count} meshes, {materialDataToExport.Count} materials, {rigsCombinedToExport?.Names?.Length ?? 0} rigs");
+            return true;
+
+
+            // Helpers
+
+            [return: NotNull] RawArmature _ProcessRigs(List<Stream> rigStreamS)
+            {
+                var Rigs = new List<RawArmature>();
+                foreach (var rigStream in rigStreamS)
+                {
+                    var Rig = RIG.ProcessRig(_parserService.ReadRed4File(rigStream));
+
+                    Rigs.Add(Rig.NotNull());
+
+                    rigStream.Dispose();
+                    rigStream.Close();
+                }
+                return RIG.CombineRigs(Rigs);
+            }
+
+            (List<RawMeshContainer>, List<MatData>) _ProcessMeshesAndMaterials(Dictionary<Stream, string> meshStreamS, RawArmature rigsCombined)
+            {
+                var expMeshes = new List<RawMeshContainer>();
+                var matData = new List<MatData>();
+                foreach (var (meshStream, streamName) in meshStreamS)
+                {
+                    var cr2w = _parserService.ReadRed4File(meshStream);
+                    if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
+                    {
+                        _loggerService.Error($"Mesh stream does not look valid: {streamName}");
+                        continue;
+                    }
+
+                    using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
+
+                    var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
+
+                    var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
+                    MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
+
+                    MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh, meshExportArgs.ExportGarmentSupport);
+
+                    var meshRig = MeshTools.GetOrphanRig(cMesh);
+
+                    MeshTools.UpdateMeshJoints(ref Meshes, rigsCombined, meshRig, meshStreamS[meshStream]);
+
+                    if (meshExportArgs.withMaterials && meshExportArgs.MaterialRepo is not null)
+                    {
+                        matData.Add(SetupMaterial(cr2w, meshStream, meshExportArgs.Archives, meshExportArgs.MaterialRepo, meshesinfo, meshExportArgs.MaterialUncookExtension, meshExportArgs.ExperimentUseNewMeshExporter));
+                    }
+
+                    expMeshes.AddRange(Meshes);
+
+                    meshStream.Dispose();
+                    meshStream.Close();
+                }
+
+                return (expMeshes, matData);
+            }
+
+            void _SaveMeshes(FileInfo file, ModelRoot modelsAndRigs)
+            {
+                var typeExtPreservingFilename = $"{file.FullName}.thisextwillberemoved";
+
+                if (meshExportArgs.isGLBinary)
+                {
+                    modelsAndRigs.SaveGLB(typeExtPreservingFilename, new WriteSettings(vmode));
+                }
+                else
+                {
+                    modelsAndRigs.SaveGLTF(typeExtPreservingFilename, new WriteSettings(vmode));
+                }
+            }
+        }
+
+        // Not sure if this really needs to be two separate functions
+        // but it keeps the line count a bit shorter at least..
+        private bool HandleMeshesAndRigs(Stream cr2wStream, FileInfo cr2wFileName, MeshExportArgs meshargs)
+        {
+            var meshStreams = meshargs.meshExportType switch {
+                MeshExportType.Multimesh => _FilesToStreams(meshargs.MultiMeshMeshes),
+                MeshExportType.WithRig => new Dictionary<Stream, string> { { cr2wStream, cr2wFileName.Name } },
+                MeshExportType.MeshOnly => new Dictionary<Stream, string> { { cr2wStream, cr2wFileName.Name } },
+                _ => throw new ArgumentOutOfRangeException(nameof(meshargs.meshExportType), meshargs.meshExportType, "This isn't a mesh to export")
+            };
+
+            var rigStreams = meshargs.meshExportType switch
+            {
+                MeshExportType.Multimesh => _FilesToStreams(meshargs.MultiMeshRigs).Keys.ToList(),
+                MeshExportType.WithRig => _FilesToStreams(meshargs.Rig.GetRange(0, 1)).Keys.ToList(),
+                MeshExportType.MeshOnly => new(),
+                _ => throw new ArgumentOutOfRangeException(nameof(meshargs.meshExportType), meshargs.meshExportType, "This isn't a mesh to export")
+            };
+
+            if (!meshStreams.Any())
+            {
+                _loggerService.Warning($"Export: no meshes found! Exporting just a rig is probably not supported but let's give it a try");
+            }
+            else if (!rigStreams.Any() && meshargs.meshExportType != MeshExportType.MeshOnly)
+            {
+                _loggerService.Warning($"Export: no rigs found, WithRig and Multimesh might require one! So if this fails, that might be why..");
+            }
+            else if (!meshStreams.Any() && !rigStreams.Any())
+            {
+                _loggerService.Warning($"Export: neither meshes nor rigs found! This I can't work with");
+                return false;
+            }
+
+            return ExportMeshesAndRigs(meshStreams, rigStreams, cr2wFileName, meshargs);
+
+
+            Dictionary<Stream, string> _FilesToStreams(List<FileEntry> files) =>
+                files.Select(
+                      delegate (FileEntry entry)
+                      {
+                          var ar = entry.Archive;
+                          var ms = new MemoryStream();
+                          ar?.CopyFileToStream(ms, entry.NameHash64, false);
+                          return new KeyValuePair<Stream, string>(ms, entry.FileName);
+                      }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+#endregion NewMeshExporter
 
         private static void UncookWem(string infile, string outfile)
         {


### PR DESCRIPTION
Minimal, unstructured scaffolding to import/export type-tagged GLTFs. Since this is more involved than is ideal, export is just supported for `.morphtarget` (so that it is distinct from a `.mesh` export.) 

You can, however, use file naming to avoid having to select the import format for GLTFs. 

# BUT

Rather than try to surgically fix things here and there, I think the best option is to:

1. Get rid of the separate Mesh, WithRig and Multimesh exports and just treat everything as cases of Multimesh in a single code path (which is what import does on the return trip.) This also needs a better UI, but should work transparently anyway. -> Doing this in #1197 

2. Try to separate import/export data handling from the filesystem ops, either by returning data streams from the exporters, or by passing in a fs context that _cannot_ be changed downstream.

3. _Then_ maybe doing something more.