### PR TITLE
descriptor read-only, "simple mode" editor

### DIFF
--- a/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
+++ b/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
@@ -25,6 +25,7 @@ public class DocumentViewmodelFactory : IDocumentViewmodelFactory
     private readonly AppScriptService _scriptService;
     private readonly IHookService _hookService;
     private readonly INodeWrapperFactory _nodeWrapperFactory;
+    private readonly ISettingsManager _settingsManager;
 
 
     public DocumentViewmodelFactory(
@@ -39,7 +40,9 @@ public class DocumentViewmodelFactory : IDocumentViewmodelFactory
         IArchiveManager archiveManager,
         AppScriptService scriptService,
         IHookService hookService,
-        INodeWrapperFactory nodeWrapperFactory)
+        INodeWrapperFactory nodeWrapperFactory,
+        ISettingsManager settingsManager
+    )
     {
         _tabViewmodelFactory = tabViewmodelFactory;
         _paneViewModelFactory = paneViewModelFactory;
@@ -53,10 +56,14 @@ public class DocumentViewmodelFactory : IDocumentViewmodelFactory
         _scriptService = scriptService;
         _hookService = hookService;
         _nodeWrapperFactory = nodeWrapperFactory;
+        _settingsManager = settingsManager;
 
     }
-    public RedDocumentViewModel RedDocumentViewModel(CR2WFile file, string path, AppViewModel appViewModel, bool isReadOnly = false) 
-        => new(file, path, appViewModel, _tabViewmodelFactory, _chunkViewmodelFactory, _projectManager, _loggerService, _globals, _parserService, _watcherService, _archiveManager, _hookService, _nodeWrapperFactory, isReadOnly);
+
+    public RedDocumentViewModel RedDocumentViewModel(CR2WFile file, string path, AppViewModel appViewModel, bool isReadOnly = false)
+        => new(file, path, appViewModel, _tabViewmodelFactory, _chunkViewmodelFactory, _projectManager, _loggerService, _globals,
+            _parserService, _watcherService, _archiveManager, _hookService, _nodeWrapperFactory,
+            _settingsManager.IsNoobFilterDefaultEnabled(), isReadOnly);
 
     public WScriptDocumentViewModel WScriptDocumentViewModel(string path) => new(path, _scriptService);
 

--- a/WolvenKit.App/Helpers/StringHelper.cs
+++ b/WolvenKit.App/Helpers/StringHelper.cs
@@ -40,8 +40,7 @@ public static class StringHelper
             return "";
         }
 
-        return $"[ {string.Join(", ",
-            tweakDbIdCollection.ToList().Select(t => t.GetResolvedText() ?? "").Where((item) => item != "").ToArray())} ]";
+        return $"[ {Stringify(tweakDbIdCollection.ToList().Select(t => t.GetResolvedText() ?? "").ToArray())} ]";
     }
 
     public static string Stringify(entHardTransformBinding hardTransformBinding)
@@ -62,8 +61,7 @@ public static class StringHelper
             return "";
         }
 
-        return $"[ {string.Join(", ",
-            cNameCollection.ToList().Select(t => t.GetResolvedText() ?? "").Where((item) => item != "").ToArray())} ]";
+        return $"[ {Stringify(cNameCollection.ToList().Select(t => t.GetResolvedText() ?? "").ToArray())} ]";
     }
 
     public static string Stringify(string[] stringCollection)

--- a/WolvenKit.App/Helpers/StringHelper.cs
+++ b/WolvenKit.App/Helpers/StringHelper.cs
@@ -95,7 +95,7 @@ public static class StringHelper
     public static string Stringify(CColor color)
     {
         var ret = $"R: {color.Red}, G: {color.Green}, B: {color.Blue}";
-        return color.Alpha == 1 ? ret : $"{ret}, A: {color.Alpha}";
+        return color.Alpha == 255 ? ret : $"{ret}, A: {color.Alpha}";
     }
 
 

--- a/WolvenKit.App/Helpers/StringHelper.cs
+++ b/WolvenKit.App/Helpers/StringHelper.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using WolvenKit.App.Helpers.StringHelpers;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.Helpers;
 
-public class StringHelper
+public static class StringHelper
 {
     public static string Stringify(CArray<scnOutputSocket> scnOutputAry)
     {
@@ -91,7 +92,17 @@ public class StringHelper
         return $"[ {string.Join(", ", paths)} ]";
     }
 
-    public static string? StringifyOrNull(ResourcePath? depotPath, bool getFilenameOnly)
+    public static string Stringify(CColor color)
+    {
+        var ret = $"R: {color.Red}, G: {color.Green}, B: {color.Blue}";
+        return color.Alpha == 1 ? ret : $"{ret}, A: {color.Alpha}";
+    }
+
+
+    public static string Stringify(ResourcePath? depotPath, bool getFilenameOnly = false) =>
+        StringifyOrNull(depotPath, getFilenameOnly) ?? "";
+
+    public static string? StringifyOrNull(ResourcePath? depotPath, bool getFilenameOnly = false)
     {
         if (depotPath?.GetResolvedText() is not string path || path == "")
         {
@@ -105,4 +116,37 @@ public class StringHelper
 
         return path;
     }
+
+    public static string? StringifyOrNull(CName cname)
+    {
+        if (cname.GetResolvedText() is not string path || path == "")
+        {
+            return null;
+        }
+
+        return cname.GetResolvedText();
+    }
+
+    public static string Stringify(WorldTransform bind) =>
+        $"Pos: (X: {(float)bind.Position.X:G9}, Y: {(float)bind.Position.Y:G9}, Z: {(float)bind.Position.Z:G9}), Orientation: ({bind.Orientation})";
+
+    public static string Stringify(WorldPosition position) => $"{(float)position.X:G9}, {(float)position.Y:G9}, {(float)position.Z:G9}";
+
+    public static string Stringify(worldNode? worldNode, bool asValue = false) => StringHelperWorldNode.Stringify(worldNode, asValue);
+
+    public static string Stringify(animAnimNode_Base node, bool asValue = false) => StringHelperAnimNode.Stringify(node, asValue);
+    public static string Stringify(redTagList tagList) => Stringify(tagList.Tags);
+
+    public static string StringifyMeshAppearance(CResourceAsyncReference<CMesh> mesh, CName? meshAppearance)
+    {
+        var ret = mesh.DepotPath.GetResolvedText() ?? "";
+        if (meshAppearance?.GetResolvedText() is not string s || s == "" || s == "default")
+        {
+            return ret;
+        }
+
+        return $"{ret} ({s})";
+    }
+
+    public static string? GetNodeName(CWeakHandle<animAnimNode_Base> linkNode) => StringHelperAnimNode.GetNodeName(linkNode);
 }

--- a/WolvenKit.App/Helpers/StringHelpers/StringHelperAnimNode.cs
+++ b/WolvenKit.App/Helpers/StringHelpers/StringHelperAnimNode.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.App.Helpers.StringHelpers;
+
+internal static class StringHelperAnimNode
+{
+    public static string? GetNodeName(CWeakHandle<animAnimNode_Base>? linkNode)
+    {
+        if (linkNode is null)
+        {
+            return null;
+        }
+
+        if (linkNode.GetValue() is animAnimNode_Base node)
+        {
+            return GetNodeName(node);
+        }
+
+        if (linkNode.InnerType is { Name: not null })
+        {
+            return linkNode.InnerType.Name.Split("_").LastOrDefault();
+        }
+
+        return null;
+    }
+
+    private static string? GetNodeName(animAnimNode_Base? linkNode)
+    {
+        if (linkNode is null)
+        {
+            return null;
+        }
+
+        if (linkNode.GetType() is { Name: not null } t)
+        {
+            return t.Name.Split("_").LastOrDefault();
+        }
+
+        return "";
+    }
+
+
+    public static string Stringify(animAnimNode_Base? animNode, bool stringifyValue = false)
+    {
+        if (stringifyValue)
+        {
+            return StringifyValue(animNode);
+        }
+
+        return animNode?.DebugName.GetResolvedText() ?? "";
+    }
+
+
+    private static string StringifyValue(animAnimNode_Base? animNode) => animNode switch
+    {
+        animAnimNode_Output { Node: animPoseLink link } => GetNodeName(link.Node) ?? "",
+        _ => ""
+    };
+}

--- a/WolvenKit.App/Helpers/StringHelpers/StringHelperWorldNode.cs
+++ b/WolvenKit.App/Helpers/StringHelpers/StringHelperWorldNode.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.App.Helpers.StringHelpers;
+
+internal static class StringHelperWorldNode
+{
+    public static string Stringify(worldNode? worldNode, bool stringifyValue = false)
+    {
+        if (stringifyValue)
+        {
+            return StringifyValue(worldNode);
+        }
+
+        return worldNode?.DebugName.GetResolvedText() ?? "";
+    }
+
+    private static string PrintMesh(CResourceAsyncReference<CMesh> mesh, CName? meshAppearance) =>
+        StringHelper.StringifyMeshAppearance(mesh, meshAppearance);
+
+
+    private static string StringifyValue(worldNode? worldNode) => worldNode switch
+    {
+        worldMeshNode node => $"{PrintMesh(node.Mesh, node.MeshAppearance)}",
+        worldBendedMeshNode node => $"{PrintMesh(node.Mesh, node.MeshAppearance)}",
+        worldTerrainMeshNode node => $"{PrintMesh(node.MeshRef, null)}",
+        worldStaticOccluderMeshNode node => $"${node.OccluderType.ToEnumString()} {node.Mesh.DepotPath.GetResolvedText()}",
+        worldStaticParticleNode node => $"${node.ParticleSystem.DepotPath.GetResolvedText()}",
+        worldStaticLightNode node => $"{StringHelper.Stringify(node.Color)}",
+        worldStaticQuestMarkerNode node => $"{node.QuestType.ToEnumString()}",
+        worldStaticSoundEmitterNode node => $"{node.AudioName.GetResolvedText()}",
+        worldStaticDecalNode node => $"{node.Material.DepotPath.GetResolvedText()}",
+        worldStaticStickerNode node => $"{StringHelper.Stringify(node.Labels.Select((l) => (string)l).ToArray())}",
+        worldAIDirectorSpawnAreaNode spawnAreaNode => $"{spawnAreaNode.GroupKey}",
+        worldAIDirectorSpawnNode directorSpawnNode => $"{StringHelper.Stringify(directorSpawnNode.Tags)}",
+        worldAudioTagNode worldAudioTagNode => $"{worldAudioTagNode.AudioTag}",
+        worldFoliageNode worldFoliageNode => $"{PrintMesh(worldFoliageNode.Mesh, worldFoliageNode.MeshAppearance)}",
+        worldDeviceNode worldDeviceNode => $"[{worldDeviceNode.DeviceConnections.Count}]",
+        worldEffectNode worldEffectNode => $"[{worldEffectNode.Effect.DepotPath.GetResolvedText()}]",
+        worldDistantGINode worldDistantGiNode => $"[{worldDistantGiNode.DataAlbedo.DepotPath.GetResolvedText()}]",
+
+        _ => ""
+    };
+}

--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -31,6 +31,7 @@ public interface ISettingsDto
     public bool ShowTweakDBIDAsHex { get; set; }
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; }
+    public bool EnableNoobFilterByDefault { get; set; }
     public Dictionary<string, LaunchProfile>? LaunchProfiles { get; set; }
     public Dictionary<string, bool>? ScriptStatus { get; set; }
     public bool AnalyzeModArchives { get; set; }

--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -126,4 +126,9 @@ public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
     void SetThemeAccent(Color color);
 
     string GetVersionNumber();
+
+    /// <summary>
+    /// For "simple" editor view: hides fields that the user shouldn't edit 
+    /// </summary>
+    bool IsNoobFilterEnabled();
 }

--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -131,9 +131,4 @@ public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
     /// For "simple" editor view: hides fields that the user shouldn't edit 
     /// </summary>
     bool IsNoobFilterDefaultEnabled();
-
-    /// <summary>
-    /// For "simple" editor view: hides fields that the user shouldn't edit 
-    /// </summary>
-    bool HideNoobFilterToggleButton();
 }

--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -130,5 +130,10 @@ public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
     /// <summary>
     /// For "simple" editor view: hides fields that the user shouldn't edit 
     /// </summary>
-    bool IsNoobFilterEnabled();
+    bool IsNoobFilterDefaultEnabled();
+
+    /// <summary>
+    /// For "simple" editor view: hides fields that the user shouldn't edit 
+    /// </summary>
+    bool HideNoobFilterToggleButton();
 }

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -33,6 +33,7 @@ public class SettingsDto : ISettingsDto
         ShowResourcePathAsHex = settings.ShowResourcePathAsHex;
         ShowNodeRefAsHex = settings.ShowNodeRefAsHex;
         ShowTweakDBIDAsHex = settings.ShowTweakDBIDAsHex;
+        EnableNoobFilterByDefault = settings.EnableNoobFilterByDefault;
         ShowReferenceGraph = settings.ShowReferenceGraph;
         GameLanguage = settings.GameLanguage;
         LaunchProfiles = settings.LaunchProfiles;
@@ -69,6 +70,8 @@ public class SettingsDto : ISettingsDto
     public bool ShowCNameAsHex { get; set; }
     public bool ShowResourcePathAsHex { get; set; }
     public bool ShowNodeRefAsHex { get; set; }
+
+    public bool EnableNoobFilterByDefault { get; set; }
     public bool ShowTweakDBIDAsHex { get; set; }
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; } = EGameLanguage.en_us;
@@ -108,6 +111,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.ShowResourcePathAsHex = ShowResourcePathAsHex;
         settingsManager.ShowNodeRefAsHex = ShowNodeRefAsHex;
         settingsManager.ShowTweakDBIDAsHex = ShowTweakDBIDAsHex;
+        settingsManager.EnableNoobFilterByDefault = EnableNoobFilterByDefault;
         settingsManager.ShowReferenceGraph = ShowReferenceGraph;
         settingsManager.LaunchProfiles = LaunchProfiles;
         settingsManager.ScriptStatus = ScriptStatus;

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -198,6 +198,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private uint _treeViewGroupSize = 100;
 
+    // [Display(Name = "Simple mode", GroupName = "File Editor")] [ObservableProperty]
+    // private bool _enableNoobFilter;
+
     [Display(Name = "Ignored Extensions (Open using System Editor. Syntax: .ext1|.ext2)", GroupName = "File Editor")]
     [ObservableProperty]
     private string? _treeViewIgnoredExtensions = "";
@@ -327,6 +330,8 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             : Path.Combine(GetRED4GameRootDir(), "bin", "x64", Core.Constants.Oodle);
 
     public bool IsHealthy() => File.Exists(CP77ExecutablePath) && File.Exists(GetRED4OodleDll());
+
+    public bool IsNoobFilterEnabled() => false; // EnableNoobFilter;
 
     #endregion methods
 }

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -199,10 +199,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     private uint _treeViewGroupSize = 100;
 
     [Display(Name = "Default to simple mode", GroupName = "File Editor")] [ObservableProperty]
-    private bool _enableNoobFilter;
-
-    [Display(Name = "Hide simple mode toggle", GroupName = "File Editor")] [ObservableProperty]
-    private bool _hideNoobFilterToggle;
+    private bool _enableNoobFilterByDefault;
 
     [Display(Name = "Ignored Extensions (Open using System Editor. Syntax: .ext1|.ext2)", GroupName = "File Editor")]
     [ObservableProperty]
@@ -334,9 +331,8 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
 
     public bool IsHealthy() => File.Exists(CP77ExecutablePath) && File.Exists(GetRED4OodleDll());
 
-    public bool IsNoobFilterDefaultEnabled() => true; // EnableNoobFilter;
+    public bool IsNoobFilterDefaultEnabled() => EnableNoobFilterByDefault;
 
-    public bool HideNoobFilterToggleButton() => HideNoobFilterToggle;
 
     #endregion methods
 }

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -50,6 +50,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(ShowNodeRefAsHex),
             nameof(ShowTweakDBIDAsHex),
             nameof(ShowReferenceGraph),
+            nameof(EnableNoobFilterByDefault),
             nameof(GameLanguage),
             nameof(AnalyzeModArchives),
             nameof(ExtraModDirPath),

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -198,8 +198,11 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private uint _treeViewGroupSize = 100;
 
-    // [Display(Name = "Simple mode", GroupName = "File Editor")] [ObservableProperty]
-    // private bool _enableNoobFilter;
+    [Display(Name = "Default to simple mode", GroupName = "File Editor")] [ObservableProperty]
+    private bool _enableNoobFilter;
+
+    [Display(Name = "Hide simple mode toggle", GroupName = "File Editor")] [ObservableProperty]
+    private bool _hideNoobFilterToggle;
 
     [Display(Name = "Ignored Extensions (Open using System Editor. Syntax: .ext1|.ext2)", GroupName = "File Editor")]
     [ObservableProperty]
@@ -331,7 +334,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
 
     public bool IsHealthy() => File.Exists(CP77ExecutablePath) && File.Exists(GetRED4OodleDll());
 
-    public bool IsNoobFilterEnabled() => false; // EnableNoobFilter;
+    public bool IsNoobFilterDefaultEnabled() => true; // EnableNoobFilter;
+
+    public bool HideNoobFilterToggleButton() => HideNoobFilterToggle;
 
     #endregion methods
 }

--- a/WolvenKit.App/ViewModels/Documents/DocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/DocumentViewModel.cs
@@ -28,7 +28,6 @@ public abstract partial class DocumentViewModel : PaneViewModel, IDocumentViewMo
 
     [ObservableProperty] private string _filePath;
     [ObservableProperty] private bool _isReadOnly;
-    [ObservableProperty] private bool _isSimpleViewEnabled;
 
     private bool _isDirty;
 
@@ -36,6 +35,14 @@ public abstract partial class DocumentViewModel : PaneViewModel, IDocumentViewMo
     {
         get => _isDirty;
         protected set => SetProperty(ref _isDirty, value);
+    }
+
+    private bool _isSimpleViewEnabled;
+
+    public bool IsSimpleViewEnabled
+    {
+        get => _isSimpleViewEnabled;
+        set => SetProperty(ref _isSimpleViewEnabled, value);
     }
 
     public bool IsInitialized() => _isInitialized;

--- a/WolvenKit.App/ViewModels/Documents/DocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/DocumentViewModel.cs
@@ -28,6 +28,7 @@ public abstract partial class DocumentViewModel : PaneViewModel, IDocumentViewMo
 
     [ObservableProperty] private string _filePath;
     [ObservableProperty] private bool _isReadOnly;
+    [ObservableProperty] private bool _isSimpleViewEnabled;
 
     private bool _isDirty;
 
@@ -56,6 +57,6 @@ public abstract partial class DocumentViewModel : PaneViewModel, IDocumentViewMo
     [RelayCommand]
     public abstract void SaveAs(object parameter);
 
-    
+
     public abstract bool Reload(bool force);
 }

--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -49,6 +49,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
 
         _data = data;
 
+        IsSimpleViewEnabled = Parent.IsSimpleViewEnabled;
 
         parent.PropertyChanged += RDTDataViewModel_PropertyChanged;
         

--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
@@ -47,6 +48,9 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
         _appViewModel = appViewModel;
 
         _data = data;
+
+
+        parent.PropertyChanged += RDTDataViewModel_PropertyChanged;
         
         if (SelectedChunk == null && Chunks.Count > 0)
         {
@@ -59,6 +63,16 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
 
         Nodes.Add(new ResourcePathWrapper(this, new ReferenceSocket(Chunks[0].RelativePath), _appViewModel, _chunkViewmodelFactory));
         _nodePaths.Add(Chunks[0].RelativePath);
+    }
+
+    private void RDTDataViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RedDocumentViewModel.IsSimpleViewEnabled))
+        {
+            return;
+        }
+
+        IsSimpleViewEnabled = Parent.IsSimpleViewEnabled;
     }
 
     public RDTDataViewModel(string header, IRedType data, RedDocumentViewModel file, AppViewModel appViewModel,
@@ -97,6 +111,8 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
     [ObservableProperty] private object? _selectedChunk;
 
     [ObservableProperty] private object? _selectedChunks;
+
+    [ObservableProperty] private bool _IsSimpleViewEnabled;
 
 
     [ObservableProperty] private ChunkViewModel? _rootChunk;

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentTabViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentTabViewModel.cs
@@ -35,6 +35,7 @@ public abstract partial class RedDocumentTabViewModel : ObservableObject
 
     [ObservableProperty] private bool _canClose;
 
+
     public static IRedType? CopiedChunk;
 
     public static List<IRedType> CopiedChunks { get; } = new();
@@ -45,6 +46,7 @@ public abstract partial class RedDocumentTabViewModel : ObservableObject
     {
         if (this is RDTDataViewModel datavm)
         {
+            
             for (var i = 0; i < Parent.Cr2wFile.EmbeddedFiles.Count; i++)
             {
                 var file = Parent.Cr2wFile.EmbeddedFiles[i];

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -65,6 +65,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
         IArchiveManager archiveManager,
         IHookService hookService,
         INodeWrapperFactory nodeWrapperFactory,
+        bool isSimpleViewEnabled = false,
         bool isReadyOnly = false) : base(path)
     {
         _documentTabViewmodelFactory = documentTabViewmodelFactory;
@@ -93,6 +94,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
         Cr2wFile = file;
         IsReadOnly = isReadyOnly;
+        IsSimpleViewEnabled = isSimpleViewEnabled;
         _isInitialized = true;
         PopulateItems();
     }

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -122,7 +122,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         _scriptService.SetAppViewModel(this);
 
         _progressService.PropertyChanged += ProgressService_PropertyChanged;
-
+        
         UpdateTitle();
 
         ShowFirstTimeSetup();
@@ -723,7 +723,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     private bool CanReloadFile() => ActiveDocument is not null;
     [RelayCommand(CanExecute = nameof(CanReloadFile))]
-    private void ReloadFile()
+    public void ReloadFile()
     {
         if (ActiveDocument == null)
         {

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -2,34 +2,27 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using DynamicData.Binding;
 using Microsoft.Win32;
 using WolvenKit.App.Controllers;
 using WolvenKit.App.Extensions;
 using WolvenKit.App.Factories;
-using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models;
 using WolvenKit.App.Models.Nodify;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Documents;
-using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Common;
 using WolvenKit.Common.Services;
 using WolvenKit.Core.Extensions;
@@ -243,6 +236,9 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         CalculateDescriptor();
         CalculateIsDefault();
 
+        // Certain properties should not be editable by or visible to the user
+        CalculateUserInteractionStates();
+
         if (Parent is null)
         {
             return;
@@ -408,6 +404,9 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
 
     // For view decoration. Extrapolated values will be darker.
     [ObservableProperty] private bool _isValueExtrapolated;
+
+    // For view visibility - if the noob filter is enabled, only show properties that the user wants to edit
+    [ObservableProperty] private bool _isHiddenByNoobFilter;
     
     [ObservableProperty]
     //[NotifyCanExecuteChangedFor(nameof(OpenRefCommand))]

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -144,6 +144,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         CalculateValue();
         CalculateDescriptor();
         CalculateIsDefault();
+        CalculateUserInteractionStates();
     }
 
     public ChunkViewModel(IRedType data, RDTDataViewModel tab, AppViewModel appViewModel,
@@ -223,7 +224,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         {
             CalculateProperties();
         }
-
+        
         if (_modifierViewStateService.GetModifierState(ModifierKeys.Shift))
         {
             SetChildExpansionStates(IsExpanded);

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
@@ -449,7 +449,8 @@ public partial class ChunkViewModel
                 Descriptor = sgn.NodeId.Id.ToString();
                 return;
             case meshMeshMaterialBuffer matBuffer:
-                Descriptor = $"[{matBuffer.Materials.Count}]";
+                // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract this can be null!
+                Descriptor = $"[{matBuffer.Materials?.Count ?? 0}]";
                 return;
             case worldCompiledEffectInfo info:
                 Descriptor = string.Join(", ", info.PlacementInfos);

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
@@ -11,470 +11,467 @@ using WolvenKit.RED4.Types;
 using WolvenKit.RED4.Types.Pools;
 using static WolvenKit.RED4.Types.RedReflection;
 
+// ReSharper disable once CheckNamespace
 namespace WolvenKit.App.ViewModels.Shell;
 
 public partial class ChunkViewModel
 {
+    private bool CalculateDescriptorFromData()
+    {
+        switch (Data)
+        {
+            case IBrowsableDictionary ibd:
+            {
+                var pns = ibd.GetPropertyNames();
+                Descriptor = $"[{pns.Count()}]";
+                return true;
+            }
+            case IList list:
+                Descriptor = $"[{list.Count}]";
+                return true;
+            case Dictionary<string, object> dict:
+                Descriptor = $"[{dict.Count}]";
+                return true;
+            case TweakDBID tdb:
+                //Descriptor = Locator.Current.GetService<TweakDBService>().GetString(tdb);
+                Descriptor = tdb.GetResolvedText();
+                return true;
+            case gamedataLocKeyWrapper locKey:
+                Descriptor = ((ulong)locKey).ToString();
+                //Value = Locator.Current.GetService<LocKeyService>().GetFemaleVariant(value);
+                return true;
+            case IRedString str:
+            {
+                var s = str.GetString();
+                if (s is not null && s.StartsWith("LocKey#") && ulong.TryParse(s[7..], out var locKey2))
+                {
+                    Descriptor = locKey2.ToString();
+                }
+
+                return true;
+            }
+            //if (ResolvedData is CMaterialInstance && Parent is not null)
+            //{
+            //    if (Parent.Parent is not null && Parent.Parent.Parent is not null && Parent.Parent.Data is CMesh mesh)
+            //    {
+            //        Descriptor = mesh.MaterialEntries[int.Parse(Name)].Name;
+            //    }
+            //}
+            case Vector3 v3:
+                Descriptor = $"{v3.X}, {v3.Y}, {v3.Z}";
+                return true;
+            case Vector4 v4:
+                Descriptor = $"{v4.X}, {v4.Y}, {v4.Z}, {v4.W}";
+                return true;
+            case Quaternion q:
+                Descriptor = $"{q.I}, {q.J}, {q.K}, {q.R}";
+                return true;
+
+            default:
+                return false;
+        }
+    }
+    
     public void CalculateDescriptor()
     {
         Descriptor = "";
 
-        if (Data is worldNodeData sst && Tab is RDTDataViewModel dvm &&
-            dvm.Chunks[0].Data is worldStreamingSector wss && sst.NodeIndex < wss.Nodes.Count)
-        {
-            Descriptor = $"[{sst.NodeIndex}] {GetNameFrom(wss.Nodes[sst.NodeIndex].NotNull().Chunk)}";
-            return;
-        }
 
-        if (Data is worldStreamingSectorDescriptor wssd)
+        switch (ResolvedData)
         {
-            Descriptor = (wssd.Data.DepotPath.GetResolvedText() ?? "")
-                .Replace("base\\worlds\\03_night_city\\_compiled\\default\\", "").Replace(".streamingsector", "");
-            return;
-        }
+            case null:
+            case RedDummy:
+                return;
 
-        if (ResolvedData is IRedArray ary && ary.Count > 0)
-        {
-            // csv files and the like 
-            if (Parent is { Name: "compiledData" } && GetRootModel().Data is C2dArray csv)
-            {
-                var index = 0;
-                for (var i = 0; i < csv.CompiledHeaders.Count; i++)
-                {
-                    if (((string)csv.CompiledHeaders[i]).Contains("name", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        index = i;
-                        break;
-                    }
-                }
+            case worldNodeData sst when Tab is RDTDataViewModel dvm &&
+                                        dvm.Chunks[0].Data is worldStreamingSector wss && sst.NodeIndex < wss.Nodes.Count:
+                Descriptor = $"[{sst.NodeIndex}] {StringHelper.Stringify(wss.Nodes[sst.NodeIndex].Chunk)}";
+                return;
+            case worldStreamingSectorDescriptor wssd:
+                Descriptor = (wssd.Data.DepotPath.GetResolvedText() ?? "")
+                    .Replace(@"base\worlds\03_night_city\_compiled\default\", "").Replace(".streamingsector", "");
+                break;
+            case worldNode worldNode when StringHelper.Stringify(worldNode) is string s && s != "":
+                Descriptor = s;
+                return;
+            case worldNode:
+                // TODO find fallback properties for other node types
+                break;
+            case CHandle<animAnimNode_Base> { Chunk: animAnimNode_Switch } handle
+                when handle.Chunk.GetProperty("InputNodes") is CArray<animPoseLink> animAry:
 
-                Descriptor = $"{ary[index]}";
+                Descriptor = StringHelper.Stringify(animAry
+                    .Select((animPoseLink) => GetNodeName(animPoseLink.Node) ?? "").ToArray());
                 if (Descriptor != "")
                 {
                     return;
                 }
-            }
 
-            Descriptor = $"[{ary.Count}]";
-        }
-        else if (ResolvedData is appearanceAppearancePart part)
-        {
-            Descriptor = part.Resource.DepotPath.GetResolvedText() ?? "";
-            if (Descriptor != "")
-            {
-                return;
-            }
-        }
-        else if (ResolvedData is locVoLineEntry voLineEntry)
-        {
-            Descriptor = voLineEntry.StringId.ToString();
-            if (Descriptor != "")
-            {
-                return;
-            }
-        }
-        else if (ResolvedData is locVoLengthEntry voLengthEntry)
-        {
-            Descriptor = voLengthEntry.StringId.ToString();
-            if (Descriptor != "")
-            {
-                return;
-            }
-        }
-        else if (ResolvedData is animAnimSetEntry entry && entry.Animation?.GetValue() is animAnimation animation)
-        {
-            Descriptor = animation.GetProperty(nameof(Name))?.ToString() ?? "";
+                break;
+            // csv files
+            case IRedArray { Count: > 0 } csvAry when Parent is { Name: "compiledData" } && GetRootModel().Data is C2dArray csv:
 
-            if (ulong.TryParse(Descriptor, out var result))
-            {
-                Descriptor = ResourcePathPool.ResolveHash(result);
-            }
-            if (Descriptor != "")
-            {
-                return;
-            }
-        }
-        else if (ResolvedData is scnWorkspotData_ExternalWorkspotResource externalWorkspotResource)
-        {
-            Descriptor = $"{externalWorkspotResource.DataId.Id.ToString()}";
-            return;
-        }
-        else if (ResolvedData is animAnimSetupEntry animSetupEntry)
-        {
-            Descriptor = $"{animSetupEntry.AnimSet.DepotPath.GetResolvedText()}";
-            return;
-        }
-        else if (ResolvedData is entAnimationControlBinding controlBinding)
-        {
-            Descriptor = $"{controlBinding.BindName.GetResolvedText()}";
-            return;
-        }
-        else if (ResolvedData is scnSceneWorkspotInstanceId workspotInstanceId)
-        {
-            Descriptor = $"{workspotInstanceId.Id}";
-            return;
-        }
-        else if (ResolvedData is scnWorkspotInstance workspotInstance)
-        {
-            Descriptor = $"{workspotInstance.OriginMarker.NodeRef.GetResolvedText()}";
-            return;
-        }
-        else if (ResolvedData is scnChoiceNodeOption choiceNodeOption)
-        {
-            Descriptor = $"{choiceNodeOption.Caption}";
-            return;
-        }
-        else if (ResolvedData is scnSectionNode sectionNode)
-        {
-            Descriptor = $"{sectionNode.NodeId.Id}";
-            return;
-        }
-        else if (ResolvedData is scnInteractionShapeParams shapeParams)
-        {
-            Descriptor = $"{shapeParams.Preset}";
-            return;
-        }
-        else if (ResolvedData is scnSceneWorkspotDataId workspotDataId)
-        {
-            Descriptor = $"{workspotDataId.Id}";
-            return;
-        }
-        else if (ResolvedData is scnNodeId id)
-        {
-            Descriptor = $"{id.Id}";
-            return;
-        }
-        else if (ResolvedData is scnPlayerActorDef playerActorDef)
-        {
-            Descriptor = $"{playerActorDef.PlayerName}";
-            return;
-        }
-        else if (ResolvedData is scnMarker sceneMarker)
-        {
-            Descriptor = sceneMarker.NodeRef.GetResolvedText();
-        }
-        else if (ResolvedData is scnlocLocStoreEmbeddedVariantDescriptorEntry locDescriptorEmbedded &&
-                 locDescriptorEmbedded.VpeIndex > 0)
-        {
-            Descriptor = locDescriptorEmbedded.VpeIndex.ToString();
-        }
-        else if (ResolvedData is scnlocLocStoreEmbeddedVariantPayloadEntry locPayloadEmbedded)
-        {
-            Descriptor = locPayloadEmbedded.VariantId.Ruid.ToString();
-        }
-        else if (ResolvedData is scnPropDef propDef)
-        {
-            Descriptor = $"{propDef.PropName}";
-            if (propDef.SpecPropRecordId.GetResolvedText() is string s && s != "")
-            {
-                Descriptor = $"{Descriptor} ID: {s}";
-            }
-
-            return;
-        }
-        else if (ResolvedData is scnSpawnDespawnEntityParams spawnDespawnParams)
-        {
-            Descriptor = $"{spawnDespawnParams.DynamicEntityUniqueName.GetResolvedText()}";
-            if (spawnDespawnParams.SpawnMarkerNodeRef.GetResolvedText() is string s && s != "")
-            {
-                Descriptor = $"{Descriptor} ID: {s}";
-            }
-
-            return;
-        }
-        else if (ResolvedData is scnNodeSymbol scnNodeSymbol)
-        {
-            Descriptor = $"NodeID: {scnNodeSymbol.NodeId.Id}";
-            return;
-        }
-        else if (ResolvedData is scnWorkspotSymbol scnWorkspotSymbol)
-        {
-            Descriptor = $"NodeID: {scnWorkspotSymbol.WsInstance.Id} (Instance {scnWorkspotSymbol.WsInstance.Id})";
-            return;
-        }
-        else if (ResolvedData is scnSceneEventSymbol sceneEventSymbol)
-        {
-            Descriptor = $"EditorEventId: {sceneEventSymbol.EditorEventId}";
-            return;
-        }
-        else if (ResolvedData is scnPerformerSymbol performerSymbol)
-        {
-            Descriptor = $"{performerSymbol.EntityRef.DynamicEntityUniqueName.GetResolvedText()}";
-            return;
-        }
-        else if (ResolvedData is gameEntityReference gameEntRef)
-        {
-            Descriptor = $"{gameEntRef.DynamicEntityUniqueName.GetResolvedText()}";
-            return;
-        }
-        else if (ResolvedData is scnLipsyncAnimSetSRRef lipsyncAnim)
-        {
-            if (lipsyncAnim.LipsyncAnimSet.DepotPath.GetResolvedText() is string animSetDepotPath &&
-                animSetDepotPath != "")
-            {
-                Descriptor = $"{animSetDepotPath}";
-            }
-            else if (lipsyncAnim.AsyncRefLipsyncAnimSet.DepotPath.GetResolvedText() is string asyncSetDepotPath &&
-                     asyncSetDepotPath != "")
-            {
-                Descriptor = $"{asyncSetDepotPath}";
-            }
-
-            return;
-        }
-        else if (ResolvedData is scnscreenplayDialogLine scnscreenplayDialogLine)
-        {
-            Descriptor = scnscreenplayDialogLine.FemaleLipsyncAnimationName.GetResolvedText() ?? "";
-            if (scnscreenplayDialogLine.MaleLipsyncAnimationName.GetResolvedText() is string s1 && s1 != "")
-            {
-                var separator = Value == "" ? "" : " | ";
-                Descriptor = $"{Descriptor}{separator}${s1}";
-            }
-        }
-        // animgraph - something is broken here. Why does the orange text go away? Why do I need the try/catch
-        // around the GetNodename?
-        else if (Data is CHandle<animAnimNode_Base> handle)
-        {
-            if (handle.Chunk is animAnimNode_Switch)
-            {
-                var inputNodes = handle.Chunk.GetProperty("InputNodes");
-                if (inputNodes is CArray<animPoseLink> animAry)
+                var nameIndex = 0;
+                for (var i = 0; i < csv.CompiledHeaders.Count; i++)
                 {
-                    var names = animAry
-                        .Select((animPoseLink) => GetNodeName(animPoseLink.Node) ?? "")
-                        .Where((name) => name != "")
-                        .ToArray();
-                    Descriptor = string.Join(", ", names);
-                    // Value = string.Join(", ", names);
-                    // IsValueExtrapolated = true;
+                    if (!((string)csv.CompiledHeaders[i]).Contains("name", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    nameIndex = i;
+                    break;
+                }
+
+                Descriptor = $"{csvAry[nameIndex]}";
+                if (Descriptor != "")
+                {
                     return;
                 }
-            }
-        }
-        else if (ResolvedData is IRedBufferPointer rbp && rbp.GetValue().Data is RedPackage pkg)
-        {
-            Descriptor = $"[{pkg.Chunks.Count}]";
-        }
-        else if (ResolvedData is IRedBufferPointer rbp2 && rbp2.GetValue().Data is CR2WList cl)
-        {
-            Descriptor = $"[{cl.Files.Count}]";
-        }
-        else if (ResolvedData is CKeyValuePair kvp)
-        {
-            Descriptor = kvp.Key;
-        }
-        else if (ResolvedData is questNodeDefinition qnd)
-        {
-            Descriptor = qnd.Id.ToString();
-            return;
-        }
-        else if (ResolvedData is scnSceneGraphNode sgn)
-        {
-            Descriptor = sgn.NodeId.Id.ToString();
-            return;
-        }
-        else if (ResolvedData is meshMeshMaterialBuffer matBuffer)
-        {
-            Descriptor = $"[{matBuffer.Materials?.Count ?? 0}]";
-            return;
-        }
-        else if (ResolvedData is worldCompiledEffectInfo info)
-        {
-            Descriptor = string.Join(", ", info.PlacementInfos);
-            return;
-        }
-        else if (Data is TweakDBID tdb)
-        {
-            //Descriptor = Locator.Current.GetService<TweakDBService>().GetString(tdb);
-            Descriptor = tdb.GetResolvedText();
-            return;
-        }
-        else if (Data is gamedataLocKeyWrapper locKey)
-        {
-            Descriptor = ((ulong)locKey).ToString();
-            //Value = Locator.Current.GetService<LocKeyService>().GetFemaleVariant(value);
-        }
-        else if (Data is IRedString str)
-        {
-            var s = str.GetString();
-            if (s is not null && s.StartsWith("LocKey#") && ulong.TryParse(s[7..], out var locKey2))
-            {
-                Descriptor = locKey2.ToString();
-            }
-        }
-        //if (ResolvedData is CMaterialInstance && Parent is not null)
-        //{
-        //    if (Parent.Parent is not null && Parent.Parent.Parent is not null && Parent.Parent.Data is CMesh mesh)
-        //    {
-        //        Descriptor = mesh.MaterialEntries[int.Parse(Name)].Name;
-        //    }
-        //}
-        else if (Data is Vector3 v3)
-        {
-            Descriptor = $"{v3.X}, {v3.Y}, {v3.Z}";
-        }
-        else if (Data is Vector4 v4)
-        {
-            Descriptor = $"{v4.X}, {v4.Y}, {v4.Z}, {v4.W}";
-        }
-        else if (Data is Quaternion q)
-        {
-            Descriptor = $"{q.I}, {q.J}, {q.K}, {q.R}";
-        }
 
-        // For local and external materials
-        if (ResolvedData is CMaterialInstance or CResourceAsyncReference<IMaterial> && NodeIdxInParent > -1
-            && GetRootModel().GetModelFromPath("materialEntries")?.ResolvedData is CArray<CMeshMaterialEntry>
-                materialEntries && materialEntries.Count > NodeIdxInParent)
-        {
-            var isLocalMaterial = ResolvedData is CMaterialInstance;
-            var entry = materialEntries[NodeIdxInParent];
+                break;
 
-            // If we immediately found the right material: use material name
-            if (entry.IsLocalInstance == isLocalMaterial && entry.Index == NodeIdxInParent)
+            // regular arrays
+            case IRedArray { Count: > 0 } ary:
             {
-                Descriptor = entry.Name.GetResolvedText();
+                Descriptor = $"[{ary.Count}]";
+                break;
+            }
+            case appearanceAppearancePart part:
+            {
+                Descriptor = part.Resource.DepotPath.GetResolvedText() ?? "";
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case locVoLineEntry voLineEntry:
+            {
+                Descriptor = voLineEntry.StringId.ToString();
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case animAnimEvent animEvent:
+            {
+                Descriptor = animEvent.EventName.GetResolvedText();
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case locVoLengthEntry voLengthEntry:
+            {
+                Descriptor = voLengthEntry.StringId.ToString();
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case animAnimSetEntry entry when entry.Animation?.GetValue() is animAnimation animation:
+            {
+                Descriptor = animation.GetProperty(nameof(Name))?.ToString() ?? "";
+
+                if (ulong.TryParse(Descriptor, out var result))
+                {
+                    Descriptor = ResourcePathPool.ResolveHash(result);
+                }
+
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case scnWorkspotData_ExternalWorkspotResource externalWorkspotResource:
+                Descriptor = $"{externalWorkspotResource.DataId.Id.ToString()}";
+                return;
+            case animAnimSetupEntry animSetupEntry:
+                Descriptor = $"{animSetupEntry.AnimSet.DepotPath.GetResolvedText()}";
+                return;
+            case entAnimationControlBinding controlBinding:
+                Descriptor = $"{controlBinding.BindName.GetResolvedText()}";
+                return;
+            case scnSceneWorkspotInstanceId workspotInstanceId:
+                Descriptor = $"{workspotInstanceId.Id}";
+                return;
+            case scnWorkspotInstance workspotInstance:
+                Descriptor = $"{workspotInstance.OriginMarker.NodeRef.GetResolvedText()}";
+                return;
+            case scnChoiceNodeOption choiceNodeOption:
+                Descriptor = $"{choiceNodeOption.Caption}";
+                return;
+            case scnSectionNode sectionNode:
+                Descriptor = $"{sectionNode.NodeId.Id}";
+                return;
+            case scnInteractionShapeParams shapeParams:
+                Descriptor = $"{shapeParams.Preset}";
+                return;
+            case scnSceneWorkspotDataId workspotDataId:
+                Descriptor = $"{workspotDataId.Id}";
+                return;
+            case scnNodeId id:
+                Descriptor = $"{id.Id}";
+                return;
+            case scnPlayerActorDef playerActorDef:
+                Descriptor = $"{playerActorDef.PlayerName}";
+                return;
+            case scnMarker sceneMarker:
+                Descriptor = sceneMarker.NodeRef.GetResolvedText();
+                break;
+            case scnlocLocStoreEmbeddedVariantDescriptorEntry locDescriptorEmbedded when
+                locDescriptorEmbedded.VpeIndex > 0:
+                Descriptor = locDescriptorEmbedded.VpeIndex.ToString();
+                break;
+            case scnlocLocStoreEmbeddedVariantPayloadEntry locPayloadEmbedded:
+                Descriptor = locPayloadEmbedded.VariantId.Ruid.ToString();
+                break;
+            case scnPropDef propDef:
+            {
+                Descriptor = $"{propDef.PropName}";
+                if (propDef.SpecPropRecordId.GetResolvedText() is string s && s != "")
+                {
+                    Descriptor = $"{Descriptor} ID: {s}";
+                }
+
+                return;
+            }
+            case scnSpawnDespawnEntityParams spawnDespawnParams:
+            {
+                Descriptor = $"{spawnDespawnParams.DynamicEntityUniqueName.GetResolvedText()}";
+                if (spawnDespawnParams.SpawnMarkerNodeRef.GetResolvedText() is string s && s != "")
+                {
+                    Descriptor = $"{Descriptor} ID: {s}";
+                }
+
+                return;
+            }
+            case scnNodeSymbol scnNodeSymbol:
+                Descriptor = $"NodeID: {scnNodeSymbol.NodeId.Id}";
+                return;
+            case scnWorkspotSymbol scnWorkspotSymbol:
+                Descriptor = $"NodeID: {scnWorkspotSymbol.WsInstance.Id} (Instance {scnWorkspotSymbol.WsInstance.Id})";
+                return;
+            case scnSceneEventSymbol sceneEventSymbol:
+                Descriptor = $"EditorEventId: {sceneEventSymbol.EditorEventId}";
+                return;
+            case scnPerformerSymbol performerSymbol:
+                Descriptor = $"{performerSymbol.EntityRef.DynamicEntityUniqueName.GetResolvedText()}";
+                return;
+            case gameEntityReference gameEntRef:
+                Descriptor = $"{gameEntRef.DynamicEntityUniqueName.GetResolvedText()}";
+                return;
+            case scnLipsyncAnimSetSRRef lipsyncAnim:
+                Descriptor = StringHelper.StringifyOrNull(lipsyncAnim.LipsyncAnimSet.DepotPath)
+                             ?? StringHelper.StringifyOrNull(lipsyncAnim.AsyncRefLipsyncAnimSet.DepotPath) ?? "";
+                if (Descriptor != "")
+                {
+                    return;
+                }
+
+                break;
+
+            case scnscreenplayDialogLine scnscreenplayDialogLine:
+            {
+                Descriptor = scnscreenplayDialogLine.FemaleLipsyncAnimationName.GetResolvedText() ?? "";
+                if (StringHelper.StringifyOrNull(scnscreenplayDialogLine.MaleLipsyncAnimationName) is string s1)
+                {
+                    var separator = Value == "" ? "" : " | ";
+                    Descriptor = $"{Descriptor}{separator}${s1}";
+                }
+
+                break;
+            }
+            // animgraph - something is broken here. Why does the orange text go away? Why do I need the try/catch
+            // around the GetNodename?
+            // For local and external materials
+            case CMaterialInstance or CResourceAsyncReference<IMaterial> when NodeIdxInParent > -1
+                                                                              && GetRootModel().GetModelFromPath("materialEntries")
+                                                                                      ?.ResolvedData is CArray<CMeshMaterialEntry>
+                                                                                  materialEntries &&
+                                                                              materialEntries.Count > NodeIdxInParent:
+            {
+                var isLocalMaterial = ResolvedData is CMaterialInstance;
+                var entry = materialEntries[NodeIdxInParent];
+
+                // If we immediately found the right material: use material name
+                if (entry.IsLocalInstance == isLocalMaterial && entry.Index == NodeIdxInParent)
+                {
+                    Descriptor = entry.Name.GetResolvedText();
+                    if (Descriptor != null)
+                    {
+                        return;
+                    }
+                }
+
+                // Else: Iterate to find material name
+                entry = materialEntries
+                    .FirstOrDefault(e => e.Index == NodeIdxInParent && e.IsLocalInstance == isLocalMaterial);
+
+                // Will return null if no entry is found
+                Descriptor = entry?.Name.GetResolvedText();
+
                 if (Descriptor != null)
                 {
                     return;
                 }
+
+                break;
             }
-
-            // Else: Iterate to find material name
-            entry = materialEntries
-                .Where((e, idx) => e.Index == NodeIdxInParent && e.IsLocalInstance == isLocalMaterial)
-                .FirstOrDefault();
-
-            // Will return null if no entry is found
-            Descriptor = entry?.Name.GetResolvedText();
-
-            if (Descriptor != null)
+            case localizationPersistenceOnScreenEntry localizationPersistenceOnScreenEntry:
             {
-                return;
-            }
-        }
-        else if (ResolvedData is localizationPersistenceOnScreenEntry localizationPersistenceOnScreenEntry)
-        {
-            var desc = $"[{localizationPersistenceOnScreenEntry.PrimaryKey}]";
-            if (!string.IsNullOrEmpty(localizationPersistenceOnScreenEntry.SecondaryKey))
-            {
-                desc += $" {localizationPersistenceOnScreenEntry.SecondaryKey}";
-            }
+                var desc = $"[{localizationPersistenceOnScreenEntry.PrimaryKey}]";
+                if (!string.IsNullOrEmpty(localizationPersistenceOnScreenEntry.SecondaryKey))
+                {
+                    desc += $" {localizationPersistenceOnScreenEntry.SecondaryKey}";
+                }
 
-            Descriptor = desc;
-        }
-        else if (ResolvedData is entHardTransformBinding tBinding)
-        {
-            Descriptor = tBinding.BindName;
-        }
-        else if (ResolvedData is WorldTransform bind)
-        {
-            Descriptor =
-                $"Pos: (X: {(float)bind.Position.X:G9}, Y: {(float)bind.Position.Y:G9}, Z: {(float)bind.Position.Z:G9})";
-            Descriptor =
-                $"{Descriptor}, Orientation: ({bind.Orientation})";
-            return;
-        }
-        else if (ResolvedData is WorldPosition position)
-        {
-            Descriptor = $"{(float)position.X:G9}, {(float)position.Y:G9}, {(float)position.Z:G9}";
-            return;
-        }
-        else if (ResolvedData is inkTextureSlot texturesSlot)
-        {
-            var desc = texturesSlot.Texture.DepotPath.GetResolvedText();
-            if (!string.IsNullOrEmpty(desc))
-            {
                 Descriptor = desc;
+                break;
             }
-        }
-        else if (ResolvedData is worldInstancedMeshNode instancedMeshNode)
-        {
-            // If this isn't overwritten by debugName, put the mesh name instead
-            var desc = GetNameFrom(instancedMeshNode);
-            if (!string.IsNullOrEmpty(desc))
-            {
-                Descriptor = desc;
-            }
-        }
-        else if (ResolvedData is entEffectDesc { EffectName: var name })
-        {
-            Descriptor = name;
-            if (Descriptor is not null and not "")
-            {
+            case entHardTransformBinding tBinding:
+                Descriptor = tBinding.BindName;
+                break;
+            case WorldTransform bind:
+                Descriptor = StringHelper.Stringify(bind);
                 return;
-            }
-        }
-        else if (ResolvedData is senseVisibleObject senseVisibleObject)
-        {
-            Descriptor = senseVisibleObject.Description;
+            case WorldPosition position:
+                Descriptor = StringHelper.Stringify(position);
+                return;
+            case inkTextureSlot texturesSlot:
+            {
+                Descriptor = StringHelper.StringifyOrNull(texturesSlot.Texture.DepotPath);
+                if (Descriptor is not null)
+                {
+                    return;
+                }
 
-            if (Descriptor is not null and not "")
+                break;
+            }
+            case entEffectDesc { EffectName: var name }:
             {
+                Descriptor = name;
+                if (Descriptor is not null and not "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case senseVisibleObject senseVisibleObject:
+            {
+                Descriptor = senseVisibleObject.Description;
+
+                if (Descriptor is not null and not "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case FxResourceMapData mapData:
+            {
+                Descriptor = mapData.Key;
+                if (Descriptor is not null and not "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case rendGradientEntry rendGradientEntry:
+                Descriptor = $"{StringHelper.Stringify(rendGradientEntry.Color)}";
+                break;
+            case localizationPersistenceOnScreenEntries jsonRoot:
+            {
+                Descriptor = $"[{jsonRoot.Entries.Count}]";
                 return;
             }
-        }
-        else if (ResolvedData is FxResourceMapData mapData)
-        {
-            Descriptor = mapData.Key;
-            if (Descriptor is not null and not "")
+            case gameFxResource fxResource:
             {
+                Descriptor = StringHelper.StringifyOrNull(fxResource.Effect.DepotPath);
+                if (Descriptor is not null)
+                {
+                    return;
+                }
+
+                break;
+            }
+            case gameBinkVideoRecord videoRecord:
+            {
+                Descriptor = $"{videoRecord.BinkDuration}";
+                if (Descriptor is not "")
+                {
+                    return;
+                }
+
+                break;
+            }
+            case IRedBufferPointer rbp when rbp.GetValue().Data is RedPackage pkg:
+                Descriptor = $"[{pkg.Chunks.Count}]";
+                break;
+            case IRedBufferPointer rbp2 when rbp2.GetValue().Data is CR2WList cl:
+                Descriptor = $"[{cl.Files.Count}]";
+                break;
+            case CKeyValuePair kvp:
+                Descriptor = kvp.Key;
+                break;
+            case questNodeDefinition qnd:
+                Descriptor = qnd.Id.ToString();
                 return;
-            }
-        }
-        else if (ResolvedData is localizationPersistenceOnScreenEntries jsonRoot)
-        {
-            Descriptor = $"[{jsonRoot.Entries.Count}]";
-            if (Descriptor is not null and not "")
-            {
+            case questVarComparison_ConditionType qnd:
+                Descriptor = qnd.FactName;
                 return;
-            }
-        }
-        else if (ResolvedData is gameFxResource fxResource)
-        {
-            Descriptor = fxResource.Effect.DepotPath.GetResolvedText();
-            if (Descriptor is not null and not "")
-            {
+            case questVarVsVarComparison_ConditionType qnd:
+                Descriptor = StringHelper.Stringify([qnd.FactName1, qnd.FactName2]);
                 return;
-            }
-        }
-        else if (ResolvedData is gameBinkVideoRecord videoRecord)
-        {
-            Descriptor = $"{videoRecord.BinkDuration}";
-            if (Descriptor is not null and not "")
-            {
+            case scnSceneGraphNode sgn:
+                Descriptor = sgn.NodeId.Id.ToString();
                 return;
+            case meshMeshMaterialBuffer matBuffer:
+                Descriptor = $"[{matBuffer.Materials.Count}]";
+                return;
+            case worldCompiledEffectInfo info:
+                Descriptor = string.Join(", ", info.PlacementInfos);
+                return;
+            case animAnimNode_Container nodeContainer:
+                Descriptor = $"[{nodeContainer.Nodes.Count}]";
+                return;
+            default:
+            {
+                // mesh: boneTransforms (in different coordinate spaces)
+                if (NodeIdxInParent > -1 &&
+                    Parent?.Name is "boneTransforms" or "aPoseLS" or "aPoseMS" &&
+                    GetRootModel().GetModelFromPath("boneNames")?.ResolvedData is CArray<CName> boneNames &&
+                    boneNames.Count > NodeIdxInParent)
+                {
+                    Descriptor = boneNames[NodeIdxInParent];
+                    break;
+                }
+
+                if (CalculateDescriptorFromData())
+                {
+                    return;
+                }
+
+                break;
             }
         }
-        // mesh: boneTransforms (in different coordinate spaces)
-        else if (NodeIdxInParent > -1 &&
-                 (Parent?.Name == "boneTransforms" || Parent?.Name == "aPoseLS" || Parent?.Name == "aPoseMS") &&
-                 GetRootModel().GetModelFromPath("boneNames")?.ResolvedData is CArray<CName> boneNames &&
-                 boneNames.Count > NodeIdxInParent)
-        {
-            Descriptor = boneNames[NodeIdxInParent];
-        }
-        else if (ResolvedData is not null)
-        {
-            if (Data is IBrowsableDictionary ibd)
-            {
-                var pns = ibd.GetPropertyNames();
-                Descriptor = $"[{pns.Count()}]";
-            }
-            else if (Data is IList list)
-            {
-                Descriptor = $"[{list.Count}]";
-            }
-            else if (Data is Dictionary<string, object> dict)
-            {
-                Descriptor = $"[{dict.Count}]";
-            }
-        }
-        
-        
+
+
         if (ResolvedData is RedBaseClass irc)
         {
-            foreach (var propName in s_DescriptorPropNames)
+            foreach (var propName in s_descriptorPropNames)
             {
                 var prop = GetPropertyByRedName(irc.GetType(), propName);
                 if (prop is null)
@@ -494,7 +491,7 @@ public partial class ChunkViewModel
         }
         else
         {
-            foreach (var propName in s_DescriptorPropNames)
+            foreach (var propName in s_descriptorPropNames)
             {
                 var prop = Data?.GetType().GetProperty(propName);
 
@@ -517,30 +514,11 @@ public partial class ChunkViewModel
         Descriptor ??= "";
     }
 
-    private static string GetNameFrom(worldNode? linkNode)
-    {
-        if (linkNode is null)
-        {
-            return "None";
-        }
-
-        if (linkNode.DebugName.GetResolvedText() is string s && s != "" && s != "None")
-        {
-            return s;
-        }
-
-        if (linkNode is worldInstancedMeshNode inst)
-        {
-            return inst.Mesh.DepotPath.GetResolvedText()?.Split("/").LastOrDefault() ?? "None";
-        }
-
-        return "None";
-    }
 
     /// <summary>
     /// Property names for descriptor field
     /// </summary>
-    private static readonly string[] s_DescriptorPropNames =
+    private static readonly string[] s_descriptorPropNames =
     [
         "name", // default property
         "partName", // ?
@@ -572,11 +550,11 @@ public partial class ChunkViewModel
     ];
     // For search&replace
 
-    private static readonly string[] s_replacementPropertyNames = s_DescriptorPropNames
+    private static readonly string[] s_replacementPropertyNames = s_descriptorPropNames
         .Where((s) => !s_nonRenamableProperties.Contains(s))
         .Concat<string>([
             "depotPath",
             "meshAppearance",
         ]).ToArray();
-    
+
 }

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
@@ -390,7 +390,7 @@ public partial class ChunkViewModel
                 break;
             }
             case rendGradientEntry rendGradientEntry:
-                Descriptor = $"{StringHelper.Stringify(rendGradientEntry.Color)}";
+                Descriptor = $"{rendGradientEntry.Value}";
                 break;
             case localizationPersistenceOnScreenEntries jsonRoot:
             {

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Descriptor.cs
@@ -389,6 +389,16 @@ public partial class ChunkViewModel
 
                 break;
             }
+            case CParticleEmitter particleEmitter:
+            {
+                Descriptor = particleEmitter.EditorName;
+                if (Descriptor is not null and not "")
+                {
+                    return;
+                }
+
+                break;
+            }
             case rendGradientEntry rendGradientEntry:
                 Descriptor = $"{rendGradientEntry.Value}";
                 break;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
@@ -21,7 +21,7 @@ public partial class ChunkViewModel
     // Properties (by name) that should never be changed by the user
     private static readonly List<string> s_globalReadonlyFields =
     [
-        "saveDateTime", "resourceVersion", "cookingPlatform"
+        "saveDateTime", "resourceVersion", "cookingPlatform", "renderBuffer"
     ];
 
     // Fields (by parent class) that should be marked as read-only
@@ -33,7 +33,7 @@ public partial class ChunkViewModel
 
     private void CalculateIsReadOnly()
     {
-        if (s_globalReadonlyFields.Contains(Name) || s_globalReadonlyTypes.Contains(ResolvedData.GetType()))
+        if (Parent?.IsReadOnly is true || s_globalReadonlyFields.Contains(Name) || s_globalReadonlyTypes.Contains(ResolvedData.GetType()))
         {
             IsReadOnly = true;
             return;
@@ -45,7 +45,7 @@ public partial class ChunkViewModel
         }
     }
 
-    private void CalculateUserInteractionStates()
+    internal void CalculateUserInteractionStates()
     {
         // Either a root field, or a field that isn't initialized yet
         if (Parent is null || ResolvedData is RedDummy || IsReadOnly || IsHiddenByNoobFilter)
@@ -56,7 +56,7 @@ public partial class ChunkViewModel
         CalculateIsReadOnly();
 
         // If we're in simple view, hide all "unnecessary" properties from the user
-        if (_settingsManager.IsNoobFilterEnabled())
+        if (_settingsManager.IsNoobFilterDefaultEnabled())
         {
             CalculateConditionalHiding();
         }
@@ -68,25 +68,43 @@ public partial class ChunkViewModel
     /// </summary>
     private void CalculateConditionalHiding()
     {
-        if (IsReadOnly)
+        if (s_alwaysHiddenFields.Contains(Name))
         {
             IsHiddenByNoobFilter = true;
             return;
         }
-
+        
         if (Parent is not null && s_hiddenFields.TryGetValue(Parent.ResolvedData.GetType(), out var hiddenFields))
         {
             IsHiddenByNoobFilter = hiddenFields.Contains(Name);
         }
     }
 
+    private static readonly List<string> s_alwaysHiddenFields = new()
+    {
+        "topology",
+        "topologyData",
+        "topologyDataStride",
+        "topologyMetadata",
+        "topologyMetadataStride",
+        "version",
+        "vertexBufferSize"
+    }; 
+
     private static readonly Dictionary<Type, List<string>> s_hiddenFields = new()
     {
         {
             typeof(CMesh), [
-                "boundingBox", "boneNames", "boneRigMatrices", "castGlobalShadowsCachedInCook", "castLocalShadowsCachedInCook",
-                "castRayTracedShadowsFromOriginalGeometry", "consoleBias", "floatTrackNames", "forceLoadAllAppearances", "lodBoneMask",
+                "boundingBox", "boneNames", "boneVertexEpsilons", "boneRigMatrices", "castGlobalShadowsCachedInCook",
+                "castLocalShadowsCachedInCook",
+                "castsRayTracedShadowsFromOriginalGeometry", "consoleBias", "floatTrackNames", "forceLoadAllAppearances", "lodBoneMask",
                 "objectType", "resourceVersion", "saveDateTime", "surfaceAreaPerAxis", "useRayTracingShadowLODBias"
+            ]
+        },
+        { // Mesh: Render blob header
+            typeof(rendRenderMeshBlobHeader), [
+                "bonePositions", "customData", "customDataElemStride", "dataProcessing", "indexBufferOffset", "indexBufferStride",
+                "opacityMicromaps", "quantizationOffset", "quantizationScale", "renderChunks"
             ]
         },
     };

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using WolvenKit.RED4.Types;
+
+// ReSharper disable once CheckNamespace
+namespace WolvenKit.App.ViewModels.Shell;
+
+public partial class ChunkViewModel
+{
+    // Types that should never be changed by the user 
+    private static readonly List<Type> s_globalReadonlyTypes =
+    [
+        typeof(SerializationDeferredDataBuffer),
+        typeof(rendRenderTextureBlobMemoryLayout),
+        typeof(rendRenderTextureBlobPlacement),
+        typeof(rendRenderTextureBlobMipMapInfo),
+        typeof(rendRenderTextureBlobTextureInfo),
+        typeof(rendRenderTextureBlobSizeInfo),
+    ];
+
+    // Properties (by name) that should never be changed by the user
+    private static readonly List<string> s_globalReadonlyFields =
+    [
+        "saveDateTime", "resourceVersion", "cookingPlatform"
+    ];
+
+    // Fields (by parent class) that should be marked as read-only
+    private static readonly Dictionary<Type, List<string>> s_readonlyFields = new()
+    {
+        { typeof(CBitmapTexture), ["width", "height"] }, // xbm
+        { typeof(CMesh), ["geometryHash", "consoleBias"] }, // mesh
+    };
+
+    private void CalculateIsReadOnly()
+    {
+        if (s_globalReadonlyFields.Contains(Name) || s_globalReadonlyTypes.Contains(ResolvedData.GetType()))
+        {
+            IsReadOnly = true;
+            return;
+        }
+
+        if (Parent is not null && s_readonlyFields.TryGetValue(Parent.ResolvedData.GetType(), out var hiddenFields))
+        {
+            IsReadOnly = hiddenFields.Contains(Name);
+        }
+    }
+
+    private void CalculateUserInteractionStates()
+    {
+        // Either a root field, or a field that isn't initialized yet
+        if (Parent is null || ResolvedData is RedDummy || IsReadOnly || IsHiddenByNoobFilter)
+        {
+            return;
+        }
+
+        CalculateIsReadOnly();
+
+        // If we're in simple view, hide all "unnecessary" properties from the user
+        if (_settingsManager.IsNoobFilterEnabled())
+        {
+            CalculateConditionalHiding();
+        }
+    }
+
+    /// <summary>
+    /// Should this property be hidden from the default view (because the user has toggled the noob filter)?
+    /// TODO: Not implemented yet
+    /// </summary>
+    private void CalculateConditionalHiding()
+    {
+        if (IsReadOnly)
+        {
+            IsHiddenByNoobFilter = true;
+            return;
+        }
+
+        if (Parent is not null && s_hiddenFields.TryGetValue(Parent.ResolvedData.GetType(), out var hiddenFields))
+        {
+            IsHiddenByNoobFilter = hiddenFields.Contains(Name);
+        }
+    }
+
+    private static readonly Dictionary<Type, List<string>> s_hiddenFields = new()
+    {
+        {
+            typeof(CMesh), [
+                "boundingBox", "boneNames", "boneRigMatrices", "castGlobalShadowsCachedInCook", "castLocalShadowsCachedInCook",
+                "castRayTracedShadowsFromOriginalGeometry", "consoleBias", "floatTrackNames", "forceLoadAllAppearances", "lodBoneMask",
+                "objectType", "resourceVersion", "saveDateTime", "surfaceAreaPerAxis", "useRayTracingShadowLODBias"
+            ]
+        },
+    };
+}

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
@@ -119,5 +119,7 @@ public partial class ChunkViewModel
                 "opacityMicromaps", "quantizationOffset", "quantizationScale", "renderChunks"
             ]
         },
+        { typeof(inkTextureAtlas), ["activeTexture", "dynamicTexture", "parts", "slices", "texture"] },
+        { typeof(inkTextureSlot), ["slices"] }
     };
 }

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
@@ -33,6 +33,10 @@ public partial class ChunkViewModel
 
     private void CalculateIsReadOnly()
     {
+        if (IsReadOnly)
+        {
+            return;
+        }
         if (Parent?.IsReadOnly is true || s_globalReadonlyFields.Contains(Name) || s_globalReadonlyTypes.Contains(ResolvedData.GetType()))
         {
             IsReadOnly = true;
@@ -45,21 +49,22 @@ public partial class ChunkViewModel
         }
     }
 
-    internal void CalculateUserInteractionStates()
+    private void CalculateUserInteractionStates()
     {
         // Either a root field, or a field that isn't initialized yet
-        if (Parent is null || ResolvedData is RedDummy || IsReadOnly || IsHiddenByNoobFilter)
+        if (Parent is null || ResolvedData is RedDummy)
         {
             return;
         }
 
         CalculateIsReadOnly();
+        CalculateConditionalHiding();
+    }
 
-        // If we're in simple view, hide all "unnecessary" properties from the user
-        if (_settingsManager.IsNoobFilterDefaultEnabled())
-        {
-            CalculateConditionalHiding();
-        }
+    public bool ExcludeFromSimpleView()
+    {
+        CalculateConditionalHiding();
+        return IsHiddenByNoobFilter;
     }
 
     /// <summary>
@@ -68,6 +73,13 @@ public partial class ChunkViewModel
     /// </summary>
     private void CalculateConditionalHiding()
     {
+        // If we're in simple view, hide all "unnecessary" properties from the user
+        if (Tab?.IsSimpleViewEnabled != true)
+        {
+            IsHiddenByNoobFilter = false;
+            return;
+        }
+        
         if (s_alwaysHiddenFields.Contains(Name))
         {
             IsHiddenByNoobFilter = true;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
@@ -8,6 +8,7 @@ using WolvenKit.Core.Extensions;
 using WolvenKit.RED4.Types;
 using WolvenKit.RED4.Types.Pools;
 
+// ReSharper disable once CheckNamespace
 namespace WolvenKit.App.ViewModels.Shell;
 
 public partial class ChunkViewModel
@@ -15,7 +16,7 @@ public partial class ChunkViewModel
     [MemberNotNull(nameof(Value))]
     public void CalculateValue()
     {
-        Value = Data is null ? "null" : "";
+        Value = "";
 
         // nothing to calculate
         if (ResolvedData is RedDummy)
@@ -29,7 +30,7 @@ public partial class ChunkViewModel
             if (!string.IsNullOrEmpty(value))
             {
                 Value = value;
-                if (Value.StartsWith("LocKey#") && ulong.TryParse(Value[7..], out var key))
+                if (Value.StartsWith("LocKey#") && ulong.TryParse(Value[7..], out var _))
                 {
                     Value = "";
                 }
@@ -42,18 +43,15 @@ public partial class ChunkViewModel
         }
         else if (PropertyType.IsAssignableTo(typeof(LocalizationString)) && Data is LocalizationString l)
         {
-            var value = l;
-            Value = value.Value is "" or null ? "null" : value.Value;
+            Value = l.Value is "" or null ? "null" : l.Value;
         }
         else if (PropertyType.IsAssignableTo(typeof(IRedEnum)) && Data is IRedEnum e)
         {
-            var value = e;
-            Value = value.ToEnumString();
+            Value = e.ToEnumString();
         }
         else if (PropertyType.IsAssignableTo(typeof(IRedBitField)) && Data is IRedBitField f)
         {
-            var value = f;
-            Value = value.ToBitFieldString();
+            Value = f.ToBitFieldString();
         }
         else if (NodeIdxInParent > -1 && Parent?.Name == "referenceTracks" &&
                  GetRootModel().GetModelFromPath("trackNames")?.ResolvedData is CArray<CName> trackNames)
@@ -68,18 +66,15 @@ public partial class ChunkViewModel
         //}
         else if (PropertyType.IsAssignableTo(typeof(CBool)) && Data is CBool cb)
         {
-            var value = cb;
-            Value = value ? "True" : "False";
+            Value = cb ? "True" : "False";
         }
         else if (PropertyType.IsAssignableTo(typeof(CRUID)) && Data is CRUID cr)
         {
-            var value = cr;
-            Value = ((ulong)value).ToString();
+            Value = ((ulong)cr).ToString();
         }
         else if (PropertyType.IsAssignableTo(typeof(CUInt64)) && Data is CUInt64 uInt64)
         {
-            var value = uInt64;
-            Value = value != 0 ? ((NodeRef)(ulong)value).ToString() : ((ulong)value).ToString();
+            Value = uInt64 != 0 ? ((NodeRef)(ulong)uInt64).ToString() : ((ulong)uInt64).ToString();
         }
         else if (PropertyType.IsAssignableTo(typeof(gamedataLocKeyWrapper)))
         {
@@ -89,19 +84,15 @@ public partial class ChunkViewModel
         }
         else if (PropertyType.IsAssignableTo(typeof(IRedInteger)) && Data is IRedInteger i)
         {
-            var value = i;
-
-            Value = value.ToString(CultureInfo.CurrentCulture);
+            Value = i.ToString(CultureInfo.CurrentCulture);
         }
         else if (PropertyType.IsAssignableTo(typeof(FixedPoint)) && Data is FixedPoint fp)
         {
-            var value = fp;
-            Value = ((float)value).ToString("G9");
+            Value = ((float)fp).ToString("G9");
         }
         else if (PropertyType.IsAssignableTo(typeof(NodeRef)) && Data is NodeRef nr)
         {
-            var value = nr;
-            Value = value;
+            Value = nr;
         }
         else if (PropertyType.IsAssignableTo(typeof(IRedRef)) && Data is IRedRef rr)
         {
@@ -127,19 +118,12 @@ public partial class ChunkViewModel
         {
             Value = ibt.GetBrowsableValue();
         }
-        else if (ResolvedData is animPoseLink link)
+        else if (ResolvedData is animPoseLink link && StringHelper.GetNodeName(link.Node) is string s && s != "") 
         {
-            if (link.Node is not null)
-            {
-                var desc = GetNodeName(link.Node);
-
-                if (!string.IsNullOrEmpty(desc))
-                {
-                    Value = desc;
-                    IsValueExtrapolated = true;
-                    return;
-                }
-            }
+            Value = s;
+            IsValueExtrapolated = true;
+            return;
+            
         }
 
         // factory.csv
@@ -150,14 +134,14 @@ public partial class ChunkViewModel
             Value = ary[1];
         }
         // i18n.json
-        else if (Data is localizationPersistenceOnScreenEntry i18n)
+        else if (Data is localizationPersistenceOnScreenEntry i18N)
         {
             IsValueExtrapolated = true;
             // fall back to male variant only if female variant is
-            Value = i18n.FemaleVariant;
-            if (Value == "" && i18n.MaleVariant != "")
+            Value = i18N.FemaleVariant;
+            if (Value == "" && i18N.MaleVariant != "")
             {
-                Value = i18n.MaleVariant;
+                Value = i18N.MaleVariant;
             }
         }
         // i18n.json
@@ -179,6 +163,31 @@ public partial class ChunkViewModel
                 };
                 IsValueExtrapolated = true;
                 break;
+            // csv files: Some of them have a fallbackXYZname
+            case IRedArray { Count: > 0 } csvAry when Parent is { Name: "compiledData" } && GetRootModel().Data is C2dArray csv:
+
+                var nameIndex = 0;
+                for (var i = 0; i < csv.CompiledHeaders.Count; i++)
+                {
+                    var propertyName = ((string)csv.CompiledHeaders[i]).ToLower();
+                    if (!propertyName.Contains("name") && propertyName.Contains("fallback"))
+                    {
+                        continue;
+                    }
+
+                    nameIndex = i;
+                    break;
+                }
+
+                Value = $"{csvAry[nameIndex]}";
+                if (Value != "")
+                {
+                    IsValueExtrapolated = true;
+                    return;
+                }
+
+                break;
+            
             case meshMeshAppearance { ChunkMaterials: not null } appearance:
                 Value = string.Join(", ", appearance.ChunkMaterials);
                 Value = $"[{appearance.ChunkMaterials.Count}] {Value}";
@@ -210,6 +219,14 @@ public partial class ChunkViewModel
                 Value = $"{sceneWorkspotData.Id}";
                 IsValueExtrapolated = sceneWorkspotData.Id != 0;
                 break;
+            case worldNode worldNode:
+                Value = StringHelper.Stringify(worldNode, true);
+                IsValueExtrapolated = Value != "";
+                break;
+            case graphGraphNodeDefinition nodeDef:
+                Value = $"[{nodeDef.Sockets.Count}]";
+                IsValueExtrapolated = true;
+                return;
             case scnSceneWorkspotInstanceId sceneWorkspotInstance when sceneWorkspotInstance.Id != 0:
                 Value = $"{sceneWorkspotInstance.Id}";
                 IsValueExtrapolated = sceneWorkspotInstance.Id != 0;
@@ -228,6 +245,38 @@ public partial class ChunkViewModel
                 break;
             case workWorkEntryId id:
                 Value = $"{id.Id}";
+                IsValueExtrapolated = true;
+                break;
+            case questFactsDBCondition condition:
+                switch (condition.Type.GetValue())
+                {
+                    case questVarComparison_ConditionType type:
+                        Value = $"{type.ComparisonType.ToEnumString()}: {type.FactName}";
+                        break;
+                    case questVarVsVarComparison_ConditionType type:
+                        Value = $"{type.ComparisonType.ToEnumString()}: {StringHelper.Stringify([type.FactName1, type.FactName2])}";
+                        break;
+
+                    default:
+                        break;
+                }
+
+                IsValueExtrapolated = true;
+                break;
+            case graphGraphConnectionDefinition conn:
+                List<string> nameParts = [];
+                if (conn.Source.GetValue() is graphGraphSocketDefinition source)
+                {
+                    nameParts.Add($"[{source.Connections.Count}] {source.Name.GetResolvedText()}");
+                }
+
+                if (conn.Destination.GetValue() is graphGraphSocketDefinition dest)
+                {
+                    nameParts.Add($"[{dest.Connections.Count}] {dest.Name.GetResolvedText()}");
+                }
+
+                // If they're called "In" and "Out", we don't need to know
+                Value = string.Join(" -> ", nameParts).Replace(" In", "").Replace(" Out", "");
                 IsValueExtrapolated = true;
                 break;
 
@@ -303,6 +352,10 @@ public partial class ChunkViewModel
                 break;
             case gameBinkVideoRecord videoRecord:
                 Value = ResourcePathPool.ResolveHash(videoRecord.ResourceHash);
+                IsValueExtrapolated = Value != "";
+                break;
+            case animAnimNode_Base animNodeBase:
+                Value = StringHelper.Stringify(animNodeBase);
                 IsValueExtrapolated = Value != "";
                 break;
             case entVisualControllerComponent entVisualControllerComponent:
@@ -444,6 +497,31 @@ public partial class ChunkViewModel
                 Value = $"{StringHelper.Stringify(animNames.AnimationNames)}";
                 IsValueExtrapolated = true;
                 return;
+            case rendRenderTextureBlobMemoryLayout rendTexBlobLayout:
+                Value = $"rowPitch: {rendTexBlobLayout.RowPitch}, slicePitch: {rendTexBlobLayout.SlicePitch}";
+                IsValueExtrapolated = true;
+                break;
+            case rendRenderTextureBlobPlacement rendTexBlobPlacement:
+                Value = $"Offset: {rendTexBlobPlacement.Offset}, size: {rendTexBlobPlacement.Size}";
+                IsValueExtrapolated = true;
+                break;
+            case rendRenderTextureBlobMipMapInfo rendTexMipmapInfo:
+                Value = $"rowPitch: {rendTexMipmapInfo.Layout.RowPitch}, slicePitch: {rendTexMipmapInfo.Layout.SlicePitch}";
+                IsValueExtrapolated = true;
+                break;
+            case rendRenderTextureBlobTextureInfo rtbtInfo:
+                Value = $"sliceCount: {rtbtInfo.SliceCount}, MipCount: {rtbtInfo.MipCount}";
+                IsValueExtrapolated = true;
+                break;
+            case rendRenderTextureBlobSizeInfo rtbSizeInfo:
+                Value = $"{rtbSizeInfo.Width} x {rtbSizeInfo.Height}";
+                if (rtbSizeInfo.Depth != 1)
+                {
+                    Value = $"{Value} x {rtbSizeInfo.Depth}";
+                }
+
+                IsValueExtrapolated = true;
+                break;
             case scnInputSocketId socketId:
                 Value = $"{socketId.NodeId.Id}";
                 IsValueExtrapolated = socketId.NodeId.Id != 0;
@@ -518,7 +596,7 @@ public partial class ChunkViewModel
                 Value = $"{intComponent.DefinitionResource}";
                 IsValueExtrapolated = Value != "";
                 break;
-            case FxResourceMapData mapData when mapData.Resource is gameFxResource fxResourceValue:
+            case FxResourceMapData { Resource: gameFxResource fxResourceValue }:
                 Value = fxResourceValue.Effect.DepotPath.GetResolvedText();
                 IsValueExtrapolated = Value != "";
                 break;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
@@ -434,12 +434,29 @@ public partial class ChunkViewModel
                 Value = StringHelper.Stringify(cNames);
                 IsValueExtrapolated = cNames.Count != 0;
                 break;
+            case CEvaluatorFloatConst floatConst:
+                Value = $"{floatConst.Value}";
+                break;
             case CArray<TweakDBID> tweakIds:
                 Value = StringHelper.Stringify(tweakIds);
                 IsValueExtrapolated = tweakIds.Count != 0;
                 break;
+            case CParticleEmitter particleEmitter:
+            {
+                Value = particleEmitter.Material.DepotPath.GetResolvedText() ?? "";
+                IsValueExtrapolated = Value != "";
+                break;
+            }
             case scnInterruptionScenarioId scenarioId:
                 Value = scenarioId.Id.ToString();
+                break;
+            case effectTrackItemParticles particlesEffect:
+                Value = particlesEffect.ParticleSystem.DepotPath.GetResolvedText() ?? "";
+                IsValueExtrapolated = Value != "";
+                break;
+            case effectTrackItemLoopMarker loopMarker:
+                Value = $"{loopMarker.TimeDuration}";
+                IsValueExtrapolated = Value != "";
                 break;
             case scnscreenplayItemId scnscreenplayItemId:
                 Value = scnscreenplayItemId.Id.ToString();

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.Value.cs
@@ -513,6 +513,10 @@ public partial class ChunkViewModel
                 Value = $"sliceCount: {rtbtInfo.SliceCount}, MipCount: {rtbtInfo.MipCount}";
                 IsValueExtrapolated = true;
                 break;
+            case rendGradientEntry gradient:
+                Value = $"{StringHelper.Stringify(gradient.Color)}";
+                IsValueExtrapolated = true;
+                break;
             case rendRenderTextureBlobSizeInfo rtbSizeInfo:
                 Value = $"{rtbSizeInfo.Width} x {rtbSizeInfo.Height}";
                 if (rtbSizeInfo.Depth != 1)

--- a/WolvenKit/Views/Documents/RedDocumentView.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentView.xaml
@@ -51,7 +51,6 @@
             </DataTemplate>
 
         </Grid.Resources>
-
         <syncfusion:TabControlExt
             x:Name="TabControl"
             Margin="-3,-2,-3,-3"
@@ -69,6 +68,7 @@
             TabPanelBackground="#313131"
             Tag="{Binding}">
 
+            
             <syncfusion:TabControlExt.NewTabButtonTemplate>
                 <DataTemplate>
                     <Button
@@ -89,14 +89,18 @@
                     </Button>
                 </DataTemplate>
             </syncfusion:TabControlExt.NewTabButtonTemplate>
-
+            
+            
+            
             <syncfusion:TabControlExt.ItemTemplate>
                 <DataTemplate>
                     <Grid Margin="-5" Tag="{Binding}">
+                        
                         <TextBlock
                             Padding="5"
                             Text="{Binding Header}"
-                            ToolTip="{Binding FilePath}" />
+                            ToolTip="{Binding FilePath}"
+                            Mouse.MouseDown="OnToggleNoobFilter" />
 
                         <Grid.ContextMenu>
                             <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">

--- a/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
@@ -44,5 +44,13 @@ namespace WolvenKit.Views.Documents
                 graphViewModel2.Load();
             }
         }
+
+        private void OnToggleNoobFilter(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ClickCount > 1 && DataContext is RedDocumentViewModel vm)
+            {
+                vm.IsSimpleViewEnabled = !vm.IsSimpleViewEnabled;
+            }
+        }
     }
 }

--- a/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentView.xaml.cs
@@ -1,7 +1,10 @@
 using System.Windows.Input;
 using ReactiveUI;
+using Splat;
 using Syncfusion.Windows.Tools.Controls;
 using WolvenKit.App.ViewModels.Documents;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.Views.Shell;
 
 namespace WolvenKit.Views.Documents
 {
@@ -47,10 +50,19 @@ namespace WolvenKit.Views.Documents
 
         private void OnToggleNoobFilter(object sender, MouseButtonEventArgs e)
         {
-            if (e.ClickCount > 1 && DataContext is RedDocumentViewModel vm)
+            if (e.ClickCount <= 1 || DataContext is not RedDocumentViewModel vm)
             {
-                vm.IsSimpleViewEnabled = !vm.IsSimpleViewEnabled;
+                return;
             }
+
+            vm.IsSimpleViewEnabled = !vm.IsSimpleViewEnabled;
+
+            // Send a message to update filtered items source
+            MessageBus.Current.SendMessage("UpdateFilteredItemsSource", "Command");
+
+
+            // var mainWindow = Locator.Current.GetService<AppViewModel>();
+            // mainWindow?.ReloadFile();
         }
     }
 }

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -37,7 +37,7 @@ namespace WolvenKit.Views.Shell
             DataContext = ViewModel;
 
             InitializeComponent();
-
+            
             this.WhenActivated(disposables =>
             {
                 Disposable.Create(dockingAdapter.SaveLayout).DisposeWith(disposables);

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -43,6 +43,8 @@
                 </Style.Triggers>
             </Style>
 
+
+            <!-- Text block --> 
             <Style x:Key="PropertyValueStyle" TargetType="TextBlock">
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="null">
@@ -61,6 +63,7 @@
                 </Style.Triggers>
             </Style>
 
+            <!-- Property name --> 
             <DataTemplate x:Key="PropertyNameTemplate" DataType="{x:Type shell:ChunkViewModel}">
                 <Grid>
                     <Grid.Resources>
@@ -79,7 +82,7 @@
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>
-                        <Style TargetType="TextBlock">
+                        <Style x:Key="TextblockFormatter" TargetType="TextBlock">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
                                     <Setter Property="Foreground" Value="{StaticResource BorderAlt2}" />
@@ -95,6 +98,15 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
+                    <!-- <Grid.Style> -->
+                    <!--     <Style TargetType="Grid"> -->
+                    <!--         <Style.Triggers> -->
+                    <!--             <DataTrigger Binding="{Binding IsHiddenByNoobFilter}" Value="True"> -->
+                    <!--                 <Setter Property="Visibility" Value="Collapsed" /> -->
+                    <!--             </DataTrigger> -->
+                    <!--         </Style.Triggers> -->
+                    <!--     </Style> -->
+                    <!-- </Grid.Style> -->
                     <TextBlock
                         Grid.Column="1"
                         Width="Auto"


### PR DESCRIPTION
# ChunkViewModel: Descriptors and values

- Refactored both to use switch statements rather than endless if/then/else blocks
- CVM will now check if it should be read only 
- Stub implementation for ~~noob filter~~simple editor mode (I didn't manage to hide the rows in the treeview, or I'd have left it in)

From the first commit, only `WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs` is relevant for the review (read-only)
