### PR TITLE
fix: standardize tweaks and scripts in resources folder

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -317,15 +317,7 @@ public class RED4Controller : ObservableObject, IGameController
     {
         return Path.GetExtension(fileName) switch
         {
-            ".yaml" or ".yml" or ".xl" or ".script" or ".ws" or ".tweak" => true,
-            _ => false,
-        };
-    }
-    private static bool IsYaml(string fileName)
-    {
-        return Path.GetExtension(fileName) switch
-        {
-            ".yaml" or ".yml" => true,
+            ".xl" or ".script" or ".ws" or ".tweak" => true,
             _ => false,
         };
     }
@@ -338,13 +330,16 @@ public class RED4Controller : ObservableObject, IGameController
         };
     }
 
-    private static IEnumerable<string> GetTweakXLFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(cp77Proj.ResourcesDirectory, "*", SearchOption.AllDirectories).Where(file => IsYaml(file));
+    private static string GetTweakResourcePath(Cp77Project cp77Proj) => Path.Combine(cp77Proj.ResourcesDirectory, "r6", "tweaks");
+    private static string GetScriptResourcePath(Cp77Project cp77Proj) => Path.Combine(cp77Proj.ResourcesDirectory, "r6", "scripts");
+
+    private static IEnumerable<string> GetScriptFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(GetScriptResourcePath(cp77Proj), "*.*", SearchOption.AllDirectories).Where(name => IsCDPRScript(name));
+
+
     private static IEnumerable<string> GetArchiveXlFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(cp77Proj.ResourcesDirectory, "*.xl", SearchOption.AllDirectories);
     private static IEnumerable<string> GetResourceFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(cp77Proj.ResourcesDirectory, "*.*", SearchOption.AllDirectories)
         .Where(name => !IsSpecialExtension(name))
-        .Where(x => Path.GetFileName(x) != "info.json")
-        ;
-    private static IEnumerable<string> GetScriptFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(cp77Proj.ResourcesDirectory, "*.*", SearchOption.AllDirectories).Where(name => IsCDPRScript(name));
+        .Where(x => Path.GetFileName(x) != "info.json");
     private static IEnumerable<string> GetTweakFiles(Cp77Project cp77Proj) => Directory.EnumerateFiles(cp77Proj.ResourcesDirectory, "*.tweak", SearchOption.AllDirectories);
 
     /// <summary>
@@ -407,22 +402,8 @@ public class RED4Controller : ObservableObject, IGameController
             _loggerService.Info($"{cp77Proj.Name} archives packed into {cp77Proj.GetPackedArchiveDirectory(options.IsRedmod)}");
         }
 
-        // pack tweakXL files
-        var files = GetTweakXLFiles(cp77Proj);
-        if (files.Any())
-        {
-            if (!PackTweakXlFiles(cp77Proj, files))
-            {
-                _progressService.IsIndeterminate = false;
-                _loggerService.Error("Packing tweakXL files failed, aborting.");
-                _notificationService.Error("Packing tweakXL files failed, aborting.");
-                return false;
-            }
-            _loggerService.Info($"{cp77Proj.Name} tweakXL files packed into {cp77Proj.PackedTweakDirectory}");
-        }
-
         // pack archiveXL files
-        files = GetArchiveXlFiles(cp77Proj);
+        var files = GetArchiveXlFiles(cp77Proj);
         if (files.Any())
         {
             if (!PackArchiveXlFiles(cp77Proj, files, options))
@@ -633,24 +614,6 @@ public class RED4Controller : ObservableObject, IGameController
 
             // copy files, with overwriting
             File.Copy(file, fileOutputPath, true);
-        }
-        return true;
-    }
-
-    private static bool PackTweakXlFiles(Cp77Project cp77Proj, IEnumerable<string> tweakFiles)
-    {
-        foreach (var f in tweakFiles)
-        {
-            var outDir = Path.Combine(cp77Proj.PackedTweakDirectory, Path.GetRelativePath(cp77Proj.ResourcesDirectory, Path.GetDirectoryName(f).NotNull()));
-
-            if (!Directory.Exists(outDir))
-            {
-                Directory.CreateDirectory(outDir);
-            }
-
-            var filename = Path.GetFileName(f);
-            var outPath = Path.Combine(outDir, filename);
-            File.Copy(f, outPath, true);
         }
         return true;
     }

--- a/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
@@ -113,6 +113,7 @@ public partial class NewFileViewModel : DialogViewModel
 #pragma warning disable IDE0072 // Add missing cases
         FileName = SelectedFile?.Type switch
         {
+            EWolvenKitFile.TweakXl => $"r6{sep}tweaks{sep}{project.Name}{sep}untitled.{value.Extension.NotNull().ToLower()}",
             EWolvenKitFile.RedScript => $"r6{sep}scripts{sep}{project.Name}{sep}untitled.{value.Extension.NotNull().ToLower()}",
             EWolvenKitFile.CETLua => $"bin{sep}x64{sep}plugins{sep}cyber_engine_tweaks{sep}mods{sep}{project.Name}{sep}init.{value.Extension.NotNull().ToLower()}",
             _ => $"{value.Name.NotNull().Split(' ').First()}1.{value.Extension.NotNull().ToLower()}",

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -920,6 +920,10 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             case EWolvenKitFile.ArchiveXl:
             case EWolvenKitFile.TweakXl:
+            {
+                //prep the subdirs
+                var tweakDirName = Path.GetDirectoryName(file.FullPath).NotNull();
+                Directory.CreateDirectory(tweakDirName);
                 if (!string.IsNullOrEmpty(file.SelectedFile.Template))
                 {
                     await using var resource = Assembly.GetExecutingAssembly().GetManifestResourceStream($"WolvenKit.App.Resources.{file.SelectedFile.Template}").NotNull();
@@ -931,8 +935,10 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
                     stream = File.Create(file.FullPath);
                 }
                 break;
+            }
             case EWolvenKitFile.RedScript:
             case EWolvenKitFile.CETLua:
+            {
                 //prep the subdirs
                 var scriptDirName = Path.GetDirectoryName(file.FullPath).NotNull();
                 Directory.CreateDirectory(scriptDirName);
@@ -947,6 +953,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
                     stream = File.Create(file.FullPath);
                 }
                 break;
+            }  
             case EWolvenKitFile.Cr2w:
                 var redType = file.SelectedFile.Name;
                 if (!string.IsNullOrEmpty(redType))

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -895,31 +895,28 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     [RelayCommand]
     private void CreateTXLOverride()
     {
-        var txl = GetTXL();
-        var saveFileDialog = new SaveFileDialog
+        if (_projectManager.ActiveProject is null)
         {
-            Filter = "YAML files (*.yaml; *.yml)|*.yaml;*.yml|All files (*.*)|*.*",
-            FilterIndex = 1,
-            FileName = $"{txl.ID.ResolvedText}.yaml",
-            InitialDirectory = _projectManager.ActiveProject?.ResourcesDirectory
-        };
-
-        if (saveFileDialog.ShowDialog() == true)
-        {
-            try
-            {
-                var yaml = GetTXLString(txl);
-
-                using var stream = saveFileDialog.OpenFile();
-                stream.Write(yaml.ToCharArray().Select(c => (byte)c).ToArray());
-
-                _loggerService.Success($"TweakXL YAML written for {txl.ID.ResolvedText}.");
-            }
-            catch (Exception ex)
-            {
-                _loggerService.Error(ex);
-            }
+            return;
         }
+
+        var txl = GetTXL();
+        var dir = Path.Combine(_projectManager.ActiveProject.ResourcesDirectory, "r6", "tweaks", _projectManager.ActiveProject.Name);
+        var path = Path.Combine(dir, $"{txl.ID.ResolvedText}.yaml");
+
+        try
+        {
+            var yaml = GetTXLString(txl);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(path, yaml);
+
+            _loggerService.Success($"TweakXL YAML written for {txl.ID.ResolvedText}.");
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
+        
     }
 
     public bool CanBeDroppedOn(ChunkViewModel target) => PropertyType == target.PropertyType;

--- a/WolvenKit.App/ViewModels/Tools/TweakBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/TweakBrowserViewModel.cs
@@ -14,6 +14,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SharpDX.Win32;
 using WolvenKit.App.Factories;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Models;
@@ -332,6 +333,10 @@ public partial class TweakBrowserViewModel : ToolViewModel
         {
             return;
         }
+        if (_projectManager.ActiveProject is null)
+        {
+            return;
+        }
 
         var txl = new TweakXL
         {
@@ -347,35 +352,27 @@ public partial class TweakBrowserViewModel : ToolViewModel
 
         var txlFile = new TweakXLFile { txl };
 
-        Stream myStream;
-        var saveFileDialog = new Microsoft.Win32.SaveFileDialog
+        var dir = Path.Combine(_projectManager.ActiveProject.ResourcesDirectory, "r6", "tweaks", _projectManager.ActiveProject.Name);
+        var path = Path.Combine(dir, $"{SelectedRecordEntry.DisplayName}.yaml");
+        var serializer = new SerializerBuilder()
+                 .WithTypeConverter(new TweakXLYamlTypeConverter(_locKeyService, _tweakDB))
+                 .WithIndentedSequences()
+                 .Build();
+
+        try
         {
-            Filter = "YAML files (*.yaml; *.yml)|*.yaml;*.yml|All files (*.*)|*.*",
-            FilterIndex = 1,
-            FileName = $"{SelectedRecordEntry.DisplayName}.yaml",
-            InitialDirectory = _projectManager.ActiveProject?.ResourcesDirectory
-        };
+            var yaml = serializer.Serialize(txlFile);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(path, yaml);
 
-        if (saveFileDialog.ShowDialog() == true)
-        {
-            if ((myStream = saveFileDialog.OpenFile()) is not null)
-            {
-                var serializer = new SerializerBuilder()
-                    .WithTypeConverter(new TweakXLYamlTypeConverter(_locKeyService, _tweakDB))
-                    .WithIndentedSequences()
-                    .Build();
-
-                var yaml = serializer.Serialize(txlFile);
-                myStream.Write(yaml.ToCharArray().Select(c => (byte)c).ToArray());
-                myStream.Close();
-
-                _loggerService.Success($"{SelectedRecordEntry.DisplayName} TweakXL written to: {saveFileDialog.FileName}");
-            }
-            else
-            {
-                _loggerService.Error($"Could not open file: {saveFileDialog.FileName}");
-            }
+            _loggerService.Success($"{SelectedRecordEntry.DisplayName} TweakXL written to: {path}");
         }
+        catch (Exception ex)
+        {
+            _loggerService.Error($"Failed to create TweakXL yaml. Error: {ex}");
+            throw;
+        }
+        
     }
 
     #endregion


### PR DESCRIPTION
# standardize tweaks and scripts in resources folder

this is a small project change so PR

Fixed:
- tweaks and scripts now nest the same under project/resources
- "override tweaks" now just creates the file and no save file dialogue

<Additional notes>
closes #1296