### PR TITLE
Fix: .anims Export and Import

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,8 +56,8 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="SharpDX.Direct3D11" Version="4.2.0" />
-    <PackageVersion Include="SharpGLTF.Core" Version="1.0.0-alpha0023" />
-    <PackageVersion Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0023" />
+    <PackageVersion Include="SharpGLTF.Core" Version="1.0.0-alpha0030" />
+    <PackageVersion Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0030" />
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.1" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Splat" Version="14.6.8" />

--- a/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using Quat = System.Numerics.Quaternion;
+using Vec3 = System.Numerics.Vector3;
+
+namespace WolvenKit.Modkit.RED4.Animation
+{
+    internal static class Const
+    {
+        // Current ceil *30 doesn't get every single one of the vanilla
+        // frame counts right, but neither did this.
+        //
+        public const double FramesPerDurationSecondArtisanallyCrafted = 30.1846575;
+
+        public const double FramesPerDurationSecond = 30.0;
+        public static Func<double, uint> FramesToAccommodateDuration = (duration) =>
+             (uint)Math.Ceiling(duration * FramesPerDurationSecond);
+    }
+
+    internal static class Fun
+    {
+        public static Vec3 TRVectorZup(Vec3 v) => new(v.X, -v.Z, v.Y);
+        public static Vec3 TRVectorYup(Vec3 v) => new(v.X, v.Z, -v.Y);
+
+        // NB scale is not affected by handedness
+        public static Vec3 SVectorZup(Vec3 v) => new(v.X, v.Z, v.Y);
+        public static Vec3 SVectorYup(Vec3 v) => new(v.X, v.Y, v.Z);
+
+        public static Quat RQuaternionZup(Quat q) => new(q.X, -q.Z, q.Y, q.W);
+        public static Quat RQuatYup(Quat q) => new(q.X, q.Z, -q.Y, q.W);
+    }
+
+    internal static class Gltf
+    {
+        // JSON stuffs..
+        public const string SchemaType = "wkit.cp2077.gltf.anims";
+        public const uint SchemaVersion = 2;
+
+        public static Func<Schema> CurrentSchema = () => new(SchemaType, SchemaVersion);
+        public static Func<AnimationExtrasForGltf, bool> IsSchemaVersionCompatible = (extras) =>
+            extras.Schema.Type == SchemaType && extras.Schema.Version == SchemaVersion;
+
+        public static Func<JsonSerializerOptions> SerializationOptions = () =>
+            new()
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            };
+    }
+
+    internal readonly record struct Schema(
+        string Type,
+        uint Version
+    );
+
+    internal readonly record struct AnimTrackKeySerializable(
+        ushort TrackIndex,
+        float Time,
+        float Value
+    );
+
+    internal readonly record struct AnimConstTrackKeySerializable(
+        ushort TrackIndex,
+        float Time,
+        float Value
+    );
+
+    // TODO: maybe explicit constructor for explicit defaults?
+    internal readonly record struct AnimationExtrasForGltf(
+        Schema Schema,
+        string AnimationType,
+        bool FrameClamping,
+        short FrameClampingStartFrame,
+        short FrameClampingEndFrame,
+        bool PreferLosslessLinearRotationEncoding,
+        byte NumExtraJoints,
+        byte NumeExtraTracks,
+        List<AnimConstTrackKeySerializable> ConstTrackKeys,
+        List<AnimTrackKeySerializable> TrackKeys,
+        List<ushort> FallbackFrameIndices
+    );
+}

--- a/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
@@ -26,6 +26,7 @@ namespace WolvenKit.Modkit.RED4.GeneralStructs
         public Quaternion[]? AposeLSRot;
         public Vector3[]? AposeLSScale;
         public int baseTendencyCount;
+        public float[]? ReferenceTracks;
     }
     public class MeshesInfo
     {

--- a/WolvenKit.Modkit/RED4/Tools/RigTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/RigTools.cs
@@ -28,6 +28,8 @@ namespace WolvenKit.Modkit.RED4.RigFile
                 LocalPosn = animRig.BoneTransforms.Select(p => new Vec3(p.Translation.X, p.Translation.Z, -p.Translation.Y)).ToArray(),
                 LocalRot = animRig.BoneTransforms.Select(p => new Quat(p.Rotation.I, p.Rotation.K, -p.Rotation.J, p.Rotation.R)).ToArray(),
                 LocalScale = animRig.BoneTransforms.Select(p => new Vec3(p.Scale.X, p.Scale.Y, p.Scale.Z)).ToArray(),
+
+                ReferenceTracks = animRig.ReferenceTracks.Select(_ => (float)_).ToArray(),
             };
 
             // if AposeWorld/AposeMS Exists then..... this can be done better i guess...
@@ -167,7 +169,8 @@ namespace WolvenKit.Modkit.RED4.RigFile
                 LocalScale = localScale.ToArray(),
                 LocalRot = localRot.ToArray(),
                 AposeLSExits = false,
-                AposeMSExits = false
+                AposeMSExits = false,
+                ReferenceTracks = Array.Empty<float>(),
             };
 
             return combinedRig;


### PR DESCRIPTION
## Summary

Basic support for all motion animation export/import. There's very likely a lot of work left to support all cases.

- Fixed data decoding/encoding of `.anims` buffers
- Added decoding/encoding for track information from the buffer
- Added track and other non-buffer animation data to GLTF encoded into the `extra` field (there isn't really any way to represent it in the standard `animations` format.)

## Testing

Only manually validated on a limited set of `.anims`

## BREAKING

Previously exported `.anims` contain incorrect/incomplete data. Need to see about a migration path, unless it's ~trivial to fix it on the Blender side and/or using new buffer logic 

## Known Issues

- All `.anims` data isn't exported yet
- Root Motion not reimported
- Only existing animations can be edited

Additional work tracked in #1425

## Dependencies

Probably needs work in the Blender plugin just to work, and definitely to use new capabilities.

## Fixed

Closes #1403 