### PR TITLE
import settings: enable default transparency for UI icons

### DIFF
--- a/WolvenKit.Common/RED4/CommonFunctions.cs
+++ b/WolvenKit.Common/RED4/CommonFunctions.cs
@@ -268,7 +268,7 @@ public static class CommonFunctions
         }
 
         // what else could we possibly check for?
-        return fileName.Contains("decal");
+        return fileName.Contains("decal") || fileName.Contains("icon");
     }
 
 }


### PR DESCRIPTION
I initially created this method because I wanted it for my icon files, then forgot about it -.-