### PR TITLE
Add text wrapping to String fields

### DIFF
--- a/WolvenKit/Views/Templates/RedStringEditor.xaml
+++ b/WolvenKit/Views/Templates/RedStringEditor.xaml
@@ -15,7 +15,7 @@
         <TextBox
             x:Name="TextBox"
             helpers:TextBoxBehavior.TripleClickSelectAll="True"
-            Text="{Binding Text, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+            Text="{Binding Text, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" TextWrapping="Wrap" />
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Implemented:
- turned on toggle to make string fields wrapped so that long pieces of text can be viewed in full when editing.

The use case for this feature is for when editing custom localization files in Wolvenkit. It's not easy to edit a large piece of text with only a small part of it showing at once. Editing the exported json files in a text editor can be difficult because of special characters like `\u003CRich color=\u0022TooltipText.cyberwareDescriptionHighlightColor\u0022 style=\u0022Semi-Bold\u0022\u003EFury\u003C/\u003E state`.

Here is an example before and after from `onscreens_final.json`:

Before:
![no_wrap](https://github.com/WolvenKit/WolvenKit/assets/15858718/dc4ad718-fa16-465c-8dec-9705179d89b8)

After:
![with_wrap](https://github.com/WolvenKit/WolvenKit/assets/15858718/ab2e3714-65f7-4f3c-a23c-eaa4345363a5)

### Testing:

- I tested editing and saving a localization value, which worked.
- Nothing visually looks wrong that I can see.
- I'm not familiar enough with the code to know if there are any likely side effects from this. Does this only affect string fields in `JsonResource`s?
