### PR TITLE
fix: Morphtarget Meshes Can Also Include GarmentSupport

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -167,7 +167,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Import Settings")]
         [Display(Name = "Import Garment Support (Experimental)")]
         [Description("If checked the Garment Support data will be imported from the mesh")]
-        public bool ImportGarmentSupport { get; set; } = false;
+        public bool ImportGarmentSupport { get; set; } = true;
 
         /// <summary>
         /// Selected Rig for Mesh WithRig Export. ALWAYS USE THE FIRST ENTRY IN THE LIST.

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -1737,7 +1737,7 @@ namespace WolvenKit.Modkit.RED4
             }
         }
 
-        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w, bool importGarmentSupport = false)
+        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w, bool importGarmentSupport = true)
         {
             if (importGarmentSupport && cr2w.RootChunk is CMesh cMesh)
             {

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -392,6 +392,8 @@ namespace WolvenKit.Modkit.RED4
                 }
             }
 
+            // GarmentSupport not accounted here. Might be an issue?
+            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1504 
             meshBlob.BoundingBox.Min = new Vector4 { X = min.X, Y = min.Y, Z = min.Z, W = 1f };
             meshBlob.BoundingBox.Max = new Vector4 { X = max.X, Y = max.Y, Z = max.Z, W = 1f };
 
@@ -521,6 +523,8 @@ namespace WolvenKit.Modkit.RED4
             return meshContainer;
         }
 
+        // TODO: https://github.com/WolvenKit/WolvenKit/issues/1505
+        // Maintaining compatibility but need to review if we really want to support empties via nodes
         private static RawMeshContainer GltfMeshToRawContainer(Node node)
         {
             if (node.Mesh == null)
@@ -528,12 +532,16 @@ namespace WolvenKit.Modkit.RED4
                 return CreateEmptyMesh(node.Name);
             }
 
-            var mesh = node.Mesh;
+            return GltfMeshToRawContainer(node.Mesh);
+        }
+
+        private static RawMeshContainer GltfMeshToRawContainer(Mesh mesh)
+        {
             var accessors = mesh.Primitives[0].VertexAccessors.Keys.ToList();
 
             var meshContainer = new RawMeshContainer
             {
-                name = node.Name,
+                name = mesh.Name,
 
                 // Copying PNT w/ RHS to LHS Y+ to Z+
                 positions = mesh.Primitives[0].GetVertices("POSITION").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),
@@ -651,6 +659,9 @@ namespace WolvenKit.Modkit.RED4
             }
 
             meshContainer.garmentMorph = Array.Empty<Vec3>();
+            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1506
+            //       Mesh Import Needs to Actually Check it's Working with GarmentSupport Targets.
+            //       For now we'll keep assuming GS is at index 0
             if (mesh.Primitives[0].MorphTargetsCount > 0)
             {
                 var idx = mesh.Primitives[0].GetMorphTargetAccessors(0).Keys.ToList().IndexOf("POSITION");


### PR DESCRIPTION
## Implemented

- `.morphtarget`s can include GarmentSupport data, i.e. they can (typically) shrink under clothing when GS is active
- GarmentSupport is checked by default for import for both `.mesh` and `.morphtarget` (it was already default on export)

NB: `GarmentSupport` *must* be first shapekey/target and let's require that naming too.

## Usage

General GarmentSupport guide [on the redmodding wiki](https://wiki.redmodding.org/cyberpunk-2077-modding/modding-know-how/3d-modelling/garment-support-how-does-it-work)

1. In Blender, create a shapekey named `GarmentSupport` for each submesh that you want to deform for GS, typically shrinking the mesh a bit so that it doesn't clip with tighter fits
2. Ensure `GarmentSupport` is the first shapekey (after `Basis`)
3. Include `_GARMENTSUPPORTWEIGHT` and `_GARMENTSUPPORTCAP` attributes
4. Blender-Export w/ the cp77 Blender plugin
5. Import into wkit with the garment support option checked (should be by default), first the `.mesh`, then the `.morphtarget` just like usual 

## Detes

Both morphtarget and GS data are encoded in glTF targets so we need to be careful which targets we use for which purposes.

## Issues/TODO

The following tickets still have relevant open questions or fixup/cleanup, but this is probably safe enough to test as is.

- [ ] #1504 
- [ ] #1505 
- [ ] #1506 