### PR TITLE
fix: Move AppViewModel TaskStatus to update on main thread

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -122,18 +122,21 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     {
         if (e.PropertyName == nameof(IProgressService<double>.Status))
         {
-            TaskStatus = _progressService.Status;
-            switch (TaskStatus)
+            Application.Current.Dispatcher.Invoke(() =>
             {
-                case EStatus.Running:
-                    Status = EAppStatus.Busy;
-                    break;
-                case EStatus.Ready:
-                    Status = EAppStatus.Ready;
-                    break;
-                default:
-                    break;
-            }
+                TaskStatus = _progressService.Status;
+                switch (TaskStatus)
+                {
+                    case EStatus.Running:
+                        Status = EAppStatus.Busy;
+                        break;
+                    case EStatus.Ready:
+                        Status = EAppStatus.Ready;
+                        break;
+                    default:
+                        break;
+                }
+            }, DispatcherPriority.ContextIdle);
         }
     }
 


### PR DESCRIPTION
Fixes persistent crash on deployment in Mod Manager

To reproduce crash:
1. Go to Mod Manager screen
2. Refresh to show all mods if none listed
3. Force Deploy all mods
4. Watch Crash when progress reaches step 5/5


This occurs when `TaskStatus` is updated by `ProgressService_PropertyChanged` but not on the main thread, causing "System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it." This change invokes the status update on the main thread when `ProgressService_PropertyChanged` is called.