### PR TITLE
FIX: Provide Root Explicitly for Single-Joint Rig Export

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -1008,7 +1008,18 @@ namespace WolvenKit.Modkit.RED4.Tools
             if (rig is { BoneCount: > 0 })
             {
                 skin = model.CreateSkin();
-                skin.BindJoints(RIG.ExportNodes(ref model, rig).Values.ToArray());
+
+                var actualJointNodesOnly = RIG.ExportNodes(ref model, rig).Values.ToArray();
+
+                if (actualJointNodesOnly.Length == 1)
+                {
+                    var parentArmature = actualJointNodesOnly[0].VisualParent;
+                    skin.BindJoints(parentArmature.WorldMatrix, actualJointNodesOnly);
+                }
+                else
+                {
+                    skin.BindJoints(actualJointNodesOnly);
+                }
             }
 
             Dictionary<string, Material>? materials = null;


### PR DESCRIPTION
Fixed:
- Single-joint models (like many hats) are exported with correct rigging

SharpGLTF's ancestor finder assumes a single node is the root node, so it calculates the inverse bind matrix incorrectly.

https://github.com/vpenades/SharpGLTF/blob/b23b5ce225637f38a00be67f4641c991ed36435d/src/SharpGLTF.Core/Schema2/gltf.Skin.cs#L238