### PR TITLE
Fix #1287, Quality of live improvements for Scripting namespace

### DIFF
--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -34,8 +34,7 @@ public partial class ScriptService : ObservableObject
 
         IsRunning = true;
 
-        var sw = new Stopwatch();
-        sw.Start();
+        var sw = Stopwatch.StartNew();
 
         DocumentLoader.Default.DiscardCachedDocuments();
 

--- a/WolvenKit.Modkit/Scripting/WKitScripting.cs
+++ b/WolvenKit.Modkit/Scripting/WKitScripting.cs
@@ -19,8 +19,8 @@ namespace WolvenKit.Modkit.Scripting;
 public class WKitScripting
 {
     protected readonly ILoggerService _loggerService;
-    protected IArchiveManager _archiveManager;
-    protected Red4ParserService _redParserService;
+    protected readonly IArchiveManager _archiveManager;
+    protected readonly Red4ParserService _redParserService;
 
     public WKitScripting(ILoggerService loggerService, IArchiveManager archiveManager, Red4ParserService parserService)
     {
@@ -38,11 +38,7 @@ public class WKitScripting
     public virtual IGameFile? GetFileFromBase(string path)
     {
         var file = _archiveManager.Lookup(FNV1A64HashAlgorithm.HashString(path));
-        if (file.HasValue)
-        {
-            return file.Value;
-        }
-        return null;
+        return file.HasValue ? file.Value : null;
     }
 
     /// <summary>
@@ -69,11 +65,7 @@ public class WKitScripting
     public virtual IGameFile? GetFileFromBase(ulong hash)
     {
         var file = _archiveManager.Lookup(hash);
-        if (file.HasValue)
-        {
-            return file.Value;
-        }
-        return null;
+        return file.HasValue ? file.Value : null;
     }
 
     /// <summary>
@@ -123,28 +115,12 @@ public class WKitScripting
     /// </summary>
     /// <param name="path">file path to check</param>
     /// <returns></returns>
-    public virtual bool FileExistsInArchive(string path)
-    {
-        if (string.IsNullOrEmpty(path))
-        {
-            return false;
-        }
-
-        return FileExistsInArchive(FNV1A64HashAlgorithm.HashString(path));
-    }
+    public virtual bool FileExistsInArchive(string path) => !string.IsNullOrEmpty(path) && FileExistsInArchive(FNV1A64HashAlgorithm.HashString(path));
 
     /// <summary>
     /// Check if file exists in the game archives
     /// </summary>
     /// <param name="hash">hash value to be checked</param>
     /// <returns></returns>
-    public virtual bool FileExistsInArchive(ulong hash)
-    {
-        if (hash == 0)
-        {
-            return false;
-        }
-        
-        return _archiveManager.Lookup(hash).HasValue;
-    }
+    public virtual bool FileExistsInArchive(ulong hash) => hash != 0 && _archiveManager.Lookup(hash).HasValue;
 }


### PR DESCRIPTION
### Quality of live improvements for Scripting namespace

Implemented:
- Use the `Stopwatch.StartNew()` method to create and start a new Stopwatch instance.

- Use the C# `readonly` modifier for fields that are only set in the constructor and should not be modified afterward, such as `_archiveManager` and `_redParserService`.~
- Use expression body for simple getter like methods for a consistent code style

Fixed:
- Fixes #1287
