### PR TITLE
Another memory optimization patch

### DIFF
--- a/WolvenKit.Core/Compression/KrakenNative.cs
+++ b/WolvenKit.Core/Compression/KrakenNative.cs
@@ -6,12 +6,22 @@ public static class KrakenNative
 {
     public static int Decompress(byte[] buffer, byte[] outputBuffer)
         => Kraken_Decompress(buffer, buffer.Length, outputBuffer, outputBuffer.Length);
+    
+    public static unsafe int Decompress(byte* buffer, long bufferLength, byte* outputBuffer, long outputLength)
+        => Kraken_Decompress(buffer, bufferLength, outputBuffer, outputLength);
 
     public static int Compress(byte[] buffer, byte[] outputBuffer, int level)
         => Kraken_Compress(buffer, buffer.Length, outputBuffer, level);
 
     private const string dllName = "kraken";
 
+    [DllImport(dllName, CallingConvention = CallingConvention.StdCall)]
+    private static extern unsafe int Kraken_Decompress(
+        byte* buffer,
+        long bufferSize,
+        byte* outputBuffer,
+        long outputBufferSize);
+    
     // EXPORT int Kraken_Decompress(const byte* src, size_t src_len, byte* dst, size_t dst_len);
     [DllImport(dllName, CallingConvention = CallingConvention.StdCall)]
     private static extern int Kraken_Decompress(

--- a/WolvenKit.Core/Compression/Oodle.cs
+++ b/WolvenKit.Core/Compression/Oodle.cs
@@ -256,6 +256,27 @@ public static class Oodle
 
         return result;
     }
+    
+    public static unsafe long Decompress(byte* inputBuffer, long inputBufferSize, byte* outputBuffer, long outputBufferSize)
+    {
+        int result;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            result = CompressionSettings.Get().UseOodle
+                ? OodleLib.OodleLZ_Decompress(inputBuffer, inputBufferSize, outputBuffer, outputBufferSize)
+                : KrakenNative.Decompress(inputBuffer, inputBufferSize, outputBuffer, outputBufferSize);
+        }
+        else
+        {
+            result = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? KrakenNative.Decompress(inputBuffer, inputBufferSize, outputBuffer, outputBufferSize)
+                : RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    ? KrakenNative.Decompress(inputBuffer, inputBufferSize, outputBuffer, outputBufferSize)
+                    : throw new NotImplementedException();
+        }
+
+        return result;
+    }
 
     /// <summary>
     /// Decompresses and copies a segment of zsize bytes from a stream to another stream

--- a/WolvenKit.Core/Helpers/GCHelper.cs
+++ b/WolvenKit.Core/Helpers/GCHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime;
+
+namespace WolvenKit.Core.Helpers;
+
+public static class GcHelper
+{
+    public static void CleanupMemory()
+    {
+        // Setting LargeObjectHeapCompactionMode to CompactOnce
+        // Will ask GC to collect garbage from LOH ONCE.
+        GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            
+        // Since a lot of stuff is unoptimized right now - just ask GC to clear everything aggressivly.
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
+    }
+}

--- a/WolvenKit.Core/Unmanaged/UnmanagedMemory.cs
+++ b/WolvenKit.Core/Unmanaged/UnmanagedMemory.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace WolvenKit.Core.Unmanaged;
+
+public struct UnmanagedMemory : IDisposable
+{
+    private readonly int _bufferSize;
+    private readonly IntPtr _address;
+    private readonly Lazy<UnmanagedMemoryStream> _lazyStream;
+    
+    private long _disposed = 0;
+
+    public unsafe UnmanagedMemory(int bufferSize)
+    {
+        var address = Marshal.AllocHGlobal(bufferSize);
+        
+        _bufferSize = bufferSize;
+        _address = address;
+        _lazyStream = new Lazy<UnmanagedMemoryStream>(() => new UnmanagedMemoryStream((byte*) address.ToPointer(), bufferSize));
+    }
+
+    public unsafe byte* Pointer => (byte*)_address.ToPointer();
+    public int Size => _bufferSize;
+    public unsafe Span<byte> GetSpan() => new(Pointer, Size);
+    
+    public UnmanagedMemoryStream GetStream() => _lazyStream.Value;
+
+    public void Dispose()
+    {
+        if(Interlocked.Read(ref _disposed) != 0)
+            return;
+        
+        Interlocked.Increment(ref _disposed);
+        
+        if(_lazyStream.IsValueCreated)
+            _lazyStream.Value.Dispose();
+        
+        Marshal.FreeHGlobal(_address);
+    }
+
+    public static UnmanagedMemory Allocate(int bufferSize) => new(bufferSize);
+}

--- a/WolvenKit.RED4/Types/Pools/ResourcePathPool.cs
+++ b/WolvenKit.RED4/Types/Pools/ResourcePathPool.cs
@@ -63,10 +63,15 @@ public static class ResourcePathPool
         return hash;
     }
 
-    public static void SetNative(Dictionary<ulong, string> dict)
+    public static void SetNative(ConcurrentDictionary<ulong, string> dict)
     {
-        s_nativePoolReverse = new ConcurrentDictionary<ulong, string>(dict);
-        s_nativePool = new ConcurrentDictionary<string, ulong>(dict.ToDictionary(x => x.Value, x => x.Key));
+        s_nativePoolReverse = dict;
+        s_nativePool = new ConcurrentDictionary<string, ulong>();
+
+        foreach (var (key, value) in dict)
+        {
+            s_nativePool.GetOrAdd(value, key);
+        }
     }
 
     public delegate string? ExtResolveHash(ulong hash);

--- a/WolvenKit/Initializations.cs
+++ b/WolvenKit/Initializations.cs
@@ -18,6 +18,7 @@ using Syncfusion.Themes.MaterialDark.WPF;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.Core.Helpers;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Helpers;
 using WolvenKit.Views.Shell;
@@ -84,6 +85,9 @@ namespace WolvenKit
         {
             // Set service locator.
             var mainWindow = Locator.Current.GetService<IViewFor<AppViewModel>>();
+
+            GcHelper.CleanupMemory();
+            
             if (mainWindow is MainView window)
             {
                 window.Show();


### PR DESCRIPTION
## Another memory optimization patch

**Implemented:**
- Oodle decompressing now allocates/deallocates unmanaged memory only to prevent massive byte[] going into LOH
- Right after shell initialization application now requests LOH (and every other generation) cleanup to handle other unfixed LOH cases for now.
