### PR TITLE
Fix/empty node name none

### DIFF
--- a/WolvenKit.App/Helpers/StringHelpers/StringHelperWorldNode.cs
+++ b/WolvenKit.App/Helpers/StringHelpers/StringHelperWorldNode.cs
@@ -7,13 +7,26 @@ internal static class StringHelperWorldNode
 {
     public static string Stringify(worldNode? worldNode, bool stringifyValue = false)
     {
+        if (worldNode is null)
+        {
+            return "";
+        }
+
         if (stringifyValue)
         {
             return StringifyValue(worldNode);
         }
 
-        return worldNode?.DebugName.GetResolvedText() ?? "";
+        if (worldNode.DebugName != CName.Empty)
+        {
+            return worldNode.DebugName.GetResolvedText() ?? "";
+        }
+
+        return "";
     }
+
+    private static string PrintEntNode(worldEntityNode entNode, bool asValue = false) =>
+        StringHelper.StringifyOrNull(entNode.EntityTemplate.DepotPath, asValue) ?? "";
 
     private static string PrintMesh(CResourceAsyncReference<CMesh> mesh, CName? meshAppearance) =>
         StringHelper.StringifyMeshAppearance(mesh, meshAppearance);
@@ -35,7 +48,8 @@ internal static class StringHelperWorldNode
         worldAIDirectorSpawnNode directorSpawnNode => $"{StringHelper.Stringify(directorSpawnNode.Tags)}",
         worldAudioTagNode worldAudioTagNode => $"{worldAudioTagNode.AudioTag}",
         worldFoliageNode worldFoliageNode => $"{PrintMesh(worldFoliageNode.Mesh, worldFoliageNode.MeshAppearance)}",
-        worldDeviceNode worldDeviceNode => $"[{worldDeviceNode.DeviceConnections.Count}]",
+        worldDeviceNode node => $"{PrintEntNode(node)} [{node.DeviceConnections.Count}]",
+        worldEntityNode node => $"{PrintEntNode(node)}",
         worldEffectNode worldEffectNode => $"[{worldEffectNode.Effect.DepotPath.GetResolvedText()}]",
         worldDistantGINode worldDistantGiNode => $"[{worldDistantGiNode.DataAlbedo.DepotPath.GetResolvedText()}]",
 


### PR DESCRIPTION
# Fix/empty node name none

When DebugName is not set, nodes will fall back to MeshPath/EntPath instead of displaying "None"
