### PR TITLE
Project Explorer fixes

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -720,7 +720,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         var newFullPath = Path.Combine(Path.GetDirectoryName(filename).NotNull(), newFilename);
 
-        if (File.Exists(newFullPath))
+        if (File.Exists(newFullPath) || filename == newFullPath)
         {
             return;
         }

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -452,11 +452,17 @@ namespace WolvenKit.Views.Tools
             return tabControl.SelectedIndex switch
             {
                 0 => true,
-                1 => fm.RawRelativePath.StartsWith("archive"),
-                2 => fm.RawRelativePath.StartsWith("raw", StringComparison.CurrentCultureIgnoreCase),
-                3 => fm.RawRelativePath.StartsWith("resources"),
+                1 => IsFileInInternal("archive"),
+                2 => IsFileInInternal("raw"),
+                3 => IsFileInInternal("resources"),
                 _ => true
             };
+
+            bool IsFileInInternal(string folder)
+            {
+                return fm.RawRelativePath == folder ||
+                       fm.RawRelativePath.StartsWith($"{folder}{Path.DirectorySeparatorChar}");
+            }
         }
 
         private bool IsFileInFlat(object o) => tabControl != null && o is FileSystemModel fm && IsFileIn(o) && !fm.IsDirectory;


### PR DESCRIPTION
# Project Explorer fixes

**Fixed:**
- Renaming folder losing expansion state
- Pasting folder structures into project folder not adding the child items
- Filtered ProjectExplorer showing wrong folders
