### PR TITLE
ArchiveXL dynamic paths, fixes mesh_ent preview

### DIFF
--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Splat;
+using WolvenKit.App.Services;
+using WolvenKit.Core.Interfaces;
+
+namespace WolvenKit.App.Helpers;
+
+/// <summary>
+/// This class will resolve ArchiveXL dynamic variant depot paths.
+/// They start with an asterisk (*) and contain substitution wildcards (<see cref="s_keysAndValues"/>).  
+/// </summary>
+internal class ArchiveXlHelper
+{
+    private static readonly Dictionary<string, string[]> s_keysAndValues = new()
+    {
+        { "{camera}", ["fpp", "tpp"] },
+        { "{feet}", ["lifted", "flat", "high_heels", "flat_shoes"] },
+        { "{gender}", ["m", "w"] },
+        { "{body}", ["base_body"] },
+    };
+
+    private static ILoggerService? s_loggerService;
+    private static ILoggerService? LoggerService => s_loggerService ??= Locator.Current.GetService<ILoggerService>();
+
+    private static IProjectManager? s_projectManager;
+    private static IProjectManager? ProjectManager => s_projectManager ??= Locator.Current.GetService<IProjectManager>();
+
+    private static int CountBraces(string depotPath)
+    {
+        var openBracesCount = depotPath.Count(c => c == '{');
+        var closingBracesCount = depotPath.Count(c => c == '}');
+        if (openBracesCount != closingBracesCount)
+        {
+            throw new Exception("Failed to resolve ArchiveXL substitution, no equal amount of { and }");
+        }
+
+        return openBracesCount;
+    }
+
+    private static IEnumerable<string> Substitute(string depotPath)
+    {
+        // Base case: if the string does not contain '{', return the string as the only element in a list
+        if (!depotPath.Contains('{'))
+        {
+            return [depotPath];
+        }
+
+        // Find the first key in the string
+        var start = depotPath.IndexOf('{');
+        var end = depotPath.IndexOf('}');
+        var key = depotPath.Substring(start, end - start + 1);
+
+        // If the key is not in the dictionary, throw an exception
+        if (!s_keysAndValues.TryGetValue(key, out var substitutionList))
+        {
+            throw new Exception($"Key {key} not found in dictionary");
+        }
+
+        // For each value of this key, replace the key in the string with the value and recursively call the function
+        var results = new List<string>();
+        foreach (var substitution in substitutionList)
+        {
+            var newPath = depotPath.Replace(key, substitution);
+            results.AddRange(Substitute(newPath));
+        }
+
+        // Return the combined results
+        return results;
+    }
+
+    /// <summary>
+    /// Returns any existing depot path, or null. If no substitution is used, it will still check for the file's existence
+    /// and return null if it can't be found. 
+    /// </summary>
+    public static string? GetFirstExistingPath(string? depotPath)
+    {
+        if (depotPath is null || ProjectManager?.ActiveProject?.ModDirectory is not string pathToArchiveFolder)
+        {
+            return null;
+        }
+
+        return ResolveDynamicPaths(depotPath).FirstOrDefault((f) => File.Exists(Path.Combine(pathToArchiveFolder, f)));
+    }
+
+    /// <summary>
+    /// Returns a list with all potential substitutions. If the path doesn't enable substitution, the list will have one element.
+    /// To get _any_ existing depot path, use <see cref="GetFirstExistingPath(string?)"/> instead.
+    /// </summary>
+    public static IEnumerable<string> ResolveDynamicPaths(string depotPath)
+    {
+        if (!depotPath.StartsWith('*'))
+        {
+            return [depotPath];
+        }
+
+        depotPath = depotPath[1..];
+
+        var braceCount = 0;
+        try
+        {
+            braceCount = CountBraces(depotPath);
+        }
+        catch (Exception err)
+        {
+            LoggerService?.Error(err.Message);
+        }
+
+        if (braceCount == 0)
+        {
+            return [depotPath];
+        }
+
+        return Substitute(depotPath);
+    }
+}

--- a/WolvenKit.App/Models/LoadableModel.cs
+++ b/WolvenKit.App/Models/LoadableModel.cs
@@ -36,6 +36,9 @@ public class LoadableModel : IBindable, INode
 
     public INode? Parent { get; set; }
     public List<LoadableModel> Models { get; set; } = new();
+
+    public CName ComponentName { get; set; } = CName.Empty;
+
     public void AddModel(LoadableModel child)
     {
         child.Parent = this;

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -41,6 +41,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
     public GameType GameType => GameType.Cyberpunk2077;
 
 
+    /// <summary>
+    /// Returns all files inside <see cref="FileDirectory"/> 
+    /// </summary>
     public List<string> Files
     {
         get
@@ -55,6 +58,10 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+
+    /// <summary>
+    /// Returns all files inside <see cref="ModDirectory"/> 
+    /// </summary>
     public List<string> ModFiles
     {
         get
@@ -69,6 +76,10 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+
+    /// <summary>
+    /// Returns all files inside <see cref="RawDirectory"/> 
+    /// </summary>
     public List<string> RawFiles
     {
         get
@@ -83,6 +94,10 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+
+    /// <summary>
+    /// Path to root level directory (where the .csproj file is)
+    /// </summary>
     public string ProjectDirectory
     {
         get
@@ -93,11 +108,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
     }
 
 
-
-
-
-
-
+    /// <summary>
+    /// Path to /source/raw
+    /// </summary>
     public string FileDirectory
     {
         get
@@ -117,6 +130,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /source/archive
+    /// </summary>
     public string ModDirectory
     {
         get
@@ -136,6 +152,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /_backups
+    /// </summary>
     public string BackupDirectory
     {
         get
@@ -150,6 +169,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /source/raw
+    /// </summary>
     public string RawDirectory
     {
         get
@@ -170,6 +192,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
     }
 
 
+    /// <summary>
+    /// Path to /source/customSounds
+    /// </summary>
     public string SoundDirectory
     {
         get
@@ -184,6 +209,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /source/resources
+    /// </summary>
     public string ResourcesDirectory
     {
         get
@@ -198,6 +226,10 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+
+    /// <summary>
+    /// Path to /source/resources/r6/tweaks
+    /// </summary>
     public string ResourceTweakDirectory
     {
         get
@@ -212,6 +244,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /source/resources/r6/scripts
+    /// </summary>
     public string ResourceScriptsDirectory
     {
         get
@@ -226,7 +261,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
-    // packed folders
+    /// <summary>
+    /// Path to /packed
+    /// </summary>
     public string PackedRootDirectory
     {
         get
@@ -241,6 +278,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /packed/mods
+    /// </summary>
     public string PackedRedModDirectory
     {
         get
@@ -255,6 +295,10 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+
+    /// <summary>
+    /// Path to /packed/archive/pc/mod or /packed/mods
+    /// </summary>
     public string GetPackedArchiveDirectory(bool isRedMod)
     {
         var dir = isRedMod ? Path.Combine(PackedRedModDirectory, "archives") : Path.Combine(PackedRootDirectory, "archive", "pc", "mod");
@@ -267,6 +311,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         return dir;
     }
 
+    /// <summary>
+    /// Path to /packed/customSounds
+    /// </summary>
     public string PackedSoundsDirectory
     {
         get
@@ -281,6 +328,9 @@ public sealed class Cp77Project : IEquatable<Cp77Project>, ICloneable
         }
     }
 
+    /// <summary>
+    /// Path to /packed/r6/tweaks
+    /// </summary>
     public string PackedTweakDirectory
     {
         get

--- a/WolvenKit.App/Models/ResourcePathWrapper.cs
+++ b/WolvenKit.App/Models/ResourcePathWrapper.cs
@@ -69,14 +69,21 @@ public partial class ResourcePathWrapper : ObservableObject, INode<ReferenceSock
     [RelayCommand(CanExecute = nameof(CanLoadRef))]
     private void LoadRef()
     {
-        var cr2w = DataViewModel.Parent.GetFileFromDepotPathOrCache(Socket.File);
-        if (cr2w != null && cr2w.RootChunk != null)
+        if (Socket.File.GetResolvedText() is not string path || ArchiveXlHelper.GetFirstExistingPath(path) is not string existingPath)
         {
-            var chunk = _chunkViewmodelFactory.ChunkViewModel(cr2w.RootChunk, Socket, _appViewModel);
-            chunk.Location = Location;
-            DataViewModel.Nodes.Remove(this);
-            DataViewModel.Nodes.Add(chunk);
-            DataViewModel.LookForReferences(chunk);
+            return;
         }
+
+        var cr2w = DataViewModel.Parent.GetFileFromDepotPathOrCache(existingPath);
+        if (cr2w is not { RootChunk: not null })
+        {
+            return;
+        }
+
+        var chunk = _chunkViewmodelFactory.ChunkViewModel(cr2w.RootChunk, Socket, _appViewModel);
+        chunk.Location = Location;
+        DataViewModel.Nodes.Remove(this);
+        DataViewModel.Nodes.Add(chunk);
+        DataViewModel.LookForReferences(chunk);
     }
 }

--- a/WolvenKit.App/WolvenKit.App.csproj
+++ b/WolvenKit.App/WolvenKit.App.csproj
@@ -63,6 +63,7 @@
 	<PackageReference Include="HelixToolkit.SharpDX.Core.Wpf" />
     <PackageReference Include="AutomaticGraphLayout" />
     <PackageReference Include="Nodify" />
+    <PackageReference Include="Splat"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml.cs
@@ -73,14 +73,40 @@ namespace WolvenKit.Views.Documents
         {
             base.OnKeyDown(e);
 
-            ViewModel.CtrlKeyPressed = true;
+            if (ViewModel is null)
+            {
+                return;
+            }
+
+            if (e.Key is Key.LeftCtrl or Key.RightCtrl)
+            {
+                ViewModel.CtrlKeyPressed = true;
+            }
+
+            if (e.Key is Key.LeftShift or Key.RightShift)
+            {
+                ViewModel.ShiftKeyPressed = true;
+            }
         }
 
         protected override void OnKeyUp(KeyEventArgs e)
         {
             base.OnKeyUp(e);
 
-            ViewModel.CtrlKeyPressed = false;
+            if (ViewModel is null)
+            {
+                return;
+            }
+
+            if (ViewModel.CtrlKeyPressed && e.Key is Key.LeftCtrl or Key.RightCtrl)
+            {
+                ViewModel.CtrlKeyPressed = false;
+            }
+
+            if (ViewModel.ShiftKeyPressed && e.Key is Key.LeftShift or Key.RightShift)
+            {
+                ViewModel.ShiftKeyPressed = false;
+            }
         }
 
         private void HxViewport_MouseDown3D(object sender, RoutedEventArgs e) => throw new System.NotImplementedException();


### PR DESCRIPTION
# ArchiveXL dynamic paths

**Fixed:**
- mesh entity preview for meshes with dynamic path subsitutions
- currently, only one appearance is added, but at least you can see _something_

**Additional notes:**
Partially resolves #1563 (or maybe does resolve it, but root entity file previews don't work yet. See the TODOs in `RDTMeshViewModel:RenderEntity`)
