### PR TITLE
Use Default Encoder for RedJsonSerializer

### DIFF
--- a/WolvenKit.Common/Constants.cs
+++ b/WolvenKit.Common/Constants.cs
@@ -5,6 +5,6 @@ namespace WolvenKit.Common
         public const string RedDbKark = "red.kark";
         public const string RedDb = "red.db";
 
-        public const string RedJsonVersion = "0.0.8";
+        public const string RedJsonVersion = "0.0.9";
     }
 }

--- a/WolvenKit.Common/RED4/CR2W/JSON/RedJsonSerializer.cs
+++ b/WolvenKit.Common/RED4/CR2W/JSON/RedJsonSerializer.cs
@@ -35,7 +35,7 @@ public static class RedJsonSerializer
                     NumberHandlingResolver
                 }
             },
-            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+            Encoder = JavaScriptEncoder.Default,
             WriteIndented = true,
             MaxDepth = 2048,
             Converters =


### PR DESCRIPTION
Given how small this PR is and how many classes this ultimately affects during json exports, further study may be needed, but this works for every file type I've test so far.

- Closes #1701
- Forces the default character escaping outside of `UnicodeRanges.BasicLatin` character range which will fail json validation
- Bumps json version number since this is a different encoding than previously used (`UnicodeRanges.All`)

Example of previously failing json in linked issue