### PR TITLE
renumber child index properties

### DIFF
--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -470,6 +470,22 @@
                     </MenuItem.Icon>
                 </MenuItem>
 
+                <!--  
+                For arrays of indexables: Renumber Indices of child nodes, starting at 0
+                Useful if you paste a bunch of material definitions from multiple sources 
+                -->
+                <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.ReindexChildDataIndexPropertiesCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Recalculate child index properties"
+                    IsCheckable="False"
+                    Style="{StaticResource SyncfusionMenuItemStyle}"
+                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowRenumberArrayIndexProperties, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial Kind="Calculator" Style="{StaticResource ContextMenuIconStyleMaterial}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
                 <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.ExportChunkCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Export to JSON"


### PR DESCRIPTION
# Renumber child index properties for definition arrays

Super useful, I will be using the shit out of this. Display is strictly conditional and will only display for the right node type.
https://github.com/WolvenKit/WolvenKit/assets/965785/653913fe-4263-4371-915d-dd366dd4542f

