### PR TITLE
#1420 Asset Browser select all checkbox

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -436,7 +436,10 @@ public partial class AssetBrowserViewModel : ToolViewModel
     /// <summary>
     /// Add File to Project
     /// </summary>
-    [RelayCommand]
+    /// 
+    private bool CanAddToProject() => ProjectLoaded;
+
+    [RelayCommand(CanExecute = nameof(CanAddToProject))]
     private async Task AddSelectedAsync()
     {
         _watcherService.IsSuspended = true;

--- a/WolvenKit/Layout/SFDataGridCommands.cs
+++ b/WolvenKit/Layout/SFDataGridCommands.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Windows.Controls;
 using System.Windows.Input;
 using DynamicData;
 using Syncfusion.UI.Xaml.Grid;
+using Syncfusion.UI.Xaml.TreeGrid;
 using WolvenKit.Common.Interfaces;
 
 namespace WolvenKit.Layout
@@ -16,25 +18,22 @@ namespace WolvenKit.Layout
 
         private static void OnCanExecuteCheckAndUnCheck(object sender, CanExecuteRoutedEventArgs args) => args.CanExecute = true;
 
+        // NOTE: this is needed because sfdatagrid.SelectAll() does not send OnSelectionChanged events
         private static void OnCheckUnCheckCommand(object sender, ExecutedRoutedEventArgs args)
         {
-            if (args.Parameter is not SfDataGrid sfdatagrid)
-            {
-                return;
-            }
-            if (sender is not CheckBox checkBox)
+            if (args.Parameter is not SfDataGrid { ItemsSource: IEnumerable<object> source } sfDataGrid ||
+                sender is not CheckBox checkBox || checkBox.IsChecked is null)
             {
                 return;
             }
 
-            // NOTE: this is needed because sfdatagrid.SelectAll() does not send OnSelectionChanged events
             if (checkBox.IsChecked.Value)
             {
-                sfdatagrid.SelectedItems.AddRange(sfdatagrid.ItemsSource as IEnumerable<object>);
+                sfDataGrid.SelectedItems.AddRange(source);
             }
             else
             {
-                sfdatagrid.SelectedItems.RemoveMany(sfdatagrid.ItemsSource as IEnumerable<object>);
+                sfDataGrid.SelectedItems.RemoveMany(source);
             }
         }
     }

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -347,7 +347,8 @@
                                     MappingName="IsChecked">
                                     <syncfusion:GridCheckBoxColumn.HeaderTemplate>
                                         <DataTemplate>
-                                            <CheckBox Command="layout:SFDataGridCommands.CheckAndUnCheck" CommandParameter="{Binding ElementName=InnerList}" />
+                                            <CheckBox Command="layout:SFDataGridCommands.CheckAndUnCheck"
+                                                      CommandParameter="{Binding ElementName=RightFileView}" />
                                         </DataTemplate>
                                     </syncfusion:GridCheckBoxColumn.HeaderTemplate>
                                 </syncfusion:GridCheckBoxColumn>
@@ -449,7 +450,6 @@
                 </StackPanel>
             </Grid>
         </Border>
-
         <Border
             x:Name="NoProjectBorder"
             Grid.RowSpan="3"
@@ -457,11 +457,20 @@
             Visibility="{Binding Path=ShouldShowLoadButton, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid>
                 <StackPanel VerticalAlignment="Center">
+                    <TextBlock
+                        Margin="0,15"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        FontSize="18"
+                        FontWeight="Bold"
+                        Foreground="#7EFFFFFF"
+                        Text="You need a Wolvenkit project to edit files."
+                        TextWrapping="Wrap" />
                     <Button HorizontalAlignment="Center" Command="{Binding LoadAssetBrowserCommand}">
                         <TextBlock
                             Margin="20,10"
                             FontSize="16"
-                            Text="Load Asset Browser" />
+                            Text="Load Asset Browser (read-only)" />
                     </Button>
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
# Asset browser fixes

- "Select all" checkbox is working again
- "Add to project" context menu item will only be visible if there's a project
- Changed asset browser message for manual loading
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/c6616143-fbde-41b9-b1c5-7f527bb6ef81)

# Fixes issue
https://github.com/WolvenKit/WolvenKit/issues/1420