### PR TITLE
Custom hash improvement

### DIFF
--- a/WolvenKit.App/Services/HashServiceExt.cs
+++ b/WolvenKit.App/Services/HashServiceExt.cs
@@ -131,6 +131,11 @@ public class HashServiceExt : HashService
 
         MigrateLegacyProjectCache(project);
 
+        foreach (var p in project.ModFiles.Where(AddResourcePath))
+        {
+            ResourcePathPool.AddOrGetHash(p);
+        }
+
         var customRefsFile = Path.Combine(project.ProjectDirectory, "custom_refs.txt");
         if (File.Exists(customRefsFile))
         {


### PR DESCRIPTION
Force adding project files to custom hashes. Prevents some unresolveable paths for modded files when the custom lookup is missing on load.