### PR TITLE
projectFileBrowser: hopefully more robust copy

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -580,7 +580,7 @@ namespace WolvenKit.Views.Tools
 
             // Abort if a directory is dragged on itself or its parent
             if (!isCopy && sourceFiles.Count == 1 &&
-                (sourceFiles[0] == targetDirectory || !isCopy && Path.GetDirectoryName(sourceFiles[0]) == targetDirectory))
+                (sourceFiles[0] == targetDirectory || Path.GetDirectoryName(sourceFiles[0]) == targetDirectory))
             {
                 return;
             }

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -688,9 +688,15 @@ namespace WolvenKit.Views.Tools
                 return;
             }
 
-            // We have been moving, so let's make sure we're not leaving any empty directories behind
-            directories.OrderByDescending(dir => dir.Length).Where(dir => !Directory.EnumerateFileSystemEntries(dir).Any()).ToList()
-                .ForEach(Directory.Delete);
+            foreach (var directory in directories.OrderByDescending(dir => dir.Length).ToList())
+            {
+                if (Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).Any())
+                {
+                    continue;
+                }
+
+                Directory.Delete(directory, true);
+            }
         }
 
         private void TreeGrid_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)


### PR DESCRIPTION
# projectFileBrowser: hopefully more robust copy

Project browser's drag&drop move often failed silently - this is hopefully more robust. 
Additionally, copying without overwriting will now create `- Copy` items, the same as Windows Explorer.