### PR TITLE
Added WScript CreateInstanceAsJSON function

### DIFF
--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -849,4 +849,23 @@ public class AppScriptFunctions : ScriptFunctions
 
         return JsonSerializer.Serialize((object)cacheEntry, new JsonSerializerOptions { IncludeFields = true, WriteIndented = true });
     }
+
+    /// <summary>
+    /// Creates a new instance of the given class, and returns it converted to a JSON string
+    /// </summary>
+    /// <param name="className">Name of the class</param>
+    /// <returns></returns>
+    public virtual object? CreateInstanceAsJSON(string className)
+    {
+        if (string.IsNullOrEmpty(className) == false)
+        {
+            var data = RedTypeManager.CreateRedType(className);
+            return RedJsonSerializer.Serialize(data);
+        }
+        else
+        {
+            _loggerService.Error("className cannot be null or empty");
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
# WScript `CreateInstanceAsJSON` function

**Implemented:**
- `CreateInstanceAsJSON(className)`
- Takes the name of the class of which an instance is to be created, and returns it as a JSON formated string
- e.g. `wkit.CreateInstanceAsJSON("worldStaticMeshNode")`

**Additional notes:**
- Implements #1668, except for always returning JSON, as cr2w does not make any sense in this use-case
