### PR TITLE
Add a save image item to the right click menu on the image preview.

### DIFF
--- a/WolvenKit/Views/Documents/RDTTextureView.xaml
+++ b/WolvenKit/Views/Documents/RDTTextureView.xaml
@@ -81,6 +81,7 @@
             <Border.ContextMenu>
                 <ContextMenu>
                     <MenuItem Click="ResetZoomPan" Header="Reset Zoom/Pan" />
+                    <MenuItem Click="SaveImage" Header="Save Image" />
                     <MenuItem Command="{Binding ReplaceTextureCommand}" Header="Replace Texture" />
                 </ContextMenu>
             </Border.ContextMenu>

--- a/WolvenKit/Views/Documents/RDTTextureView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTTextureView.xaml.cs
@@ -7,9 +7,11 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
 using Microsoft.Win32;
 using ReactiveUI;
 using Splat;
+using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Core.Interfaces;
@@ -17,6 +19,7 @@ using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 using static WolvenKit.RED4.Types.Enums;
+using Path = System.IO.Path;
 
 namespace WolvenKit.Views.Documents
 {
@@ -208,6 +211,27 @@ namespace WolvenKit.Views.Documents
             pan.Y = 0;
             end.X = 0;
             end.Y = 0;
+
+        }
+
+        public void SaveImage(object sender, RoutedEventArgs e)
+        {
+            var saveFileDialog1 = new SaveFileDialog
+            {
+                Filter = "PNG Image|*.png",
+                Title = "Save an Image As",
+                FileName = Path.GetFileNameWithoutExtension(ViewModel.FilePath)+"_embedded.png"
+            };
+            saveFileDialog1.ShowDialog();
+
+            if (saveFileDialog1.FileName != "" && ViewModel.Image is not null)
+            {
+                BitmapEncoder encoder = new PngBitmapEncoder();
+                encoder.Frames.Add(BitmapFrame.Create(ViewModel.Image as BitmapSource));
+
+                using var fileStream = new FileStream(saveFileDialog1.FileName, FileMode.Create);
+                encoder.Save(fileStream);                
+            }
         }
 
         public void ResetZoomPan(object sender, RoutedEventArgs e)
@@ -222,6 +246,11 @@ namespace WolvenKit.Views.Documents
             pan.Y = 0;
             end.X = 0;
             end.Y = 0;
+            var temp_filename = Path.Combine(ISettingsManager.GetTemp_OBJPath(), "embedded_preview.png");
+            BitmapEncoder encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(ViewModel.Image as BitmapSource));
+            using var fileStream = new FileStream(temp_filename, FileMode.Create);
+            encoder.Save(fileStream);
         }
     }
 }


### PR DESCRIPTION

Implemented:
- Added a right click option to Save Image to the image preview pane to allow embedded images to be saved

Fixed:
- Having to tell people to screengrab the Interface to get the images.

<Additional notes>
I don't consider this a solution to the larger 'how to handle embeddeds' that we've been discussing for a while, its just a sticking plaster to deal with my immediate main issue. Will  be fine with it being ripped out if a proper solution appears.