### PR TITLE
1753: name and e-mail default for new project in settings

### DIFF
--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -40,4 +40,6 @@ public interface ISettingsDto
     public int PinnedOrder { get; set; }
     public int RecentOrder { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; }
+    public string? ModderName { get; set; }
+    public string? ModderEmail { get; set; }
 }

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -44,6 +44,8 @@ public class SettingsDto : ISettingsDto
         PinnedOrder = settings.PinnedOrder;
         RecentOrder = settings.RecentOrder;
         ShowGraphEditorNodeProperties = settings.ShowGraphEditorNodeProperties;
+        ModderName = settings.ModderName;
+        ModderEmail = settings.ModderEmail;
         
         if (settings.SettingsVersion < 2)
         {
@@ -84,6 +86,8 @@ public class SettingsDto : ISettingsDto
     public int PinnedOrder { get; set; }
     public int RecentOrder { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
+    public string? ModderName { get; set; }
+    public string? ModderEmail { get; set; }
 
     public SettingsManager ReconfigureSettingsManager(SettingsManager settingsManager)
     {
@@ -124,6 +128,8 @@ public class SettingsDto : ISettingsDto
         settingsManager.PinnedOrder = PinnedOrder;
         settingsManager.RecentOrder = RecentOrder;
         settingsManager.ShowGraphEditorNodeProperties = ShowGraphEditorNodeProperties;
+        settingsManager.ModderName = ModderName;
+        settingsManager.ModderEmail = ModderEmail;
 
         return settingsManager;
     }

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -58,7 +58,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(LastUsedProjectPath),
             nameof(PinnedOrder),
             nameof(RecentOrder),
-            nameof(ShowGraphEditorNodeProperties)
+            nameof(ShowGraphEditorNodeProperties),
+            nameof(ModderName),
+            nameof(ModderEmail)
             )
           .Subscribe(_ =>
           {
@@ -259,6 +261,14 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [Display(Name = "Additional Mod directory", Description = "Path to an optional directory containing mod archives", GroupName = "Cyberpunk")]
     [ObservableProperty]
     private string? _extraModDirPath;
+
+    [Display(Name = "Your name", Description = "Will be used for project properties on creation", GroupName = "General")]
+    [ObservableProperty]
+    private string? _modderName;
+
+    [Display(Name = "Your e-Mail", Description = "Will be used for project properties on creation", GroupName = "General")]
+    [ObservableProperty]
+    private string? _modderEmail;
 
     [ObservableProperty]
 #pragma warning disable CS0657 // Not a valid attribute location for this declaration

--- a/WolvenKit/Views/Dialogs/ProjectWizardView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/ProjectWizardView.xaml.cs
@@ -3,6 +3,8 @@ using System.Reactive.Disposables;
 using System.Windows.Controls;
 using System.Windows.Input;
 using ReactiveUI;
+using Splat;
+using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 
 namespace WolvenKit.Views.Dialogs
@@ -24,7 +26,7 @@ namespace WolvenKit.Views.Dialogs
             {
                 _syncModName = true;
                 _autoUpdate = false;
-
+                
                 //this.Bind(ViewModel,
                 //    vm => vm,
                 //    v => v.DataContext).DisposeWith(disposables);
@@ -80,7 +82,29 @@ namespace WolvenKit.Views.Dialogs
 
                 ProjectNameTextBox.VerifyData();
                 ModNameTextBox.VerifyData();
+
+                ReadDefaultValuesFromSettings();
+                VersionTextBox.SetCurrentValue(TextBox.TextProperty, "1.0.0");
             });
+        }
+
+        private void ReadDefaultValuesFromSettings()
+        {
+            var settings = Locator.Current.GetService<ISettingsManager>();
+            if (settings is null)
+            {
+                return;
+            }
+
+            if (settings.ModderName is not null)
+            {
+                AuthorTextBox.SetCurrentValue(TextBox.TextProperty, settings.ModderName);
+            }
+
+            if (settings.ModderEmail is not null)
+            {
+                EmailTextBox.SetCurrentValue(TextBox.TextProperty, settings.ModderEmail);
+            }
         }
 
         private HandyControl.Data.OperationResult<bool> VerifyProjectName(string str)


### PR DESCRIPTION
Added modder name and e-mail to settings. On creation of a new project, the default values will be populated, if they are set. 

Closes #1753 