### PR TITLE
Multi mesh materials

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -355,6 +355,7 @@ namespace WolvenKit.Modkit.RED4
             var matData = new MatData(matRepo, rawMaterials, texturesList, matTemplates, info.appearances);
 
             return matData;
+
             void ExtractFile(string path)
             {
                 if (string.IsNullOrEmpty(path))

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -213,7 +213,7 @@ namespace WolvenKit.Modkit.RED4.Tools
             return true;
         }
 
-        public static MeshesInfo GetMeshesinfo(rendRenderMeshBlob rendMeshBlob, CMesh? cMesh = null)
+        public static MeshesInfo GetMeshesinfo(rendRenderMeshBlob rendMeshBlob, CMesh? cMesh = null, string meshname="")
         {
             var meshesInfo = new MeshesInfo(rendMeshBlob.Header.RenderChunkInfos.Count);
             var redQuantScale = rendMeshBlob.Header.QuantizationScale;
@@ -349,7 +349,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                         ArgumentNullException.ThrowIfNull(m);
                         materialNames[e] = m;
                     }
-                    meshesInfo.appearances.Add(app.Name + $"{i}", materialNames);
+                    meshesInfo.appearances.Add(Path.GetFileNameWithoutExtension(meshname) + '_' + app.Name + $"{i}", materialNames);
                 }
             }
 
@@ -568,7 +568,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                 meshContainer.materialNames = new string[info.appearances.Count];
 
                 
-                var Mesh_apps = info.appearances.Keys.Select(key => Path.GetFileNameWithoutExtension(meshname)+'_' + key).ToList();
+                //var Mesh_apps = info.appearances.Keys.Select(key => Path.GetFileNameWithoutExtension(meshname)+'_' + key).ToList();
 
                 var apps = info.appearances.Keys.ToList();
 
@@ -576,7 +576,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                 {
                     // Null-proof materials
                     var d = info.appearances[apps[e]];
-                    info.appearances[Mesh_apps[e]] = InitializeDefaultMaterial(info.meshCount, d.NotNull());
+                    info.appearances[apps[e]] = InitializeDefaultMaterial(info.meshCount, d.NotNull());
                     meshContainer.materialNames[e] = d[index];
                 }
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -349,7 +349,14 @@ namespace WolvenKit.Modkit.RED4.Tools
                         ArgumentNullException.ThrowIfNull(m);
                         materialNames[e] = m;
                     }
-                    meshesInfo.appearances.Add(Path.GetFileNameWithoutExtension(meshname) + '_' + app.Name + $"{i}", materialNames);
+                    if (meshname.Length > 0)
+                    {
+                        meshesInfo.appearances.Add(Path.GetFileNameWithoutExtension(meshname) + '_' + app.Name + $"{i}", materialNames);
+                    }
+                    else
+                    {
+                        meshesInfo.appearances.Add( app.Name + $"{i}", materialNames);
+                    }
                 }
             }
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -355,7 +355,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             return meshesInfo;
         }
-        public static List<RawMeshContainer> ContainRawMesh(MemoryStream gfs, MeshesInfo info, bool lodFilter, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false)
+        public static List<RawMeshContainer> ContainRawMesh(MemoryStream gfs, MeshesInfo info, bool lodFilter, ulong chunkMask = ulong.MaxValue, bool mergeMeshes = false, string meshname="")
         {
             ArgumentNullException.ThrowIfNull(info.appearances, nameof(info));
 
@@ -550,19 +550,33 @@ namespace WolvenKit.Modkit.RED4.Tools
                     meshContainer.indices[i] = gbr.ReadUInt16();
                 }
 
+                if (meshname.Length>0)
+                {
+                    meshContainer.name = mergeMeshes ?
+                                        info.appearances.Keys.FirstOrDefault("default") :
+                                        Path.GetFileNameWithoutExtension(meshname)+"_submesh_" + Convert.ToString(index).PadLeft(2, '0') + "_LOD_" + info.LODLvl[index];
 
-                meshContainer.name = mergeMeshes ?
-                    info.appearances.Keys.FirstOrDefault("default") :
-                    "submesh_" + Convert.ToString(index).PadLeft(2, '0') + "_LOD_" + info.LODLvl[index];
+                }
+                else
+                {
+                    meshContainer.name = mergeMeshes ?
+                                        info.appearances.Keys.FirstOrDefault("default") :
+                                        "submesh_" + Convert.ToString(index).PadLeft(2, '0') + "_LOD_" + info.LODLvl[index];
+                }
+                
 
                 meshContainer.materialNames = new string[info.appearances.Count];
+
+                
+                var Mesh_apps = info.appearances.Keys.Select(key => Path.GetFileNameWithoutExtension(meshname)+'_' + key).ToList();
+
                 var apps = info.appearances.Keys.ToList();
 
                 for (var e = 0; e < apps.Count; e++)
                 {
                     // Null-proof materials
                     var d = info.appearances[apps[e]];
-                    info.appearances[apps[e]] = InitializeDefaultMaterial(info.meshCount, d.NotNull());
+                    info.appearances[Mesh_apps[e]] = InitializeDefaultMaterial(info.meshCount, d.NotNull());
                     meshContainer.materialNames[e] = d[index];
                 }
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -795,7 +795,7 @@ namespace WolvenKit.Modkit.RED4
 
                 using var ms = new MemoryStream(rendblob.RenderBuffer.Buffer.GetBytes());
 
-                var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
+                var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh, meshStream.Value);
 
                 var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter,  ulong.MaxValue,  false, meshStream.Value );
                 MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream.Key, cr2w);

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -785,9 +785,9 @@ namespace WolvenKit.Modkit.RED4
 
             var expMeshes = new List<RawMeshContainer>();
             var matData = new List<MatData>();
-            foreach (var meshStream in meshStreamS.Keys)
+            foreach (var meshStream in meshStreamS)
             {
-                var cr2w = _parserService.ReadRed4File(meshStream);
+                var cr2w = _parserService.ReadRed4File(meshStream.Key);
                 if (cr2w == null || cr2w.RootChunk is not CMesh cMesh || cMesh.RenderResourceBlob == null || cMesh.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendblob)
                 {
                     continue;
@@ -797,14 +797,14 @@ namespace WolvenKit.Modkit.RED4
 
                 var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh);
 
-                var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter);
-                MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
+                var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter,  ulong.MaxValue,  false, meshStream.Value );
+                MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream.Key, cr2w);
 
                 MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh, meshExportArgs.ExportGarmentSupport);
 
                 var meshRig = MeshTools.GetOrphanRig(cMesh);
 
-                MeshTools.UpdateMeshJoints(ref Meshes, expRig, meshRig, meshStreamS[meshStream]);
+                MeshTools.UpdateMeshJoints(ref Meshes, expRig, meshRig, meshStreamS[meshStream.Key]);
 
                 if (meshExportArgs.withMaterials)
                 {
@@ -813,13 +813,13 @@ namespace WolvenKit.Modkit.RED4
                         _loggerService.Error("Depot path is not set: Choose a Depot location within Settings for generating materials.");
                         return false;
                     }
-                    matData.Add(SetupMaterial(cr2w, meshStream, meshExportArgs.Archives, meshExportArgs.MaterialRepo, meshesinfo, meshExportArgs.MaterialUncookExtension));
+                    matData.Add(SetupMaterial(cr2w, meshStream.Key, meshExportArgs.Archives, meshExportArgs.MaterialRepo, meshesinfo, meshExportArgs.MaterialUncookExtension));
                 }
 
                 expMeshes.AddRange(Meshes);
 
-                meshStream.Dispose();
-                meshStream.Close();
+                meshStream.Key.Dispose();
+                meshStream.Key.Close();
             }
             var model = MeshTools.RawMeshesToGLTF(expMeshes, expRig, withMaterials: meshExportArgs.withMaterials);
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -798,7 +798,7 @@ namespace WolvenKit.Modkit.RED4
                 var meshesinfo = MeshTools.GetMeshesinfo(rendblob, cr2w.RootChunk as CMesh, meshName);
 
                 var Meshes = MeshTools.ContainRawMesh(ms, meshesinfo, meshExportArgs.LodFilter,  ulong.MaxValue,  false, meshName);
-                MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream.Key, cr2w);
+                MeshTools.UpdateSkinningParamCloth(ref Meshes, meshStream, cr2w);
 
                 MeshTools.WriteGarmentParametersToMesh(ref Meshes, cMesh, meshExportArgs.ExportGarmentSupport);
 

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -804,7 +804,7 @@ namespace WolvenKit.Modkit.RED4
 
                 var meshRig = MeshTools.GetOrphanRig(cMesh);
 
-                MeshTools.UpdateMeshJoints(ref Meshes, expRig, meshRig, meshStreamS[meshStream]);
+                MeshTools.UpdateMeshJoints(ref Meshes, expRig, meshRig, meshName);
 
                 if (meshExportArgs.withMaterials)
                 {


### PR DESCRIPTION
Multimesh Material JSON Appearance fix
Implemented:
- added the mesh names to the submeshes rather than just the numerical prefix (only on multimesh)
- added the mesh names to the appearances in the material json so that if multimesh import has 2 meshes with the same named appearances both still get imported.

Fixed:
- Materials being available for multimesh output

<Additional notes>
Still need to do a bit of work on the Blender side to make appearance selection work, as they dont have the same name the app file has for them (but I'm not sure this has worked previously either)

