### PR TITLE
Asset Browser: Extract from Specific Archive and Load Order

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -29,6 +29,7 @@ using WolvenKit.Common.Services;
 using WolvenKit.Core.Extensions;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Core.Services;
+using WolvenKit.RED4.Archive;
 
 namespace WolvenKit.App.ViewModels.Tools;
 
@@ -208,6 +209,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     [NotifyCanExecuteChangedFor(nameof(BrowseToFolderCommand))]
     [NotifyCanExecuteChangedFor(nameof(OpenFileOnlyCommand))]
     [NotifyCanExecuteChangedFor(nameof(CopyRelPathCommand))]
+    [NotifyPropertyChangedFor(nameof(AddFromArchiveItems))]
     private IFileSystemViewModel? _rightSelectedItem;
 
     [ObservableProperty]
@@ -224,6 +226,9 @@ public partial class AssetBrowserViewModel : ToolViewModel
 
     [ObservableProperty] 
     private string? _optionsSearchBarText;
+
+    [ObservableProperty]
+    private ObservableCollectionEx<IGameArchive> _addFromArchiveItems = new();
 
     #endregion properties
 
@@ -378,6 +383,20 @@ public partial class AssetBrowserViewModel : ToolViewModel
         });
 
         _progressService.IsIndeterminate = false;
+    }
+
+    public void UpdateSearchInArchives()
+    {
+        if (RightSelectedItem is RedFileViewModel file)
+        {
+            AddFromArchiveItems.Clear();
+
+            var archives = _archiveManager.Archives.Items.Where(_ => _.Files.ContainsKey(file.GetGameFile().Key));
+            foreach (var archive in archives)
+            {
+                AddFromArchiveItems.Add(archive);
+            }
+        }
     }
 
     /// <summary>

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -446,20 +446,20 @@ namespace WolvenKit.RED4.CR2W.Archive
             legacyFiles.Sort(string.CompareOrdinal);
             legacyFiles.Reverse();
 
-            // load REDmod mods first
-            foreach (var file in redModFiles)
-            {
-                LoadModArchive(file, analyzeFiles);
-            }
-
-            // load legacy mods in "modlist.txt" second
+            // load legacy mods in "modlist.txt"
             foreach (var file in legacyModTxtFiles)
             {
                 LoadModArchive(file, analyzeFiles);
             }
 
-            // finally, legacy mods that aren't in "modlist.txt"
+            // legacy mods that aren't in "modlist.txt" next
             foreach (var file in legacyFiles)
+            {
+                LoadModArchive(file, analyzeFiles);
+            }
+            
+            // load REDmod mods last
+            foreach (var file in redModFiles)
             {
                 LoadModArchive(file, analyzeFiles);
             }

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -158,12 +158,12 @@ namespace WolvenKit.RED4.CR2W.Archive
                 return;
             }
 
-            var redModFolder = archivedir.Name.Contains(Path.DirectorySeparatorChar + "mods" + Path.DirectorySeparatorChar);
+            var redModFolder = archiveDir.Name.Contains(Path.DirectorySeparatorChar + "mods" + Path.DirectorySeparatorChar);
 
             IsManagerLoading = true;
 
             // TODO: this will still load things in sub-directories beyond "archive" for REDMod mods
-            var archiveFiles = Directory.GetFiles(archivedir.FullName, "*.archive",
+            var archiveFiles = Directory.GetFiles(archiveDir.FullName, "*.archive",
                 new EnumerationOptions { RecurseSubdirectories = redModFolder}).ToList();
 
             archiveFiles.Sort(CompareArchives);

--- a/WolvenKit/Converters/IGameArchiveToMenuItemStringConverter.cs
+++ b/WolvenKit/Converters/IGameArchiveToMenuItemStringConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using WolvenKit.Core.Interfaces;
+
+namespace WolvenKit.Converters;
+public class IGameArchiveToMenuItemStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is IGameArchive archive)
+        {
+            if (!archive.Name.Contains('_'))
+            {
+                return archive.Name;
+            }
+            else
+            {
+                return archive.Name.Replace("_", "__");
+            }
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+}

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -2,7 +2,7 @@
     x:Class="WolvenKit.Views.Tools.AssetBrowserView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters1="clr-namespace:WolvenKit.Converters"
+    xmlns:converters="clr-namespace:WolvenKit.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
@@ -106,8 +106,6 @@
                         SearchStarted="FileSearchBar_SearchStarted"
                         ShowClearButton="False"
                         Style="{StaticResource SearchBarPlus}" />
-
-
                 </Grid>
 
                 <syncfusion:Splitter Grid.Row="1" Background="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}" />
@@ -125,7 +123,7 @@
                     <Grid Grid.Column="0" Margin="0">
 
                         <Grid.Resources>
-                            <converters1:ExtensionToImageConverter x:Key="ExtensionToImageConverter" />
+                            <converters:ExtensionToImageConverter x:Key="ExtensionToImageConverter" />
                             <DataTemplate x:Key="TemplateToolTip">
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -140,7 +138,6 @@
                         </Grid.Resources>
 
                         <!--  Folder Tree  -->
-                        <!--  RequestTreeItems="LeftNavigation_RequestTreeItems"  -->
                         <syncfusion:SfTreeGrid
                             x:Name="LeftNavigation"
                             Margin="0"
@@ -223,7 +220,6 @@
                             <syncfusion:SfTreeGrid.ExpanderContextMenu>
                                 <ContextMenu>
                                     <MenuItem Click="Expand_OnClick" Header="Expand" />
-                                    <!--<MenuItem Click="ExpandAll_OnClick" Header="Expand all" />-->
                                     <MenuItem Click="Collapse_OnClick" Header="Collapse" />
                                     <MenuItem Click="CollapseAll_OnClick" Header="Collapse all" />
                                 </ContextMenu>
@@ -266,6 +262,9 @@
 
                             <syncfusion:SfDataGrid.RecordContextMenu>
                                 <ContextMenu>
+                                    <ContextMenu.Resources>
+                                        <converters:IGameArchiveToMenuItemStringConverter x:Key="IGameArchiveToMenuItemStringConverter" />
+                                    </ContextMenu.Resources>
                                     <MenuItem
                                         x:Name="AddSelected"
                                         Header="Add selected items to project"
@@ -277,6 +276,18 @@
                                                 Foreground="{StaticResource WolvenKitYellow}"
                                                 Kind="ArrowCircleLeft" />
                                         </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem
+                                        x:Name="AddFromArchive"
+                                        Header="Add selected from archive"
+                                        Visibility="{Binding Path=DataGrid.DataContext.ProjectLoaded, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        ItemsSource="{Binding Path=DataGrid.DataContext.AddFromArchiveItems}">
+                                        <MenuItem.ItemContainerStyle>
+                                            <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                                                <Setter Property="Header" Value="{Binding Path=DataContext, RelativeSource={RelativeSource Self}, Converter={StaticResource IGameArchiveToMenuItemStringConverter}}"/>
+                                                <Setter Property="Command" Value="{Binding Path=AddFromSelectedArchiveItem_Click}" />
+                                            </Style>
+                                        </MenuItem.ItemContainerStyle>
                                     </MenuItem>
                                     <Separator Visibility="{Binding Path=DataGrid.DataContext.ProjectLoaded, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <MenuItem x:Name="OpenFileOnly" Header="Open without adding to project">
@@ -316,7 +327,7 @@
                                     <Setter Property="Padding" Value="0,0,0,2" />
                                 </Style>
 
-                                <converters1:ExtensionToBitmapConverter x:Key="ExtensionToBmp" />
+                                <converters:ExtensionToBitmapConverter x:Key="ExtensionToBmp" />
 
                                 <DataTemplate x:Key="TemplateToolTip">
                                     <TextBlock Text="{Binding FullName}" />

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -285,7 +285,8 @@
                                         <MenuItem.ItemContainerStyle>
                                             <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
                                                 <Setter Property="Header" Value="{Binding Path=DataContext, RelativeSource={RelativeSource Self}, Converter={StaticResource IGameArchiveToMenuItemStringConverter}}"/>
-                                                <Setter Property="Command" Value="{Binding Path=AddFromSelectedArchiveItem_Click}" />
+                                                <Setter Property="Command" Value="{Binding Path=DataContext.AddFromArchiveCommand, RelativeSource={RelativeSource AncestorType={x:Type syncfusion:SfDataGrid}}}" /> <!--Mode=FindAncestor, AncestorType={x:Type MenuItem}-->
+                                                <Setter Property="CommandParameter" Value="{Binding Path=DataContext, RelativeSource={RelativeSource Self}}"/>
                                             </Style>
                                         </MenuItem.ItemContainerStyle>
                                     </MenuItem>

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -66,7 +66,6 @@ namespace WolvenKit.Views.Tools
                         viewModel => viewModel.RightSelectedItem,
                         view => view.RightFileView.SelectedItem)
                     .DisposeWith(disposables);
-
                 this.BindCommand(ViewModel,
                         viewModel => viewModel.FindUsesCommand,
                         view => view.RightContextMenuFindUsesMenuItem)
@@ -83,7 +82,6 @@ namespace WolvenKit.Views.Tools
                       viewModel => viewModel.CopyRelPathCommand,
                       view => view.RightContextMenuCopyPathMenuItem)
                   .DisposeWith(disposables);
-
                 this.BindCommand(ViewModel,
                       viewModel => viewModel.OpenFileOnlyCommand,
                       view => view.OpenFileOnly)
@@ -92,6 +90,9 @@ namespace WolvenKit.Views.Tools
                       viewModel => viewModel.AddSelectedCommand,
                       view => view.AddSelected)
                   .DisposeWith(disposables);
+                this.BindCommand(ViewModel,
+                    viewModel => viewModel.AddFromArchiveCommand,
+                    view => view.AddFromArchive);
 
                 LeftNavigation.KeyUp += LeftNavigation_KeyDown;
             });
@@ -263,9 +264,9 @@ namespace WolvenKit.Views.Tools
             vm.UpdateSearchInArchives();
         }
 
-        private void AddFromSelectedArchiveItem_Click(object sender, RoutedEventArgs e)
-        {
-        }
+        //private void AddFromSelectedArchiveItem_Click(object sender, RoutedEventArgs e)
+        //{
+        //}
 
         private void RightFileView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -259,6 +259,12 @@ namespace WolvenKit.Views.Tools
             var propertiesViewModel = Locator.Current.GetService<PropertiesViewModel>();
 
             propertiesViewModel.ExecuteSelectFile(vm.RightSelectedItem);
+
+            vm.UpdateSearchInArchives();
+        }
+
+        private void AddFromSelectedArchiveItem_Click(object sender, RoutedEventArgs e)
+        {
         }
 
         private void RightFileView_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)


### PR DESCRIPTION
### Please check the order. I swear no one has a real clue what the actual order is and we always get different answers. Maybe @psiberx knows 😅 

Updates the asset browser to support pulling files from specific archives (including mod archives). Also will sort the mod browser by the (a?) load order to show the first loaded files up top. This also includes support for `modlist.txt` in `archive/pc/mod` and REDmod mods. No support for REDmod `modlist.txt` as of this update. See example image.

![image](https://github.com/WolvenKit/WolvenKit/assets/931177/ee32422b-4f95-4969-a63e-15fe358e1e6f)
