### PR TITLE
Fix retrieved plugin version might be unstable version

### DIFF
--- a/WolvenKit.App/Services/PluginService.cs
+++ b/WolvenKit.App/Services/PluginService.cs
@@ -261,8 +261,7 @@ public partial class PluginService : ObservableObject, IPluginService
             IEnumerable<Octokit.ReleaseAsset> asset = new List<Octokit.ReleaseAsset>();
             try
             {
-                var releases = await ghClient.Repository.Release.GetAll(id.GetUrl().Split('/').First(), id.GetUrl().Split('/').Last());
-                var latest = releases[0];
+                var latest = await ghClient.Repository.Release.GetLatest(id.GetUrl().Split('/').First(), id.GetUrl().Split('/').Last());
                 var assets = latest.Assets.ToList();
                 asset = assets.Where(x => Regex.IsMatch(x.Name, id.GetFile()));
             }


### PR DESCRIPTION
Fix retrieved plugin version might be unstable version

Fixed:
- Retrieved plugin versions are now the latest stable version

The plugin version installed are the last published, as opposed to the latest stable version released. This is an issue with Redscript which has newer, but unstable and incompatible versions.

Fixes #1476 