### PR TITLE
minor tweaks&fixes

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -346,7 +346,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             CalculateDescriptor();
             Parent.CalculateIsDefault();
             Parent.CalculateDescriptor();
-            Parent.CalculateValue();
         }
         else if (Data is CName && Parent.Data is IRedArray &&
                  Parent.Parent is
@@ -373,6 +372,11 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         if (Parent.IsValueExtrapolated)
         {
             Parent.CalculateValue();
+        }
+
+        if (Parent.Parent?.IsValueExtrapolated is true)
+        {
+            Parent.Parent.CalculateValue();
         }
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.UserInteractionStates.cs
@@ -148,7 +148,7 @@ public partial class ChunkViewModel
         {
             typeof(CMesh), [
                 "preloadExternalMaterials", "preloadLocalMaterials", "preloadLocalMaterialInstances", "preloadLocalMaterials",
-                "inplaceResources",
+                "inplaceResources", "localMaterialInstances"
             ]
         }, // .app file
         {

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -629,13 +629,13 @@
                 <!--  Overwrite Array/Buffer With Selection  -->
                 <MenuItem
                     Command="{Binding Path=PlacementTarget.Tag.ClearAndPasteSelectionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Clear Array/Buffer and Paste Selection"
+                    Header="Overwrite Array/Buffer With Selection"
                     IsCheckable="False"
                     Style="{StaticResource SyncfusionMenuItemStyle}"
                     Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowOverwriteArray, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                     <MenuItem.Icon>
-                        <iconPacks:PackIconMaterial Kind="ContentPaste" Style="{StaticResource ContextMenuIconStyleMaterial}" />
+                        <iconPacks:PackIconMaterial Kind="ClipboardArrowDownOutline" Style="{StaticResource ContextMenuIconStyleMaterial}" />
                     </MenuItem.Icon>
                 </MenuItem>
 
@@ -648,7 +648,7 @@
                     Visibility="{Binding Path=PlacementTarget.Tag.IsArray, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                     <MenuItem.Icon>
-                        <iconPacks:PackIconMaterial Kind="ContentPaste" Style="{StaticResource ContextMenuIconStyleMaterial}" />
+                        <iconPacks:PackIconMaterial Kind="ContentCopy" Style="{StaticResource ContextMenuIconStyleMaterial}" />
                     </MenuItem.Icon>
                 </MenuItem>
 


### PR DESCRIPTION
# Context Menu
better icon+text for "Paste and overwrite"

# CVM
after updating data, recalculate parent and grandparent value if they're interpolated

# Easy Editor: Mesh
Added `localMaterialInstances` (not the one in "materials") to the list of hidden items