### PR TITLE
Root Motion

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimRootMotion.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimRootMotion.cs
@@ -8,6 +8,17 @@ using Vec3 = System.Numerics.Vector3;
 
 namespace WolvenKit.Modkit.RED4.Animation
 {
+    internal enum RootMotionType
+    {
+        Unknown,
+        None,
+        TransformLinearSparseFrames,
+        TransformSplineSparseFrames,
+        TransformLinearEveryFrame,
+        TranslationPlaneWithYawAllFrames,
+        TranslationWithYawAllFrames,
+    }
+
     internal class ROOT_MOTION
     {
         private const ushort wSignMask = 0x8000;

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimRootMotion.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimRootMotion.cs
@@ -2,9 +2,31 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Types;
+
+using static WolvenKit.RED4.Types.Enums;
+using static WolvenKit.Modkit.RED4.Animation.Const;
+using static WolvenKit.Modkit.RED4.Animation.Fun;
+using static WolvenKit.Modkit.RED4.Animation.Gltf;
+
+using WkVector4 = WolvenKit.RED4.Types.Vector4;
+
 using Quat = System.Numerics.Quaternion;
 using Vec3 = System.Numerics.Vector3;
+using Vec4 = System.Numerics.Vector4;
+
+using JointsTranslationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+using JointsRotationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>>;
+using JointsScalesAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+
+using TranslationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+using RotationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>;
+using ScalesAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+using WolvenKit.Core.Extensions;
+using ICSharpCode.SharpZipLib;
+
 
 namespace WolvenKit.Modkit.RED4.Animation
 {
@@ -21,16 +43,22 @@ namespace WolvenKit.Modkit.RED4.Animation
 
     internal class ROOT_MOTION
     {
-        private const ushort wSignMask = 0x8000;
-        private const ushort componentTypeMask = 0x6000;
-        private const ushort boneIdxMask = 0x1FFF;
-        private const int wSignRightShift = 15;
-        private const int componentRightShift = 13;
-        private const int boneIdxRightShift = 0;
-        public static void AddRootMotion(ref Dictionary<ushort, Dictionary<float, Vec3>> positions, ref Dictionary<ushort, Dictionary<float, Quat>> rotations, animAnimation animAnimDes)
+
+#region export
+
+        public static RootMotionType DecodeRootMotion(out JointsTranslationsAtTimes translations, out JointsRotationsAtTimes rotations, ref readonly animIMotionExtraction? motionEx, ILoggerService _loggerService)
         {
-            var motionEx = animAnimDes.MotionExtraction.Chunk;
-            var duration = animAnimDes.Duration;
+            translations = [];
+            rotations = [];
+
+            if (motionEx == null)
+            {
+                return RootMotionType.None;
+            }
+
+            translations.Add(0, []);
+            rotations.Add(0, []);
+
             var numFrames = 0;
             var numPositions = 0;
             var numRotations = 0;
@@ -50,31 +78,20 @@ namespace WolvenKit.Modkit.RED4.Animation
                 posTime = lc.PosTime.Select( x => (float)x).ToArray();
                 rotTime = lc.RotTime.Select(x => (float)x).ToArray();
 
-                if (numPositions > 0)
-                {
-                    if (!positions.ContainsKey(0))
-                    {
-                        positions.Add(0, new Dictionary<float, Vec3>());
-                    }
-                }
-                if (numRotations > 0)
-                {
-                    if (!rotations.ContainsKey(0))
-                    {
-                        rotations.Add(0, new Dictionary<float, Quat>());
-                    }
-                }
                 for (var i = 0; i < numPositions; i++)
                 {
                     var v = lc.PosFrames[i];
-                    positions[0].Add(posTime[i], new Vec3(v.X, v.Z, -v.Y));
+                    translations[0].Add(posTime[i], new Vec3(v.X, v.Z, -v.Y));
                 }
                 for (var i = 0; i < numRotations; i++)
                 {
                     var q = lc.RotFrames[i];
                     rotations[0].Add(rotTime[i], new Quat(q.I, q.K, -q.J, q.R));
                 }
+
+                return RootMotionType.TransformLinearSparseFrames;
             }
+            // NB. same as non-plane, but with only XY and Z=angle
             else if (motionEx is animPlaneUncompressedMotionExtraction pc)
             {
                 duration = pc.Duration;
@@ -97,211 +114,217 @@ namespace WolvenKit.Modkit.RED4.Animation
             }
             else if (motionEx is animSplineCompressedMotionExtraction sc)
             {
-                duration = sc.Duration;
+                var duration = sc.Duration;
 
-                #region rotations
-                if (sc.RotKeysData != null)
-                {
-                    var b = sc.RotKeysData.Select(x => x.ToByte());
-                    rotBuffer = b.ToArray();
-                    numRotations = rotBuffer.Length / 16;
-                    if (numRotations > 0)
-                    {
-                        if (!rotations.ContainsKey(0))
-                        {
-                            rotations.Add(0, new Dictionary<float, Quat>());
-                        }
-                    }
-                    using (ms = new MemoryStream(rotBuffer))
-                    using (br = new BinaryReader(ms))
-                    {
-                        br.BaseStream.Seek(0, SeekOrigin.Begin);
-                        for (var i = 0; i < numRotations; i++)
-                        {
-                            var timeNormalized = br.ReadUInt16() / (float)ushort.MaxValue;
-                            var bitWiseData = br.ReadUInt16();
-                            var wSign = Convert.ToUInt16((bitWiseData & wSignMask) >> wSignRightShift);
-                            var component = Convert.ToUInt16((bitWiseData & componentTypeMask) >> componentRightShift);
-                            var boneIdx = Convert.ToUInt16((bitWiseData & boneIdxMask) >> boneIdxRightShift);
-
-                            var x = br.ReadSingle();
-                            var y = br.ReadSingle();
-                            var z = br.ReadSingle();
-
-                            switch (component)
-                            {
-                                case 0:
-                                    if (positions.ContainsKey(boneIdx))
-                                    {
-                                        positions[boneIdx].Add(timeNormalized * duration, new Vec3(x, z, -y));
-                                    }
-                                    else
-                                    {
-                                        var dic = new Dictionary<float, Vec3>
-                                        {
-                                            { timeNormalized * duration, new Vec3(x, z, -y) }
-                                        };
-                                        positions.Add(boneIdx, dic);
-                                    }
-                                    break;
-                                case 1:
-                                    var dotPr = (x * x) + (y * y) + (z * z);
-                                    x *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    y *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    z *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    var w = 1f - dotPr;
-                                    if (wSign == 1)
-                                    {
-                                        w = -w;
-                                    }
-
-                                    var q = new Quat(x, z, -y, w);
-                                    if (rotations.ContainsKey(boneIdx))
-                                    {
-                                        rotations[boneIdx].Add(timeNormalized * duration, Quat.Normalize(q));
-                                    }
-                                    else
-                                    {
-                                        var dic = new Dictionary<float, Quat>
-                                        {
-                                            { timeNormalized * duration, Quat.Normalize(q) }
-                                        };
-                                        rotations.Add(boneIdx, dic);
-                                    }
-                                    break;
-                                default:
-                                    break;
-                            }
-                        }
-                    }
-                }
-                #endregion
                 if (sc.PosKeysData != null)
                 {
                     var b = sc.PosKeysData.Select(x => x.ToByte());
                     posBuffer = b.ToArray();
                     numPositions = posBuffer.Length / 16;
-                    if (numPositions > 0)
-                    {
-                        if (!positions.ContainsKey(0))
-                        {
-                            positions.Add(0, new Dictionary<float, Vec3>());
-                        }
-                    }
+
                     using (ms = new MemoryStream(posBuffer))
                     using (br = new BinaryReader(ms))
                     {
                         br.BaseStream.Seek(0, SeekOrigin.Begin);
                         for (var i = 0; i < numPositions; i++)
                         {
-                            var timeNormalized = br.ReadUInt16() / (float)ushort.MaxValue;
-                            var bitWiseData = br.ReadUInt16();
-                            var wSign = Convert.ToUInt16((bitWiseData & wSignMask) >> wSignRightShift);
-                            var component = Convert.ToUInt16((bitWiseData & componentTypeMask) >> componentRightShift);
-                            var boneIdx = Convert.ToUInt16((bitWiseData & boneIdxMask) >> boneIdxRightShift);
+                            var transform = ReadTransform16byte(br);
 
-                            var x = br.ReadSingle();
-                            var y = br.ReadSingle();
-                            var z = br.ReadSingle();
-
-                            switch (component)
+                            if (transform.TRS.t is null)
                             {
-                                case 0:
-                                    if (positions.ContainsKey(boneIdx))
-                                    {
-                                        positions[boneIdx].Add(timeNormalized * duration, new Vec3(x, z, -y));
-                                    }
-                                    else
-                                    {
-                                        var dic = new Dictionary<float, Vec3>
-                                        {
-                                            { timeNormalized * duration, new Vec3(x, z, -y) }
-                                        };
-                                        positions.Add(boneIdx, dic);
-                                    }
-                                    break;
-                                case 1:
-                                    var dotPr = (x * x) + (y * y) + (z * z);
-                                    x *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    y *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    z *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
-                                    var w = 1f - dotPr;
-                                    if (wSign == 1)
-                                    {
-                                        w = -w;
-                                    }
-
-                                    var q = new Quat(x, z, -y, w);
-                                    if (rotations.ContainsKey(boneIdx))
-                                    {
-                                        rotations[boneIdx].Add(timeNormalized * duration, Quat.Normalize(q));
-                                    }
-                                    else
-                                    {
-                                        var dic = new Dictionary<float, Quat>
-                                        {
-                                            { timeNormalized * duration, Quat.Normalize(q) }
-                                        };
-                                        rotations.Add(boneIdx, dic);
-                                    }
-                                    break;
-                                default:
-                                    break;
+                                throw new InvalidOperationException($"Should only have translations in translations");
                             }
+
+                            if (transform.JointIndex != RootJointIndex)
+                            {
+                                throw new ValueOutOfRangeException($"Motion extraction in joint {transform.JointIndex}, unable to handle this!,");
+                            }
+
+                            var x = transform.TRS.t;
+
+                            translations[RootJointIndex].Add(transform.TimePercent, ((TGVec3)transform.TRS.t)._);
                         }
                     }
                 }
+
+                if (sc.RotKeysData != null)
+                {
+                    var b = sc.RotKeysData.Select(x => x.ToByte());
+                    rotBuffer = b.ToArray();
+                    numRotations = rotBuffer.Length / 16;
+
+                    using (ms = new MemoryStream(rotBuffer))
+                    using (br = new BinaryReader(ms))
+                    {
+                        br.BaseStream.Seek(0, SeekOrigin.Begin);
+                        for (var i = 0; i < numRotations; i++)
+                        {
+                            var transform = ReadTransform16byte(br);
+
+                            if (transform.TRS.r is null)
+                            {
+                                throw new InvalidOperationException($"Should only have rotations in rotations");
+                            }
+
+                            if (transform.JointIndex != RootJointIndex)
+                            {
+                                throw new ValueOutOfRangeException($"Motion extraction in joint {transform.JointIndex}, unable to handle this!,");
+                            }
+
+                            rotations[RootJointIndex].Add(transform.TimePercent, ((RGQuat)transform.TRS.r)._);
+                        }
+                    }
+                }
+
+                return RootMotionType.TransformSplineSparseFrames;
             }
             else if (motionEx is animUncompressedAllAnglesMotionExtraction aa)
             {
-                duration = aa.Duration;
+                var duration = aa.Duration;
                 numFrames = aa.Frames.Count;
                 fps = (numFrames - 1f) / duration;
                 ft = 1f / fps;
-                if (numFrames > 0)
-                {
-                    if (!positions.ContainsKey(0))
-                    {
-                        positions.Add(0, new Dictionary<float, Vec3>());
-                    }
-                    if (!rotations.ContainsKey(0))
-                    {
-                        rotations.Add(0, new Dictionary<float, Quat>());
-                    }
-                }
+
                 for (var i = 0; i < numFrames; i++)
                 {
                     var frame = aa.Frames[i];
                     var v = frame.Position;
                     var q = frame.Orientation;
-                    positions[0].Add(ft * i, new Vec3(v.X, v.Z, -v.Y));
+                    translations[0].Add(ft * i, new Vec3(v.X, v.Z, -v.Y));
                     rotations[0].Add(ft * i, new Quat(q.I, q.K, -q.J, q.R));
                 }
+
+                return RootMotionType.TransformLinearEveryFrame;
             }
-            else if (motionEx is animUncompressedMotionExtraction uc)
-            {
-                duration = uc.Duration;
-                numFrames = uc.Frames.Count;
-                numPositions = numFrames;
-                fps = (numFrames - 1f) / duration;
-                ft = 1f / fps;
-                if (numPositions > 0)
-                {
-                    if (!positions.ContainsKey(0))
-                    {
-                        positions.Add(0, new Dictionary<float, Vec3>());
-                    }
-                }
-                for (var i = 0; i < numFrames; i++)
-                {
-                    var v = uc.Frames[i];
-                    if (v.W != 0f || v.W != 1f)
-                    {
-                        throw new Exception("vec4 W unexpected value ???");
-                    }
-                    positions[0].Add(ft * i, new Vec3(v.X, v.Z, -v.Y));
-                }
-            }
+
+            throw new InvalidOperationException("Should never get here");
         }
+
+#endregion export
+
+#region helpers
+
+        internal const ushort WsignMask = 0x8000;
+        internal const ushort TransformTypeMask = 0x6000;
+        internal const ushort JointIndexMask = 0x1FFF;
+        internal const int WsignShift = 15;
+        internal const int TransformTypeShift = 13;
+        internal const int JointIndexShift = 0;
+
+        internal const ushort TransformCompressedWidthBytes = 16; // u16 + u16 + f32 + f32 + f32
+
+        internal enum TransformTypeId : ushort
+        {
+            Translation = 0,
+            Rotation = 1,
+            Scale = 2,
+        }
+
+        internal record struct TransformTripletRaw(
+            TransformTypeId TransformType,
+            float TimePercent,
+            ushort JointIndex,
+            Vec3 V,
+            bool Wsign
+        );
+
+        internal record struct TransformParsed(
+            float TimePercent,
+            ushort JointIndex,
+            TransformTypeId TransformType,
+            (TGVec3? t, RGQuat? r, SGVec3? s) TRS
+        );
+
+        internal static Quat ReconstructQuat(Vec3 v, bool wSign)
+        {
+            var dotPr = (v.X * v.X) + (v.Y * v.Y) + (v.Z * v.Z);
+
+            v.X *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
+            v.Y *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
+            v.Z *= Convert.ToSingle(Math.Sqrt(2f - dotPr));
+
+            float W = wSign ? -(1f - dotPr) : 1f - dotPr;
+
+            return Quat.Normalize(new(v, W));
+        }
+
+        internal static (Vec3 v, bool wSign) CompressQuat(Quat q)
+        {
+            bool wSign = q.W < 0f;
+
+            float dotWeight = Convert.ToSingle(Math.Sqrt(2f - (1f - Math.Abs(q.W))));
+
+            float x = q.X / dotWeight;
+            float y = q.Y / dotWeight;
+            float z = q.Z / dotWeight; 
+
+            return (new Vec3(x, y, z), wSign);
+        }
+
+        internal static TransformTripletRaw ReadTransformTripletRaw(BinaryReader br)
+        {
+            // NB time first here, const keys is opposite
+            ushort timePercentU16Ratio = br.ReadUInt16();
+            ushort bitWiseData = br.ReadUInt16();
+            float x = br.ReadSingle();
+            float y = br.ReadSingle();
+            float z = br.ReadSingle();
+
+            return new TransformTripletRaw {
+                    TransformType = (TransformTypeId)Convert.ToUInt16((bitWiseData & TransformTypeMask) >> TransformTypeShift),
+                    TimePercent = timePercentU16Ratio / (float)ushort.MaxValue,
+                    JointIndex = Convert.ToUInt16((bitWiseData & JointIndexMask) >> JointIndexShift),
+                    V = new(x, y, z),
+                    Wsign = 0f > Convert.ToUInt16((bitWiseData & WsignMask) >> WsignMask),
+                };
+        }
+
+        internal static bool WriteTransformTripletRaw(BinaryWriter bw, TransformTypeId transformTypeId, float timePercent, ushort jointIndex, Vec3 transform, bool wSign)
+        {
+            ushort timePercentAsU16Ratio = (ushort)(timePercent * ushort.MaxValue);
+
+            ushort bitWiseData = Convert.ToUInt16(
+                0
+                | ((wSign ? 1 : 0) << WsignMask)
+                | ((ushort)transformTypeId << TransformTypeShift)
+                | jointIndex
+            );
+
+            // NB time first here, const keys is opposite
+            bw.Write((ushort)timePercentAsU16Ratio);
+            bw.Write((ushort)bitWiseData);
+            bw.Write((float)transform.X);
+            bw.Write((float)transform.Y);
+            bw.Write((float)transform.Z);
+
+            return true;
+        }
+
+        internal static TransformParsed ReadTransform16byte(BinaryReader br)
+        {
+            var t = ReadTransformTripletRaw(br);
+
+            return (ushort)t.TransformType switch {
+                    0 => new(t.TimePercent, t.JointIndex, TransformTypeId.Translation, (TVectorGltf(t.V), null, null)),
+                    1 => new(t.TimePercent, t.JointIndex, TransformTypeId.Rotation, (null, RQuaternionGltf(ReconstructQuat(t.V, t.Wsign)), null)),
+                    2 => new(t.TimePercent, t.JointIndex, TransformTypeId.Scale, (null, null, SVectorGltf(t.V))),
+                    _ => throw new ArgumentOutOfRangeException(nameof(t), "No valid transform type, shouldn't get here"),
+                };
+        }
+
+        internal static bool WriteTransform16byte(BinaryWriter bw, TransformParsed trs)
+        {
+            (Vec3 transform, bool wSign) = trs.TRS switch {
+                    (TGVec3 t, null, null) => (TVectorWkit(t)._, false),
+                    (null, RGQuat r, null) => CompressQuat(RQuaternionWkit(r)._),
+                    (null, null, SGVec3 s) => (SVectorWkit(s)._, false),
+                    _ => throw new ArgumentNullException(nameof(trs), "No transform type or multiple, shouldn't get here!"),
+                };
+
+            return WriteTransformTripletRaw(bw, trs.TransformType, trs.TimePercent, trs.JointIndex, transform, wSign);
+        }
+
+#endregion helpers
+
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using SharpGLTF.Schema2;
 
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Types;
 
 using Quat = System.Numerics.Quaternion;
@@ -13,37 +14,42 @@ using static WolvenKit.RED4.Types.Enums;
 using static WolvenKit.Modkit.RED4.Animation.Fun;
 using static WolvenKit.Modkit.RED4.Animation.Gltf;
 
+using JointsTranslationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+using JointsRotationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>>;
+using JointsScalesAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+
+
 namespace WolvenKit.Modkit.RED4.Animation
 {
-    public class CompressedBuffer
+    internal class CompressedBuffer
     {
-        public static void ExportAsAnimationToModel(ref ModelRoot model, animAnimation animAnimDes, bool additiveAddRelative = true, bool incRootMotion = true)
+#region export
+        internal static void DecodeAnimationData(out AnimationBufferData result, animAnimation animAnimDes, ILoggerService _loggerService)
         {
-            if (animAnimDes.AnimBuffer.GetValue() is not animAnimationBufferCompressed blob)
+            if (animAnimDes.AnimBuffer.GetValue() is not animAnimationBufferCompressed animBuf)
             {
                 throw new ArgumentNullException();
             }
-            blob.ReadBuffer();
+            animBuf.ReadBuffer();
 
-            // boneidx time value
-            var positions = new Dictionary<ushort, Dictionary<float, Vec3>>();
-            var rotations = new Dictionary<ushort, Dictionary<float, Quat>>();
-            var scales = new Dictionary<ushort, Dictionary<float, Vec3>>();
+            var translations = new JointsTranslationsAtTimes();
+            var rotations = new JointsRotationsAtTimes();
+            var scales = new JointsScalesAtTimes();
 
-            if (animAnimDes.MotionExtraction != null && animAnimDes.MotionExtraction.Chunk != null && incRootMotion)
-            {
-                ROOT_MOTION.AddRootMotion(ref positions, ref rotations, animAnimDes);
-            }
+            var constTranslations = new JointsTranslationsAtTimes();
+            var constRotations = new JointsRotationsAtTimes();
+            var constScales = new JointsScalesAtTimes();
 
-            foreach (var key in blob.AnimKeys)
+
+            foreach (var key in animBuf.AnimKeys)
             {
                 if (key is animKeyPosition p)
                 {
-                    if (!positions.ContainsKey(p.Idx))
+                    if (!translations.ContainsKey(p.Idx))
                     {
-                        positions[p.Idx] = new Dictionary<float, Vec3>();
+                        translations[p.Idx] = new Dictionary<float, Vec3>();
                     }
-                    positions[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
+                    translations[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
                 }
                 else if (key is animKeyRotation r)
                 {
@@ -51,7 +57,7 @@ namespace WolvenKit.Modkit.RED4.Animation
                     {
                         rotations[r.Idx] = new Dictionary<float, Quat>();
                     }
-                    rotations[r.Idx][r.Time] = RQuaternionYupRhs(r.Rotation);
+                    rotations[r.Idx][r.Time] = RQuaternionNormalize(RQuaternionYupRhs(r.Rotation));
                 }
                 else if (key is animKeyScale s)
                 {
@@ -59,19 +65,19 @@ namespace WolvenKit.Modkit.RED4.Animation
                     {
                         scales[s.Idx] = new Dictionary<float, Vec3>();
                     }
-                    scales[s.Idx][s.Time] = SVectorYupRhs(s.Scale);
+                    scales[s.Idx][s.Time] = SVectorNormalize(SVectorYupRhs(s.Scale));
                 }
             }
 
-            foreach (var key in blob.AnimKeysRaw)
+            foreach (var key in animBuf.AnimKeysRaw)
             {
                 if (key is animKeyPosition p)
                 {
-                    if (!positions.ContainsKey(p.Idx))
+                    if (!translations.ContainsKey(p.Idx))
                     {
-                        positions[p.Idx] = new Dictionary<float, Vec3>();
+                        translations[p.Idx] = new Dictionary<float, Vec3>();
                     }
-                    positions[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
+                    translations[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
                 }
                 else if (key is animKeyRotation r)
                 {
@@ -79,7 +85,7 @@ namespace WolvenKit.Modkit.RED4.Animation
                     {
                         rotations[r.Idx] = new Dictionary<float, Quat>();
                     }
-                    rotations[r.Idx][r.Time] = RQuaternionYupRhs(r.Rotation);
+                    rotations[r.Idx][r.Time] = RQuaternionNormalize(RQuaternionYupRhs(r.Rotation));
                 }
                 else if (key is animKeyScale s)
                 {
@@ -87,121 +93,181 @@ namespace WolvenKit.Modkit.RED4.Animation
                     {
                         scales[s.Idx] = new Dictionary<float, Vec3>();
                     }
-                    scales[s.Idx][s.Time] = SVectorYupRhs(s.Scale);
+                    scales[s.Idx][s.Time] = SVectorNormalize(SVectorYupRhs(s.Scale));
                 }
             }
 
-            foreach (var key in blob.ConstAnimKeys)
+            foreach (var key in animBuf.ConstAnimKeys)
             {
                 if (key is animKeyPosition p)
                 {
-                    if (!positions.ContainsKey(p.Idx))
+                    if (!constTranslations.ContainsKey(p.Idx))
                     {
-                        positions[p.Idx] = new Dictionary<float, Vec3>();
+                        constTranslations[p.Idx] = [];
                     }
-                    positions[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
+                    constTranslations[p.Idx][p.Time] = TRVectorYupRhs(p.Position);
                 }
                 else if (key is animKeyRotation r)
                 {
-                    if (!rotations.ContainsKey(r.Idx))
+                    if (!constRotations.ContainsKey(r.Idx))
                     {
-                        rotations[r.Idx] = new Dictionary<float, Quat>();
+                        constRotations[r.Idx] = [];
                     }
-                    rotations[r.Idx][r.Time] = RQuaternionYupRhs(r.Rotation);
+                    constRotations[r.Idx][r.Time] = RQuaternionNormalize(RQuaternionYupRhs(r.Rotation));
                 }
                 else if (key is animKeyScale s)
                 {
-                    if (!scales.ContainsKey(s.Idx))
+                    if (!constScales.ContainsKey(s.Idx))
                     {
-                        scales[s.Idx] = new Dictionary<float, Vec3>();
+                        constScales[s.Idx] = [];
                     }
-                    scales[s.Idx][s.Time] = SVectorYupRhs(s.Scale);
+                    constScales[s.Idx][s.Time] = SVectorNormalize(SVectorYupRhs(s.Scale));
                 }
             }
 
-            // Can switch to system Json when SharpGLTF support released (maybe in .31)
-            // Right now it's not possible to add an empty array to a JsonContent.
-            // Can work around that elsewhere but... just don't implement your own
-            // JSON parser, kids.
-            var animExtras = new AnimationExtrasForGltf(
-                CurrentSchema(),
-                animAnimDes.AnimationType.ToString(),
-                animAnimDes.FrameClamping,
-                animAnimDes.FrameClampingStartFrame,
-                animAnimDes.FrameClampingEndFrame,
-                blob.NumExtraJoints,
-                blob.NumExtraTracks,
-                blob.ConstTrackKeys.Select(_ => new AnimConstTrackKeySerializable(_.TrackIndex, _.Time, _.Value)).ToList(),
-                blob.TrackKeys.Select(_ => new AnimTrackKeySerializable(_.TrackIndex, _.Time, _.Value)).ToList(),
-                blob.FallbackFrameIndices.Select(_ => (ushort)_).ToList(),
-                new AnimationOptimizationHints(
-                    false,
-                    blob.HasRawRotations ? AnimationEncoding.Uncompressed : AnimationEncoding.QuaternionAsFixed3x16bit
-                )
-            );
-
-            // All the data is gathered, stitch it together
-
-            var anim = model.CreateAnimation(animAnimDes.Name);
-            var skin = model.LogicalSkins.FirstOrDefault(_ => _.Name is "Armature");
-            if (skin is null)
-            {
-                ArgumentNullException.ThrowIfNull(nameof(skin));
-                return;
-            }
-
-            // -.-
-            anim.Extras = SharpGLTF.IO.JsonContent.Parse(JsonSerializer.Serialize(animExtras, SerializationOptions()));
-
-            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
-            var exportAdditiveToBind = additiveAddRelative && animAnimDes.AnimationType != animAnimationType.Normal;
-
-            for (ushort i = 0; i < blob.NumJoints - blob.NumExtraJoints; i++)
-            {
-                var node = skin.GetJoint(i).Joint;
-                if (rotations.ContainsKey(i))
-                {
-                    var isLinear = rotations[i].Count > 1;
-
-                    if (exportAdditiveToBind)
-                    {
-                        foreach (var (t, r) in rotations[i])
-                        {
-                            rotations[i][t] = node.LocalTransform.Rotation * r;
-                        }
-                    }
-
-                    anim.CreateRotationChannel(node, rotations[i], isLinear);
-                }
-                if (positions.ContainsKey(i))
-                {
-                    var isLinear = positions[i].Count > 1;
-
-                    if (exportAdditiveToBind)
-                    {
-                        foreach (var (t, p) in positions[i])
-                        {
-                            positions[i][t] = node.LocalTransform.Translation + p;
-                        }
-                    }
-
-                    anim.CreateTranslationChannel(node, positions[i], isLinear);
-                }
-                if (scales.ContainsKey(i))
-                {
-                    var isLinear = scales[i].Count > 1;
-
-                    if (exportAdditiveToBind)
-                    {
-                        foreach (var (t, s) in scales[i])
-                        {
-                            scales[i][t] = node.LocalTransform.Scale * s;
-                        }
-                    }
-
-                    anim.CreateScaleChannel(node, scales[i], isLinear);
-                }
-            }
+            result = new AnimationBufferData {
+                Duration = animBuf.Duration,
+                FrameCount = animBuf.NumFrames,
+                Translations = translations,
+                ConstTranslations = constTranslations,
+                Rotations = rotations,
+                ConstRotations = constRotations,
+                Scales = scales,
+                ConstScales = constScales,
+                TrackKeys = animBuf.TrackKeys.Select(_ => new AnimTrackKeySerializable(_.TrackIndex, _.Time, _.Value)).ToList(),
+                ConstTrackKeys = animBuf.ConstTrackKeys.Select(_ => new AnimConstTrackKeySerializable(_.TrackIndex, _.Time, _.Value)).ToList(),
+                FallbackFrameIndices = animBuf.FallbackFrameIndices.Select(_ => (ushort)_).ToList(),
+                NumJoints = animBuf.NumJoints,
+                NumExtraJoints = animBuf.NumExtraJoints,
+                JointsCountActual = Convert.ToUInt16(animBuf.NumJoints - animBuf.NumExtraJoints),
+                NumTracks = animBuf.NumTracks,
+                NumExtraTracks = animBuf.NumExtraTracks,
+                TracksCountActual = Convert.ToUInt16(animBuf.NumTracks - animBuf.NumExtraTracks),
+                IsSimd = false,
+                CompressionUsed =
+                    animBuf.HasRawRotations
+                    ? AnimationCompression.Uncompressed
+                    : AnimationCompression.QuaternionAsFixed3x16bit
+            };
         }
+
+#endregion export
+#region import
+        internal static void EncodeAnimationData(out animAnimDataChunk newAnimDataChunk, out animAnimationBufferCompressed newCompressedBuffer, ref readonly AnimationBufferData incomingAnimBufferData, animAnimDataAddress chunkDataAddress, ILoggerService _loggerService)
+        {
+            var constAnimKeys = new List<animKey?>();
+            var animKeys = new List<animKey?>();
+            var animKeysRaw = new List<animKey?>();
+
+            var rotationCompressionAllowed = incomingAnimBufferData.CompressionUsed != AnimationCompression.Uncompressed;
+
+            for (ushort jointIdx = 0; jointIdx < incomingAnimBufferData.JointsCountActual; ++jointIdx)
+            {
+                // Const (non-interpolated) keyframes are all similarly encoded, S, R and T
+                
+                // TODO https://github.com/WolvenKit/WolvenKit/issues/1661
+                //      Warn on failing sanity checks like no 0 timestamp for const keyframes.
+                //      There's probably a bunch of possible additional warnings we can raise.
+
+                foreach (var (time, translation) in incomingAnimBufferData.ConstTranslations.GetValueOrDefault(jointIdx, []))
+                {
+                    constAnimKeys.Add(new animKeyPosition() { Idx = jointIdx, Time = time, Position = TRVectorZupLhs(translation), });
+                }
+
+                foreach (var (time, rotation) in incomingAnimBufferData.ConstRotations.GetValueOrDefault(jointIdx, []))
+                {
+                    constAnimKeys.Add(new animKeyRotation() { Idx = jointIdx, Time = time, Rotation = RQuaternionZupLhs(rotation), });
+                }
+
+                foreach (var (time, scale) in incomingAnimBufferData.ConstScales.GetValueOrDefault(jointIdx, []))
+                {
+                    constAnimKeys.Add(new animKeyScale() { Idx = jointIdx, Time = time, Scale = SVectorZupLhs(scale), });
+                }
+
+                // For linear keyframes, T and S are essentially always* 'raw', i.e. uncompressed...
+                // * Not strictly true
+
+                foreach (var (time, translation) in incomingAnimBufferData.Translations.GetValueOrDefault(jointIdx, []))
+                {
+                    animKeysRaw.Add(new animKeyPosition() { Idx = jointIdx, Time = time, Position = TRVectorZupLhs( translation ), });
+                }
+
+                foreach (var (time, scale) in incomingAnimBufferData.Scales.GetValueOrDefault(jointIdx, []))
+                {
+                    animKeysRaw.Add(new animKeyScale() { Idx = jointIdx, Time = time, Scale = SVectorZupLhs(scale), });
+                }
+
+                // ...but R can optionally be compressed
+                var preferredStorage = rotationCompressionAllowed ? animKeys : animKeysRaw;
+
+                foreach (var (time, rotation) in incomingAnimBufferData.Rotations.GetValueOrDefault(jointIdx, []))
+                {
+                    preferredStorage.Add(new animKeyRotation() { Idx = jointIdx, Time = time, Rotation = RQuaternionZupLhs(rotation), });
+                }
+            }
+
+            var fallbackIndices = incomingAnimBufferData.FallbackFrameIndices.Select(_ =>
+                (CUInt16)_).ToList();
+
+            // These must be nullable for carray init -.-
+            var constTrackKeys = incomingAnimBufferData.ConstTrackKeys.Select<AnimConstTrackKeySerializable, animKeyTrack?>(_ =>
+                new animKeyTrack() { TrackIndex = _.TrackIndex, Time = _.Time, Value = _.Value, }).ToList();
+
+            var trackKeys = incomingAnimBufferData.TrackKeys.Select<AnimTrackKeySerializable, animKeyTrack?>(_ =>
+                new animKeyTrack() { TrackIndex = _.TrackIndex, Time = _.Time, Value = _.Value, }).ToList();
+
+            // There's three ways 'constant scale' could be understood:
+            //
+            // 1. Every joint maintains uniform scale, i.e. 1:1
+            // 2. Every joint maintains same scale S throughout anim
+            // 3. Each joint  maintains separate scale S' throughout anim
+            //
+            // Using the first definition here.
+            //
+            var allScalesUniform1to1 =
+                ((List<JointsScalesAtTimes>)[incomingAnimBufferData.Scales, incomingAnimBufferData.ConstScales]).All(_ =>
+                    _.All(_ => _.Value.All(_ => EqWithEpsilon(_.Value, Scale1to1))));
+
+            newCompressedBuffer = new animAnimationBufferCompressed()
+            {
+                Duration = incomingAnimBufferData.Duration,
+                NumFrames = incomingAnimBufferData.FrameCount,
+                NumExtraJoints = incomingAnimBufferData.NumExtraJoints,
+                NumExtraTracks = incomingAnimBufferData.NumExtraTracks,
+                NumJoints = incomingAnimBufferData.NumJoints,
+                NumTracks = incomingAnimBufferData.NumTracks,
+                NumConstAnimKeys = Convert.ToUInt32(constAnimKeys.Count),
+                NumAnimKeysRaw = Convert.ToUInt32(animKeysRaw.Count),
+                NumAnimKeys = Convert.ToUInt32(animKeys.Count),
+                NumConstTrackKeys = Convert.ToUInt32(constTrackKeys.Count),
+                NumTrackKeys = Convert.ToUInt32(trackKeys.Count),
+                IsScaleConstant = allScalesUniform1to1,
+                HasRawRotations = !rotationCompressionAllowed,
+
+                FallbackFrameIndices = new CArray<CUInt16>(fallbackIndices),
+
+                DataAddress = chunkDataAddress,
+
+                // These are internal only, they'll be packed into a buffer...
+                ConstAnimKeys = new(constAnimKeys),
+                AnimKeysRaw = new(animKeysRaw),
+                AnimKeys = new(animKeys),
+
+                ConstTrackKeys = new(constTrackKeys),
+                TrackKeys = new(trackKeys),
+
+                TempBuffer = new(),
+            };
+
+            // ...specifically TempBuffer, here.
+            newCompressedBuffer.WriteBuffer();
+
+            // And bookkeeping
+            newCompressedBuffer.DataAddress.ZeInBytes = newCompressedBuffer.TempBuffer.Buffer.MemSize;
+
+            newAnimDataChunk = new() { Buffer = new SerializationDeferredDataBuffer(newCompressedBuffer.TempBuffer.Buffer.GetBytes()) };
+        }
+#endregion import
+
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/Shared.cs
@@ -6,6 +6,15 @@ using WolvenKit.Modkit.RED4.Animation.Deprecated;
 using Quat = System.Numerics.Quaternion;
 using Vec3 = System.Numerics.Vector3;
 
+using TranslationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+using RotationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>;
+using ScalesAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+
+using JointsTranslationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+using JointsRotationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>>;
+using JointsScalesAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+
+
 namespace WolvenKit.Modkit.RED4.Animation
 {
     internal static class Const
@@ -18,33 +27,87 @@ namespace WolvenKit.Modkit.RED4.Animation
         public const double FramesPerDurationSecond = 30.0;
         public static Func<double, uint> FramesToAccommodateDuration = (duration) =>
              (uint)Math.Ceiling(duration * FramesPerDurationSecond);
+
+        public const ushort RootJointIndex = 0;
+
+        public const bool GLTF_SAMPLER_LINEAR = true;
+        public const bool GLTF_SAMPLER_CONST = false;
     }
 
     internal static class Fun
     {
+        // Type-level coordinate system and transform kind safety,
+        // so that you can't accidentally mix up translation and
+        // scale or glTF-format with ours (or System. stuff.)
+        //
+        // TODO: https://github.com/WolvenKit/WolvenKit/issues/1788 Actually Use Type-Level Coordinate and Vector Checking
+        //
+        // G = glTF = Y up, Righthanded
+        // W = Wkit = Z up, Lefthanded
+
+        public readonly record struct TWVec3( Vec3 _ );
+        public readonly record struct TGVec3( Vec3 _ );
+        public readonly record struct SWVec3( Vec3 _ );
+        public readonly record struct SGVec3( Vec3 _ );
+        public readonly record struct RWQuat( Quat _ );
+        public readonly record struct RGQuat( Quat _ );
+
+        public static TWVec3 TVectorWkit(TGVec3 v) => new(new(v._.X, -v._.Z, v._.Y));
+        public static TGVec3 TVectorGltf(TWVec3 v) => new(new(v._.X, v._.Z, -v._.Y));
+        public static TGVec3 TVectorGltf(Vec3 v) => new(new(v.X, v.Z, -v.Y));
+
+
+        public static RWQuat RQuaternionWkit(RGQuat q) => new(new(q._.X, -q._.Z, q._.Y, q._.W));
+        public static RGQuat RQuaternionGltf(RWQuat q) => new(new(q._.X, q._.Z, -q._.Y, q._.W));
+        public static RGQuat RQuaternionGltf(Quat q) => new(new(q.X, q.Z, -q.Y, q.W));
+
+        // NB scale is not affected by handedness, only axis
+        public static SWVec3 SVectorWkit(SGVec3 v) => new(new(v._.X, v._.Z, v._.Y));
+        public static SGVec3 SVectorGltf(SWVec3 v) => new(new(v._.X, v._.Z, v._.Y));
+        public static SGVec3 SVectorGltf(Vec3 v) => new(new(v.X, v.Z, v.Y));
+
+        public static Quat RQuatFromAnglesDegree(Vec3 axisDegrees) => RQuatFromAnglesDegree(axisDegrees.X, axisDegrees.Y, axisDegrees.Z);
+        public static Quat RQuatFromAnglesDegree(float pitchX, float rollY, float yawZ) =>
+            RQuatFromAnglesRadian(float.DegreesToRadians(pitchX), float.DegreesToRadians(rollY), float.DegreesToRadians(yawZ));
+
+        public static Quat RQuatFromAnglesRadian(Vec3 axisRadians) => RQuatFromAnglesDegree(axisRadians.X, axisRadians.Y, axisRadians.Z);
+        public static Quat RQuatFromAnglesRadian(float pitchX, float rollY, float yawZ) =>
+            // C# uses yaw=Y, pitch=X, roll=Z so we want correct axis in correct position
+            Quat.CreateFromYawPitchRoll(rollY, pitchX, yawZ);
+
+#region DEPRECATE
+        // OLD impl
+
         public static Vec3 TRVectorZupLhs(Vec3 yupV) => new(yupV.X, -yupV.Z, yupV.Y);
         public static Vec3 TRVectorYupRhs(Vec3 zupV) => new(zupV.X, zupV.Z, -zupV.Y);
 
         // NB scale is not affected by handedness
         public static Vec3 SVectorZupLhs(Vec3 yupV) => new(yupV.X, yupV.Z, yupV.Y);
-        public static Vec3 SVectorYupRhs(Vec3 zupV) => new(zupV.X, zupV.Y, zupV.Z);
+        public static Vec3 SVectorYupRhs(Vec3 zupV) => new(zupV.X, zupV.Z, zupV.Y);
+
 
         public static Quat RQuaternionZupLhs(Quat yupQ) => new(yupQ.X, -yupQ.Z, yupQ.Y, yupQ.W);
         public static Quat RQuaternionYupRhs(Quat zupQ) => new(zupQ.X, zupQ.Z, -zupQ.Y, zupQ.W);
+#endregion DEPRECATE
 
-        public static Vec3 Scale1to1 = new(1.0f, 1.0f, 1.0f);
 
-        public static Vec3 WithEpsilon(Vec3 vec, Vec3 reference) =>
+        public static Vec3 Scale1to1 = new(1f, 1f, 1f);
+        public static float MicrometerPrecisionEpsilon = 0.0000001f;
+
+        public static Vec3 WithEpsilon(Vec3 vec, Vec3 reference, float epsilon = Single.Epsilon) =>
             new(
-                Math.Abs(vec.X - reference.X) <= Single.Epsilon ? reference.X : vec.X,
-                Math.Abs(vec.Y - reference.Y) <= Single.Epsilon ? reference.Y : vec.Y,
-                Math.Abs(vec.Z - reference.Z) <= Single.Epsilon ? reference.Z : vec.Z
+                Math.Abs(vec.X - reference.X) <= epsilon ? reference.X : vec.X,
+                Math.Abs(vec.Y - reference.Y) <= epsilon ? reference.Y : vec.Y,
+                Math.Abs(vec.Z - reference.Z) <= epsilon ? reference.Z : vec.Z
             );
 
-        public static bool EqWithEpsilon(Vec3 a, Vec3 b) =>
-            Math.Abs(a.X - b.X) <= Single.Epsilon &&
-            Math.Abs(a.Y - b.Y) <= Single.Epsilon &&
-            Math.Abs(a.Z - b.Z) <= Single.Epsilon;
+        public static bool EqWithEpsilon(Vec3 a, Vec3 b, float epsilon = Single.Epsilon) =>
+            Math.Abs(a.X - b.X) <= epsilon &&
+            Math.Abs(a.Y - b.Y) <= epsilon &&
+            Math.Abs(a.Z - b.Z) <= epsilon;
+
+        public static Quat RQuaternionNormalize(Quat q) => q.W == 1 ? Quat.Identity : Quat.Normalize(q);
+        public static Vec3 SVectorNormalize(Vec3 v) => WithEpsilon(v, Scale1to1, MicrometerPrecisionEpsilon);
     }
 
     internal static class Gltf
@@ -143,7 +206,29 @@ namespace WolvenKit.Modkit.RED4.Animation
 
     internal readonly record struct AnimationOptimizationHints(
         bool PreferSIMD,
-        AnimationEncoding MaxRotationCompression
+        AnimationCompression MaxRotationCompression
+    );
+
+    internal record struct AnimationBufferData(
+        float Duration,
+        uint FrameCount,
+        JointsTranslationsAtTimes Translations,
+        JointsTranslationsAtTimes ConstTranslations,
+        JointsRotationsAtTimes Rotations,
+        JointsRotationsAtTimes ConstRotations,
+        JointsScalesAtTimes Scales,
+        JointsScalesAtTimes ConstScales,
+        List<AnimTrackKeySerializable> TrackKeys,
+        List<AnimConstTrackKeySerializable> ConstTrackKeys,
+        List<ushort> FallbackFrameIndices,
+        ushort NumJoints,
+        byte NumExtraJoints,
+        ushort JointsCountActual,
+        ushort NumTracks,
+        byte NumExtraTracks,
+        ushort TracksCountActual,
+        bool IsSimd,
+        AnimationCompression CompressionUsed
     );
 
     internal readonly record struct AnimationExtrasForGltf(

--- a/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/AnimationTools.cs
@@ -25,6 +25,16 @@ using Quat = System.Numerics.Quaternion;
 using Vec3 = System.Numerics.Vector3;
 using WolvenKit.Common.Model.Arguments;
 
+using TranslationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+using RotationsAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>;
+using ScalesAtTimes = System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>;
+
+using JointsTranslationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+using JointsRotationsAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Quaternion>>;
+using JointsScalesAtTimes = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.Dictionary<float, System.Numerics.Vector3>>;
+
+using JointWiseScaleList = System.Collections.Generic.Dictionary<ushort, System.Collections.Generic.List<(float, System.Numerics.Vector3)>>;
+
 namespace WolvenKit.Modkit.RED4
 {
     public partial class ModTools
@@ -60,7 +70,7 @@ namespace WolvenKit.Modkit.RED4
             return true;
         }
 
-        public bool GetAnimation(CR2WFile animsFile, CR2WFile rigFile, string animsFileName, ref ModelRoot model, bool includeRig = true, bool additiveAddRelative = true, bool incRootMotion = true)
+        public bool GetAnimation(CR2WFile animsFile, CR2WFile rigFile, string animsFileName, ref ModelRoot gltfModel, bool includeRig = true, bool additiveAddRelative = true, bool incRootMotion = true)
         {
 
             if (animsFile.RootChunk is not animAnimSet anims)
@@ -87,17 +97,23 @@ namespace WolvenKit.Modkit.RED4
                 {
                     return false;
                 }
-                var skin = model.CreateSkin("Armature");
-                skin.BindJoints(RIG.ExportNodes(ref model, rig).Values.ToArray());
+                var skin = gltfModel.CreateSkin("Armature");
+                skin.BindJoints(RIG.ExportNodes(ref gltfModel, rig).Values.ToArray());
             }
 
-            var rigFileName = anims.Rig.DepotPath.GetResolvedText() ?? "<unknown rig depotpath??>";
+            var gltfSkin = gltfModel.LogicalSkins.FirstOrDefault(_ => _.Name is "Armature");
+            ArgumentNullException.ThrowIfNull(gltfSkin);
 
+            var rigFileName = anims.Rig.DepotPath.GetResolvedText() ?? "<unknown rig depotpath??>";
             _loggerService.Info($"{animsFileName}: Found {anims.Animations.Count} animations to export, using rig {rigFileName}");
+
+            _loggerService.Info($"{animsFileName}: Root motion export: {(incRootMotion ? "enabled" : "disabled")}");
 
             var stats = new
             {
                 AdditiveAnims = 0,
+                RootMotions = 0,
+                RootMotionConflicts = 0,
                 SimdAnims = 0,
             };
 
@@ -108,55 +124,207 @@ namespace WolvenKit.Modkit.RED4
 
                 var animAnimDes = anim.Chunk.Animation.Chunk;
 
-                if (animAnimDes.MotionExtraction != null && animAnimDes.MotionExtraction.Chunk != null && !incRootMotion)
-                {
-                    _loggerService.Debug($"{animsFileName}: {animAnimDes.Name}: contains root motion but it's not exported!");
-                }
+                stats = stats with {
+                    AdditiveAnims = stats.AdditiveAnims + (animAnimDes.AnimationType == animAnimationType.Normal ? 0 : 1),
+                };
 
-                stats = animAnimDes.AnimationType == animAnimationType.Normal ? stats : stats with { AdditiveAnims = stats.AdditiveAnims + 1 };
+                // Buffer decoding
+
+                AnimationBufferData bufferData;
 
                 if (animAnimDes.AnimBuffer.Chunk is animAnimationBufferSimd animBuffSimd)
                 {
                     stats = stats with { SimdAnims = stats.SimdAnims + 1 };
 
-                    MemoryStream deferredBuffer;
-                    if (animBuffSimd.InplaceCompressedBuffer != null)
-                    {
-                        deferredBuffer = new MemoryStream(animBuffSimd.InplaceCompressedBuffer.Buffer.GetBytes());
-                    }
-                    else if (animBuffSimd.DataAddress != null && animBuffSimd.DataAddress.UnkIndex != uint.MaxValue)
-                    {
-                        var dataAddr = animBuffSimd.DataAddress;
-                        var bytes = new byte[dataAddr.ZeInBytes];
-                        animDataBuffers[(int)(uint)dataAddr.UnkIndex].Seek(dataAddr.FsetInBytes, SeekOrigin.Begin);
-                        // bytesRead can be smaller then the bytes requested
-                        var bytesRead = animDataBuffers[(int)(uint)dataAddr.UnkIndex].Read(bytes, 0, (int)(uint)dataAddr.ZeInBytes);
-                        deferredBuffer = new MemoryStream(bytes);
-                    }
-                    else
-                    {
-                        deferredBuffer = new MemoryStream(animBuffSimd.DefferedBuffer.Buffer.GetBytes());
-                    }
-                    deferredBuffer.Seek(0, SeekOrigin.Begin);
-                    _loggerService.Debug($"{animsFileName}: Exporting SIMD animation {animAnimDes.Name} with {animBuffSimd.NumFrames * animBuffSimd.NumJoints} S/R/T transforms and {animBuffSimd.NumFrames * animBuffSimd.NumTracks} tracks");
-                    SIMD.AddAnimationSIMD(ref model, animBuffSimd, animAnimDes.Name!, deferredBuffer, animAnimDes, additiveAddRelative, incRootMotion);
+                    SIMD.DecodeSimdAnimationData(out bufferData, ref gltfModel, ref animBuffSimd, ref animDataBuffers, animAnimDes.Name!, animAnimDes, _loggerService);
                 }
                 else if (animAnimDes.AnimBuffer.Chunk is animAnimationBufferCompressed)
                 {
-                    CompressedBuffer.ExportAsAnimationToModel(ref model, animAnimDes, additiveAddRelative, incRootMotion);
+                    CompressedBuffer.DecodeAnimationData(out bufferData, animAnimDes, _loggerService);
                 }
+                else
+                {
+                    throw new InvalidDataException("Unsupported animation buffer type, can't proceed!");
+                }
+
+                // Root motion
+
+                JointsTranslationsAtTimes rootMotionTranslations = [];
+                JointsRotationsAtTimes rootMotionRotations = [];
+
+                var motionEx = animAnimDes.MotionExtraction?.Chunk;
+
+                var rootMotionType = incRootMotion
+                    ? ROOT_MOTION.DecodeRootMotion(out rootMotionTranslations, out rootMotionRotations, ref motionEx, _loggerService)
+                    : RootMotionType.Unknown;
+
+                if (rootMotionType is not RootMotionType.None and not RootMotionType.Unknown)
+                {
+                    stats = stats with { RootMotions = stats.RootMotions + 1 };
+
+                    bufferData.ConstTranslations.TryGetValue(RootJointIndex, out var rootCTs);
+                    bufferData.ConstRotations.TryGetValue(RootJointIndex, out var rootCRs);
+                    bufferData.ConstScales.TryGetValue(RootJointIndex, out var rootCSs);
+                    bufferData.Translations.TryGetValue(RootJointIndex, out var rootTs);
+                    bufferData.Rotations.TryGetValue(RootJointIndex, out var rootRs);
+                    bufferData.Scales.TryGetValue(RootJointIndex,out var rootSs);
+
+                    rootMotionTranslations.TryGetValue(RootJointIndex, out var rmRootTranslations);
+                    rootMotionRotations.TryGetValue(RootJointIndex, out var rmRootRotations);
+
+                    if (rootMotionTranslations.Count > 1 || (rootMotionTranslations.Count == 1 && rmRootTranslations is null) ||
+                        rootMotionRotations.Count > 1 || (rootMotionRotations.Count == 1 && rmRootRotations is null))
+                    {
+                        // One of the RM encodings leaves this possibility open
+                        _loggerService.Warning($"{animsFileName}: {animAnimDes.Name}: Root Motion encoded in joints outside `root` joint {RootJointIndex}! Only `root` RM will be exported.");
+                    }
+                    if (rootCTs?.Count > 0 || rootCRs?.Count > 0 || rootCSs?.Count > 0 || rootTs?.Count > 0 || rootRs?.Count > 0 || rootSs?.Count > 0)
+                    {
+                        _loggerService.Debug($"{animsFileName}: {animAnimDes.Name}: Ignoring non-Root Motion root joint transforms.");
+                        stats = stats with { RootMotionConflicts = stats.RootMotionConflicts + 1 };
+                    }
+
+                    bufferData.ConstTranslations.Remove(RootJointIndex);
+                    bufferData.ConstRotations.Remove(RootJointIndex);
+                    bufferData.ConstScales.Remove(RootJointIndex);
+
+                    bufferData.Translations.Remove(RootJointIndex);
+                    bufferData.Rotations.Remove(RootJointIndex);
+                    bufferData.Scales.Remove(RootJointIndex);
+
+                    // Root Motion only ever has T/R, as seen above
+                    bufferData.Translations.Add(RootJointIndex, rmRootTranslations ?? []);
+                    bufferData.Rotations.Add(RootJointIndex, rmRootRotations ?? []);
+                }
+
+                // All the data is gathered, time to encode it into glTF
+
+                var gltfAnim = gltfModel.CreateAnimation(animAnimDes.Name);
+
+                // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
+                var exportAdditiveToBind = additiveAddRelative && animAnimDes.AnimationType != animAnimationType.Normal;
+
+                for (ushort jointIdx = 0; jointIdx < bufferData.JointsCountActual; jointIdx++)
+                {
+                    var node = gltfSkin.GetJoint(jointIdx).Joint;
+
+                    // We *could* do some heuristics to see if we have essentially 0 translations, but for now..
+                    var jointLocalTranslation = node.LocalTransform.Translation;
+                    // ...just in case these two have been stored non-normalized
+                    var jointLocalRotation = RQuaternionNormalize(node.LocalTransform.Rotation);
+                    var jointLocalScale = SVectorNormalize(node.LocalTransform.Scale);
+
+                    bufferData.ConstTranslations.TryGetValue(jointIdx, out var jointConstTranslations);
+                    bufferData.ConstRotations.TryGetValue(jointIdx, out var jointConstRotations);
+                    bufferData.ConstScales.TryGetValue(jointIdx, out var jointConstScales);
+                    bufferData.Translations.TryGetValue(jointIdx, out var jointTranslations);
+                    bufferData.Rotations.TryGetValue(jointIdx, out var jointRotations);
+                    bufferData.Scales.TryGetValue(jointIdx, out var jointScales);
+                    
+                    var (hasTranslationsToExport, translationConflict, exportTranslations, translationInterpolation) = (jointTranslations ?? [], jointConstTranslations ?? []) switch {
+                        ({Count: >= 1} linear, {Count: >= 1} step) => (true, true, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: >= 1} linear, {Count: 0} step) => (true, false, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: 0} linear, {Count: >= 1} step) => (true, false, step, GLTF_SAMPLER_CONST),
+                        _ => (false, false, [], GLTF_SAMPLER_CONST),
+                    };
+                    
+                    var (hasRotationsToExport, rotationConflict, exportRotations, rotationInterpolation) = (jointRotations ?? [], jointConstRotations ?? []) switch {
+                        ({Count: >= 1} linear, {Count: >= 1} step) => (true, true, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: >= 1} linear, {Count: 0} step) => (true, false, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: 0} linear, {Count: >= 1} step) => (true, false, step, GLTF_SAMPLER_CONST),
+                        _ => (false, false, [], GLTF_SAMPLER_CONST),
+                    };
+                    
+                    var (hasScalesToExport, scaleConflict, exportScales, scaleInterpolation) = (jointScales ?? [], jointConstScales ?? []) switch {
+                        ({Count: >= 1} linear, {Count: >= 1} step) => (true, true, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: >= 1} linear, {Count: 0} step) => (true, false, linear, GLTF_SAMPLER_LINEAR),
+                        ({Count: 0} linear, {Count: >= 1} step) => (true, false, step, GLTF_SAMPLER_CONST),
+                        _ => (false, false, [], GLTF_SAMPLER_CONST),
+                    };
+
+                    if (translationConflict || rotationConflict || scaleConflict)
+                    {
+                        _loggerService.Warning($"{animsFileName}: {animAnimDes.Name}: {node.Name} ({jointIdx}): Joint has both LINEAR and STEP transforms! Only exporting LINEAR.");
+                    }
+
+                    if (hasTranslationsToExport)
+                    {
+                        gltfAnim.CreateTranslationChannel(
+                            node,
+                            exportAdditiveToBind
+                                ? exportTranslations.Select((t) => (t.Key, jointLocalTranslation + t.Value)).ToDictionary()
+                                : exportTranslations,
+                            translationInterpolation
+                        );
+                    }
+
+                    if (hasRotationsToExport)
+                    {
+                        gltfAnim.CreateRotationChannel(
+                            node,
+                            exportAdditiveToBind
+                                ? exportRotations.Select((t) => (t.Key, RQuaternionNormalize(jointLocalRotation * t.Value))).ToDictionary()
+                                : exportRotations,
+                            rotationInterpolation
+                        );
+                    }
+
+                    if (hasScalesToExport)
+                    {
+                        gltfAnim.CreateScaleChannel(
+                            node,
+                            exportAdditiveToBind
+                                ? exportScales.Select((t) => (t.Key, SVectorNormalize(jointLocalScale * t.Value))).ToDictionary()
+                                : exportScales,
+                            scaleInterpolation
+                        );
+                    }
+                }
+
+                // glTF doesn't support everything we need for anims, so stuff it in extras
+
+                var animExtras = new AnimationExtrasForGltf {
+                    Schema = CurrentSchema(),
+                    AnimationType = animAnimDes.AnimationType.ToString(),
+                    RootMotionType = rootMotionType.ToString(),
+                    FrameClamping = animAnimDes.FrameClamping,
+                    FrameClampingStartFrame = animAnimDes.FrameClampingStartFrame,
+                    FrameClampingEndFrame = animAnimDes.FrameClampingEndFrame,
+                    NumExtraJoints = bufferData.NumExtraJoints,
+                    NumExtraTracks = bufferData.NumExtraTracks,
+                    ConstTrackKeys = bufferData.ConstTrackKeys,
+                    TrackKeys = bufferData.TrackKeys,
+                    FallbackFrameIndices = bufferData.FallbackFrameIndices,
+                    OptimizationHints = new AnimationOptimizationHints {
+                        PreferSIMD = bufferData.IsSimd,
+                        MaxRotationCompression = bufferData.CompressionUsed,
+                    },
+                };
+
+                // -.-
+                //
+                // TODO https://github.com/WolvenKit/WolvenKit/issues/1693 Anime JSON Format Cleanup if and when SharpGLTF Updates
+                //
+                // Can switch to system Json when SharpGLTF support released (maybe in .31)
+                // Right now it's not possible to add an empty array to a JsonContent.
+                // Can work around that elsewhere but... just don't implement your own
+                // JSON parser, kids.
+                gltfAnim.Extras = SharpGLTF.IO.JsonContent.Parse(JsonSerializer.Serialize(animExtras, SerializationOptions()));
             }
 
+            if (stats.RootMotionConflicts > 0)
+            {
+                _loggerService.Warning($"{animsFileName}: {stats.RootMotionConflicts} animations had regular root joint transforms in addition to Root Motion. Only exporting Root Motion. Re-importing with Root Motion will delete the non-RM. This is probably correct, but you can additionally export without Root Motion to get the regular transforms.");
+            }
             if (stats.SimdAnims > 0)
             {
                 _loggerService.Info($"{animsFileName}: Exported {stats.SimdAnims} SIMD animations. They can only be imported back as regular animations, so you may want to simplify them when editing, or omit them from the re-import to keep the old ones."); 
             }
-
             if (stats.AdditiveAnims > 0)
             {
                 if (additiveAddRelative)
                 {
-                    _loggerService.Info($"{animsFileName}: Exported {stats.AdditiveAnims} additive animations already added to the bind pose. Reimport will strip the bind pose again.");
+                    _loggerService.Info($"{animsFileName}: Exported {stats.AdditiveAnims} additive animations added on top of the local transform.");
                 }
                 else
                 {
@@ -189,12 +357,13 @@ namespace WolvenKit.Modkit.RED4
                 return false;
             }
 
-            var rig = RIG.ProcessRig(result.File!);
-            if (rig is null || rig.BoneCount < 1)
+            var maybeRig = RIG.ProcessRig(result.File!);
+            if (maybeRig is null || maybeRig.BoneCount < 1)
             {
                 _loggerService.Error($"{gltfFileName}: couldn't process rig from {rigFileName}, can't import anims!");
                 return false;
             }
+            RawArmature rig = maybeRig;
 
             var model = ModelRoot.Load(gltfFile.FullName, new ReadSettings(ValidationMode.TryFix));
 
@@ -223,7 +392,13 @@ namespace WolvenKit.Modkit.RED4
         {
             _loggerService.Info($"{gltfFileName}: found {model.LogicalAnimations.Count} animations to import");
 
-            var (simdCount, additiveCount, additiveStrippedCount) = (0, 0, 0);
+            var stats = new {
+                Additives = 0,
+                AdditivesStripped = 0,
+                RootMotions = 0,
+                RootTransformsStripped = 0,
+                SIMDs = 0,
+            };
 
             var newAnimSetEntries = new CArray<CHandle<animAnimSetEntry>>();
             var newAnimChunks = new CArray<animAnimDataChunk>();
@@ -238,7 +413,8 @@ namespace WolvenKit.Modkit.RED4
                     throw new InvalidOperationException($"{gltfFileName}: animation `{incomingAnim.Name}` appears more than once, can't import!");
                 }
 
-                // Can switch to system Json when SharpGLTF support released (maybe in .31)
+                // Prep and metadata
+
                 if (incomingAnim.Extras.Content is null)
                 {
                     throw new InvalidOperationException($"{gltfFileName}: animation `{incomingAnim.Name}` has no extra data, can't import!");
@@ -260,36 +436,40 @@ namespace WolvenKit.Modkit.RED4
                     _loggerService.Debug($"{gltfFileName}: new: `{incomingAnim.Name}` not found in animset, treating as new animation!");
                 }
 
-                var keyframeTranslations = new Dictionary<AnimationInterpolationMode, Dictionary<ushort, List<(float, Vec3)>>> {
-                    [AnimationInterpolationMode.STEP] = new (),
-                    [AnimationInterpolationMode.LINEAR] = new (),
-                };
-
-                var keyframeRotations = new Dictionary<AnimationInterpolationMode, Dictionary<ushort, List<(float, Quat)>>> {
-                    [AnimationInterpolationMode.STEP] = new (),
-                    [AnimationInterpolationMode.LINEAR] = new (),
-                };
-
-                var keyframeScales = new Dictionary<AnimationInterpolationMode, Dictionary<ushort, List<(float, Vec3)>>> {
-                    [AnimationInterpolationMode.STEP] = new (),
-                    [AnimationInterpolationMode.LINEAR] = new (),
-                };
-
                 var incomingAnimationType = (animAnimationType)Enum.Parse(typeof(animAnimationType), extras.AnimationType);
 
                 var stripLocalFromAdditives = incomingAnimationType != animAnimationType.Normal &&
                                               importArgs.AdditiveStripLocalTransform;
 
-                additiveCount += incomingAnimationType != animAnimationType.Normal ? 1 : 0;
-                additiveStrippedCount += stripLocalFromAdditives ? 1 : 0;
-                simdCount += extras.OptimizationHints.PreferSIMD ? 1 : 0;
+                stats = stats with {
+                    Additives = incomingAnimationType != animAnimationType.Normal ? stats.Additives + 1 : stats.Additives,
+                    AdditivesStripped = stripLocalFromAdditives ? stats.AdditivesStripped + 1 : stats.AdditivesStripped,
+                    SIMDs = extras.OptimizationHints.PreferSIMD ? stats.SIMDs + 1 : stats.SIMDs,
+                };
+
+                // Ok, process incoming data
+
+                var keyframeTranslations = new Dictionary<AnimationInterpolationMode, JointsTranslationsAtTimes> {
+                    [AnimationInterpolationMode.STEP] = [],
+                    [AnimationInterpolationMode.LINEAR] = []
+                };
+
+                var keyframeRotations = new Dictionary<AnimationInterpolationMode, JointsRotationsAtTimes> {
+                    [AnimationInterpolationMode.STEP] = [],
+                    [AnimationInterpolationMode.LINEAR] = [],
+                };
+
+                var keyframeScales = new Dictionary<AnimationInterpolationMode, JointsScalesAtTimes> {
+                    [AnimationInterpolationMode.STEP] = [],
+                    [AnimationInterpolationMode.LINEAR] = [],
+                };
 
                 foreach (var chan in incomingAnim.Channels)
                 {
-                    var idx = Array.IndexOf(rig.Names.NotNull(), chan.TargetNode.Name);
-                    if (idx < 0)
+                    var jointIdx = Array.IndexOf(rig.Names.NotNull(), chan.TargetNode.Name);
+                    if (jointIdx < 0)
                     {
-                        throw new Exception($"{gltfFileName} ${incomingAnim.Name}: Invalid Joint Transform, joint {chan.TargetNode.Name} not present in the associated rig {rigFileName}");
+                        throw new Exception($"{gltfFileName} ${incomingAnim.Name}: Invalid Joint Transform, glTF joint {chan.TargetNode.Name} not present in the associated rig {rigFileName}");
                     }
 
                     switch (chan.TargetNodePath)
@@ -298,39 +478,40 @@ namespace WolvenKit.Modkit.RED4
                             var translationSampler = chan.GetTranslationSampler();
                             var typedTranslations = keyframeTranslations[translationSampler.InterpolationMode] ?? throw new Exception($"{gltfFileName} ${incomingAnim.Name}: Unsupported interpolation mode {translationSampler.InterpolationMode}!");
 
-                            var translations = stripLocalFromAdditives
-                                ?  translationSampler.GetLinearKeys().Select(_ => (_.Key, _.Value - chan.TargetNode.LocalTransform.Translation)).ToList()
-                                : translationSampler.GetLinearKeys().ToList();
+                            var localTranslation = chan.TargetNode.LocalTransform.Translation;
 
-                            typedTranslations.Add((ushort)idx, translations);
+                            var translations = stripLocalFromAdditives
+                                ?  translationSampler.GetLinearKeys().Select(_ => (_.Key, _.Value - localTranslation)).ToDictionary()
+                                : translationSampler.GetLinearKeys().ToDictionary();
+
+                            typedTranslations.Add((ushort)jointIdx, translations);
                             break;
 
                         case PropertyPath.rotation:
                             var rotationSampler = chan.GetRotationSampler();
                             var typedRotations = keyframeRotations[rotationSampler.InterpolationMode] ?? throw new Exception($"{gltfFileName} ${incomingAnim.Name}: Unsupported interpolation mode {rotationSampler.InterpolationMode}!");
 
-                            var rotations = stripLocalFromAdditives
-                                ? rotationSampler.GetLinearKeys().Select(_ => (_.Key, _.Value / chan.TargetNode.LocalTransform.Rotation)).ToList()
-                                : rotationSampler.GetLinearKeys().ToList();
+                            var localRotation = RQuaternionNormalize(chan.TargetNode.LocalTransform.Rotation);
 
-                            typedRotations.Add((ushort)idx, rotations);
+                            var rotations = stripLocalFromAdditives
+                                ? rotationSampler.GetLinearKeys().Select(_ => (_.Key, RQuaternionNormalize(RQuaternionNormalize(_.Value) / localRotation))).ToDictionary()
+                                : rotationSampler.GetLinearKeys().Select(_ => (_.Key, RQuaternionNormalize(_.Value))).ToDictionary();
+
+                            typedRotations.Add((ushort)jointIdx, rotations);
                             break;
 
                         case PropertyPath.scale:
                             var scaleSampler = chan.GetScaleSampler();
                             var typedScales = keyframeScales[scaleSampler.InterpolationMode] ?? throw new Exception($"{gltfFileName} ${incomingAnim.Name}: Unsupported interpolation mode {scaleSampler.InterpolationMode}!");
 
-                            var localScale = WithEpsilon(chan.TargetNode.LocalTransform.Scale, Scale1to1);
+                            var localScale = SVectorNormalize(chan.TargetNode.LocalTransform.Scale);
 
                             var scales = stripLocalFromAdditives
                                 ? scaleSampler.GetLinearKeys().Select(_ =>
-                                    (_.Key, Value: WithEpsilon(_.Value, Scale1to1) / localScale)).ToList()
-                                // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
-                                //      It's possible we shouldn't be normalizing here, but I think this might be safer
-                                : scaleSampler.GetLinearKeys().Select(_ =>
-                                    (_.Key, Value: WithEpsilon(_.Value, Scale1to1))).ToList();
+                                    (_.Key, Value: SVectorNormalize(SVectorNormalize(_.Value) / localScale))).ToDictionary()
+                                : scaleSampler.GetLinearKeys().Select(_ => (_.Key, Value: SVectorNormalize(_.Value))).ToDictionary();
 
-                            typedScales.Add((ushort)idx, scales);
+                            typedScales.Add((ushort)jointIdx, scales);
                             break;
 
                         case PropertyPath.weights:
@@ -340,158 +521,81 @@ namespace WolvenKit.Modkit.RED4
                     }
                 }
   
-                // We could validate there's only one of each const but not 100% that's a requirement
-                var constKeyTranslations = keyframeTranslations[AnimationInterpolationMode.STEP];
-                var constKeyRotations = keyframeRotations[AnimationInterpolationMode.STEP];
-                var constKeyScales = keyframeScales[AnimationInterpolationMode.STEP];
+                // ROOT MOTION
 
-                var keyTranslations = keyframeTranslations[AnimationInterpolationMode.LINEAR];
-                var keyRotations = keyframeRotations[AnimationInterpolationMode.LINEAR];
-                var keyScales = keyframeScales[AnimationInterpolationMode.LINEAR];
-
-                // TODO umm do we need to remove root motion if it was present in the original anim?
-
-                var constAnimKeys = new List<animKey?>();
-                var animKeys = new List<animKey?>();
-                var animKeysRaw = new List<animKey?>();
-
-                var rotationCompressionAllowed = extras.OptimizationHints.MaxRotationCompression != AnimationEncoding.Uncompressed;
-
-                for (ushort jointIdx = 0; jointIdx < (ushort)rig.BoneCount; ++jointIdx) {
-
-                    // Const keyframes are all similarly encoded, S, R and T
-
-                    // Order of SRT doesn't seem to matter
-                    foreach (var (time, value) in constKeyRotations.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        constAnimKeys.Add(new animKeyRotation() { Idx = jointIdx, Time = time, Rotation = RQuaternionZupLhs(value), });
-                    }
-                    foreach (var (time, value) in constKeyTranslations.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        constAnimKeys.Add(new animKeyPosition() { Idx = jointIdx, Time = time, Position = TRVectorZupLhs(value), });
-                    }
-                    foreach (var (time, value) in constKeyScales.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        constAnimKeys.Add(new animKeyScale() { Idx = jointIdx, Time = time, Scale = SVectorZupLhs( value ), });
-                    }
-
-                    // For linear keyframes, T and S are always 'raw' but R can optionally be compressed
-
-                    foreach (var (time, value) in keyTranslations.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        animKeysRaw.Add(new animKeyPosition() { Idx = jointIdx, Time = time, Position = TRVectorZupLhs( value ), });
-                    }
-                    foreach (var (time, value) in keyScales.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        animKeysRaw.Add(new animKeyScale() { Idx = jointIdx, Time = time, Scale = SVectorZupLhs(value), });
-                    }
-
-                    var preferredStorage = rotationCompressionAllowed ? animKeys : animKeysRaw;
-
-                    foreach (var (time, value) in keyRotations.GetValueOrDefault(jointIdx, new ()))
-                    {
-                        preferredStorage.Add(new animKeyRotation() { Idx = jointIdx, Time = time, Rotation = RQuaternionZupLhs(value), });
-                    }
-                }
-
-                // -.-
-                var fallbackIndices = extras.FallbackFrameIndices?.Select(_ =>
-                    (CUInt16)_
-                ).ToList() ?? new List<CUInt16>();
-
-                var constTrackKeys = extras.ConstTrackKeys?.Select<AnimConstTrackKeySerializable, animKeyTrack?>(_ =>
-                    new animKeyTrack() {
-                        TrackIndex = _.TrackIndex,
-                        Time = _.Time,
-                        Value = _.Value,
-                    }
-                ).ToList() ?? new List<animKeyTrack?>();
-
-                var trackKeys = extras.TrackKeys?.Select<AnimTrackKeySerializable, animKeyTrack?>(_ =>
-                    new animKeyTrack() {
-                        TrackIndex = _.TrackIndex,
-                        Time = _.Time,
-                        Value = _.Value,
-                    }
-                ).ToList() ?? new List<animKeyTrack?>();
-
-                // TODO: https://github.com/WolvenKit/WolvenKit/issues/1630 Scale handling review
-                //
-                // There's three ways 'constant scale' could be understood:
-                //
-                // 1. Each joint maintains the scale of the bind, i.e. 1
-                // 2. Every joint maintains same scale S throughout anim
-                // 3. Each joint  maintains separate scale S' throughout anim
-                //
-                // Using the first definition here. Not sure it's the right one, need to test,
-                // but I think it's safe enough to be conservative initially.
-                var allScales1 =
-                    keyScales.All(j => j.Value.All(s => EqWithEpsilon(s.Item2, Scale1to1))) &&
-                    constKeyScales.All(j => j.Value.All(s => EqWithEpsilon(s.Item2, Scale1to1)));
+                // TODO https://github.com/WolvenKit/WolvenKit/issues/1752 Full Entity Update Support (Model, Rig, Anims, Ent...)
+                //      For now we just use the rig data, but this should be updated properly.
+                var numJoints = Convert.ToUInt16(rig.BoneCount);
+                var numExtraJoints = extras.NumExtraJoints;
+                var jointsCountActual = Convert.ToUInt16(numJoints - numExtraJoints);
+                var numTracks = Convert.ToUInt16(rig.ReferenceTracks?.Length ?? 0);
+                var numExtraTracks = extras.NumExtraTracks;
+                var tracksCountActual = Convert.ToUInt16(numTracks - numExtraTracks);
 
                 // Have all the raw data in hand now, let's mangle it into CR2W
 
-                var compressed = new animAnimationBufferCompressed()
-                {
+                // For now just dump the data always into `AnimationDataChunk`s, it seems
+                // to work okay regardless of the original buffer type — but presumably those
+                // exist for a reason, so it may be necessary to add support.
+
+                // Currently SIMD not supported
+
+                var incomingAnimData = new AnimationBufferData {
                     Duration = incomingAnim.Duration,
-                    NumFrames = FramesToAccommodateDuration(incomingAnim.Duration),
-                    NumExtraJoints = extras.NumExtraJoints,
-                    NumExtraTracks = extras.NumExtraTracks,
-                    NumJoints = Convert.ToUInt16(rig.BoneCount),
-                    NumTracks = Convert.ToUInt16(rig.ReferenceTracks?.Length ?? 0),
-                    NumConstAnimKeys = Convert.ToUInt32(constAnimKeys.Count),
-                    NumAnimKeysRaw = Convert.ToUInt32(animKeysRaw.Count),
-                    NumAnimKeys = Convert.ToUInt32(animKeys.Count),
-                    NumConstTrackKeys = Convert.ToUInt32(constTrackKeys.Count),
-                    NumTrackKeys = Convert.ToUInt32(trackKeys.Count),
-                    IsScaleConstant = allScales1,
-                    HasRawRotations = !rotationCompressionAllowed,
-
-                    FallbackFrameIndices = new CArray<CUInt16>(fallbackIndices),
-
-                    // These are internal only, they'll be packed into a buffer...
-                    ConstAnimKeys = new (constAnimKeys),
-                    AnimKeysRaw = new (animKeysRaw),
-                    AnimKeys = new (animKeys),
-
-                    ConstTrackKeys = new (constTrackKeys),
-                    TrackKeys = new (trackKeys),
-
-                    TempBuffer = new (),
+                    FrameCount = FramesToAccommodateDuration(incomingAnim.Duration),
+                    Translations = keyframeTranslations[AnimationInterpolationMode.LINEAR],
+                    ConstTranslations = keyframeTranslations[AnimationInterpolationMode.STEP],
+                    Rotations = keyframeRotations[AnimationInterpolationMode.LINEAR],
+                    ConstRotations = keyframeRotations[AnimationInterpolationMode.STEP],
+                    Scales = keyframeScales[AnimationInterpolationMode.LINEAR],
+                    ConstScales = keyframeScales[AnimationInterpolationMode.STEP],
+                    TrackKeys = extras.TrackKeys ?? [],
+                    ConstTrackKeys = extras.ConstTrackKeys ?? [],
+                    FallbackFrameIndices = extras.FallbackFrameIndices ?? [],
+                    NumJoints = numJoints,
+                    NumExtraJoints = numExtraJoints,
+                    JointsCountActual = jointsCountActual,
+                    NumTracks = numTracks,
+                    NumExtraTracks = numExtraTracks,
+                    TracksCountActual = tracksCountActual,
+                    IsSimd = false,
+                    CompressionUsed = extras.OptimizationHints.MaxRotationCompression,
                 };
 
-                // ...specifically TempBuffer, here.
-                compressed.WriteBuffer();
+                // Backfill from original where we must, for now
+                var oldAnimDesc = oldAnim?.Animation?.Chunk;
+
+                // Sneak out Root Motion
+                var incomingRootMotionType = (RootMotionType)Enum.Parse(typeof(RootMotionType), extras.RootMotionType);
+                var (rootMotionType, rootTransformsStripped) = ROOT_MOTION.ExtractRootMotion(out var rootMotion, ref incomingAnimData, ref oldAnimDesc, incomingRootMotionType, incomingAnim.Name, _loggerService);
+
+                stats = stats with {
+                        RootMotions = (rootMotionType is RootMotionType.None or RootMotionType.Unknown) ? stats.RootMotions : stats.RootMotions + 1,
+                        RootTransformsStripped = rootTransformsStripped ? stats.RootTransformsStripped + 1 : stats.RootTransformsStripped
+                    };
 
                 // These could also be written to a single chunk (or fewer chunks)
                 // but for now we'll do a chunk per animation.
                 //
                 // Might have some kind of streaming optimization potential chunk count vs. size?
-                compressed.DataAddress.UnkIndex = (uint)newAnimChunks.Count;
-                compressed.DataAddress.FsetInBytes = 0;
-                compressed.DataAddress.ZeInBytes = compressed.TempBuffer.Buffer.MemSize;
-
-                // For now just dump the data always into `AnimationDataChunk`s,
-                // may need to handle `InplaceCompressedBuffer` and `DefferedBuffer` (sic)
-                // separately if this doesn't work for those reliably...
-                var newAnimDataChunk = new animAnimDataChunk()
-                {
-                    Buffer = new SerializationDeferredDataBuffer(compressed.TempBuffer.Buffer.GetBytes())
+                var chunkDataAddress = new animAnimDataAddress {
+                    UnkIndex = (uint)newAnimChunks.Count,
+                    FsetInBytes = 0,
+                    ZeInBytes = 0,
                 };
 
-                // Backfill from original where possible, for now
-                var oldAnimDesc = oldAnim?.Animation?.Chunk;
+                CompressedBuffer.EncodeAnimationData(out var newAnimDataChunk, out var newCompressedBuffer, ref incomingAnimData, chunkDataAddress, _loggerService);
 
                 var newAnimDesc = new animAnimation()
                 {
                     Name = incomingAnim.Name,
-                    AnimBuffer = new(compressed),
-                    Duration = incomingAnim.Duration,
+                    AnimBuffer = new(newCompressedBuffer),
+                    Duration = incomingAnimData.Duration,
                     AnimationType = incomingAnimationType,
                     FrameClamping = extras.FrameClamping,
                     FrameClampingStartFrame = Convert.ToSByte(extras.FrameClampingStartFrame),
                     FrameClampingEndFrame = Convert.ToSByte(extras.FrameClampingEndFrame),
-                    MotionExtraction = new((animIMotionExtraction?)(oldAnimDesc?.MotionExtraction?.Chunk?.DeepCopy())),
+                    MotionExtraction = new(rootMotion),
                 };
 
                 // I hate C#
@@ -539,17 +643,21 @@ namespace WolvenKit.Modkit.RED4
             anims.AnimationDataChunks = newAnimChunks;
             anims.Animations = newAnimSetEntries;
 
-            if (simdCount > 0)
+            if (stats.SIMDs > 0)
             {
-                _loggerService.Warning($"{gltfFileName}: EXPERIMENTAL: SIMD anims are not fully supported, converted {simdCount} to normal anims. These mostly work ok, but if you have trouble, you can omit them from the animset to keep the existing SIMD versions.");
+                _loggerService.Warning($"{gltfFileName}: Encoding: SIMD anims are not fully supported, converted {stats.SIMDs} to normal anims. These mostly work ok, but if you have trouble, you can omit them from the animset to keep the existing SIMD versions.");
             }
-            if (additiveStrippedCount > 0)
+            if (stats.AdditivesStripped > 0)
             {
-                _loggerService.Info($"{gltfFileName}: stripped local transform from all {additiveStrippedCount} additive animations");
+                _loggerService.Info($"{gltfFileName}: Additive: stripped local transform from all {stats.AdditivesStripped} additive animations");
             }
-            if (additiveCount != additiveStrippedCount)
+            if (stats.Additives != stats.AdditivesStripped)
             {
-                _loggerService.Warning($"{gltfFileName}: additive animations present but were not stripped of local transform, make sure this is what you want");
+                _loggerService.Warning($"{gltfFileName}: Additive: additive animations present but were not stripped of local transform, make sure this is what you want");
+            }
+            if (stats.RootMotions > 0)
+            {
+                _loggerService.Info($"{gltfFileName}: Root Motion: {stats.RootMotions} animations with Root Motion extracted.");
             }
 
             _loggerService.Success($"{gltfFileName}: total: {newAnimSetEntries.Count} animations ({updatedAnims.Count} updated, {newAnimsImported.Count} new, {originalAnimsNotInImport.Count} originals kept)");
@@ -565,6 +673,9 @@ namespace WolvenKit.Modkit.RED4
                 {
                     animAnimationBufferCompressed compressed => compressed.DataAddress,
                     animAnimationBufferSimd simd => simd.DataAddress,
+                    // TODO https://github.com/WolvenKit/WolvenKit/issues/1660
+                    //      Implement Copying for Anime InplaceBuffers and Direct SerializedBuffers.
+                    //      Can steal code from export, but better to refactor it properly.
                     _ => throw new Exception("Unexpected animation buffer type"),
                 };
 

--- a/WolvenKit.RED4/Types/ClassesExt/CustomData/animAnimationBufferCompressed.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/CustomData/animAnimationBufferCompressed.cs
@@ -161,7 +161,7 @@ public partial class animAnimationBufferCompressed //: IRedAppendix
         }
     }
 
-    internal static Func<UInt16, float> DequantU16toF32 = (ui16) => (1f / 65535f) * ui16 * 2 - 1f;
+    internal static Func<UInt16, float> DequantU16toF32 = (ui16) => ((1f / 65535f) * ui16 * 2) - 1f;
     internal static Func<float, UInt16> QuantizeF32toU16 = (f32) => Convert.ToUInt16((f32 + 1) / 2 * (65535));
 
     public void ReadBuffer()


### PR DESCRIPTION
## Fixes

- [x] Root Motion export logic (incl. yaw-only rotations)

## Adds

- [x] Root Motion import 
- [x] Lightweight type level support for differentiating ZupLhs (wkit) and YupRhs (glTF) coordinates so that you can enforce using the correct one in the correct place plus conversions

## Other

- [x] Ton of refactoring in AnimTools and , primarily there's now a struct for passing the data around from and to encoders so that logic is not duplicated where possible.

## Detes

- Root Motion export with toggle, import without toggle based on glTF data
- Root Motion is `Translation` and possibly `Rotation`, type dependent. No `Scale`.
- Only Root Motion *or* regular root joint transforms (if any) are exported, not both, not mixed
- glTF storage for RM is in root joint, as per above
- glTF extras for each anime schema v4 includes `RootMotionType` that tries to be clearer on intent
  - `None` if RM requested but there's none
  - `Unknown` if not requested (whether or not one exists)
  - Others if requested and found
- Previous schemas migrated with `RootMotionType.Unknown`
  - `None` uses root transforms as regular and deletes old RM
  - `Unknown` copies old RM from CR2W, if any, doesn't touch root joint, essentially equivalent to toggle
  - Others store indicated type and clear root joint transforms
 
 ## Also Done
 
 closes #1692  

# TODO separately

- [ ] #1796 
- [ ] #1788 