### PR TITLE
scenes - animName - rid animation container index name

### DIFF
--- a/WolvenKit.RED4/Types/ClassesExt/Appendix/scnAnimName.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/Appendix/scnAnimName.cs
@@ -37,7 +37,7 @@ public partial class scnAnimName : IRedAppendix
 
         var cnt = size / 2;
 
-        if (Type == Enums.scnAnimNameType.reference)
+        if (Type == Enums.scnAnimNameType.reference || Type == Enums.scnAnimNameType.container)
         {
             Unk2 = new CArray<CUInt16>();
             for (int i = 0; i < cnt; i++)
@@ -57,7 +57,7 @@ public partial class scnAnimName : IRedAppendix
 
     public void Write(Red4Writer writer)
     {
-        if (Type == Enums.scnAnimNameType.reference)
+        if (Type == Enums.scnAnimNameType.reference || Type == Enums.scnAnimNameType.container)
         {
             foreach (var val in Unk2)
             {


### PR DESCRIPTION
Fix for [Discord link](https://discord.com/channels/717692382849663036/1173444494247600259/1173444494247600259)

It fixes wrong name / index for RID animation container. Now it puts a string from string pool defined in the scene file. It somehow works, but it's a nightmare for editing and very hard to edit it.
This fix changes internal reading from CName to UInt16, hence changes usage of "unk1" to "unk2". I tested it on several scene files and it works as expected.

**Only problem with this fix is that already exported scene files in json can't be converted back. You first need to export them with the new fix and then you can import them back. This should be somehow noted before releasing.**