### PR TITLE
script manager: hiding internal (library + helper) script files

### DIFF
--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -104,6 +104,11 @@ public partial class ScriptService : ObservableObject
         return engine;
     }
 
+    /// <summary>
+    /// Exclude files including these partials from script manager's view
+    /// </summary>
+    private static readonly string[] s_hideFromScriptManager = { "\\Internal\\", "Helper.wscript", "Logger.wscript" };
+    
     public virtual IList<ScriptFile> GetScripts(string path)
     {
         var result = new List<ScriptFile>();
@@ -129,7 +134,7 @@ public partial class ScriptService : ObservableObject
 
         // hide Wolvenkit's internal logic from the script manager, there's no reason to run Logger.wscript or Mesh_Helper.wscript
         return result
-            .Where((file) => !file.Path.Contains("\\Internal\\") && !file.Path.Contains("Helper.wscript"))
+            .Where(file => s_hideFromScriptManager.All(exclude => !file.Path.Contains(exclude)))
             .ToArray();
     }
 }

--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.ClearScript;
@@ -123,10 +124,12 @@ public partial class ScriptService : ObservableObject
             {
                 _scriptCache.TryAdd(file, new ScriptFile(file));
             }
-
             result.Add(_scriptCache[file]);
         }
 
-        return result;
+        // hide Wolvenkit's internal logic from the script manager, there's no reason to run Logger.wscript or Mesh_Helper.wscript
+        return result
+            .Where((file) => !file.Path.Contains("\\Internal\\") && !file.Path.Contains("Helper.wscript"))
+            .ToArray();
     }
 }


### PR DESCRIPTION
# Script manager: Hiding internal and helper scripts from run options

Users don't need to run Logger.wscript