### PR TITLE
Mesh material name index fix

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -112,7 +112,7 @@ namespace WolvenKit.Common.Model.Arguments
         [Category("Import Settings")]
         [Display(Name = "Use Object Name as Submesh Name (Compatibility)")]
         [Description("If checked, each submesh name will be overridden by the node name (e.g. Blender object) to match previous behavior.")]
-        public bool OverrideMeshNameWithNodeName { get; set; } = false;
+        public bool OverrideMeshNameWithNodeName { get; set; } = true;
 
         /// <summary>
         /// Should a Material.Json be imported?


### PR DESCRIPTION
# Mesh material name index fix

Mesh materials will now actually check if the material definition's index property is matching before just assuming that everything is fine if the array index is fine