### PR TITLE
fix(anims): Additive Anim Import Uses Correct Math to Strip Local Transform

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -337,6 +337,15 @@ namespace WolvenKit.Common.Model.Arguments
         public bool IsBinary { get => _isBinary; set => SetProperty(ref _isBinary, value); }
 
         /// <summary>
+        /// Additive Animation Relative Positioning Bool, 
+        /// </summary>
+        [Category("Export Settings")]
+        [Display(Name = "Additive Anims Relative to Local Transform")]
+        [Description("Additive animations are typically relative to origin. If selected, they will be relative to the joint's Local Transform (e.g. vehicle parts will be in 'correct' position), which is probably what you want. By default import will strip them out again.")]
+        [WkitScriptAccess()]
+        public bool AdditiveRelativeToLocalTransform { get; set; } = true;
+
+        /// <summary>
         /// Root Motion Export Bool
         /// </summary>
         [Category("Export Settings")]
@@ -349,7 +358,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")}, Root Motion: {incRootMotion}";
+        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")}, Additive Anims Relative: { AdditiveRelativeToLocalTransform }, Root Motion: {incRootMotion}";
     }
 
     /// <summary>

--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -136,10 +136,18 @@ namespace WolvenKit.Common.Model.Arguments
         /// <summary>
         /// Use object or node name as mesh name
         /// </summary>
-        [Category("Import Settings")]
-        [Display(Name = "Use Object Name as Submesh Name (Compatibility)")]
+        [Category("Compatibility Settings")]
+        [Display(Name = "Use Object Name as Submesh Name")]
         [Description("If checked, each submesh name will be overridden by the node name (e.g. Blender object) to match previous behavior.")]
         public bool OverrideMeshNameWithNodeName { get; set; } = true;
+
+        /// <summary>
+        /// Strip Bind Pose transform from additive animations
+        /// </summary>
+        [Category("Animation Settings")]
+        [Display(Name = "Strip Local Transform from Additives")]
+        [Description("Only uncheck if your additive animations don't include joint's Local Transform (export selection) or you're certain you know what you're doing.")]
+        public bool AdditiveStripLocalTransform { get; set; } = true;
 
         /// <summary>
         /// Should a Material.Json be imported?

--- a/WolvenKit.Modkit/RED4/Import.cs
+++ b/WolvenKit.Modkit/RED4/Import.cs
@@ -506,7 +506,7 @@ namespace WolvenKit.Modkit.RED4
                         result = ImportMorphTargets(rawRelative.ToFileInfo(), redFs, args);
                         break;
                     case GltfImportAsFormat.Anims:
-                        result = ImportAnims(rawRelative.ToFileInfo(), redFs);
+                        result = ImportAnims(rawRelative.ToFileInfo(), redFs, args);
                         break;
                     case GltfImportAsFormat.MeshWithRig:
                         result = ImportMesh(rawRelative.ToFileInfo(), redFs, args);

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSIMD.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSIMD.cs
@@ -18,7 +18,7 @@ namespace WolvenKit.Modkit.RED4.Animation
 
     internal class SIMD
     {
-        public static void AddAnimationSIMD(ref ModelRoot model, animAnimationBufferSimd blob, string animName, Stream defferedBuffer, animAnimation animAnimDes, bool incRootMotion = true)
+        public static void AddAnimationSIMD(ref ModelRoot model, animAnimationBufferSimd blob, string animName, Stream defferedBuffer, animAnimation animAnimDes, bool additiveAddRelative = true, bool incRootMotion = true)
         {
             var rootPositions = new Dictionary<ushort, Dictionary<float, Vec3>>();
             var rootRotations = new Dictionary<ushort, Dictionary<float, Quat>>();
@@ -312,7 +312,7 @@ namespace WolvenKit.Modkit.RED4.Animation
             // -.-
             anim.Extras = SharpGLTF.IO.JsonContent.Parse(JsonSerializer.Serialize(animExtras, SerializationOptions()));
 
-            var exportAdditiveToBind = animAnimDes.AnimationType != animAnimationType.Normal;
+            var exportAdditiveToBind = additiveAddRelative && animAnimDes.AnimationType != animAnimationType.Normal;
 
             for (var j = 0; j < blob.NumJoints - blob.NumExtraJoints; j++)
             {
@@ -327,6 +327,7 @@ namespace WolvenKit.Modkit.RED4.Animation
                 {
                     if (exportAdditiveToBind)
                     {
+                        // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
                         pos.Add(f * frameTime, localTransform.Translation + positions[f, j]); // Also yup but TODO to fix naming along the way
                         rot.Add(f * frameTime, localTransform.Rotation * rotationsYup[f, j]);
                         sca.Add(f * frameTime, localTransform.Scale * scalesYup[f, j]);

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -17,7 +17,7 @@ namespace WolvenKit.Modkit.RED4.Animation
 {
     public class CompressedBuffer
     {
-        public static void ExportAsAnimationToModel(ref ModelRoot model, animAnimation animAnimDes, bool incRootMotion = true)
+        public static void ExportAsAnimationToModel(ref ModelRoot model, animAnimation animAnimDes, bool additiveAddRelative = true, bool incRootMotion = true)
         {
             if (animAnimDes.AnimBuffer.GetValue() is not animAnimationBufferCompressed blob)
             {
@@ -153,7 +153,8 @@ namespace WolvenKit.Modkit.RED4.Animation
             // -.-
             anim.Extras = SharpGLTF.IO.JsonContent.Parse(JsonSerializer.Serialize(animExtras, SerializationOptions()));
 
-            var exportAdditiveToBind = animAnimDes.AnimationType != animAnimationType.Normal;
+            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
+            var exportAdditiveToBind = additiveAddRelative && animAnimDes.AnimationType != animAnimationType.Normal;
 
             for (ushort i = 0; i < blob.NumJoints - blob.NumExtraJoints; i++)
             {

--- a/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
@@ -31,6 +31,20 @@ namespace WolvenKit.Modkit.RED4.Animation
 
         public static Quat RQuaternionZupLhs(Quat yupQ) => new(yupQ.X, -yupQ.Z, yupQ.Y, yupQ.W);
         public static Quat RQuaternionYupRhs(Quat zupQ) => new(zupQ.X, zupQ.Z, -zupQ.Y, zupQ.W);
+
+        public static Vec3 Scale1to1 = new(1.0f, 1.0f, 1.0f);
+
+        public static Vec3 WithEpsilon(Vec3 vec, Vec3 reference) =>
+            new(
+                Math.Abs(vec.X - reference.X) <= Single.Epsilon ? reference.X : vec.X,
+                Math.Abs(vec.Y - reference.Y) <= Single.Epsilon ? reference.Y : vec.Y,
+                Math.Abs(vec.Z - reference.Z) <= Single.Epsilon ? reference.Z : vec.Z
+            );
+
+        public static bool EqWithEpsilon(Vec3 a, Vec3 b) =>
+            Math.Abs(a.X - b.X) <= Single.Epsilon &&
+            Math.Abs(a.Y - b.Y) <= Single.Epsilon &&
+            Math.Abs(a.Z - b.Z) <= Single.Epsilon;
     }
 
     internal static class Gltf

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -401,8 +401,8 @@ namespace WolvenKit.Modkit.RED4
             var quantTrans = new Vec4((max.X + min.X) / 2, (max.Y + min.Y) / 2, (max.Z + min.Z) / 2, 1);
             
 
-            RawArmature? oldRig = null;
-            RawArmature? newRig = null;
+            RawArmature? incomingJoints = null;
+            RawArmature? existingJoints = null;
             if (originalRig != null)
             {
 
@@ -418,18 +418,18 @@ namespace WolvenKit.Modkit.RED4
                     Array.Clear(mesh.boneindices, 0, mesh.boneindices.Length);
                 }
 
-                oldRig = MeshTools.GetOrphanRig(meshBlob);
+                incomingJoints = MeshTools.GetOrphanRig(meshBlob);
 
                 using var msr = new MemoryStream();
                 originalRig.Extract(msr);
-                newRig = RIG.ProcessRig(_parserService.ReadRed4File(msr));
+                existingJoints = RIG.ProcessRig(_parserService.ReadRed4File(msr));
             }
             else
             {
-                newRig = MeshTools.GetOrphanRig(meshBlob);
+                existingJoints = MeshTools.GetOrphanRig(meshBlob);
                 if (model.LogicalSkins.Count > 0 && model.LogicalSkins[0].JointsCount > 0)
                 {
-                    oldRig = new RawArmature
+                    incomingJoints = new RawArmature
                     {
                         BoneCount = model.LogicalSkins[0].JointsCount,
                         Names = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => model.LogicalSkins[0].GetJoint(_).Joint.Name).ToArray()
@@ -438,7 +438,7 @@ namespace WolvenKit.Modkit.RED4
             }
 
 
-            MeshTools.UpdateMeshJoints(ref meshes, newRig, oldRig);
+            MeshTools.UpdateMeshJoints(ref meshes, existingJoints, incomingJoints);
 
             UpdateSkinningParamCloth(ref meshes, ref cr2w, args);
 

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -624,13 +624,13 @@ namespace WolvenKit.Modkit.RED4.Tools
 
         }
 
-        public static void UpdateMeshJoints(ref List<RawMeshContainer> meshes, RawArmature? newRig, RawArmature? oldRig, string fileName = "")
+        public static void UpdateMeshJoints(ref List<RawMeshContainer> meshes, RawArmature? existingJoints, RawArmature? incomingJoints, string fileName = "")
         {
             // updating mesh bone indices
-            if (newRig is { BoneCount: > 0 } && oldRig is { BoneCount: > 0 })
+            if (existingJoints is { BoneCount: > 0 } && incomingJoints is { BoneCount: > 0 })
             {
-                ArgumentNullException.ThrowIfNull(newRig.Names);
-                ArgumentNullException.ThrowIfNull(oldRig.Names);
+                ArgumentNullException.ThrowIfNull(existingJoints.Names);
+                ArgumentNullException.ThrowIfNull(incomingJoints.Names);
 
                 foreach (var mesh in meshes)
                 {
@@ -642,15 +642,15 @@ namespace WolvenKit.Modkit.RED4.Tools
                         for (var eye = 0; eye < mesh.weightCount; eye++)
                         {
 
-                            if (mesh.boneindices[e, eye] >= oldRig.BoneCount)// && meshes[i].weights[e, eye] == 0)
+                            if (mesh.boneindices[e, eye] >= incomingJoints.BoneCount)// && meshes[i].weights[e, eye] == 0)
                             {
                                 mesh.boneindices[e, eye] = 0;
                             }
 
                             var found = false;
-                            for (ushort r = 0; r < newRig.BoneCount; r++)
+                            for (ushort r = 0; r < existingJoints.BoneCount; r++)
                             {
-                                if (newRig.Names[r] == oldRig.Names[mesh.boneindices[e, eye]])
+                                if (existingJoints.Names[r] == incomingJoints.Names[mesh.boneindices[e, eye]])
                                 {
                                     mesh.boneindices[e, eye] = r;
                                     found = true;
@@ -659,7 +659,7 @@ namespace WolvenKit.Modkit.RED4.Tools
                             }
                             if (!found)
                             {
-                                throw new Exception($"Bone: {oldRig.Names[mesh.boneindices[e, eye]]} not present in export Rig(s)/Import Mesh {(!fileName.Equals("") ? string.Format("({0})", fileName) : "")}");
+                                throw new Exception($"Bone: {incomingJoints.Names[mesh.boneindices[e, eye]]} not present in export Rig(s)/Import Mesh {(!fileName.Equals("") ? string.Format("({0})", fileName) : "")}");
                             }
                         }
                     }

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -554,7 +554,7 @@ namespace WolvenKit.Modkit.RED4
                     try
                     {
                         // Add "anims" to outfile name so we can "guess" it back later
-                        return ExportAnim(cr2wFile, outfile, settings.Get<AnimationExportArgs>().IsBinary, settings.Get<AnimationExportArgs>().incRootMotion);
+                        return ExportAnim(cr2wFile, outfile, settings.Get<AnimationExportArgs>().IsBinary, settings.Get<AnimationExportArgs>().AdditiveRelativeToLocalTransform, settings.Get<AnimationExportArgs>().incRootMotion);
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
## Additive Anim Import Uses Correct Math to Strip Local Transform

**Fixed:**
- Reimporting additive anims now correctly strips out the local transform, with the power of basic math
- Added epsilon comparison and normalization helpers that are used to ensure we don't e.g. scale incorrectly because of floating point division imprecision.

**Implemented:**
- Import and Export toggles for including the local transform for additive animations. Should be used symmetrically, default is to use local transform (current behavior.)

**Warnings:**
- Raw additive animations don't seem to survive roundtripping through Blender. Default behavior is current, though, so might as well include it and then try to solve it in Blender.

**Open Questions:**
- Opened #1630 to further review animation scale handling logic. Currently only anims that use `1f` scale throughout are considered constant, but this may not be correct.
- Previous tickets on using epsilons elsewhere in math too..

closes #1559  and  https://github.com/WolvenKit/Cyberpunk-Blender-add-on/issues/123
