### PR TITLE
Garment Support fixes

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -1742,7 +1742,7 @@ namespace WolvenKit.Modkit.RED4
             if (importGarmentSupport && cr2w.RootChunk is CMesh cMesh)
             {
 
-                if (meshes.All(x => x.garmentMorph?.Length > 0 && x.garmentSupportWeight?.Length > 0))
+                if (meshes.All(x => x.garmentMorph?.Length > 0))
                 {
                     var garmentMeshBlobChunk = GetParameter_meshMeshParamGarmentSupport(cMesh);
 
@@ -1806,7 +1806,6 @@ namespace WolvenKit.Modkit.RED4
             ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
             ArgumentNullException.ThrowIfNull(mesh.indices, nameof(mesh));
             ArgumentNullException.ThrowIfNull(mesh.garmentMorph, nameof(mesh));
-            ArgumentNullException.ThrowIfNull(mesh.garmentSupportWeight, nameof(mesh));
 
             var vertBuffer = new MemoryStream();
             var vertBW = new BinaryWriter(vertBuffer);
@@ -1833,13 +1832,13 @@ namespace WolvenKit.Modkit.RED4
                 morphBW.Write(mesh.garmentMorph[v].Z);
 
                 var vertexHasValidCap = mesh.garmentSupportCap?.Length > v ? mesh.garmentSupportCap[v].X >= .5f : false;
-                flagBW.Write(Convert.ToByte(mesh.garmentSupportWeight.Length > v ? mesh.garmentSupportWeight[v].X * 255 : 0));
+                flagBW.Write(Convert.ToByte(mesh.garmentSupportWeight?.Length > v ? mesh.garmentSupportWeight[v].X * 255 : 0));
                 flagBW.Write(Convert.ToByte(vertexHasValidCap ? 1 : 0));
                 flagBW.Write((byte)0);
                 flagBW.Write((byte)0);
                 if (vertexHasValidCap)
                 {
-                    capVertices.Add(v);
+                    capVertices.Add(Convert.ToUInt32(v));
                 }
             }
 


### PR DESCRIPTION
Garment Support attribute check and type fix

Implemented:
- Removed unnecessary check for color attribute before writing to garment support parameters, since importing garment support is currently driven by a checkbox in import settings

Fixed:
- Fixed an incorrect integer type being written to a parameter in the off chance that the cap color attribute has a value
