### PR TITLE
Add the selected mesh to the export list for multimesh 

### DIFF
--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using DynamicData;
 using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
 using WolvenKit.Common;

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using DynamicData;
 using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
 using WolvenKit.Common;
@@ -895,6 +896,7 @@ namespace WolvenKit.Modkit.RED4
                 case MeshExportType.Multimesh:
                 {
                     var meshes = meshargs.MultiMeshMeshes;
+                   
                     var rigs = meshargs.MultiMeshRigs;
                     if (!meshes.Any() || !rigs.Any())
                     {
@@ -922,6 +924,10 @@ namespace WolvenKit.Modkit.RED4
                                   return new KeyValuePair<Stream, string>(ms, entry.FileName);
                               }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
+                    if (!meshstreams.ContainsKey(cr2wStream))
+                    {
+                        meshstreams.Add(cr2wStream, cr2wFileName.Name);
+                    }
 
                     return ExportMultiMeshWithRig(meshstreams, rigstreams, cr2wFileName, meshargs);
                 }
@@ -1045,6 +1051,11 @@ namespace WolvenKit.Modkit.RED4
                 _ => throw new ArgumentOutOfRangeException(nameof(meshargs.meshExportType), meshargs.meshExportType, "This isn't a mesh to export")
             };
 
+            if (!meshStreams.ContainsKey(cr2wStream))
+            {
+                meshStreams.Add(cr2wStream, cr2wFileName.Name);
+            }
+
             if (!meshStreams.Any())
             {
                 _loggerService.Warning($"Export: no meshes found! Exporting just a rig is probably not supported but let's give it a try");
@@ -1060,9 +1071,8 @@ namespace WolvenKit.Modkit.RED4
             }
 
             return ExportMeshesAndRigs(meshStreams, rigStreams, cr2wFileName, meshargs);
-
-
-            Dictionary<Stream, string> _FilesToStreams(List<FileEntry> files) =>
+            
+            Dictionary<Stream, string> _FilesToStreams(List<FileEntry> files) =>            
                 files.Select(
                       delegate (FileEntry entry)
                       {
@@ -1071,6 +1081,7 @@ namespace WolvenKit.Modkit.RED4
                           ar?.CopyFileToStream(ms, entry.NameHash64, false);
                           return new KeyValuePair<Stream, string>(ms, entry.FileName);
                       }).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            
         }
 
 #endregion NewMeshExporter


### PR DESCRIPTION
Implemented:
Currently the Multimesh has a list labelled 'additional meshes' that you have to include the selected mesh into to get it to export. Minor change that adds the selected mesh to the export list if its not in there. Added to both old and new export flows, but cant test the old one as its not working for other reasons.

Fixed:
- never got round to filing a bug, but the fact the additional list wasn't additional at all but the whole export list, and the selected file wasn't automatically added.

