### PR TITLE
ProjectExplorer fixes

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -123,7 +123,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         {
             if (ActiveProject != null)
             {
-                File.WriteAllText(Path.Combine(ActiveProject.ProjectDirectory, "fileTreeState.json"), JsonSerializer.Serialize(ExpansionStateDictionary));
+                SaveFileTreeState(ActiveProject);
                 _projectWatcher.UnwatchProject(ActiveProject);
             }
 
@@ -131,16 +131,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
             if (_projectManager.ActiveProject != null)
             {
-                var statePath = Path.Combine(_projectManager.ActiveProject.ProjectDirectory, "fileTreeState.json");
-                if (File.Exists(statePath))
-                {
-                    ExpansionStateDictionary = JsonSerializer.Deserialize<Dictionary<string, bool>>(File.ReadAllText(statePath)) ?? new();
-                }
-                else
-                {
-                    ExpansionStateDictionary = new();
-                }
-
+                LoadFileTreeState(_projectManager.ActiveProject);
                 _projectWatcher.WatchProject(_projectManager.ActiveProject);
             }
         }
@@ -1137,6 +1128,31 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         cw.WriteFile(cr2w);
     }
+
+    private void LoadFileTreeState(Cp77Project project)
+    {
+        var statePath = Path.Combine(project.ProjectDirectory, "fileTreeState.json");
+        if (File.Exists(statePath))
+        {
+            ExpansionStateDictionary = JsonSerializer.Deserialize<Dictionary<string, bool>>(File.ReadAllText(statePath)) ?? new();
+        }
+        else
+        {
+            ExpansionStateDictionary = new();
+        }
+    }
+
+    public void SaveFileTreeState()
+    {
+        if (ActiveProject == null)
+        {
+            return;
+        }
+        SaveFileTreeState(ActiveProject);
+    }
+
+    private void SaveFileTreeState(Cp77Project project) =>
+        File.WriteAllText(Path.Combine(project.ProjectDirectory, "fileTreeState.json"), JsonSerializer.Serialize(ExpansionStateDictionary));
 
     public void StopWatcher() => _projectWatcher.ForceStop();
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -95,7 +95,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         _mainViewModel = appViewModel;
 
-        _projectWatcher = new WatcherService();
+        _projectWatcher = new WatcherService(_loggerService);
 
         SideInDockedMode = DockSide.Left;
 

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -161,9 +161,9 @@ namespace WolvenKit.Views.Shell
             }
 
             dockingAdapter.SaveLayout();
-            var projectExplorer = Locator.Current.GetService<ProjectExplorerViewModel>();
-            if (projectExplorer is { } pe)
+            if (ViewModel?.GetToolViewModel<ProjectExplorerViewModel>() is { } pe)
             {
+                pe.SaveFileTreeState();
                 pe.StopWatcher();
             }
             var projectManager = Locator.Current.GetService<IProjectManager>();

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -176,10 +176,51 @@ namespace WolvenKit.Views.Tools
                 {
                     _automatic = true;
 
-                    TreeGrid.ExpandAllNodes(e.Node);
+                    ExpandAllNodes(e.Node);
 
                     _automatic = false;
                     return;
+                }
+            }
+        }
+
+        private void ExpandAllNodes(TreeNode node)
+        {
+            TreeGrid.ExpandAllNodes(node);
+            if (ViewModel != null)
+            {
+                RecursiveStateSave(node.ChildNodes);
+            }
+
+            void RecursiveStateSave(TreeNodes childNodes)
+            {
+                foreach (var childNode in childNodes)
+                {
+                    if (childNode.Item is FileSystemModel fileSystemModel)
+                    {
+                        ViewModel!.ExpansionStateDictionary[fileSystemModel.RawRelativePath] = true;
+                    }
+                    RecursiveStateSave(childNode.ChildNodes);
+                }
+            }
+        }
+
+        private void CollapseAllNodes(TreeNode node)
+        {
+            if (ViewModel != null)
+            {
+                RecursiveStateSave(node.ChildNodes);
+            }
+            TreeGrid.CollapseAllNodes(node);
+            void RecursiveStateSave(TreeNodes childNodes)
+            {
+                foreach (var childNode in childNodes)
+                {
+                    if (childNode.Item is FileSystemModel fileSystemModel)
+                    {
+                        ViewModel!.ExpansionStateDictionary[fileSystemModel.RawRelativePath] = false;
+                    }
+                    RecursiveStateSave(childNode.ChildNodes);
                 }
             }
         }
@@ -218,11 +259,11 @@ namespace WolvenKit.Views.Tools
                         {
                             if (state)
                             {
-                                TreeGrid.CollapseAllNodes(childNode);
+                                CollapseAllNodes(childNode);
                             }
                             else
                             {
-                                TreeGrid.ExpandAllNodes(childNode);
+                                ExpandAllNodes(childNode);
                             }
                         }
                         else
@@ -246,7 +287,7 @@ namespace WolvenKit.Views.Tools
                 {
                     _automatic = true;
 
-                    TreeGrid.CollapseAllNodes(e.Node);
+                    CollapseAllNodes(e.Node);
 
                     _automatic = false;
                     return;
@@ -450,7 +491,7 @@ namespace WolvenKit.Views.Tools
 
             var model = ViewModel.SelectedItem;
             var node = TreeGrid.View.Nodes.GetNode(model);
-            TreeGrid.ExpandAllNodes(node);
+            ExpandAllNodes(node);
         }
 
         private void CollapseChildren_OnClick(object sender, RoutedEventArgs e)
@@ -462,7 +503,7 @@ namespace WolvenKit.Views.Tools
 
             var model = ViewModel.SelectedItem;
             var node = TreeGrid.View.Nodes.GetNode(model);
-            TreeGrid.CollapseAllNodes(node);
+            CollapseAllNodes(node);
             TreeGrid.ExpandNode(node);
         }
 
@@ -472,7 +513,7 @@ namespace WolvenKit.Views.Tools
             {
                 if (viewNode.Item is not FileSystemModel || IsFileIn(viewNode.Item))
                 {
-                    TreeGrid.ExpandAllNodes(viewNode);
+                    ExpandAllNodes(viewNode);
                 }
             }
         }
@@ -483,7 +524,7 @@ namespace WolvenKit.Views.Tools
             {
                 if (viewNode.Item is not FileSystemModel || IsFileIn(viewNode.Item))
                 {
-                    TreeGrid.CollapseAllNodes(viewNode);
+                    CollapseAllNodes(viewNode);
                 }
             }
         }


### PR DESCRIPTION
ProjectExplorer fixes

**Implemented:**
- Saving of states while closing WolvenKit

**Fixed:**
- Fixed an issue where not all states were saved while using `ExpandAllNodes` and `CollapseAllNodes`
- Fixed an issue where a new instance of `ProjectExplorer` was created instead of using the existing one
