### PR TITLE
Feature: WScript HashString function

### DIFF
--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -880,4 +880,28 @@ public class AppScriptFunctions : ScriptFunctions
             throw new WolvenKitException(0x2000, "className cannot be null or empty");
         }
     }
+
+    /// <summary>
+    /// Returns the hashcode for a given string
+    /// </summary>
+    /// <param name="data">String to be hashed</param>
+    /// <param name="method">Hash method to use. Can be "fnv1a64" or "default" (Uses the String objects built in hash function)</param>
+    /// <returns></returns>
+    public virtual ulong? HashString(string data, string method)
+    {
+        if (string.IsNullOrEmpty(data) == false)
+        {
+            switch (method)
+            {
+                case "fnv1a64":
+                    return FNV1A64HashAlgorithm.HashString(data);
+                default:
+                    return (ulong)data.GetHashCode();
+            }
+        }
+        else
+        {
+            throw new WolvenKitException(0x2000, "String to be hashed cannot be null or empty");
+        }
+    }
 }

--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -849,4 +849,23 @@ public class AppScriptFunctions : ScriptFunctions
 
         return JsonSerializer.Serialize((object)cacheEntry, new JsonSerializerOptions { IncludeFields = true, WriteIndented = true });
     }
+
+    /// <summary>
+    /// Creates a new instance of the given class, and returns it converted to a JSON string
+    /// </summary>
+    /// <param name="className">Name of the class</param>
+    /// <returns></returns>
+    public virtual object? CreateInstanceAsJSON(string className)
+    {
+        if (string.IsNullOrEmpty(className) == false)
+        {
+            var data = RedTypeManager.CreateRedType(className);
+            return RedJsonSerializer.Serialize(data);
+        }
+        else
+        {
+            _loggerService.Error("className cannot be null or empty");
+            return null;
+        }
+    }
 }

--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -877,8 +877,7 @@ public class AppScriptFunctions : ScriptFunctions
         }
         else
         {
-            _loggerService.Error("className cannot be null or empty");
-            return null;
+            throw new WolvenKitException(0x2000, "className cannot be null or empty");
         }
     }
 }


### PR DESCRIPTION
# Added function to hash strings in WScript using specified method

**Implemented:**
- `HashString(data, method) -> ulong`
- `data`: The string to be hashed
- `method`: What hash method to use, can be `fnv1a64` or `default` (Uses the built-in `String` hash method)
- e.g. `wkit.HashString("borpaSpin", "default")` -> `18446744072867596000`

P.S. I synced my fork with the main repo, but for some reason the old commits still show up here???