### PR TITLE
.mesh: improved a few descriptors

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -308,11 +308,24 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     preload.Properties[meshMaterialEntry.Index].CalculateValue();
                 }
             }
-            // if we were an external material instance without a descriptor because we haven't been unique
-            else if (Parent.Data is CResourceAsyncReference<IMaterial> && (Descriptor ?? "").Length == 0)
+            // if we were an external material instance without a descriptor because we haven't been unique, update all
+            else if (
+                Parent.Data is CResourceAsyncReference<IMaterial>
+                || Data is CResourceAsyncReference<IMaterial>
+            )
             {
                 CalculateDescriptor();
-                CalculateValue();
+                Parent.CalculateDescriptor();
+            }
+            else if (Data is CName && Parent.Data is IRedArray && Parent.Parent?.ResolvedData is meshMeshAppearance)
+            {
+                Parent.Parent?.CalculateValue();
+            }
+
+            // if we were an external material instance without a descriptor because we haven't been unique, update all
+            if (Data is CResourceAsyncReference<IMaterial>)
+            {
+                Parent.RecalculateProperties();
             }
 
             if (Parent.IsValueExtrapolated)
@@ -2017,7 +2030,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             {
                 for (var i = 0; i < arr.Count; i++)
                 {
-                    if (ReferenceEquals(arr[i], ResolvedData)
+                    if (!ReferenceEquals(arr[i], Data)
                         || (isExternal && arr[i]?.GetHashCode() != ResolvedData.GetHashCode()))
                     {
                         continue;

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -16,7 +16,7 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
-            <Style x:Key="PropertyValueStyle" TargetType="TextBlock">
+            <Style x:Key="PropertyKeyStyle" TargetType="TextBlock">
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="null">
                         <Setter Property="Foreground" Value="{StaticResource Border}" />
@@ -27,6 +27,28 @@
                     </DataTrigger>
                     <DataTrigger Binding="{Binding IsReadOnly}" Value="True">
                         <Setter Property="Foreground" Value="{StaticResource WolvenKitTan50}" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="PropertyValueStyle" TargetType="TextBlock">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                 Value="null">
+                        <Setter Property="Foreground" Value="{StaticResource Border}" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                 Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource BorderAlt2}" />
+                        <Setter Property="FontStyle" Value="Italic" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsReadOnly}" Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource WolvenKitTan50}" />
+                    </DataTrigger>
+                    <DataTrigger
+                        Binding="{Binding IsValueExtrapolated, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                        Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource BorderAlt2}" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
@@ -162,7 +184,7 @@
                         <TextBlock
                             Name="PropertyDescriptor"
                             Margin="0,0,4,2"
-                            Style="{StaticResource PropertyValueStyle}"
+                            Style="{StaticResource PropertyKeyStyle}"
                             Text="{Binding Descriptor, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                             TextTrimming="CharacterEllipsis" />
                         <TextBlock


### PR DESCRIPTION
# Changed a bunch of descriptors in .mesh files

Appearances: will list chunk materials 
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/6c22b7cc-73a8-4048-bb44-599feb65f748)

CMaterialInstances (local materials): Will show name and base material
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/20a34922-5086-46ee-ac3f-a7ffe8471061)

External materials: Will show name and base material 
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/54a351da-cc48-4e2e-9c7b-639f5836df92)

Values (CKeyValuePairs): Will show key and value now: 
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/1869dfc5-bd4d-464b-ac30-8ed2666b67b1)