### PR TITLE
fix: Change header text to "Selected" for the column of selected items

### DIFF
--- a/WolvenKit/Views/Dialogs/Windows/ChooseCollectionView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/ChooseCollectionView.xaml
@@ -90,7 +90,7 @@
                     <syncfusion:SfDataGrid.Columns>
                         <syncfusion:GridTextColumn
                             FilterRowCondition="Contains"
-                            HeaderText="Available"
+                            HeaderText="Selected"
                             MappingName="Name" />
                     </syncfusion:SfDataGrid.Columns>
 


### PR DESCRIPTION
Renamed the right column of this window when for example choosing audio hashes to export from opusinfo:
![image](https://github.com/WolvenKit/WolvenKit/assets/21307300/35f0975a-d7f5-455c-994e-181e505484d4)
