### PR TITLE
fix: Morphtarget Export and Import

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -361,12 +361,6 @@ namespace WolvenKit.Modkit.RED4
                             ? (uint)(mappingsInSubmesh.Count / 2) + 1
                             : (uint)(mappingsInSubmesh.Count / 2);
 
-                    if (mappingCountHalvedRoundedUpForRE4 * 2 != actionableDiffCountInSubmesh)
-                    {
-                        // Should not happen but better to exit if it does...
-                        throw new Exception($"Mapping count doesn't align correctly with diff count! {mappingCountHalvedRoundedUpForRE4} * 2 != {actionableDiffCountInSubmesh}");
-                    }
-
                     blob.Header.NumVertexDiffsInEachChunk[targetIndex][subMeshIndex] = actionableDiffCountInSubmesh;
                     blob.Header.NumVertexDiffsMappingInEachChunk[targetIndex][subMeshIndex] = mappingCountHalvedRoundedUpForRE4;
 

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -205,7 +205,7 @@ namespace WolvenKit.Modkit.RED4
         // Is this info already in the GLTF? Yes
         // Can I somehow get the POSITION.min/.max values with SharpGLTF? Also y-- no. Definitely no.
         // Are we therefore looping through all the vertices for like the 15th time? We sure are!
-        private (Vec3, Vec3) GetZupPositionDeltaBoundsForSubMesh(ModelRoot model, int subMeshIndex)
+        private (Vec3 max, Vec3 min) GetZupPositionDeltaBoundsForSubMesh(ModelRoot model, int subMeshIndex)
         {
             var max = Vec3.Zero;
             var min = Vec3.Zero;

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -59,14 +59,6 @@ namespace WolvenKit.Modkit.RED4
                 {
                     var rawMesh = GltfMeshToRawContainer(node);
 
-                    // Mesh logic automatically construes morphtargets as
-                    // garmentSupport. We don't want that. Can't be both.
-                    /*
-                    rawMesh.garmentMorph = Array.Empty<Vec3>();
-                    rawMesh.garmentSupportCap = Array.Empty<Vec4>();
-                    rawMesh.garmentSupportWeight = Array.Empty<Vec4>();
-                    */
-
                     RawMeshes.Add(rawMesh);
                 }
                 else if (args.FillEmpty)
@@ -84,8 +76,6 @@ namespace WolvenKit.Modkit.RED4
 
             // The /2 is because this one is stored in a signed int16... *sigh*
             var baseQuantOffset = new Vec4((maxBound.X + minBound.X) / 2f, (maxBound.Y + minBound.Y) / 2f, (maxBound.Z + minBound.Z) / 2f, 0f);
-            // Hardcoded from pwa
-            //var baseQuantScale = new Vec4(0.237320215f, 0.144603401f, 0.884930849f, 0f);
             var baseQuantScale = new Vec4((maxBound.X - minBound.X) / 2f, (maxBound.Y - minBound.Y) / 2f, (maxBound.Z - minBound.Z) / 2f, 0f);
 
             RawArmature? oldRig = null;

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.DependencyModel;
 using SharpGLTF.Schema2;
 using WolvenKit.Common.FNV1A;
 using WolvenKit.Common.Model.Arguments;
@@ -58,13 +59,18 @@ namespace WolvenKit.Modkit.RED4
                 {
                     var rawMesh = GltfMeshToRawContainer(node);
 
-            var max = new Vec3(float.MinValue, float.MinValue, float.MinValue);
-            var min = new Vec3(float.MaxValue, float.MaxValue, float.MaxValue);
+                    // Mesh logic automatically construes morphtargets as
+                    // garmentSupport. We don't want that. Can't be both.
+                    /*
+                    rawMesh.garmentMorph = Array.Empty<Vec3>();
+                    rawMesh.garmentSupportCap = Array.Empty<Vec4>();
+                    rawMesh.garmentSupportWeight = Array.Empty<Vec4>();
+                    */
 
                     RawMeshes.Add(rawMesh);
                 }
                 else if (args.FillEmpty)
-            {
+                {
                     RawMeshes.Add(CreateEmptyMesh(node.Name));
                 }
             }
@@ -102,46 +108,69 @@ namespace WolvenKit.Modkit.RED4
             meshesInfo.quantScale = baseQuantScale;
             meshesInfo.quantTrans = baseQuantOffset;
 
+            // ^ This basically finishes up the mesh setup. Morphtargets are
+            // effectively injected at this point, and the mesh written out
+            // at the end. The mesh processing needs to be unified so that
+            // it's not duplicated here and in MeshImportTools.
+
             var diffsBuffer = new MemoryStream();
             var mappingsBuffer = new MemoryStream();
             var texbuffer = new MemoryStream();
 
-            // Deserialize mappings buffer
-            /*if (renderblob.MappingBuffer.IsSerialized)
-            {
-                intargetStream.Seek(cr2w.Buffers[mappingsBufferId].Offset, SeekOrigin.Begin);
-                intargetStream.DecompressAndCopySegment(mappingsBuffer, cr2w.Buffers[mappingsBufferId].DiskSize, cr2w.Buffers[mappingsBufferId].MemSize);
-            }*/
+            // Reset some more data - why is this not a new data structure, again?
+            // Resetting up here because this is mutable data so there's no telling
+            // who might fuck with it somewhere.
 
-            // Zero out some values that will be set later
+            var subMeshesCount = red4Meshes.Count;
+            var morphTargetCount = model.LogicalMeshes[0].Primitives[0].MorphTargetsCount;
+            var targetCountsMatch = model.LogicalMeshes.All(l => l.Primitives[0].MorphTargetsCount == morphTargetCount);
+
+            if (!targetCountsMatch)
+            {
+                var totals = model.LogicalMeshes.Select(subMesh => $"{subMesh.Name}: {morphTargetCount}").ToArray();
+                throw new Exception($"All submeshes don't have the same number of morph targets!\n{string.Join("\n", totals)}");
+            }
+
+            if (morphTargetCount == 0)
+            {
+                throw new Exception("Mesh contains no morph targets to import.");
+            }
+
             renderblob.Header.NumDiffs = 0;
+            renderblob.Header.NumDiffsMapping = 0;
+            renderblob.Header.NumVertexDiffsInEachChunk = new(morphTargetCount);
+            renderblob.Header.NumVertexDiffsMappingInEachChunk = new(morphTargetCount);
+            renderblob.Header.TargetStartsInVertexDiffs = new(morphTargetCount);
+            renderblob.Header.TargetStartsInVertexDiffsMapping = new(morphTargetCount);
+            renderblob.Header.TargetPositionDiffOffset = new(morphTargetCount);
+            renderblob.Header.TargetPositionDiffScale = new(morphTargetCount);
 
-            for (var i = 0; i < renderblob.Header.TargetStartsInVertexDiffs.Count; i++)
+            for (var i = 0; i < morphTargetCount; i++)
             {
+                renderblob.Header.NumVertexDiffsInEachChunk[i] = new(subMeshesCount);
+                renderblob.Header.NumVertexDiffsMappingInEachChunk[i] = new(subMeshesCount);
+
                 renderblob.Header.TargetStartsInVertexDiffs[i] = 0;
-            }
-
-            for (var i = 0; i < renderblob.Header.TargetStartsInVertexDiffsMapping.Count; i++)
-            {
                 renderblob.Header.TargetStartsInVertexDiffsMapping[i] = 0;
+
+                renderblob.Header.TargetPositionDiffOffset[i] = new Vec4(0f, 0f, 0f, 0);
+                renderblob.Header.TargetPositionDiffScale[i] = new Vec4(1f, 1f, 1f, 0);
             }
 
-            SetTargets(cr2w, model, renderblob, diffsBuffer, mappingsBuffer);
+            // Do the thing
+            ConvertAndSetTargetsData(cr2w, (uint)morphTargetCount, (uint)subMeshesCount, model, renderblob, diffsBuffer, mappingsBuffer);
+
+            // Well most of the thing, this part of the thing is here instead
             renderblob.DiffsBuffer.Buffer.SetBytes(diffsBuffer.ToArray());
             renderblob.MappingBuffer.Buffer.SetBytes(mappingsBuffer.ToArray());
 
+            // Fill out the rest (render data mostly)
             var ms = GetEditedCr2wFile(cr2w, meshesInfo, meshBuffer);
 
             ms.Seek(0, SeekOrigin.Begin);
-            //if (outStream != null)
-            //{
-            //    ms.CopyTo(outStream);
-            //}
-            //else
-            {
-                intargetStream.SetLength(0);
-                ms.CopyTo(intargetStream);
-            }
+            intargetStream.SetLength(0);
+            ms.CopyTo(intargetStream);
+ 
             return true;
         }
 
@@ -178,16 +207,16 @@ namespace WolvenKit.Modkit.RED4
                 modelMin.X = Math.Min(modelMin.X, Math.Min(subMeshMin.X, (subMeshMin.X + smMorphMin.X)));
                 modelMin.Y = Math.Min(modelMin.Y, Math.Min(subMeshMin.Y, (subMeshMin.Y + smMorphMin.Y)));
                 modelMin.Z = Math.Min(modelMin.Z, Math.Min(subMeshMin.Z, (subMeshMin.Z + smMorphMin.Z)));
-                }
+            }
 
             return (modelMax, modelMin);
-                }
+        }
 
         // Is this info already in the GLTF? Yes
         // Can I somehow get the POSITION.min/.max values with SharpGLTF? Also y-- no. Definitely no.
         // Are we therefore looping through all the vertices for like the 15th time? We sure are!
         private (Vec3, Vec3) GetZupPositionDeltaBoundsForSubMesh(ModelRoot model, int subMeshIndex)
-                {
+        {
             var max = Vec3.Zero;
             var min = Vec3.Zero;
 
@@ -232,110 +261,163 @@ namespace WolvenKit.Modkit.RED4
                 min.X = Math.Min(min.X, morphPositionDeltas.Min(l => l.X));
                 min.Y = Math.Min(min.Y, morphPositionDeltas.Min(l => -l.Z));
                 min.Z = Math.Min(min.Z, morphPositionDeltas.Min(l => l.Y));
-                }
+            }
 
             var quantScale = new Vec4(max.X - min.X, max.Y - min.Y, max.Z - min.Z, 0);
             var quantOffset = new Vec4(min.X, min.Y, min.Z, 0);
 
             return (quantScale, quantOffset);
-            }
+        }
 
+        // Inverse, export transform is (mostly) in `ContainRawTarget()`
+        private void ConvertAndSetTargetsData(CR2WFile cr2w, uint morphTargetCount, uint subMeshCount, ModelRoot model, rendRenderMorphTargetMeshBlob blob, Stream diffsBuffer, Stream mappingsBuffer)
+        {
             var diffsWriter = new BinaryWriter(diffsBuffer);
             var mappingsWriter = new BinaryWriter(mappingsBuffer);
 
-            for (var i = 0; i < morphTargetCount; i++)
+            for (var targetIndex = 0; targetIndex < morphTargetCount; targetIndex++)
             {
-                // Write scale and offsets
-                var (scale, offset) = CalculateTargetQuant(model, i);
+                var (targetQuantScale, targetQuantOffset) = CalculateQuantizationForTargetInZUp(model, targetIndex);
 
-                var posOffset = blob.Header.TargetPositionDiffOffset[i];
-                var posScale = blob.Header.TargetPositionDiffScale[i];
+                blob.Header.TargetPositionDiffOffset[targetIndex] = targetQuantOffset; 
+                blob.Header.TargetPositionDiffScale[targetIndex] = targetQuantScale;
 
-                ArgumentNullException.ThrowIfNull(posOffset);
-                ArgumentNullException.ThrowIfNull(posScale);
-
-                posOffset.X = offset.X;
-                posOffset.Y = offset.Y;
-                posOffset.Z = offset.Z;
-                posScale.X = scale.X;
-                posScale.Y = scale.Y;
-                posScale.Z = scale.Z;
-
-
-                for (var subMeshId = 0; subMeshId < model.LogicalMeshes.Count; subMeshId++)
+                for (var subMeshIndex = 0; subMeshIndex < subMeshCount; subMeshIndex++)
                 {
-                    var logicalMesh = model.LogicalMeshes[subMeshId].Primitives[0];
-                    var morphTarget = logicalMesh.GetMorphTargetAccessors(i);
+                    var subMesh = model.LogicalMeshes[subMeshIndex].Primitives[0];
+                    var morphTarget = subMesh.GetMorphTargetAccessors(targetIndex);
 
                     if (!morphTarget.ContainsKey("TANGENT"))
                     {
-                        throw new Exception($"Morph target {i} does not contain any tangents. Did you remember to export them?");
+                        throw new Exception($"Morph target {targetIndex} does not contain any tangents. Did you remember to export them?");
                     }
 
                     if (!morphTarget.ContainsKey("NORMAL"))
                     {
-                        throw new Exception($"Morph target {i} does not contain any normals. Did you remember to export them?");
+                        throw new Exception($"Morph target {targetIndex} does not contain any normals. Did you remember to export them?");
                     }
 
-                    var vertices = morphTarget["POSITION"].AsVector3Array();
-                    var normals = morphTarget["NORMAL"].AsVector3Array();
-                    var tangents = morphTarget["TANGENT"].AsVector3Array();
+                    var positionDeltas = morphTarget["POSITION"].AsVector3Array();
+                    var normalDeltas = morphTarget["NORMAL"].AsVector3Array();
+                    var tangentDeltas = morphTarget["TANGENT"].AsVector3Array();
 
-                    var mappings = new List<ushort>();
-                    var deltaCount = 0;
+                    var mappingsInSubmesh = new List<ushort>();
+                    uint actionableDiffCountInSubmesh = 0;
+                    var diffsWithOnlyNormalOrTangentCount = 0;
 
-                    for (var x = 0; x < vertices.Count; x++)
+                    for (var diffIndex = 0; diffIndex < positionDeltas.Count; diffIndex++)
                     {
-                        var vertexDelta = vertices[x];
-                        var normalsDelta = normals[x];
-                        var tangentsDelta = tangents[x];
+                        var positionDelta = positionDeltas[diffIndex];
+                        var normalDelta = normalDeltas[diffIndex];
+                        var tangentDelta = tangentDeltas[diffIndex];
 
-                        if (vertexDelta.X == 0 && vertexDelta.Y == 0 && vertexDelta.Z == 0)
+                        var hasPositionDelta = positionDelta.X != 0 || positionDelta.Y != 0 || positionDelta.Z != 0;
+                        var hasNormalDelta = normalDelta.X != 0 || normalDelta.Y != 0 || normalDelta.Z != 0;
+                        var hasTangentDelta = tangentDelta.X != 0 || tangentDelta.Y != 0 || tangentDelta.Z != 0;
+
+                        if (!hasPositionDelta)
                         {
-                            continue;
+                            if (!hasNormalDelta && !hasTangentDelta)
+                            {
+                                continue;
+                            }
+
+                            diffsWithOnlyNormalOrTangentCount += 1;   // Dunno if this is actually relevant info?
                         }
 
+                        mappingsInSubmesh.Add((ushort)diffIndex);
 
-                        // Mappings
-                        mappings.Add((ushort)x);
+                        actionableDiffCountInSubmesh += 1;
 
-                        deltaCount++;
+                        // GLTF's RHCS Y up -> Red4 LHCS Z up
+                        var zUpPositionDelta = new TargetVec3(positionDelta.X, -positionDelta.Z, positionDelta.Y);
+                        var zUpNormalDelta = new Vec4(normalDelta.X, -normalDelta.Z, normalDelta.Y, 0f);
+                        var zUpTangentDelta = new Vec4(tangentDelta.X, -tangentDelta.Z, tangentDelta.Y, 0f);
 
-                        var convertX = (vertexDelta.X - offset.X) / scale.X;
-                        var convertY = (vertexDelta.Y - offset.Z) / scale.Z;
-                        var convertZ = (vertexDelta.Z - -offset.Y) / scale.Y;
+                        // Quant already converted earlier
+                        var zUpQuantizedPositionDelta =
+                            new TargetVec3(
+                                targetQuantScale.X != 0 ? ((zUpPositionDelta.X - targetQuantOffset.X) / targetQuantScale.X) : 0,
+                                targetQuantScale.Y != 0 ? ((zUpPositionDelta.Y - targetQuantOffset.Y) / targetQuantScale.Y) : 0,
+                                targetQuantScale.Z != 0 ? ((zUpPositionDelta.Z - targetQuantOffset.Z) / targetQuantScale.Z) : 0);
 
-                        // Position
-                        var output = Converters.Vec3ToU32(new TargetVec3(convertX, -convertZ, convertY), 1);
+                        // NB different encoding for position!
+                        var positionAs10BitUnsignedInt = Converters.Vec3ToU32(zUpQuantizedPositionDelta, 1);
+                        var normalAs10BitShiftedInt = Converters.Vec4ToU32(zUpNormalDelta);
+                        var tangentAs10BitShiftedInt = Converters.Vec4ToU32(zUpTangentDelta);
 
-                        diffsWriter.Write(output);
-
-                        // Normal
-                        output = Converters.Vec4ToU32(new Vec4(normalsDelta.X, -normalsDelta.Z, normalsDelta.Y, 1f));
-                        diffsWriter.Write(output);
-
-                        // Tangent
-                        output = Converters.Vec4ToU32(new Vec4(tangentsDelta.X, -tangentsDelta.Z, tangentsDelta.Y, 1f));
-                        diffsWriter.Write(output);
+                        // 4 + 4 + 4 bytes per diff, no padding
+                        diffsWriter.Write(positionAs10BitUnsignedInt);
+                        diffsWriter.Write(normalAs10BitShiftedInt);
+                        diffsWriter.Write(tangentAs10BitShiftedInt);
                     }
 
-                    // Write mappings
-                    foreach (var mapping in mappings)
+                    // 2 bytes per mapping
+                    foreach (var mapping in mappingsInSubmesh)
                     {
                         mappingsWriter.Write(mapping);
                     }
 
-                    // Padding?
-                    foreach (var mapping in mappings)
+                    var oddDiffCountNeedsMappingsPadding = mappingsInSubmesh.Count % 2 != 0;
+
+                    if (oddDiffCountNeedsMappingsPadding)
                     {
                         mappingsWriter.Write((ushort)0);
                     }
 
-                    blob.Header.NumVertexDiffsInEachChunk[i].NotNull()[subMeshId] = (uint)deltaCount;
-                    blob.Header.NumVertexDiffsMappingInEachChunk[i].NotNull()[subMeshId] = (uint)deltaCount;
-                    blob.Header.NumDiffs += (uint)deltaCount;
+                    // Fun story
+                    var mappingCountHalvedRoundedUpForRE4 =
+                        oddDiffCountNeedsMappingsPadding
+                            ? (uint)(mappingsInSubmesh.Count / 2) + 1
+                            : (uint)(mappingsInSubmesh.Count / 2);
+
+                    if (mappingCountHalvedRoundedUpForRE4 * 2 != actionableDiffCountInSubmesh)
+                    {
+                        // Should not happen but better to exit if it does...
+                        throw new Exception($"Mapping count doesn't align correctly with diff count! {mappingCountHalvedRoundedUpForRE4} * 2 != {actionableDiffCountInSubmesh}");
+                    }
+
+                    blob.Header.NumVertexDiffsInEachChunk[targetIndex][subMeshIndex] = actionableDiffCountInSubmesh;
+                    blob.Header.NumVertexDiffsMappingInEachChunk[targetIndex][subMeshIndex] = mappingCountHalvedRoundedUpForRE4;
+
+                    _loggerService.Debug($"Target {targetIndex} submesh {subMeshIndex} ({positionDeltas.Count} vertices): {actionableDiffCountInSubmesh} diffs applied (of which {diffsWithOnlyNormalOrTangentCount} diffs with only normal/tangent, no position)");
                 }
             }
+
+            // Set rest of blob-level stuff computed from the import.
+            // (This should really be immutable or returned but here we are.)
+
+            blob.Header.NumTargets = morphTargetCount;
+
+            blob.Header.NumDiffs = 0;
+            blob.Header.NumDiffsMapping = 0;
+
+            // Reduce into totals and subtotals... f# where art thou
+            for (var targetIndex = (int)morphTargetCount - 1; targetIndex >= 0; targetIndex--)
+            {
+                blob.Header.TargetStartsInVertexDiffs[targetIndex] = 0;
+                blob.Header.TargetStartsInVertexDiffsMapping[targetIndex] = 0;
+
+                uint diffCountInTarget = 0;
+                uint mappingCountInTarget = 0;
+
+                for (var subMeshIndex = 0; subMeshIndex < subMeshCount; subMeshIndex++)
+                {
+                    diffCountInTarget += blob.Header.NumVertexDiffsInEachChunk[targetIndex][subMeshIndex];
+                    mappingCountInTarget += blob.Header.NumVertexDiffsMappingInEachChunk[targetIndex][subMeshIndex];
+                }
+
+                blob.Header.NumDiffs += diffCountInTarget;
+                blob.Header.NumDiffsMapping += mappingCountInTarget;
+
+                for (var higherTargetIndex = targetIndex + 1; higherTargetIndex < morphTargetCount; higherTargetIndex++)
+                {
+                    blob.Header.TargetStartsInVertexDiffs[higherTargetIndex] += diffCountInTarget;
+                    blob.Header.TargetStartsInVertexDiffsMapping[higherTargetIndex] += mappingCountInTarget;
+                }
+            }
+
+            return;
         }
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -400,7 +400,7 @@ namespace WolvenKit.Modkit.RED4
                 for (var i = 0; i < mesh.texCoords0.Length; i++)
                 {
                     bw.Write(mesh.texCoords0[i].X);
-                    bw.Write(mesh.texCoords0[i].Y);
+                    bw.Write((mesh.texCoords0[i].Y * -1) + 1); // Flip UV Y like mesh export does
                 }
                 for (var i = 0; i < mesh.texCoords1.Length; i++)
                 {

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -255,21 +255,18 @@ namespace WolvenKit.Modkit.RED4
 
                 for (var diffIndex = 0; diffIndex < diffsCount; diffIndex++)
                 {
-                    if (diffsbr.BaseStream.Position < (diffsbr.BaseStream.Length - 3))
-                    {
-                        var positionDelta = Converters.TenBitUnsigned(diffsbr.ReadUInt32());
-                        var normalDelta = Converters.TenBitShifted(diffsbr.ReadUInt32());
-                        var tangentDelta = Converters.TenBitShifted(diffsbr.ReadUInt32());
+                    var positionDelta = Converters.TenBitUnsigned(diffsbr.ReadUInt32());
+                    var normalDelta = Converters.TenBitShifted(diffsbr.ReadUInt32());
+                    var tangentDelta = Converters.TenBitShifted(diffsbr.ReadUInt32());
 
-                        var dequantizedPositionDeltaX = (positionDelta.X * targetPositionDiffScale.X) + targetPositionDiffOffset.X;
-                        var dequantizedPositionDeltaY = (positionDelta.Y * targetPositionDiffScale.Y) + targetPositionDiffOffset.Y;
-                        var dequantizedPositionDeltaZ = (positionDelta.Z * targetPositionDiffScale.Z) + targetPositionDiffOffset.Z;
+                    var dequantizedPositionDeltaX = (positionDelta.X * targetPositionDiffScale.X) + targetPositionDiffOffset.X;
+                    var dequantizedPositionDeltaY = (positionDelta.Y * targetPositionDiffScale.Y) + targetPositionDiffOffset.Y;
+                    var dequantizedPositionDeltaZ = (positionDelta.Z * targetPositionDiffScale.Z) + targetPositionDiffOffset.Z;
 
-                        // LHCS Zup to RHCS Yup
-                        positionDeltas[diffIndex] = new TargetVec3(dequantizedPositionDeltaX, dequantizedPositionDeltaZ, -dequantizedPositionDeltaY);
-                        normalDeltas[diffIndex] = new Vec3(normalDelta.X, normalDelta.Z, -normalDelta.Y);
-                        tangentDeltas[diffIndex] = new Vec3(tangentDelta.X, tangentDelta.Z, -tangentDelta.Y);
-                    }
+                    // LHCS Zup to RHCS Yup
+                    positionDeltas[diffIndex] = new TargetVec3(dequantizedPositionDeltaX, dequantizedPositionDeltaZ, -dequantizedPositionDeltaY);
+                    normalDeltas[diffIndex] = new Vec3(normalDelta.X, normalDelta.Z, -normalDelta.Y);
+                    tangentDeltas[diffIndex] = new Vec3(tangentDelta.X, tangentDelta.Z, -tangentDelta.Y);
                 }
 
                 for (var mapIdx = 0; mapIdx < actualMapsCount; mapIdx++)

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -82,7 +82,7 @@ namespace WolvenKit.Modkit.RED4
                     temp_NumVertexDiffsInEachChunk[e] = targetsInfo.NumVertexDiffsInEachChunk[i, e];
                     temp_NumVertexDiffsMappingInEachChunk[e] = targetsInfo.NumVertexDiffsMappingInEachChunk[i, e];
                 }
-                expTargets.Add(ContainRawTargets(diffsbuffer, mappingbuffer, temp_NumVertexDiffsInEachChunk, temp_NumVertexDiffsMappingInEachChunk, targetsInfo.TargetStartsInVertexDiffs[i], targetsInfo.TargetStartsInVertexDiffsMapping[i], targetsInfo.TargetPositionDiffOffset[i], targetsInfo.TargetPositionDiffScale[i], expMeshes.Count));
+                expTargets.Add(ContainRawTarget(diffsbuffer, mappingbuffer, temp_NumVertexDiffsInEachChunk, temp_NumVertexDiffsMappingInEachChunk, targetsInfo.TargetStartsInVertexDiffs[i], targetsInfo.TargetStartsInVertexDiffsMapping[i], targetsInfo.TargetPositionDiffOffset[i], targetsInfo.TargetPositionDiffScale[i], expMeshes.Count));
             }
 
             var textureStreams = ContainTextureStreams(blob, texbuffer);
@@ -199,7 +199,7 @@ namespace WolvenKit.Modkit.RED4
             return targetsInfo;
         }
 
-        private static RawTargetContainer[] ContainRawTargets(MemoryStream diffsbuffer, MemoryStream mappingbuffer, uint[] numVertexDiffsInEachChunk, uint[] numVertexDiffsMappingInEachChunk, uint targetStartsInVertexDiffs, uint targetStartsInVertexDiffsMapping, Vec4 targetPositionDiffOffset, Vec4 targetPositionDiffScale, int subMeshC)
+        private static RawTargetContainer[] ContainRawTarget(MemoryStream diffsbuffer, MemoryStream mappingbuffer, uint[] numVertexDiffsInEachChunk, uint[] numVertexDiffsMappingInEachChunk, uint targetStartsInVertexDiffs, uint targetStartsInVertexDiffsMapping, Vec4 targetPositionDiffOffset, Vec4 targetPositionDiffScale, int subMeshC)
         {
             var rawtarget = new RawTargetContainer[subMeshC];
 


### PR DESCRIPTION
## Highlights

Export: produces correct data so that it actually *can* be imported correctly\*
Import: produces working morphtargets for vanilla/modified/custom morphs\*\*

## Breaking

Previously exported and/or imported morphtargets are likely to have at least some issues. Users may need to re-export and port their work on top of that.

## More

The commits are kinda split up and the commit messages worth reading but, YMMV, it may be easier to actually review the code by reading the entire file instead of a diff.

\*,\*\* I mean, like, _probably_? I haven't tested that extensively.

_Evidence for the defense: sculpted neck on a head morph (with still-working customization & expressions)_
![image](https://user-images.githubusercontent.com/13802421/230675330-f27639d1-895a-4be1-995d-c91f18d56664.png)
