### PR TITLE
fix annoying error msg spam

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -309,6 +309,9 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
 
     public ObservableCollectionExtended<ChunkViewModel> DisplayProperties => MightHaveChildren() ? Properties : SelfList;
 
+    // Fix annoying "Property not found" error spam
+    public bool IsDeletable => true;
+
     [ObservableProperty] private string? _value;
 
     [ObservableProperty] private string? _descriptor;


### PR DESCRIPTION
This is a fix for

```
System.Windows.Data Error: 40 : BindingExpression path error: 'IsDeletable' property not found on 'object' ''ChunkViewModel' (HashCode=2829827)'. BindingExpression:Path=IsDeletable; DataItem='ChunkViewModel' (HashCode=2829827); target element is 'StackPanel' (Name=''); target property is 'Visibility' (type 'Visibility')
```