### PR TITLE
Option to Override Mesh Name with Node Name when Importing for Compatibility

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -99,6 +99,22 @@ namespace WolvenKit.Common.Model.Arguments
         private GltfImportAsFormat _importFormat = GltfImportAsFormat.Mesh;
 
         /// <summary>
+        /// Imports garment support data from GLB.
+        /// </summary>
+        [Category("Import Settings")]
+        [Display(Name = "Import Garment Support (Experimental)")]
+        [Description("If checked the Garment Support data will be imported from the mesh")]
+        public bool ImportGarmentSupport { get; set; } = true;
+
+        /// <summary>
+        /// Use object or node name as mesh name
+        /// </summary>
+        [Category("Import Settings")]
+        [Display(Name = "Use Object Name as Submesh Name (Compatibility)")]
+        [Description("If checked, each submesh name will be overridden by the node name (e.g. Blender object) to match previous behavior.")]
+        public bool OverrideMeshNameWithNodeName { get; set; } = false;
+
+        /// <summary>
         /// Should a Material.Json be imported?
         /// </summary>
         [Category("Import Settings")]
@@ -160,14 +176,6 @@ namespace WolvenKit.Common.Model.Arguments
         [Display(Name = "Contains LOD8 named LOD0")]
         [Description("If checked the included LOD0 submesh will be handled as LOD8")]
         public bool ReplaceLod { get; set; } = false;
-
-        /// <summary>
-        /// Imports garment support data from GLB.
-        /// </summary>
-        [Category("Import Settings")]
-        [Display(Name = "Import Garment Support (Experimental)")]
-        [Description("If checked the Garment Support data will be imported from the mesh")]
-        public bool ImportGarmentSupport { get; set; } = true;
 
         /// <summary>
         /// Selected Rig for Mesh WithRig Export. ALWAYS USE THE FIRST ENTRY IN THE LIST.

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -115,7 +115,7 @@ namespace WolvenKit.Modkit.RED4
             for (var i = 0; i < subMeshesCount; i++)
             {
                 var submesh = model.LogicalMeshes[i];
-                var rawMesh = GltfMeshToRawContainer(submesh);
+                var rawMesh = GltfMeshToRawContainer(submesh, args);
 
                 // Substitute whatever mesh import did with what we know to be the GarmentSupport (or none)
                 rawMesh.garmentMorph = garmentSupportPerSubmesh[i].Select(gs =>
@@ -125,7 +125,7 @@ namespace WolvenKit.Modkit.RED4
                 rawMeshes.Add(rawMesh);
             }
 
-            var rawMeshesSorted = rawMeshes.OrderBy(m => m.name).ToList();
+            var rawMeshesSorted = rawMeshes.OrderBy(r => r.name).ToList();
 
             // TODO: Calculated without GarmentSupport for now because that's what mesh import does
             // TODO: https://github.com/WolvenKit/WolvenKit/issues/1504 


### PR DESCRIPTION
To support older files without modders having to fix their mesh naming in Blender, new import option that forces using the node name (object name in Blender) instead of the actual mesh name.

![Screenshot 2024-01-18 082336](https://github.com/WolvenKit/WolvenKit/assets/13802421/1b4079d9-c379-4d88-ba91-a232231e1ba3)

There's a warning printed if the names don't match either way.

![Screenshot 2024-01-18 083313](https://github.com/WolvenKit/WolvenKit/assets/13802421/50d37502-119e-40d7-b1ab-d8cec70379e4)

## Breaking

- Error if a mesh is referenced by multiple nodes, unless someone comes up with a valid use case (in which case the entire import logic needs to be reviewed.)

closes #1519 