### PR TITLE
Import export tools bugfixes

### DIFF
--- a/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
@@ -137,8 +137,10 @@ public partial class ExportViewModel : AbstractExportViewModel
 
         if (sucessful > 0)
         {
-            _notificationService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
-            _loggerService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
+            _notificationService.Success(
+                $"{sucessful}/{total} files have been processed and are available in the Project Explorer's 'raw' section");
+            _loggerService.Success(
+                $"{sucessful}/{total} files have been processed and are available in the Project Explorer's 'raw' section");
         }
 
         //We format the list of failed export/import items here

--- a/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
@@ -192,8 +192,9 @@ public partial class ModsViewModel : PageViewModel
         if (!_pluginService.IsInstalled(EPlugin.redmod))
         {
             var res = await Interactions
-                .ShowMessageBoxAsync("The RedMod tools are not installed and mod compilation will not work. Would you like to install the RedMod tools now?",
-                "RedMod not found");
+                .ShowMessageBoxAsync(
+                    "The RedMod tools are not installed and mod compilation will not work. Would you like to install the RedMod tools now?",
+                    "RedMod not found");
 
             switch (res)
             {
@@ -208,6 +209,25 @@ public partial class ModsViewModel : PageViewModel
                 default:
                     break;
             }
+        }
+    }
+    
+    [RelayCommand]
+    private void LaunchGameFromLastSave()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = _settings.GetRED4GameLaunchCommand(),
+                Arguments = $"{_settings.GetRED4GameLaunchOptions()} -modded",
+                ErrorDialog = true,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.Error("Launch: error launching game! Please check your executable path in Settings.");
+            _logger.Info($"Launch: error debug info: {ex.Message}");
         }
     }
 

--- a/WolvenKit.App/ViewModels/Importers/ImportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Importers/ImportViewModel.cs
@@ -188,8 +188,10 @@ public partial class ImportViewModel : AbstractImportViewModel
 
         if (sucessful > 0)
         {
-            _notificationService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
-            _loggerService.Success($"{sucessful}/{total} files have been processed and are available in the Project Explorer");
+            _notificationService.Success(
+                $"{sucessful}/{total} files have been processed and are available in the Project Explorer's 'archive' section");
+            _loggerService.Success(
+                $"{sucessful}/{total} files have been processed and are available in the Project Explorer's 'archive' section");
         }
 
         //We format the list of failed export/import items here

--- a/WolvenKit.App/ViewModels/Shell/RibbonViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/RibbonViewModel.cs
@@ -35,6 +35,7 @@ public partial class RibbonViewModel : ObservableObject
         MainViewModel.PropertyChanged += MainViewModel_OnPropertyChanged;
 
         _launchProfileText = "Launch Profiles";
+        _launchGameText = "Launch Game";
     }
 
     private void MainViewModel_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -93,7 +94,8 @@ public partial class RibbonViewModel : ObservableObject
     }
 
 
-
     [ObservableProperty] private string _launchProfileText;
+
+    [ObservableProperty] private string _launchGameText;
 
 }

--- a/WolvenKit.App/ViewModels/Tools/ImportExportItemViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportItemViewModel.cs
@@ -21,10 +21,8 @@ public abstract partial class ImportExportItemViewModel : ObservableObject, ISel
         Properties.PropertyChanged += Properties_PropertyChanged;
     }
 
-    private void Properties_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
+    private void Properties_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) =>
         PropertiesDisplay = Properties.ToString();
-    }
 
     public string BaseFile { get; set; }
 
@@ -45,11 +43,7 @@ public abstract partial class ImportExportItemViewModel : ObservableObject, ISel
 
     public void SetProperties(ImportExportArgs args)
     {
-        Properties.PropertyChanged -= Properties_PropertyChanged;
-        
         Properties = args;
         PropertiesDisplay = Properties.ToString();
-        
-        Properties.PropertyChanged += Properties_PropertyChanged;
     }
 }

--- a/WolvenKit.App/ViewModels/Tools/ImportExportItemViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportItemViewModel.cs
@@ -43,7 +43,11 @@ public abstract partial class ImportExportItemViewModel : ObservableObject, ISel
 
     public void SetProperties(ImportExportArgs args)
     {
+        Properties.PropertyChanged -= Properties_PropertyChanged;
+        
         Properties = args;
         PropertiesDisplay = Properties.ToString();
+
+        Properties.PropertyChanged += Properties_PropertyChanged;
     }
 }

--- a/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportExportViewModel.cs
@@ -72,28 +72,24 @@ public abstract partial class ImportExportViewModel : FloatingPaneViewModel
     [RelayCommand(CanExecute = nameof(IsAnyFileSelected))]  // TODO NotifyCanExecuteChangedFor
     private void PasteArgumentsTemplateTo()
     {
-        var results = Items.Where(x => x.IsChecked);
-        var count = 0;
+        var (settings, type) = _currentSettings;
 
-        foreach (var item in results)
-        {
-            var (settings, type) = _currentSettings;
-
-            if (item.Properties.GetType() != type)
+        var count = Items
+            .Where(item => item.IsChecked && item.Properties.GetType() == type)
+            .Count(item =>
             {
-                continue;
-            }
+                if (settings.Deserialize(type, _jsonSerializerSettings) is not ImportExportArgs ds)
+                {
+                    return false;
+                }
 
-            if (settings.Deserialize(type, _jsonSerializerSettings) is ImportExportArgs ds)
-            {
                 item.SetProperties(ds);
-                count++;
-            }
-        }
+                return true;
+            });
 
         if (count > 0)
         {
-            _notificationService.Success($"Template has been copied to the selected items.");
+            _notificationService.Success($"Template has been copied to {count} items.");
         }
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ImportableItemViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ImportableItemViewModel.cs
@@ -69,8 +69,8 @@ public class ImportableItemViewModel : ImportExportItemViewModel
                 => new GltfImportArgs()
                 {
                     ImportFormat = formatFromFilename ?? GltfImportAsFormat.Mesh,
-                    ImportGarmentSupport =
-                        formatFromFilename is GltfImportAsFormat.Mesh or GltfImportAsFormat.MeshWithRig
+                    // Mesh won't have an internal extension
+                    ImportGarmentSupport = formatFromFilename is null or GltfImportAsFormat.MeshWithRig 
                 },
 
             // common import

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -65,7 +65,11 @@ namespace WolvenKit.Common.Model.Arguments
     /// </summary>
     public class MorphTargetExportArgs : ExportArgs
     {
+        // Export as GLTF?
         private bool _isBinary = true;
+
+        // Export textures?
+        private bool _exportTextures = false;
 
         /// <summary>
         /// Binary Export Bool, Decides between GLB and GLTF
@@ -77,10 +81,19 @@ namespace WolvenKit.Common.Model.Arguments
         public bool IsBinary { get => _isBinary; set => SetProperty(ref _isBinary, value); }
 
         /// <summary>
+        /// Export morphtarget's textures (pngs)
+        /// </summary>
+        [Category("Export Settings")]
+        [Display(Name = "Export textures (pngs)")]
+        [Description("If selected, the morphtarget's textures will be exported.")]
+        [WkitScriptAccess("ExportTextures")]
+        public bool ExportTextures { get => _exportTextures; set => SetProperty(ref _exportTextures, value); }
+
+        /// <summary>
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"GLTF/GLB | Is Binary :  {IsBinary}";
+        public override string ToString() => $"GLTF/GLB | Is Binary: {IsBinary} | Textures: {ExportTextures}";
 
     }
 

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -93,7 +93,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"GLTF/GLB | Is Binary: {IsBinary} | Textures: {ExportTextures}";
+        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")} | Textures: {ExportTextures}";
 
     }
 
@@ -284,7 +284,18 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"GLTF/GLB | Export Type : {meshExportType} | Lod filter : {LodFilter} | Is Binary : {isGLBinary}";
+        public override string ToString()
+        {
+            var stringParts = new List<string> { isGLBinary ? "glb" : "gltf" };
+            if (withMaterials)
+            {
+                stringParts.Add("materials: true");
+            }
+
+            stringParts.Add(meshExportType.ToString());
+            stringParts.Add($"Lod filter : {LodFilter}");
+            return string.Join(" | ", stringParts);
+        }
     }
 
     /// <summary>
@@ -338,7 +349,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => "GLTF/GLB | " + $"Is Binary: {IsBinary}, Root Motion: {incRootMotion}";
+        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")}, Root Motion: {incRootMotion}";
     }
 
     /// <summary>

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -338,7 +338,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => "GLTF/GLB | " + $"Is Binary :  {IsBinary}";
+        public override string ToString() => "GLTF/GLB | " + $"Is Binary: {IsBinary}, Root Motion: {incRootMotion}";
     }
 
     /// <summary>

--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Linq;
+using DynamicData;
 using SharpGLTF.Validation;
 using WolvenKit.RED4.Archive;
 using static WolvenKit.RED4.Types.Enums;
@@ -88,7 +91,31 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => TextureGroup.ToString();
+        public override string ToString()
+        {
+            List<string> stringArgs = [];
+            stringArgs.Add(TextureGroup.ToString().Replace("TEXG_", ""));
+
+            if (PremultiplyAlpha)
+            {
+                stringArgs.Add("premultiplyAlpha: true");
+            }
+
+            if (IsGamma)
+            {
+                stringArgs.Add("isGamma: true");
+            }
+
+            if (GenerateMipMaps)
+            {
+                stringArgs.Add("mipMaps: true");
+            }
+
+            stringArgs.Add($"Compression: {Compression.ToString()}");
+            stringArgs.Add($"raw format: {RawFormat.ToString()}");
+
+            return string.Join(" | ", stringArgs);
+        }
     }
 
     /// <summary>
@@ -198,7 +225,44 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"Mesh/Morphtarget | Import Format :  {ImportFormat}";
+        public override string ToString()
+        {
+            var stringParts = new List<string>();
+            switch (ImportFormat)
+            {
+                case GltfImportAsFormat.Anims:
+                    stringParts.Add("Animation");
+                    break;
+                case GltfImportAsFormat.Morphtarget:
+                    stringParts.Add("Morphtarget");
+                    break;
+                case GltfImportAsFormat.Rig:
+                    stringParts.Add("Armature");
+                    break;
+                case GltfImportAsFormat.PhysicalScene:
+                default:
+                case GltfImportAsFormat.MeshWithRig:
+                case GltfImportAsFormat.Mesh:
+                    stringParts.Add("Mesh");
+                    break;
+            }
+
+            if (ImportMaterials)
+            {
+                stringParts.Add("material: true");
+            }
+            else if (ImportMaterialOnly)
+            {
+                stringParts.Add("only material");
+            }
+
+            if (ImportGarmentSupport)
+            {
+                stringParts.Add("garmentSupport: true");
+            }
+
+            return string.Join(" | ", stringParts);
+        } 
     }
 
     public enum GltfImportAsFormat

--- a/WolvenKit.Modkit/RED4/Import.cs
+++ b/WolvenKit.Modkit/RED4/Import.cs
@@ -424,12 +424,7 @@ namespace WolvenKit.Modkit.RED4
         {
             var maybeType = TypeFromFileExt(rawRelative.Name);
 
-            var (internalExt, importFormat) =
-                maybeType.HasValue
-                ? (InternalExtForType(maybeType.Value), ImportFormatFor(maybeType.Value))
-                : args.ImportFormat == GltfImportAsFormat.MeshWithRig
-                    ? ($".mesh", args.ImportFormat)
-                    : ($".{args.ImportFormat.ToString().ToLower()}", args.ImportFormat);
+            var (internalExt, importFormat) = GetImportExtensionAndFormat(args, maybeType);
 
             // Drops the .glb/.gltf, and either adds or replaces the already present type ext
             var possibleRedPath =
@@ -548,6 +543,23 @@ namespace WolvenKit.Modkit.RED4
 
 
         }
+
+        private static (string, GltfImportAsFormat) GetImportExtensionAndFormat(GltfImportArgs args,
+            Optional<string> maybeType)
+        {
+            if (!maybeType.HasValue || maybeType.Value == "anims")
+            {
+                return (InternalExtForType(maybeType.Value), ImportFormatFor(maybeType.Value));
+            }
+
+            return args.ImportFormat switch
+            {
+                GltfImportAsFormat.MeshWithRig => ($".mesh", args.ImportFormat),
+                GltfImportAsFormat.Anims => ($".anims", GltfImportAsFormat.Anims),
+                _ => ($".{args.ImportFormat.ToString().ToLower()}", args.ImportFormat)
+            };
+        }
+            
 
 #pragma warning disable IDE0072 // Add missing cases
         private static ECookedFileFormat FromRawExtension(ERawFileFormat rawextension) =>

--- a/WolvenKit.Modkit/RED4/Import.cs
+++ b/WolvenKit.Modkit/RED4/Import.cs
@@ -547,11 +547,12 @@ namespace WolvenKit.Modkit.RED4
         private static (string, GltfImportAsFormat) GetImportExtensionAndFormat(GltfImportArgs args,
             Optional<string> maybeType)
         {
-            if (!maybeType.HasValue || maybeType.Value == "anims")
+            // Anything but .mesh should have a value
+            if (!maybeType.HasValue)
             {
-                return (InternalExtForType(maybeType.Value), ImportFormatFor(maybeType.Value));
+                return ($".mesh", args.ImportFormat);
             }
-
+           
             return args.ImportFormat switch
             {
                 GltfImportAsFormat.MeshWithRig => ($".mesh", args.ImportFormat),

--- a/WolvenKit.Modkit/RED4/ModTools.Types.cs
+++ b/WolvenKit.Modkit/RED4/ModTools.Types.cs
@@ -29,11 +29,22 @@ public partial class ModTools
 			_ => $".{internalType}"
 		};
 
+    /// <summary>
+    /// Will match any potential type extension before the .glb/gltf
+    /// </summary>
     private static readonly Func<string, Optional<string>> TypeFromFileExt = (path) =>
 		TypeExtensionMatcher.Match(path).Groups["typeExtension"].Value switch {
 			string matched when !string.IsNullOrWhiteSpace(matched) => Optional.Some(matched.ToLower()),
 			_ => Optional.None<string>()
 		};
+
+    public static GltfImportAsFormat? GltfImportAsFormatFromFileExt(string path)
+    {
+	    var internalExtension = TypeFromFileExt(path).ToString() ?? "_";
+	    var importFormatString = char.ToUpper(internalExtension[0]) + internalExtension.Substring(1);
+
+	    return Enum.TryParse<GltfImportAsFormat>(importFormatString, out var importFormat) ? importFormat : null;
+    }
 
 	private static readonly Func<string, GltfImportAsFormat> ImportFormatFor = (type) =>
 		type switch {

--- a/WolvenKit.Modkit/RED4/ModTools.Types.cs
+++ b/WolvenKit.Modkit/RED4/ModTools.Types.cs
@@ -26,7 +26,7 @@ public partial class ModTools
     private static readonly Func<string, string> InternalExtForType = (internalType) =>
 		internalType switch {
 			"meshwithrig" => ".mesh",
-			_ => $".{internalType}"
+			_ => $" "
 		};
 
     /// <summary>

--- a/WolvenKit.Modkit/RED4/RedMod.cs
+++ b/WolvenKit.Modkit/RED4/RedMod.cs
@@ -12,7 +12,7 @@ namespace WolvenKit.Modkit.RED4
             var args = $"animation-import -depot=\"{depot}\" -input=\"{input}\" -animset={animset}";
             if (!string.IsNullOrEmpty(output))
             {
-                args += $" -output={output}";
+                args += $" -output={output.Replace(".anims", "")}";
             }
             if (!string.IsNullOrEmpty(animationRename))
             {

--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -49,11 +49,11 @@ namespace WolvenKit.Modkit.RED4
 
             if (isGLBinary)
             {
-                model.SaveGLB(outfile.FullName, new WriteSettings(vmode));
+                model.SaveGLB($"{outfile.FullName}.anims", new WriteSettings(vmode));
             }
             else
             {
-                model.SaveGLTF(outfile.FullName, new WriteSettings(vmode));
+                model.SaveGLTF($"{outfile.FullName}.anims", new WriteSettings(vmode));
             }
 
             return true;

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -553,6 +553,7 @@ namespace WolvenKit.Modkit.RED4
                 case animAnimSet:
                     try
                     {
+                        // Add "anims" to outfile name so we can "guess" it back later
                         return ExportAnim(cr2wFile, outfile, settings.Get<AnimationExportArgs>().IsBinary, settings.Get<AnimationExportArgs>().incRootMotion);
                     }
                     catch (Exception e)

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -546,7 +546,9 @@ namespace WolvenKit.Modkit.RED4
                     // actual type extension we want it to...
                     var typePreservingOutfile = new FileInfo($"{outfile.FullName}.dummyextguardthatwillberemoved");
 
-                    return ExportMorphTargets(cr2wFile, typePreservingOutfile, settings.Get<MorphTargetExportArgs>().IsBinary);
+                    return ExportMorphTargets(cr2wFile, typePreservingOutfile,
+                        settings.Get<MorphTargetExportArgs>().IsBinary,
+                        settings.Get<MorphTargetExportArgs>().ExportTextures);
 
                 case animAnimSet:
                     try

--- a/WolvenKit/Views/Exporters/ExportView.xaml.cs
+++ b/WolvenKit/Views/Exporters/ExportView.xaml.cs
@@ -1,7 +1,7 @@
-﻿using System.Reactive.Disposables;
+﻿using System.Linq;
+using System.Reactive.Disposables;
 using ReactiveUI;
 using Syncfusion.UI.Xaml.Grid;
-using Syncfusion.UI.Xaml.Grid.Cells;
 using Syncfusion.Windows.PropertyGrid;
 using WolvenKit.App.ViewModels.Exporters;
 using WolvenKit.App.ViewModels.Tools;
@@ -49,17 +49,16 @@ public partial class ExportView : ReactiveUserControl<ExportViewModel>
 
     private void OverlayPropertyGrid_AutoGeneratingPropertyGridItem(object sender, AutoGeneratingPropertyGridItemEventArgs e)
     {
-        switch (e.DisplayName)
+        if (e.DisplayName is
+            nameof(ReactiveObject.Changed) or
+            nameof(ReactiveObject.Changing) or
+            nameof(ReactiveObject.ThrownExceptions)
+           )
         {
-            case nameof(ReactiveObject.Changed):
-            case nameof(ReactiveObject.Changing):
-            case nameof(ReactiveObject.ThrownExceptions):
-                e.Cancel = true;
-                return;
-            default:
-                break;
+            e.Cancel = true;
+            return;
         }
-
+        
         // Generate special editors for certain properties
         // we need the callback function
         // we need the propertyname
@@ -84,7 +83,7 @@ public partial class ExportView : ReactiveUserControl<ExportViewModel>
     {
         foreach (var item in e.AddedItems)
         {
-            if (item is GridRowInfo info && info.RowData is ImportExportItemViewModel vm)
+            if (item is GridRowInfo { RowData: ImportExportItemViewModel vm })
             {
                 vm.IsChecked = true;
             }
@@ -92,17 +91,17 @@ public partial class ExportView : ReactiveUserControl<ExportViewModel>
 
         foreach (var item in e.RemovedItems)
         {
-            if (item is GridRowInfo info && info.RowData is ImportExportItemViewModel vm)
+            if (item is GridRowInfo { RowData: ImportExportItemViewModel vm } &&
+                !e.AddedItems.Contains(item))
             {
                 vm.IsChecked = false;
             }
         }
 
-
-        ViewModel.ProcessSelectedCommand.NotifyCanExecuteChanged();
-        ViewModel.CopyArgumentsTemplateToCommand.NotifyCanExecuteChanged();
-        ViewModel.PasteArgumentsTemplateToCommand.NotifyCanExecuteChanged();
-        ViewModel.ImportSettingsCommand.NotifyCanExecuteChanged();
+        ViewModel?.ProcessSelectedCommand.NotifyCanExecuteChanged();
+        ViewModel?.CopyArgumentsTemplateToCommand.NotifyCanExecuteChanged();
+        ViewModel?.PasteArgumentsTemplateToCommand.NotifyCanExecuteChanged();
+        ViewModel?.ImportSettingsCommand.NotifyCanExecuteChanged();
     }
 
 }

--- a/WolvenKit/Views/Importers/TextureImportView.xaml.cs
+++ b/WolvenKit/Views/Importers/TextureImportView.xaml.cs
@@ -199,7 +199,7 @@ public partial class ImportView : ReactiveUserControl<ImportViewModel>
     {
         foreach (var item in e.AddedItems)
         {
-            if (item is GridRowInfo info && info.RowData is ImportExportItemViewModel vm)
+            if (item is GridRowInfo { RowData: ImportExportItemViewModel vm })
             {
                 vm.IsChecked = true;
             }
@@ -207,18 +207,17 @@ public partial class ImportView : ReactiveUserControl<ImportViewModel>
 
         foreach (var item in e.RemovedItems)
         {
-            if (item is GridRowInfo info && info.RowData is ImportExportItemViewModel vm)
+            if (item is GridRowInfo { RowData: ImportExportItemViewModel vm } && !e.AddedItems.Contains(item))
             {
                 vm.IsChecked = false;
             }
         }
 
-
-        ViewModel.ProcessSelectedCommand.NotifyCanExecuteChanged();
-        ViewModel.CopyArgumentsTemplateToCommand.NotifyCanExecuteChanged();
-        ViewModel.PasteArgumentsTemplateToCommand.NotifyCanExecuteChanged();
-        ViewModel.ImportSettingsCommand.NotifyCanExecuteChanged();
-        ViewModel.DefaultSettingsCommand.NotifyCanExecuteChanged();
+        ViewModel?.ProcessSelectedCommand.NotifyCanExecuteChanged();
+        ViewModel?.CopyArgumentsTemplateToCommand.NotifyCanExecuteChanged();
+        ViewModel?.PasteArgumentsTemplateToCommand.NotifyCanExecuteChanged();
+        ViewModel?.ImportSettingsCommand.NotifyCanExecuteChanged();
+        ViewModel?.DefaultSettingsCommand.NotifyCanExecuteChanged();
 
         // toggle additional options
         ShowSettings();

--- a/WolvenKit/Views/Shell/RibbonView.xaml
+++ b/WolvenKit/Views/Shell/RibbonView.xaml
@@ -377,7 +377,8 @@
                 </Menu>
 
                 <Menu>
-                    <MenuItem Header="Launch Game" SubmenuOpened="MenuItem_SubmenuOpened">
+                    <MenuItem
+                        x:Name="MenuHeaderLaunchGame" Header="Launch Game" SubmenuOpened="MenuItem_SubmenuOpened">
                         <MenuItem.Icon>
                             <iconPacks:PackIconCodicons
                                 Foreground="{StaticResource WolvenKitYellow}"
@@ -401,11 +402,27 @@
                             </MenuItem.Icon>
                         </MenuItem>
 
-                        <!--  launch game fromsave  -->
+                        <!--  launch game and load last save  -->
+                        <MenuItem
+                            x:Name="MenuItemLaunchGameFromLastSave"
+                            Margin="2,1"
+                            CommandParameter="0"
+                            Header="Launch from last save"
+                            ToolTip="Launch game and load last save">
+                            <MenuItem.Icon>
+                                <iconPacks:PackIconCodicons
+                                    Margin="6,0"
+                                    Foreground="{StaticResource WolvenKitYellow}"
+                                    Kind="Play"
+                                    Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+
+                        <!--  launch game from save  -->
                         <MenuItem
                             x:Name="MenuItemLaunchGameSave"
                             Margin="2,1"
-                            Header="Launch game from save"
+                            Header="Launch game from save..."
                             ToolTip="Launch Game from savefile">
                             <MenuItem.Icon>
                                 <iconPacks:PackIconCodicons


### PR DESCRIPTION
# Import/Export tools

- Morphtargets will now have a checkbox (disabled by default) to export their texture files
- Pasting import/export settings will now refresh the property display of changed items
- Fixed the annoying multiselect bug where the active item would get deselected
- .anims will now export to .anims.glb (and automatically import to Animation)
- minor refactoring in import tool to allow better type switching from file name