### PR TITLE
handling&doku when game executable couldn't be launched

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -435,7 +435,7 @@ public class RED4Controller : ObservableObject, IGameController
             return true;
         }
 
-        if (_settingsManager.GetRED4GameExecutablePath() is not string launchCommand || string.IsNullOrEmpty(launchCommand))
+        if (_settingsManager.GetRED4GameLaunchCommand() is not string launchCommand || string.IsNullOrEmpty(launchCommand))
         {
             throw new WolvenKitException(0x5001, "No game executable set");
         }

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -430,15 +430,29 @@ public class RED4Controller : ObservableObject, IGameController
         _progressService.IsIndeterminate = false;
 
         // launch game
-        if (options.LaunchGame)
+        if (!options.LaunchGame)
+        {
+            return true;
+        }
+
+        if (_settingsManager.GetRED4GameExecutablePath() is not string launchCommand || string.IsNullOrEmpty(launchCommand))
+        {
+            throw new WolvenKitException(0x5001, "No game executable set");
+        }
+
+        try
         {
             Process.Start(new ProcessStartInfo
             {
-                FileName = _settingsManager.GetRED4GameLaunchCommand(),
+                FileName = launchCommand,
                 Arguments = options.GameArguments ?? "",
                 ErrorDialog = true,
                 UseShellExecute = true,
             });
+        }
+        catch (Exception)
+        {
+            throw new WolvenKitException(0x5002, "Failed to launch game executable");
         }
 
         return true;

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -303,7 +303,8 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
 
     public string GetRED4GameExecutablePath() => CP77ExecutablePath.NotNull();
 
-    public string GetRED4GameLaunchCommand() => CP77LaunchCommand ?? "";
+    // If no launch command is set, use the executable path
+    public string GetRED4GameLaunchCommand() => CP77LaunchCommand ?? CP77ExecutablePath ?? "";
 
     public string GetRED4GameLaunchOptions() => CP77LaunchOptions ?? "";
 

--- a/WolvenKit/Helpers/LogCodeHelper.cs
+++ b/WolvenKit/Helpers/LogCodeHelper.cs
@@ -22,6 +22,10 @@ public static class LogCodeHelper
         s_mapping.Add(0x4001, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/settings#additional-mod-directory");
         s_mapping.Add(0x4002, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/settings#game-executable-.exe-path");
         s_mapping.Add(0x4003, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/usage/wolvenkit-projects");
+
+        // 5: everything else
+        s_mapping.Add(0x5000, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes#id-0x5000-invalid-settings");
+        s_mapping.Add(0x5001, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes#id-0x5001-invalid-game-file-executable");
         
     }
 


### PR DESCRIPTION
# Better error handling for failing game launch

Before: 
```
Unhandled exception in WolvenKit vx.x.x.x
Message: Cannot start process because a file name has not been provided.
Source: System.Diagnostics.Process
StackTrace:    at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at WolvenKit.App.Controllers.RED4Controller.LaunchProject(LaunchProfile options) in D:\a\WolvenKit\WolvenKit\WolvenKit.App\Controllers\RED4Controller.cs:line 423
   at WolvenKit.App.ViewModels.Shell.RibbonViewModel.LaunchProfileAsync() in D:\a\WolvenKit\WolvenKit\WolvenKit.App\ViewModels\Shell\RibbonViewModel.cs:line 86
   at CommunityToolkit.Mvvm.Input.AsyncRelayCommand.AwaitAndThrowIfFailed(Task executionTask)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```
After: Pretty Wolvenkit Exceptions with error messages!