### PR TITLE
feat: Display REDmod deploy progress steps

### DIFF
--- a/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
@@ -104,7 +104,7 @@ public partial class ModsViewModel : PageViewModel
         }
     }
 
-    private void ProgressService_ProgressChanged(object? sender, double e) => Progress = e * 100;
+    private void ProgressService_ProgressChanged(object? sender, double e) => Step = (int)(e * 5 - 1);
 
     private void Settings_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -117,12 +117,13 @@ public partial class ModsViewModel : PageViewModel
         }
     }
 
+    [ObservableProperty] private bool _showLog = false;
 
     [ObservableProperty] private string _logText;
 
     [ObservableProperty] private string _confirmText;
 
-    [ObservableProperty] private double _progress;
+    [ObservableProperty] private int _step;
 
     [ObservableProperty] private bool _loadOrderChanged;
 
@@ -149,6 +150,12 @@ public partial class ModsViewModel : PageViewModel
     {
         IsFinished = false;
         IsProcessing = false;
+    }
+
+    [RelayCommand]
+    private void ToggleLog()
+    {
+        ShowLog = !ShowLog;
     }
 
     [RelayCommand]
@@ -294,7 +301,7 @@ public partial class ModsViewModel : PageViewModel
             _logger.Info($"WorkDir: {redmodPath}");
             _logger.Info($"Running commandlet: {args}");
 
-            _progressService.Report(0.1);
+            _progressService.Report(0.0);
 
             var workingDir = Path.Combine(_settings.GetRED4GameRootDir(), "tools", "redmod", "bin");
             var result = await ProcessUtil.RunRedmodAsync(redmodPath, args, workingDir, progress: _progressService);
@@ -304,27 +311,8 @@ public partial class ModsViewModel : PageViewModel
 
             IsFinished = true;
             ConfirmText = result 
-                ? $"Deployed {enabledMods.Count} enabled mods with RedMod." 
-                : "RedMod deploy failed. Please check the log for details.";
-
-            //if (!result)
-            //{
-            //    await Interactions.ShowMessageBoxAsync(
-            //        "RedMod deploy failed. Please check the log for details.",
-            //        "RedMod",
-            //        WMessageBoxButtons.Ok,
-            //        WMessageBoxImage.Error);
-            //}
-            //else
-            //{
-            //    await Interactions.ShowMessageBoxAsync(
-            //        $"Deployed {enabledMods.Count} enabled mods with RedMod.",
-            //        "RedMod deploy",
-            //        WMessageBoxButtons.Ok,
-            //        WMessageBoxImage.Exclamation);
-
-            //    SetLoadOrderChanged(false);
-            //}
+                ? $"Sucessfully deployed {enabledMods.Count} mods with REDmod." 
+                : "REDmod deploy failed. Please check the log for details.";
 
             return result;
         }

--- a/WolvenKit/Converters/BooleanToSfStepTypeConverter.cs
+++ b/WolvenKit/Converters/BooleanToSfStepTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using Syncfusion.UI.Xaml.ProgressBar;
+
+namespace WolvenKit.Converters;
+public class BooleanToSfStepTypeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool boolVal)
+        {
+            return boolVal ? StepStatus.Indeterminate : StepStatus.Active;
+        }
+        else
+        {
+            return StepStatus.Inactive;
+        }
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/WolvenKit/Views/HomePage/Pages/ModsView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/ModsView.xaml
@@ -3,22 +3,24 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
-    xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:homepage="clr-namespace:WolvenKit.App.ViewModels.HomePage.Pages;assembly=WolvenKit.App"
+    xmlns:converters="clr-namespace:WolvenKit.Converters"
     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
     xmlns:local="clr-namespace:WolvenKit.Views.HomePage.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     d:DataContext="{d:DesignInstance Type=homepage:ModsViewModel}"
-    d:DesignHeight="600"
+    d:DesignHeight="800"
     d:DesignWidth="800"
     x:TypeArguments="homepage:ModsViewModel"
     Background="{StaticResource ContentBackgroundAlt3}"
     mc:Ignorable="d">
 
     <Grid>
+        <Grid.Resources>
+            <converters:BooleanToSfStepTypeConverter x:Key="BoolToSfStepType" />
+        </Grid.Resources>
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -240,24 +242,26 @@
 
             <Grid.RowDefinitions>
                 <RowDefinition Height="2*" />
-                <RowDefinition Height="1*" />
+                <RowDefinition Height="2*" />
                 <RowDefinition Height="1*" />
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
 
                 <StackPanel VerticalAlignment="Center" Visibility="{Binding IsNotFinished, Converter={StaticResource boolToVisibilityConverter}}">
-                    <syncfusion:SfBusyIndicator AnimationType="Gear" />
-                    <TextBlock
-                        x:Name="ImportExportOverlayText"
-                        Margin="0,65,0,0"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        FontSize="20"
-                        Text="Mods are being deployed ..." />
+                    <syncfusion:SfBusyIndicator AnimationType="Gear" ViewboxHeight="100" ViewboxWidth="100">
+                        <syncfusion:SfBusyIndicator.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="REDMod mods are being deployed..."
+                                       TextAlignment="Center"
+                                       FontSize="20" />
+                            </DataTemplate>
+                        </syncfusion:SfBusyIndicator.HeaderTemplate>
+                    </syncfusion:SfBusyIndicator>
+
                 </StackPanel>
 
-                <StackPanel VerticalAlignment="Center" Visibility="{Binding IsFinished, Converter={StaticResource boolToVisibilityConverter}}">
+                <StackPanel VerticalAlignment="Center" Visibility="{Binding IsFinished, Converter={StaticResource boolToVisibilityConverter}}" d:Visibility="Visible">
                     <TextBlock
                         Margin="0,0,0,0"
                         HorizontalAlignment="Center"
@@ -266,7 +270,13 @@
                         Text="{Binding ConfirmText}" />
                     <Button
                         Height="40"
-                        Margin="0,65,0,0"
+                        Margin="0,40,0,0"
+                        Command="{Binding ToggleLogCommand}">
+                        <TextBlock FontSize="14" Text="Show Log" />
+                    </Button>
+                    <Button
+                        Height="40"
+                        Margin="0,20,0,0"
                         Command="{Binding ConfirmCommand}">
                         <TextBlock FontSize="14" Text="Close" />
                     </Button>
@@ -275,19 +285,39 @@
 
             </Grid>
 
-            <syncfusion:SfLinearProgressBar
+            <syncfusion:SfStepProgressBar
                 x:Name="DeploymentProgressBar"
                 Grid.Row="1"
-                Height="20"
-                Margin="50,50,50,50"
-                Progress="{Binding Progress}" />
+                Margin="50"
+                AnimationDuration="0:0:0.75"
+                ItemsStretch="Fill"
+                SelectedItemStatus="{Binding IsNotFinished, Converter={StaticResource BoolToSfStepType}}"
+                SelectedIndex="{Binding Step}">
+                <syncfusion:SfStepProgressBar.ItemContainerStyle>
+                    <Style TargetType="syncfusion:StepViewItem">
+                        <Setter Property="Content" Value="{Binding Text}" />
+                    </Style>
+                </syncfusion:SfStepProgressBar.ItemContainerStyle>
+                <syncfusion:SfStepProgressBar.SecondaryContentTemplate>
+                    <DataTemplate>
+                        <TextBlock Text=""/>
+                    </DataTemplate>
+                </syncfusion:SfStepProgressBar.SecondaryContentTemplate>
+                <syncfusion:StepViewItem Content="Initialization" />
+                <syncfusion:StepViewItem Content="Script Compilation" />
+                <syncfusion:StepViewItem Content="TweakDB Compilation" />
+                <syncfusion:StepViewItem Content="Audio Deployment" />
+                <syncfusion:StepViewItem Content="Finalization" />
+            </syncfusion:SfStepProgressBar>
 
             <TextBox
                 Grid.Row="2"
                 Margin="5"
                 VerticalContentAlignment="Top"
+                Visibility="{Binding ShowLog, Converter={StaticResource boolToVisibilityConverter}}"
                 Background="{StaticResource ContentBackgroundAlt3}"
-                Text="{Binding LogText}" />
+                Text="{Binding LogText}"
+                VerticalScrollBarVisibility="Auto"/>
 
         </Grid>
 


### PR DESCRIPTION
Mod Manager QoL Improvements:
* Changes deployment page to use a step progress bar
* Hides log by default for a cleaner look (can be shown after deployment completes or fails)


https://user-images.githubusercontent.com/931177/224888488-10e29c63-35f9-439b-bfde-cf65df47b731.mp4

Note: video shows 1s animation time between steps, changed to 0.75s in PR