### PR TITLE
ProjectExplorer: fixed modifier state tracking

### DIFF
--- a/WolvenKit.App/Services/IModifierViewStateService.cs
+++ b/WolvenKit.App/Services/IModifierViewStateService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -9,6 +10,15 @@ namespace WolvenKit.Core.Services;
 
 public interface IModifierViewStateService: INotifyPropertyChanged
 {
+    public static List<Key> ModifierKeys =
+    [
+        Key.LeftShift,
+        Key.RightShift,
+        Key.LeftCtrl,
+        Key.RightCtrl,
+        Key.LeftAlt,
+        Key.RightAlt
+    ];
     public abstract void RefreshModifierStates(bool skipUpdate = false);
     public abstract bool GetModifierState(ModifierKeys key, bool noOtherModifiersPressed = false);
     void OnKeystateChanged(KeyEventArgs? e);

--- a/WolvenKit.App/Services/ModifierViewStateService.cs
+++ b/WolvenKit.App/Services/ModifierViewStateService.cs
@@ -99,12 +99,11 @@ public partial class ModifierViewStateService() : ObservableObject, IModifierVie
 
     public void OnKeystateChanged(KeyEventArgs? e)
     {
-        if (e?.Key is not (Key.RightCtrl or Key.LeftCtrl or Key.LeftShift or Key.RightShift or Key.LeftAlt
-            or Key.RightAlt))
+        if (e is null || !IModifierViewStateService.ModifierKeys.Contains(e.Key))
         {
             return;
         }
-
+        
         // If the key state hasn't changed, ignore the event
         if (_keyStates.TryGetValue(e.Key, out var value) && value == e.IsDown)
         {

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -28,6 +28,8 @@
     SizeToContent="Manual"
     TitleTextAlignment="Right"
     UseLayoutRounding="True"
+    KeyDown="OnKeyStateChanged"
+    KeyUp="OnKeyStateChanged"
     UseNativeChrome="True">
     <!--  TextBlock Text="{Binding Title}" FontSize="{Binding TitileFontSize}" VerticalAlignment="Center" Margin="10,0,0,0" Opacity="{Binding Opacity, ElementName=ModalOverlay}"/  -->
 

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Windows;
+using System.Windows.Input;
 using AdonisUI.Controls;
 using ReactiveUI;
 using Splat;
@@ -14,6 +15,7 @@ using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Services;
 using WolvenKit.Views.Dialogs.Windows;
 
 namespace WolvenKit.Views.Shell
@@ -22,6 +24,7 @@ namespace WolvenKit.Views.Shell
 
     public partial class MainView : IViewFor<AppViewModel>
     {
+        private readonly IModifierViewStateService _modifierViewStateService;
         public AppViewModel ViewModel { get; set; }
 
         object IViewFor.ViewModel
@@ -30,8 +33,12 @@ namespace WolvenKit.Views.Shell
             set => ViewModel = (AppViewModel)value;
         }
 
-        public MainView(AppViewModel vm = null)
+        public MainView(
+            IModifierViewStateService modifierViewStateService,
+            AppViewModel vm = null
+        )
         {
+            _modifierViewStateService = modifierViewStateService;
             ViewModel = vm ?? Locator.Current.GetService<AppViewModel>();
             DataContext = ViewModel;
 
@@ -188,5 +195,7 @@ namespace WolvenKit.Views.Shell
         private void ChromelessWindow_Loaded(object sender, RoutedEventArgs e) { }
         // This is never called 
         private void ChromelessWindow_Closing(object sender, CancelEventArgs e) { }
+
+        private void OnKeyStateChanged(object sender, KeyEventArgs e) => _modifierViewStateService.OnKeystateChanged(e);
     }
 }

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -18,6 +18,7 @@
     d:DesignHeight="450"
     d:DesignWidth="400"
     x:TypeArguments="tools:ProjectExplorerViewModel"
+    ContextMenuOpening="RefreshModifierStates"
     mc:Ignorable="d">
 
     <UserControl.Resources>
@@ -506,6 +507,26 @@
                 </Setter>
             </Style>
 
+            <Style TargetType="{x:Type Button}" x:Key="HideOnShift" BasedOn="{StaticResource ButtonDefault}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsShiftKeyPressed}" Value="False">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsShiftKeyPressed}" Value="True">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style TargetType="{x:Type Button}" x:Key="UnhideOnShift" BasedOn="{StaticResource ButtonDefault}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsShiftKeyPressed}" Value="False">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding IsShiftKeyPressed}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
 
     </UserControl.Resources>
@@ -641,6 +662,7 @@
                     <Button
                         Margin="3,0,0,0"
                         Click="ExpandAll_OnClick"
+                        Style="{StaticResource HideOnShift}"
                         ToolTip="Expand All">
                         <iconPacks:PackIconCodicons
                             Width="13"
@@ -650,6 +672,7 @@
                     <Button
                         Margin="3,0,0,0"
                         Click="CollapseAll_OnClick"
+                        Style="{StaticResource HideOnShift}"
                         ToolTip="Collapse All">
                         <iconPacks:PackIconCodicons
                             Width="13"
@@ -659,6 +682,7 @@
                     <Button
                         Margin="3,0,0,0"
                         Click="ExpandChildren_OnClick"
+                        Style="{StaticResource UnhideOnShift}"
                         ToolTip="Expand Children">
                         <iconPacks:PackIconBootstrapIcons
                             Width="13"
@@ -668,11 +692,22 @@
                     <Button
                         Margin="3,0,0,0"
                         Click="CollapseChildren_OnClick"
+                        Style="{StaticResource UnhideOnShift}"
                         ToolTip="Collapse Children">
                         <iconPacks:PackIconBootstrapIcons
                             Width="13"
                             Height="13"
                             Kind="ArrowsCollapse" />
+                    </Button>
+                    <Button
+                        Margin="3,0,0,0"
+                        Click="ScrollToOpenFile_OnClick"
+                        IsEnabled="{Binding CanScrollToOpenFile}"
+                        ToolTip="Scroll to open file">
+                        <iconPacks:Material
+                            Width="13"
+                            Height="13"
+                            Kind="Crosshairs" />
                     </Button>
                     <Button
                         x:Name="RefreshButton"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -13,15 +13,19 @@ using System.Windows.Input;
 using HandyControl.Data;
 using ReactiveUI;
 using Syncfusion.Data;
+using Syncfusion.UI.Xaml.Grid.ScrollAxis;
 using Syncfusion.UI.Xaml.TreeGrid;
 using WolvenKit.App.Extensions;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Core.Services;
 using WolvenKit.Views.Dialogs;
 using WolvenKit.Views.Dialogs.Windows;
+using RowColumnIndex = Syncfusion.UI.Xaml.ScrollAxis.RowColumnIndex;
 
 namespace WolvenKit.Views.Tools
 {
@@ -350,6 +354,8 @@ namespace WolvenKit.Views.Tools
         /// Called from view on keyup/keydown event. Synchronises modifier state with ModifierViewStateModel.
         /// </summary>
         private void OnKeyStateChanged(object sender, KeyEventArgs e) => ViewModel?.RefreshModifierStates();
+
+        public void RefreshModifierStates(object sender, RoutedEventArgs routedEventArgs) => ViewModel?.RefreshModifierStates();
 
         /// <summary>
         /// Called from view on key down event. Handles search bar and rename/delete commands.
@@ -870,6 +876,25 @@ namespace WolvenKit.Views.Tools
             }
 
             public ListSortDirection SortDirection { get; set; }
+        }
+
+        private void ScrollToOpenFile_OnClick(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel?.GetActiveEditorFile() is not IDocumentViewModel activeFile
+                || TreeGrid.View.Nodes.FirstOrDefault(node => node.Item is FileSystemModel model && model.FullName == activeFile.FilePath)
+                    is not TreeNode activeFileNode)
+            {
+                return;
+            }
+
+            TreeGrid.SetCurrentValue(Syncfusion.UI.Xaml.Grid.SfGridBase.SelectedItemProperty, activeFileNode);
+
+            ViewModel.SelectedItem = activeFileNode.Item as FileSystemModel;
+
+            var rowIndex = TreeGrid.ResolveToRowIndex(activeFileNode);
+            var columnIndex = TreeGrid.ResolveToStartColumnIndex();
+            TreeGrid.ScrollInView(new RowColumnIndex(rowIndex, columnIndex));
+            TreeGrid.View.MoveCurrentToPosition(rowIndex);
         }
     }
 }

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -114,6 +114,7 @@
     <Page Remove="NewFolder1\**" />
     <Page Remove="Resources\Styles\CustomBase\**" />
     <Page Remove="Resources\Styles\Custom\**" />
+    <Compile Remove="Converters\BooleanConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Views\Templates\RedFixedPointEditor.cs" />


### PR DESCRIPTION
- Fixed the context menu getting stuck sometimes (by adding another modifier state listener to the main app)
- Added visibility toggle for expand/collapse children (shift modifier)
- Added "find currently open file" button. It'll only be enabled if there's a currently active file.

TODO: Enable the button only for files in current project.

no shift
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/e76a6c63-4739-4eb5-bcd7-333a13f1f1a8)
shift
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/417cbd82-a13b-4a7c-9b44-e17751833717)
