### PR TITLE
HashTool window now uses new algo to calculate NodeRef's hash

### DIFF
--- a/Tests/WolvenKit.UnitTests/FNV1A64Tests.cs
+++ b/Tests/WolvenKit.UnitTests/FNV1A64Tests.cs
@@ -110,6 +110,7 @@ namespace WolvenKit.UnitTests
         [TestMethod]
         [DataRow("$/test/important/123/456")]
         [DataRow("$/test/important;#alias/123/456")]
+        [DataRow("$/test/important;#alias/123;#alias2/456;#alias3")]
         public void Hasher_Should_Handle_Semicolon(string source)
         {
             var hash = FNV1A64HashAlgorithm.HashStringWithoutAliases(source);

--- a/WolvenKit/Views/Tools/HashToolView.xaml.cs
+++ b/WolvenKit/Views/Tools/HashToolView.xaml.cs
@@ -44,7 +44,7 @@ public partial class HashToolView : ReactiveUserControl<HashToolViewModel>
         DepotHash.SetCurrentValue(TextBox.TextProperty, depotHash.ToString());
         DepotHashHex.SetCurrentValue(TextBox.TextProperty, $"0x{depotHash:X16}");
 
-        var nodeRefHash = FNV1A64HashAlgorithm.HashString(InputTextBox.Text.Replace("#", ""));
+        var nodeRefHash = FNV1A64HashAlgorithm.HashStringWithoutAliases(InputTextBox.Text);
         NodeRefHash.SetCurrentValue(TextBox.TextProperty, nodeRefHash.ToString());
         NodeRefHashHex.SetCurrentValue(TextBox.TextProperty, $"0x{nodeRefHash:X16}");
 


### PR DESCRIPTION
**Fixed:**
- Hash Tool window used old algorithm to calculate NodeRef's hash. That is fixed now.

