### PR TITLE
fix: Delete Incorrectly Assumed GarmentSupport on MorphTargetImport

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -60,7 +60,9 @@ namespace WolvenKit.Modkit.RED4
                 if (node.Mesh != null)
                 {
                     var rawMesh = GltfMeshToRawContainer(node);
-
+                    // This should probably be fixed in the mesh import code,
+                    // but that stuff needs to be rewritten anyway so surgical for now
+                    rawMesh.garmentMorph = Array.Empty<Vec3>();
                     rawMeshes.Add(rawMesh);
                 }
                 else if (args.FillEmpty)


### PR DESCRIPTION
Fixed:
- Import eye (`he0`) morphtargets correctly

Mesh import assumes targets mean garmentSupport, and it _seems_ that the reason it fails for eyes only is because of the `doubled` submesh that creates a buffer size discrepancy.
