### PR TITLE
Cvm: more default expansion states

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -51,8 +51,10 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
 
         IsSimpleViewEnabled = Parent.IsSimpleViewEnabled;
 
-        parent.PropertyChanged += RDTDataViewModel_PropertyChanged;
-        
+        Nodes.Add(new ResourcePathWrapper(this, new ReferenceSocket(Chunks[0].RelativePath), _appViewModel, _chunkViewmodelFactory));
+        _nodePaths.Add(Chunks[0].RelativePath);
+
+
         if (SelectedChunk == null && Chunks.Count > 0)
         {
             SelectedChunk = Chunks[0];
@@ -62,8 +64,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
             }
         }
 
-        Nodes.Add(new ResourcePathWrapper(this, new ReferenceSocket(Chunks[0].RelativePath), _appViewModel, _chunkViewmodelFactory));
-        _nodePaths.Add(Chunks[0].RelativePath);
+        parent.PropertyChanged += RDTDataViewModel_PropertyChanged;
     }
 
     private void RDTDataViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -410,6 +411,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
     public void SetSelection(ChunkViewModel chunk)
     {
         ClearSelection();
+        chunk.IsSelected = true;
         SelectedChunk = chunk;
         if (SelectedChunks is IList lst)
         {

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1475,6 +1475,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         var undefinedMaterialNames = mesh.Appearances
             .Select((handle) => handle.GetValue() as meshMeshAppearance).Where((i) => i != null)
             .SelectMany(mA => mA!.ChunkMaterials.Select(chunkMaterial => chunkMaterial.GetResolvedText() ?? "").ToArray())
+            .Select((materialName) => materialName.Contains('@') ? $"@{materialName.Split('@').Last()}" : materialName) // dynamic
             .Where((chunkMaterialName) => !definedMaterialNames.Contains(chunkMaterialName))
             .ToHashSet().ToList();
 

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModel.ExpansionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModel.ExpansionStates.cs
@@ -40,6 +40,13 @@ public partial class ChunkViewModel : ObservableObject
             // .mi file
             case CMaterialInstance when TVProperties.FirstOrDefault(prop => prop.Name == "values") is ChunkViewModel valuesNode:
                 valuesNode.IsExpanded = true;
+                if (valuesNode.TVProperties.Count == 0 || _tab is null)
+                {
+                    break;
+                }
+
+                // Auto-select the single value
+                _tab.SetSelection(valuesNode.TVProperties[0]);
                 break;
             default:
                 break;


### PR DESCRIPTION
After opening an .mi file: Will select the first element in `values` (if there is one)
When generating materials: Will now correctly understand dynamic materials