### PR TITLE
Launchprofiles refactoring & overhaul

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -362,12 +362,17 @@ public class RED4Controller : ObservableObject, IGameController
             throw new WolvenKitException(0x5001, "No game executable set");
         }
 
+        var arguments = options.GameArguments ?? "";
+        if (options.LoadLastSave && ISettingsManager.GetLastSaveName() is string lastSavegame)
+        {
+            arguments = $"{arguments} --save={lastSavegame}";
+        }
         try
         {
             Process.Start(new ProcessStartInfo
             {
                 FileName = launchCommand,
-                Arguments = options.GameArguments ?? "",
+                Arguments = arguments,
                 ErrorDialog = true,
                 UseShellExecute = true,
             });

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -322,6 +322,15 @@ public class RED4Controller : ObservableObject, IGameController
             //return false;
         }
 
+        // backup
+        if (options.CreateBackup && !CreateZipfile(cp77Proj, true))
+        {
+            _progressService.IsIndeterminate = false;
+            _loggerService.Error("Creating backup failed, aborting.");
+            _notificationService.Error("Creating backup failed, aborting.");
+            return false;
+        }
+        
         // cleanup
         if (!await Task.Run(() => Cleanup(cp77Proj, options)))
         {
@@ -330,13 +339,29 @@ public class RED4Controller : ObservableObject, IGameController
             _notificationService.Error("Cleanup failed, aborting.");
             return false;
         }
-        _loggerService.Info($"{cp77Proj.Name} files cleaned up.");
 
+        // CleanAll will return true when the options disable it, so check here  
+        if (options.CleanAll)
+        {
+            _loggerService.Info($"{cp77Proj.Name} files cleaned up.");
+        }
+
+        
         // Pack it up
         if (!await PackProjectFiles(options, cp77Proj))
         {
             return false;
         }
+
+        // backup
+        if (options.CreateZipFile && !CreateZipfile(cp77Proj, false))
+        {
+            _progressService.IsIndeterminate = false;
+            _loggerService.Error("Failed to bundle up your .archive, aborting.");
+            _notificationService.Error("Creating backup failed, aborting.");
+            return false;
+        }
+
 
         // Now install it
         if (!await InstallProjectFiles(options, cp77Proj))
@@ -393,32 +418,18 @@ public class RED4Controller : ObservableObject, IGameController
             return true;
         }
 
-        // backup
-        if (options.CreateBackup)
+        // install files: is always true (abort condition above)
+        if (!InstallMod(cp77Proj))
         {
-            if (!BackupMod(cp77Proj))
-            {
-                _progressService.IsIndeterminate = false;
-                _loggerService.Error("Creating backup failed, aborting.");
-                _notificationService.Error("Creating backup failed, aborting.");
-                return false;
-            }
+            _progressService.IsIndeterminate = false;
+            _loggerService.Error("Installing mod failed, aborting.");
+            _notificationService.Error("Installing mod failed, aborting.");
+            return false;
         }
 
-        // install files
-        if (options.Install)
-        {
-            if (!InstallMod(cp77Proj))
-            {
-                _progressService.IsIndeterminate = false;
-                _loggerService.Error("Installing mod failed, aborting.");
-                _notificationService.Error("Installing mod failed, aborting.");
-                return false;
-            }
+        _loggerService.Success($"{cp77Proj.Name} installed to {_settingsManager.GetRED4GameRootDir()}");
+        _notificationService.Success($"{cp77Proj.Name} installed!");
 
-            _loggerService.Success($"{cp77Proj.Name} installed to {_settingsManager.GetRED4GameRootDir()}");
-            _notificationService.Success($"{cp77Proj.Name} installed!");
-        }
 
         // deploy redmod
         if (options.DeployWithRedmod)
@@ -439,6 +450,11 @@ public class RED4Controller : ObservableObject, IGameController
 
     private async Task<bool> PackProjectFiles(LaunchProfile options, Cp77Project cp77Proj)
     {
+        if (options is { CreateZipFile: false, Install: false })
+        {
+            return true;
+        }
+        
         // copy files to packed dir
         // pack archives
         var modfiles = Directory.EnumerateFiles(cp77Proj.ModDirectory, "*", SearchOption.AllDirectories);
@@ -503,44 +519,29 @@ public class RED4Controller : ObservableObject, IGameController
 
     private bool Cleanup(Cp77Project cp77Proj, LaunchProfile options, bool isPostBuild = false)
     {
-        var result = false;
-
-        //clean all nukes everything in the packed/ directory, not just directories covered by the commands after this block
-        //When this option is chosen, no need to continue further.
-        if (options.CleanAll || isPostBuild && options.CleanAllPostBuild)
+        if (!options.CleanAll && !(isPostBuild && options.CleanAllPostBuild))
         {
-            result = true; //base condition -- if packed/ is already empty, then the command is 'successful'.
-
-            //top level directories
-            var dirs = Directory.GetDirectories(cp77Proj.PackedRootDirectory, "*", SearchOption.TopDirectoryOnly);
-            for (var i = 0; i < dirs.Count(); i++)
-            {
-                result = SafeDirectoryDelete(dirs[i], true);
-            }
-
-            //top level files
-            var files = Directory.GetFiles(cp77Proj.PackedRootDirectory, "*", SearchOption.TopDirectoryOnly);
-            for (var i = 0; i < files.Count(); i++)
-            {
-                result = SafeFileDelete(files[i]);
-            }
-            return result;
+            return true;
         }
 
-        // legacy
-        result = SafeDirectoryDelete(cp77Proj.GetPackedArchiveDirectory(!options.IsRedmod), true);
-        result = SafeDirectoryDelete(Path.Combine(cp77Proj.PackedRootDirectory, "archive"), true);
+        var result = true; //base condition -- if packed/ is already empty, then the command is 'successful'.
 
-        // tweakXL
-        result = SafeDirectoryDelete(cp77Proj.PackedTweakDirectory, true);
+        //top level directories
+        var dirs = Directory.GetDirectories(cp77Proj.PackedRootDirectory, "*", SearchOption.TopDirectoryOnly);
+        for (var i = 0; i < dirs.Count(); i++)
+        {
+            result = SafeDirectoryDelete(dirs[i], true);
+        }
 
-        // redmod
-        result = SafeFileDelete(Path.Combine(cp77Proj.PackedRedModDirectory, "info.json"));
-        result = SafeDirectoryDelete(cp77Proj.PackedSoundsDirectory, true);
-        result = SafeDirectoryDelete(cp77Proj.GetPackedArchiveDirectory(options.IsRedmod), true);
-        result = SafeDirectoryDelete(Path.Combine(cp77Proj.PackedRootDirectory, "mods"), true);
+        //top level files
+        var files = Directory.GetFiles(cp77Proj.PackedRootDirectory, "*", SearchOption.TopDirectoryOnly);
+        for (var i = 0; i < files.Count(); i++)
+        {
+            result = SafeFileDelete(files[i]);
+        }
 
         return result;
+       
     }
 
     private bool SafeDirectoryDelete(string path, bool recursive = true)
@@ -741,7 +742,7 @@ public class RED4Controller : ObservableObject, IGameController
         return true;
     }
 
-    private bool BackupMod(Cp77Project cp77Proj)
+    private bool CreateZipfile(Cp77Project cp77Proj, bool isBackup)
     {
         var zipPathRoot = new DirectoryInfo(cp77Proj.PackedRootDirectory).Parent?.FullName;
         if (zipPathRoot is null)
@@ -749,7 +750,8 @@ public class RED4Controller : ObservableObject, IGameController
             return false;
         }
 
-        var zipPath = Path.Combine(zipPathRoot, $"{cp77Proj.Name}.zip");
+        var suffix = isBackup ? "_previousBuild" : "";
+        var zipPath = Path.Combine(zipPathRoot, $"{cp77Proj.Name}{suffix}.zip");
         try
         {
             if (File.Exists(zipPath))

--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -56,4 +56,6 @@ public static class Interactions
 
     public static Func<(IEnumerable<IDisplayable>?, IEnumerable<IDisplayable>?), IEnumerable<IDisplayable>> ShowCollectionView { get; set; } 
         = _ => throw new NotImplementedException();
+
+    public static Func<string?> ShowSelectSaveView { get; set; } = () => throw new NotImplementedException();
 }

--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -57,5 +57,6 @@ public static class Interactions
     public static Func<(IEnumerable<IDisplayable>?, IEnumerable<IDisplayable>?), IEnumerable<IDisplayable>> ShowCollectionView { get; set; } 
         = _ => throw new NotImplementedException();
 
-    public static Func<string?> ShowSelectSaveView { get; set; } = () => throw new NotImplementedException();
+    public static Func<string?, string?> ShowSelectSaveView { get; set; } =
+        (string? currentSaveGame) => throw new NotImplementedException();
 }

--- a/WolvenKit.App/Models/LaunchProfile.cs
+++ b/WolvenKit.App/Models/LaunchProfile.cs
@@ -9,7 +9,6 @@ public class LaunchProfile
     [Display(Name = "Create Backup of previous build")]
     public bool CreateBackup { get; set; }
 
-
     [Category("Build and Install")]
     [Display(Name = "Create zip file")]
     public bool CreateZipFile { get; set; }
@@ -52,64 +51,37 @@ public class LaunchProfile
         {
             if (value)
             {
-                _loadSpecificSave = false;
+                LoadSaveName = null;
             }
 
             _loadLastSave = value;
         }
     }
 
-    private bool _loadSpecificSave;
-
+    private string? _loadSaveName;
     [Category("Game Launch")]
     [Display(Name = "Load specific savegame")]
-    public bool LoadSpecificSave
-    {
-        get => _loadSpecificSave;
-        set
-        {
-            if (value)
-            {
-                _loadLastSave = false;
-            }
-
-            _loadSpecificSave = value;
-            OnPropertyChanged(nameof(LoadSpecificSave));
-        }
-    }
-
-    [Category("Game Launch")]
-    [property: Browsable(false)]
-    [Display(Name = "Load last savegame: Which?")]
     public string? LoadSaveName
     {
-        get;
-        set;
+        get => _loadSaveName;
+        set
+        {
+            if (value is not null)
+            {
+                LoadLastSave = false;
+            }
+
+            _loadSaveName = value;
+        }
     }
 
     [Category("Game Launch")]
     [Display(Name = "Game Commandline Arguments")]
     public string? GameArguments { get; set; }
 
-
     [property: Browsable(false)] public int? Order { get; set; }
 
-
-    internal LaunchProfile Copy()
-    {
-        return new LaunchProfile()
-        {
-            CreateBackup = CreateBackup,
-            CleanAll = CleanAll,
-            CleanAllPostBuild = CleanAllPostBuild,
-            Install = Install,
-            IsRedmod = IsRedmod,
-            DeployWithRedmod = DeployWithRedmod,
-            LaunchGame = LaunchGame,
-            LoadLastSave = LoadLastSave,
-            GameArguments = GameArguments
-        };
-    }
+    internal LaunchProfile Copy() => (LaunchProfile)MemberwiseClone();
 
     public void SwitchPosition(LaunchProfile otherProfile) => (Order, otherProfile.Order) = (otherProfile.Order, Order);
 

--- a/WolvenKit.App/Models/LaunchProfile.cs
+++ b/WolvenKit.App/Models/LaunchProfile.cs
@@ -6,8 +6,13 @@ namespace WolvenKit.App.Models;
 public class LaunchProfile
 {
     [Category("Build and Install")]
-    [Display(Name = "Create Backup")]
+    [Display(Name = "Create Backup of previous build")]
     public bool CreateBackup { get; set; }
+
+
+    [Category("Build and Install")]
+    [Display(Name = "Create zip file")]
+    public bool CreateZipFile { get; set; }
 
     [Category("Build and Install")]
     [Display(Name = "Install to Game directory")]

--- a/WolvenKit.App/Models/LaunchProfile.cs
+++ b/WolvenKit.App/Models/LaunchProfile.cs
@@ -4,40 +4,89 @@ using System.ComponentModel.DataAnnotations;
 namespace WolvenKit.App.Models;
 public class LaunchProfile
 {
-    [Category("General")]
+    [Category("Build and Install")]
     [Display(Name = "Create Backup")]
     public bool CreateBackup { get; set; }
 
-    [Category("Install")]
-    [Display(Name = "Install to Game")]
+    [Category("Build and Install")]
+    [Display(Name = "Install to Game directory")]
     public bool Install { get; set; }
+    
     // installsound files
     // install tweak files
     // install script files
 
-    [Category("Install")]
-    [Display(Name = "Clean packed directory before build?")]
+    [Category("Build and Install")]
+    [Display(Name = "Clean before build to prevent errors?")]
     public bool CleanAll { get; set; } = true;
 
-    [Category("Install")]
-    [Display(Name = "Clean packed directory after build?")]
+    [Category("Build and Install")]
+    [Display(Name = "Clean after build to save disk space?")]
     public bool CleanAllPostBuild { get; set; } = false;
 
-    [Category("REDmod")]
+    [Category("Bundle: REDmod")]
     [Display(Name = "Pack as REDmod")]
     public bool IsRedmod { get; set; }
 
-    [Category("REDmod")]
-    [Display(Name = "Deploy With REDmod")]
+    [Category("Bundle: REDmod")]
+    [Display(Name = "Deploy as REDmod")]
     public bool DeployWithRedmod { get; set; }
 
     [Category("Game Launch")]
-    [Display(Name = "Launch Game after Installing")]
+    [Display(Name = "Launch Game")]
     public bool LaunchGame { get; set; }
+
+    private bool _loadLastSave;
+    [Category("Game Launch")]
+    [Display(Name = "Load last savegame")]
+    public bool LoadLastSave
+    {
+        get => _loadLastSave;
+        set
+        {
+            if (value)
+            {
+                _loadSpecificSave = false;
+            }
+
+            _loadLastSave = value;
+        }
+    }
+
+    private bool _loadSpecificSave;
+
+    [Category("Game Launch")]
+    [Display(Name = "Load specific savegame")]
+    public bool LoadSpecificSave
+    {
+        get => _loadSpecificSave;
+        set
+        {
+            if (value)
+            {
+                _loadLastSave = false;
+            }
+
+            _loadSpecificSave = value;
+        }
+    }
+
+
+    [Category("Game Launch")]
+    [property: Browsable(false)]
+    [Display(Name = "Load last savegame: Which?")]
+    public string? LoadSaveName
+    {
+        get;
+        set;
+    }
 
     [Category("Game Launch")]
     [Display(Name = "Game Commandline Arguments")]
     public string? GameArguments { get; set; }
+
+
+    [property: Browsable(false)] public int? Order { get; set; }
 
 
     internal LaunchProfile Copy()
@@ -51,7 +100,15 @@ public class LaunchProfile
             IsRedmod = IsRedmod,
             DeployWithRedmod = DeployWithRedmod,
             LaunchGame = LaunchGame,
+            LoadLastSave = LoadLastSave,
             GameArguments = GameArguments
         };
+    }
+
+    public void SwitchPosition(LaunchProfile otherProfile)
+    {
+        var previousPos = Order;
+        Order = otherProfile.Order;
+        otherProfile.Order = previousPos;
     }
 }

--- a/WolvenKit.App/Models/LaunchProfile.cs
+++ b/WolvenKit.App/Models/LaunchProfile.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace WolvenKit.App.Models;
 public class LaunchProfile
@@ -68,9 +69,9 @@ public class LaunchProfile
             }
 
             _loadSpecificSave = value;
+            OnPropertyChanged(nameof(LoadSpecificSave));
         }
     }
-
 
     [Category("Game Launch")]
     [property: Browsable(false)]
@@ -105,10 +106,10 @@ public class LaunchProfile
         };
     }
 
-    public void SwitchPosition(LaunchProfile otherProfile)
-    {
-        var previousPos = Order;
-        Order = otherProfile.Order;
-        otherProfile.Order = previousPos;
-    }
+    public void SwitchPosition(LaunchProfile otherProfile) => (Order, otherProfile.Order) = (otherProfile.Order, Order);
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/WolvenKit.App/Models/SaveGame.cs
+++ b/WolvenKit.App/Models/SaveGame.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace WolvenKit.App.Models;
+
+public class SaveGame(string dirName, string screenshot, string save, DateTime lastModified)
+{
+    public string DirName { get; set; } = dirName;
+    public string Screenshot { get; set; } = screenshot;
+    public string Save { get; set; } = save;
+    public DateTime LastModified { get; set; } = lastModified;
+}

--- a/WolvenKit.App/Resources/launchprofiles.json
+++ b/WolvenKit.App/Resources/launchprofiles.json
@@ -14,10 +14,22 @@
     "DeployWithRedmod": true,
     "IsRedmod" :  true
   },
+  "Launch Game Without Install": {
+    "LaunchGame": true,
+    "GameArguments": ""
+  },
   "Install and Launch": {
     "CreateBackup": false,
     "Install": true,
     "LaunchGame": true,
+    "GameArguments": "",
+    "DeployWithRedmod": false
+  },
+  "Install, Launch, and Load Save": {
+    "CreateBackup": false,
+    "Install": true,
+    "LaunchGame": true,
+    "LoadLastSave": true,
     "GameArguments": "",
     "DeployWithRedmod": false
   }

--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -33,6 +33,7 @@ public interface ISettingsDto
     public EGameLanguage GameLanguage { get; set; }
     public bool EnableNoobFilterByDefault { get; set; }
     public Dictionary<string, LaunchProfile>? LaunchProfiles { get; set; }
+    public bool UseDefaultLaunchProfiles { get; set; }
     public Dictionary<string, bool>? ScriptStatus { get; set; }
     public bool AnalyzeModArchives { get; set; }
     public string? ExtraModDirPath { get; set; }

--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -184,10 +184,15 @@ public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
 
     string GetVersionNumber();
 
+    string LastLaunchProfile { get; set; }
+
     /// <summary>
     /// For "simple" editor view: hides fields that the user shouldn't edit 
     /// </summary>
     bool IsNoobFilterDefaultEnabled();
+
+    bool ShowRedmodInRibbon { get; set; }
+
 
     Dictionary<string, LaunchProfile> GetLaunchProfiles();
 }

--- a/WolvenKit.App/Services/ISettingsManager.cs
+++ b/WolvenKit.App/Services/ISettingsManager.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Windows.Controls;
 using System.Windows.Media;
 using WolvenKit.App.Models;
+using System.Windows.Media.Imaging;
+using DynamicData.Kernel;
 
 namespace WolvenKit.App.Services;
-
 
 public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
 {
@@ -138,6 +140,26 @@ public interface ISettingsManager : ISettingsDto, INotifyPropertyChanged
         Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             "Saved Games", "CD Projekt Red", "Cyberpunk 2077");
+
+    public static List<SaveGame> GetSaveGames()
+    {
+        var saveDir = ISettingsManager.GetSaveDirectory();
+        if (!Directory.Exists(saveDir))
+        {
+            return [];
+        }
+
+        return Directory.GetDirectories(saveDir)
+            .Select(folder => new { Folder = folder, Save = Path.Combine(folder, "sav.dat") })
+            .Where(x => File.Exists(x.Save))
+            .Select(x => new SaveGame(
+                new DirectoryInfo(x.Folder).Name,
+                Path.Combine(x.Folder, "screenshot.png"),
+                x.Save,
+                new DirectoryInfo(x.Folder).LastWriteTime))
+            .OrderByDescending(x => x.LastModified)
+            .AsList();
+    }
 
     public static string? GetLastSaveName()
     {

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -90,7 +90,7 @@ public class SettingsDto : ISettingsDto
     public string? ExtraModDirPath { get; set; }
     public string? LastUsedProjectPath { get; set; }
     public string? LastLaunchProfile { get; set; }
-    public bool ShowRedmodInRibbon { get; set; } = true;
+    public bool ShowRedmodInRibbon { get; set; }
     public int PinnedOrder { get; set; }
     public int RecentOrder { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; } = true;

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -48,6 +48,8 @@ public class SettingsDto : ISettingsDto
         ModderEmail = settings.ModderEmail;
         RefactoringCheckboxDefaultValue = settings.RefactoringCheckboxDefaultValue;
         UseDefaultLaunchProfiles = settings.UseDefaultLaunchProfiles;
+        LastLaunchProfile = settings.LastLaunchProfile;
+        ShowRedmodInRibbon = settings.ShowRedmodInRibbon;
         
         if (settings.SettingsVersion < 2)
         {
@@ -87,6 +89,8 @@ public class SettingsDto : ISettingsDto
     public bool AnalyzeModArchives { get; set; } = true;
     public string? ExtraModDirPath { get; set; }
     public string? LastUsedProjectPath { get; set; }
+    public string? LastLaunchProfile { get; set; }
+    public bool ShowRedmodInRibbon { get; set; } = true;
     public int PinnedOrder { get; set; }
     public int RecentOrder { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
@@ -136,6 +140,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.ModderEmail = ModderEmail;
         settingsManager.RefactoringCheckboxDefaultValue = RefactoringCheckboxDefaultValue;
         settingsManager.UseDefaultLaunchProfiles = UseDefaultLaunchProfiles;
+        settingsManager.LastLaunchProfile = LastLaunchProfile;
 
         return settingsManager;
     }

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -47,6 +47,7 @@ public class SettingsDto : ISettingsDto
         ModderName = settings.ModderName;
         ModderEmail = settings.ModderEmail;
         RefactoringCheckboxDefaultValue = settings.RefactoringCheckboxDefaultValue;
+        UseDefaultLaunchProfiles = settings.UseDefaultLaunchProfiles;
         
         if (settings.SettingsVersion < 2)
         {
@@ -80,6 +81,8 @@ public class SettingsDto : ISettingsDto
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; } = EGameLanguage.en_us;
     public Dictionary<string, LaunchProfile>? LaunchProfiles { get; set; }
+    public bool UseDefaultLaunchProfiles { get; set; } = true;
+    public bool RefactoringCheckboxDefaultValue { get; set; }
     public Dictionary<string, bool>? ScriptStatus { get; set; }
     public bool AnalyzeModArchives { get; set; } = true;
     public string? ExtraModDirPath { get; set; }
@@ -89,7 +92,6 @@ public class SettingsDto : ISettingsDto
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
     public string? ModderName { get; set; }
     public string? ModderEmail { get; set; }
-    public bool RefactoringCheckboxDefaultValue { get; set; }
 
     public SettingsManager ReconfigureSettingsManager(SettingsManager settingsManager)
     {
@@ -133,6 +135,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.ModderName = ModderName;
         settingsManager.ModderEmail = ModderEmail;
         settingsManager.RefactoringCheckboxDefaultValue = RefactoringCheckboxDefaultValue;
+        settingsManager.UseDefaultLaunchProfiles = UseDefaultLaunchProfiles;
 
         return settingsManager;
     }

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -270,7 +270,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private bool _showRedmodInRibbon;
 
-    [Display(Name = "Include default profiles in list",
+    [Display(Name = "Append default launch profiles",
         Description = "Should the 'Launch' menu bar show WolvenKit's default launch profiles, or just your custom ones?",
         GroupName = "Interface")]
     [ObservableProperty]

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -65,7 +65,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(ModderName),
             nameof(ModderEmail),
             nameof(RefactoringCheckboxDefaultValue),
-            nameof(UseDefaultLaunchProfiles)
+            nameof(UseDefaultLaunchProfiles),
+            nameof(LastLaunchProfile),
+            nameof(ShowRedmodInRibbon)
             )
           .Subscribe(_ =>
           {
@@ -262,6 +264,12 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private bool _refactoringCheckboxDefaultValue;
 
+    [Display(Name = "Show REDmod in Ribbon",
+        Description = "Display 'Pack as REDmod' and 'Install as REDMod' in the ribbon?",
+        GroupName = "Interface")]
+    [ObservableProperty]
+    private bool _showRedmodInRibbon;
+
     [Display(Name = "Include default profiles in list",
         Description = "Should the 'Launch' menu bar show WolvenKit's default launch profiles, or just your custom ones?",
         GroupName = "Interface")]
@@ -283,6 +291,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     [property: Browsable(false)]
     private string? _lastUsedProjectPath;
+
+    [ObservableProperty] [property: Browsable(false)]
+    private string? _lastLaunchProfile;
 
     [ObservableProperty]
     [property: Browsable(false)]
@@ -368,6 +379,8 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
         {
             return LaunchProfiles;
         }
+
+        _isLaunchprofilesInitialized = true;
 
         LaunchProfiles ??= [];
 

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -183,7 +183,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private string? _cP77LaunchOptions;
 
-    [Display(Name = "Show File Preview", GroupName = "Cyberpunk")]
+    [Display(Name = "Show File Preview", GroupName = "Interface")]
     [ObservableProperty]
     private bool _showFilePreview = true;
 
@@ -254,7 +254,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [property: Browsable(false)]
     private Dictionary<string, bool>? _scriptStatus;
 
-    [Display(Name = "Analyze mods", Description = "Check mod archives for file names and invalid files", GroupName = "Cyberpunk")] 
+    [Display(Name = "Analyze mods", Description = "Scan installed mods for file paths when opening mod browser", GroupName = "Cyberpunk")] 
     [ObservableProperty]
     private bool _analyzeModArchives;
 

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfileViewModel.cs
@@ -42,7 +42,7 @@ namespace WolvenKit.App.ViewModels.Dialogs
 
         private void OnProfilePropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName is not nameof(LaunchProfile.LoadSpecificSave))
+            if (e.PropertyName is not nameof(LaunchProfile.LoadSaveName))
             {
                 return;
             }

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfileViewModel.cs
@@ -1,5 +1,53 @@
-﻿using WolvenKit.App.Models;
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using WolvenKit.App.Models;
 
-namespace WolvenKit.App.ViewModels.Dialogs;
+namespace WolvenKit.App.ViewModels.Dialogs
+{
+    public class LaunchProfileViewModel : INotifyPropertyChanged
+    {
+        public LaunchProfileViewModel(string name, LaunchProfile profile)
+        {
+            _profile = profile;
+            Name = name;
 
-public record LaunchProfileViewModel(string Name, LaunchProfile Profile);
+            profile.PropertyChanged += OnProfilePropertyChanged;
+        }
+
+
+        public string Name { get; set; }
+
+        private LaunchProfile _profile;
+
+        public LaunchProfile Profile
+        {
+            get => _profile;
+            set
+            {
+                if (_profile == value)
+                {
+                    return;
+                }
+
+                _profile = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+
+        private void OnProfilePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is not nameof(LaunchProfile.LoadSpecificSave))
+            {
+                return;
+            }
+
+            PropertyChanged?.Invoke(sender, e);
+        }
+    }
+}

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reactive;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DynamicData.Kernel;
+using WolvenKit.App.Models;
 using WolvenKit.App.Services;
 using WolvenKit.Core.Interfaces;
 
@@ -22,12 +26,14 @@ public partial class LaunchProfilesViewModel : DialogViewModel
 
         // populate profiles
         LaunchProfiles = new();
-        if (_settingsManager.LaunchProfiles is not null)
+        if (_settingsManager.GetLaunchProfiles() is not Dictionary<string, LaunchProfile> launchProfiles)
         {
-            foreach ((var key, var value) in _settingsManager.LaunchProfiles)
-            {
-                LaunchProfiles.Add(new LaunchProfileViewModel(key, value));
-            }
+            return;
+        }
+
+        foreach (var (key, value) in launchProfiles)
+        {
+            LaunchProfiles.Add(new LaunchProfileViewModel(key, value));
         }
     }
 
@@ -45,6 +51,39 @@ public partial class LaunchProfilesViewModel : DialogViewModel
         }
     }
 
+    private bool CanPositionDown() => SelectedLaunchProfile is { Profile.Order: > 0 };
+
+    [RelayCommand(CanExecute = nameof(CanPositionDown))]
+    private void PositionDown()
+    {
+        if (SelectedLaunchProfile is null ||
+            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order - 1) is not { } other)
+        {
+            return;
+        }
+
+        SelectedLaunchProfile.Profile.SwitchPosition(other.Profile);
+        SortLaunchProfiles();
+    }
+
+    private bool CanPositionUp() => SelectedLaunchProfile != null && SelectedLaunchProfile.Profile.Order < LaunchProfiles.Count - 1;
+
+    [RelayCommand(CanExecute = nameof(CanPositionUp))]
+    private void PositionUp()
+    {
+        if (SelectedLaunchProfile is null ||
+            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order + 1) is not { } other)
+        {
+            return;
+        }
+
+        SelectedLaunchProfile.Profile.SwitchPosition(other.Profile);
+        SortLaunchProfiles();
+    }
+
+    public LaunchProfileViewModel? GetLaunchProfile(string name) => LaunchProfiles.FirstOrDefault(x => x.Name == name);
+    public LaunchProfileViewModel? GetLaunchProfile(int pos) => LaunchProfiles.FirstOrDefault(x => x.Profile.Order == pos);
+
     [RelayCommand]
     private void DeleteItem()
     {
@@ -58,6 +97,49 @@ public partial class LaunchProfilesViewModel : DialogViewModel
 
     [ObservableProperty] private LaunchProfileViewModel? _selectedLaunchProfile;
 
+    // Sort launch profiles by order for display, then write them back to the settings manager (is that even necessary?)
+    private void SortLaunchProfiles()
+    {
+        var orderedProfiles = LaunchProfiles.OrderBy(x => x.Profile.Order)
+            .ToDictionary(x => x.Name, x => x.Profile);
+
+        _settingsManager.LaunchProfiles = orderedProfiles;
+        LaunchProfiles =
+            new ObservableCollection<LaunchProfileViewModel>(orderedProfiles.Select(kvp => new LaunchProfileViewModel(kvp.Key, kvp.Value)));
+    }
+
 
     public string Title { get; set; }
+
+    public void UpdateLaunchProfileIndex(int targetPos, int offset)
+    {
+        var targetProfile = GetLaunchProfile(targetPos);
+        if (targetProfile is null || offset == 0
+                                  || (offset < 0 && targetProfile.Profile.Order - offset < 0)
+                                  || (offset > 0 && targetProfile.Profile.Order + offset > LaunchProfiles.Count - 1)
+           )
+        {
+            return;
+        }
+
+        var newOffset = targetProfile.Profile.Order + offset;
+
+        foreach (var lp in LaunchProfiles.Where((x) => x.Name != targetProfile.Name))
+        {
+            switch (offset)
+            {
+                case > 0 when lp.Profile.Order >= newOffset:
+                    lp.Profile.Order -= 1;
+                    break;
+                case < 0 when lp.Profile.Order <= newOffset:
+                    lp.Profile.Order += 1;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        targetProfile.Profile.Order = newOffset;
+        SortLaunchProfiles();
+    }
 }

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
@@ -44,6 +44,11 @@ public partial class LaunchProfilesViewModel : DialogViewModel
             newProfile.PropertyChanged += LaunchProfile_PropertyChanged;
             LaunchProfiles.Add(newProfile);
         }
+
+        if (_settingsManager.LastLaunchProfile is string profileName)
+        {
+            SelectedLaunchProfile = LaunchProfiles.FirstOrDefault(lp => lp.Name == profileName);
+        }
     }
 
     //private void LogExtended(Exception ex) => _loggerService.Error($"Message: {ex.Message}\nSource: {ex.Source}\nStackTrace: {ex.StackTrace}");

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
@@ -28,10 +28,6 @@ public partial class LaunchProfilesViewModel : DialogViewModel
 
         // populate profiles
         LaunchProfiles = new();
-
-        // Subscribe to PropertyChanged event
-        PropertyChanged += LaunchProfilesViewModel_PropertyChanged;
-
         
         if (_settingsManager.GetLaunchProfiles() is not Dictionary<string, LaunchProfile> launchProfiles)
         {
@@ -41,7 +37,6 @@ public partial class LaunchProfilesViewModel : DialogViewModel
         foreach (var (key, value) in launchProfiles)
         {
             var newProfile = new LaunchProfileViewModel(key, value);
-            newProfile.PropertyChanged += LaunchProfile_PropertyChanged;
             LaunchProfiles.Add(newProfile);
         }
 
@@ -105,40 +100,12 @@ public partial class LaunchProfilesViewModel : DialogViewModel
         {
             return;
         }
-
-        SelectedLaunchProfile.PropertyChanged -= LaunchProfile_PropertyChanged;
         LaunchProfiles.Remove(SelectedLaunchProfile);
     }
 
     [ObservableProperty] private ObservableCollection<LaunchProfileViewModel> _launchProfiles = new();
 
     [ObservableProperty] private LaunchProfileViewModel? _selectedLaunchProfile;
-
-    private void LaunchProfile_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName != nameof(LaunchProfile.LoadSpecificSave) || sender is not LaunchProfile { LoadSpecificSave: true } lp)
-        {
-            return;
-        }
-
-        var savegameName = Interactions.ShowSelectSaveView();
-        lp.LoadSaveName = savegameName;
-    }
-
-    private void LaunchProfilesViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName != nameof(LaunchProfiles))
-        {
-            return;
-        }
-
-        // Re-register listeners (if one was added)
-        foreach (var launchProfileViewModel in LaunchProfiles)
-        {
-            launchProfileViewModel.PropertyChanged -= LaunchProfile_PropertyChanged;
-            launchProfileViewModel.PropertyChanged += LaunchProfile_PropertyChanged;
-        }
-    }
 
     // Sort launch profiles by order for display, then write them back to the settings manager (is that even necessary?)
     private void SortLaunchProfiles()
@@ -183,5 +150,15 @@ public partial class LaunchProfilesViewModel : DialogViewModel
 
         targetProfile.Profile.Order = newOffset;
         SortLaunchProfiles();
+    }
+
+    public void SetLaunchProfileSaveName(string saveName)
+    {
+        if (SelectedLaunchProfile is null)
+        {
+            return;
+        }
+
+        SelectedLaunchProfile.Profile.LoadSaveName = saveName;
     }
 }

--- a/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/LaunchProfilesViewModel.cs
@@ -71,7 +71,7 @@ public partial class LaunchProfilesViewModel : DialogViewModel
     private void PositionDown()
     {
         if (SelectedLaunchProfile is null ||
-            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order - 1) is not { } other)
+            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order + 1) is not { } other)
         {
             return;
         }
@@ -86,7 +86,7 @@ public partial class LaunchProfilesViewModel : DialogViewModel
     private void PositionUp()
     {
         if (SelectedLaunchProfile is null ||
-            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order + 1) is not { } other)
+            LaunchProfiles.FirstOrDefault(p => p.Profile.Order == SelectedLaunchProfile.Profile.Order - 1) is not { } other)
         {
             return;
         }

--- a/WolvenKit.App/ViewModels/Dialogs/SaveGameSelectionDialogModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SaveGameSelectionDialogModel.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Models;
 using WolvenKit.App.Services;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
+
+// public record SaveGame(string Name, string Description, object? UserData);
 
 public partial class SaveGameSelectionDialogModel : DialogViewModel
 {
@@ -11,4 +14,35 @@ public partial class SaveGameSelectionDialogModel : DialogViewModel
     [ObservableProperty] private List<SaveGame> _saveGames;
 
     public SaveGameSelectionDialogModel() => SaveGames = ISettingsManager.GetSaveGames();
+
+    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private SaveGame? _selectedEntry;
+
+    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private SaveGame? _selectedEntryName;
+
+    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(OkCommand))]
+    private string _enteredText = "";
+
+    private bool CanExecuteOk()
+    {
+        return SelectedEntry != null;
+    }
+
+    public void SetSelectedSave(string saveGameName)
+    {
+        if (SaveGames.Find(s => s.DirName == saveGameName) is SaveGame sg)
+        {
+            SelectedEntry = sg;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExecuteOk))]
+    private void Ok()
+    {
+        DialogHandler?.Invoke(this);
+    }
+
+    [RelayCommand]
+    private void Cancel() => DialogHandler?.Invoke(null);
 }

--- a/WolvenKit.App/ViewModels/Dialogs/SaveGameSelectionDialogModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SaveGameSelectionDialogModel.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using WolvenKit.App.Models;
+using WolvenKit.App.Services;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+public partial class SaveGameSelectionDialogModel : DialogViewModel
+{
+    [ObservableProperty] private string? _selectedSave;
+    [ObservableProperty] private List<SaveGame> _saveGames;
+
+    public SaveGameSelectionDialogModel() => SaveGames = ISettingsManager.GetSaveGames();
+}

--- a/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
@@ -215,12 +215,18 @@ public partial class ModsViewModel : PageViewModel
     [RelayCommand]
     private void LaunchGameFromLastSave()
     {
+        var launchSavegameArg = "";
+        if (ISettingsManager.GetLastSaveName() is string lastSavegame)
+        {
+            launchSavegameArg = $"-save={lastSavegame}";
+        }
+         
         try
         {
             Process.Start(new ProcessStartInfo
             {
                 FileName = _settings.GetRED4GameLaunchCommand(),
-                Arguments = $"{_settings.GetRED4GameLaunchOptions()} -modded",
+                Arguments = $"{_settings.GetRED4GameLaunchOptions()} -modded {launchSavegameArg}",
                 ErrorDialog = true,
             });
         }

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -372,10 +372,10 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     private bool CanStartTask() => TaskStatus == EStatus.Ready;
 
     [RelayCommand(CanExecute = nameof(CanStartTask))]
-    private async Task PackMod() => await LaunchAsync(new LaunchProfile() { CreateBackup = true });
+    private async Task PackMod() => await LaunchAsync(new LaunchProfile() { CreateZipFile = true });
 
     [RelayCommand(CanExecute = nameof(CanStartTask))]
-    private async Task PackRedMod() => await LaunchAsync(new LaunchProfile() { CreateBackup = true, IsRedmod = true });
+    private async Task PackRedMod() => await LaunchAsync(new LaunchProfile() { CreateZipFile = true, IsRedmod = true });
 
     [RelayCommand(CanExecute = nameof(CanStartTask))]
     private async Task PackInstallMod() => await LaunchAsync(new LaunchProfile() { Install = true });

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -756,7 +756,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         Save(ActiveDocument.NotNull(), true);
     }
 
-    private bool CanSaveAll() => DockedViews.OfType<IDocumentViewModel>().Count() > 0;
+    private bool CanSaveAll() => CanSaveFile() || DockedViews.OfType<IDocumentViewModel>().Count() > 0;
     [RelayCommand(CanExecute = nameof(CanSaveAll))]
     private void SaveAll()
     {
@@ -1488,6 +1488,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SaveFileCommand))]
     [NotifyCanExecuteChangedFor(nameof(SaveAsCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveAllCommand))]
     private IDocumentViewModel? _activeDocument;
 
     [ObservableProperty]

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -163,14 +163,9 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
     }
 
-    public class DockedViewVisibleChangedEventArgs
+    public class DockedViewVisibleChangedEventArgs(IDockElement element)
     {
-        public DockedViewVisibleChangedEventArgs(IDockElement element)
-        {
-            Element = element;
-        }
-
-        public IDockElement Element { get; }
+        public IDockElement Element { get; } = element;
     }
 
     public event EventHandler<DockedViewVisibleChangedEventArgs>? DockedViewVisibleChanged;
@@ -369,7 +364,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [NotifyCanExecuteChangedFor(nameof(PackInstallRunCommand))]
     [NotifyCanExecuteChangedFor(nameof(PackInstallRedModRunCommand))]
     private EStatus _taskStatus;
-    private bool CanStartTask() => TaskStatus == EStatus.Ready;
+
+    private bool CanStartTask() => TaskStatus == EStatus.Ready && ActiveProject is not null;
 
     [RelayCommand(CanExecute = nameof(CanStartTask))]
     private async Task PackMod() => await LaunchAsync(new LaunchProfile() { CreateZipFile = true });

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -715,7 +715,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [RelayCommand]
     private void SelectFile(FileSystemModel model) => GetToolViewModel<PropertiesViewModel>().ExecuteSelectFile(model);
 
-    private bool CanSaveFile() => ActiveDocument is not null && !ActiveDocument.IsReadOnly;
+    private bool CanSaveFile() => ActiveDocument is not null;
     [RelayCommand(CanExecute = nameof(CanSaveFile))]
     private void SaveFile() => Save(ActiveDocument.NotNull());
 
@@ -745,7 +745,16 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     }
 
     [RelayCommand(CanExecute = nameof(CanSaveFile))]
-    private void SaveAs() => Save(ActiveDocument.NotNull(), true);
+    private void SaveAs()
+    {
+        if (_projectManager.ActiveProject is null)
+        {
+            Interactions.ShowConfirmation((s_noProjectText, s_noProjectTitle, WMessageBoxImage.Warning, WMessageBoxButtons.Ok));
+            return;
+        }
+
+        Save(ActiveDocument.NotNull(), true);
+    }
 
     private bool CanSaveAll() => DockedViews.OfType<IDocumentViewModel>().Count() > 0;
     [RelayCommand(CanExecute = nameof(CanSaveAll))]

--- a/WolvenKit.App/WolvenKit.App.csproj
+++ b/WolvenKit.App/WolvenKit.App.csproj
@@ -42,6 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
+      <EmbeddedResource Include="Resources\launchprofiles.json">
+          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
     <EmbeddedResource Include="Resources\WolvenKitFileDefinitions.xml" />
   </ItemGroup>
 

--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -133,6 +133,9 @@ namespace WolvenKit
                     services.AddTransient<RenameDialogViewModel>();
                     services.AddTransient<IViewFor<RenameDialogViewModel>, RenameDialog>();
 
+                    services.AddTransient<SaveGameSelectionDialogModel>();
+                    services.AddTransient<IViewFor<SaveGameSelectionDialogModel>, SaveGameSelectionDialog>();
+
                     services.AddTransient<LaunchProfilesViewModel>();
                     services.AddTransient<IViewFor<LaunchProfilesViewModel>, LaunchProfilesView>();
 

--- a/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml
@@ -72,6 +72,8 @@
                                 <ColumnDefinition />
                                 <ColumnDefinition />
                                 <ColumnDefinition />
+                                <ColumnDefinition />
+                                <ColumnDefinition />
                                 <!--<ColumnDefinition />-->
                             </Grid.ColumnDefinitions>
 
@@ -114,6 +116,36 @@
                                         Kind="Remove"
                                         Style="{StaticResource WolvenKitToolBarButtonIcon}" />
                                     <TextBlock Padding="5,0,0,0" Text="Delete" />
+                                </StackPanel>
+                            </Button>
+                            <Button
+                                x:Name="ToolbarUpItem"
+                                Grid.Column="3"
+                                IsEnabled="{Binding Path=IsEnabled}"
+                                Command="{Binding PositionUpCommand}"
+                                ToolTip="Delete Launch Profile">
+                                <StackPanel Orientation="Horizontal">
+                                    <iconPacks:PackIconCodicons
+                                        Padding="0,1,0,1"
+                                        Foreground="{StaticResource WolvenKitTan}"
+                                        Kind="ChevronUp"
+                                        Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                                    <TextBlock Padding="5,0,0,0" Text="Up" />
+                                </StackPanel>
+                            </Button>
+                            <Button
+                                x:Name="ToolbarDownItem"
+                                Grid.Column="4"
+                                IsEnabled="{Binding CanMoveDown}"
+                                Command="{Binding PositionDownCommand}"
+                                ToolTip="Delete Launch Profile">
+                                <StackPanel Orientation="Horizontal">
+                                    <iconPacks:PackIconCodicons
+                                        Padding="0,1,0,1"
+                                        Foreground="{StaticResource WolvenKitTan}"
+                                        Kind="ChevronDown"
+                                        Style="{StaticResource WolvenKitToolBarButtonIcon}" />
+                                    <TextBlock Padding="5,0,0,0" Text="Down" />
                                 </StackPanel>
                             </Button>
 

--- a/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml
@@ -192,12 +192,14 @@
                     </Grid>
 
                     <!--  PropertyGrid  -->
-                    <Grid Grid.Column="2" Margin="5">
+                    <Grid Grid.Column="1" Margin="5">
                         <syncfusion:PropertyGrid
                             x:Name="ProfilePropertyGrid"
                             AutoGeneratingPropertyGridItem="ProfilePropertyGrid_AutoGeneratingPropertyGridItem"
                             EnableGrouping="True"
-                            SelectedObject="{Binding SelectedLaunchProfile.Profile}" />
+                            EnableToolTip="True"
+                            SelectedObject="{Binding SelectedLaunchProfile.Profile}"
+                            SelectedPropertyItemChanged="PropertyGrid_SelectedPropertyItemChanged" />
                     </Grid>
 
                 </Grid>

--- a/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/LaunchProfilesView.xaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Reactive;
@@ -7,11 +9,16 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using HandyControl.Controls;
 using ReactiveUI;
 using Splat;
 using Syncfusion.UI.Xaml.Grid;
+using WolvenKit.App.Interaction;
+using WolvenKit.App.Models;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.Core;
+using Window = System.Windows.Window;
 
 namespace WolvenKit.Views.Dialogs.Windows
 {
@@ -41,6 +48,7 @@ namespace WolvenKit.Views.Dialogs.Windows
             });
 
         }
+
 
         public LaunchProfilesViewModel ViewModel { get; set; }
         object IViewFor.ViewModel { get => ViewModel; set => ViewModel = (LaunchProfilesViewModel)value; }
@@ -84,6 +92,45 @@ namespace WolvenKit.Views.Dialogs.Windows
             model.UpdateLaunchProfileIndex(targetPos, draggingRecords?.Count ?? 0);
 
             ProfilesListView.EndInit();
+        }
+
+        private string _savegameDisplayName;
+
+        private string GetSavegameNameProperty()
+        {
+            if (_savegameDisplayName is not null)
+            {
+                return _savegameDisplayName;
+            }
+
+            var propertyInfo = typeof(LaunchProfile).GetProperty("LoadSaveName");
+            var displayAttribute = propertyInfo?.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault() as DisplayAttribute;
+            if (displayAttribute != null)
+            {
+                _savegameDisplayName = displayAttribute.Name;
+            }
+
+            _savegameDisplayName ??= "Load specific savegame";
+            return _savegameDisplayName;
+        }
+
+        /// <summary>
+        /// Opens save game dialogue when user clicks on the field
+        /// </summary>
+        private void PropertyGrid_SelectedPropertyItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var savegameNameProperty = GetSavegameNameProperty();
+            // Check if a property was selected
+            if (e.NewValue is not Syncfusion.Windows.PropertyGrid.PropertyItem propertyItem
+                || ViewModel?.SelectedLaunchProfile?.Profile is not LaunchProfile lp
+                || propertyItem.DisplayName != savegameNameProperty
+               )
+            {
+                return;
+            }
+
+            ViewModel.SetLaunchProfileSaveName(Interactions.ShowSelectSaveView(lp.LoadSaveName));
+            ProfilePropertyGrid.RefreshPropertygrid();
         }
     }
 }

--- a/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml
@@ -3,13 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
-    xmlns:hc="https://handyorg.github.io/handycontrol"
-    xmlns:local="clr-namespace:WolvenKit.Views.Dialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:others="clr-namespace:WolvenKit.Views.Others"
-    xmlns:reactiveUi="http://reactiveui.net"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    xmlns:syncfusion_xaml="clr-namespace:Syncfusion.UI.Xaml.Grid;assembly=Syncfusion.SfGrid.WPF"
     Title="Select Items"
     Width="800"
     Height="600"
@@ -17,52 +13,80 @@
     d:DesignWidth="800"
     Background="{StaticResource ContentBackgroundAlt3}"
     mc:Ignorable="d">
-
-    <syncfusion:WizardControl
-        x:Name="WizardControl"
-        CancelButtonCancelsWindow="True"
-        CancelEnabled="True"
-        FinishButtonClosesWindow="True">
-
+    <syncfusion:WizardControl CancelButtonCancelsWindow="True" FinishButtonClosesWindow="True">
         <syncfusion:WizardPage
             BackVisibility="Collapsed"
+            CancelVisibility="Visible"
+            FinishVisibility="Visible"
             HelpVisibility="Collapsed"
             NextVisibility="Collapsed"
+            PreviewKeyDown="WizardPage_PreviewKeyDown"
             PageType="Exterior">
 
             <Grid>
+                <!-- selector row -->
                 <syncfusion:SfDataGrid
-                    x:Name="SavegameGrid"
-                    Margin="20 5"
-                    AllowFiltering="True"
-                    AllowSorting="True"
+                    x:Name="SaveDataGrid"
+                    Margin="5"
+                    AllowEditing="False"
+                    ColumnSizer="Star"
                     AutoGenerateColumns="False"
-                    ColumnSizer="AutoLastColumnFill"
                     FilterRowPosition="FixedTop"
+                    GridLinesVisibility="None"
                     IsReadOnly="True"
                     ItemsSource="{Binding SaveGames}"
+                    NavigationMode="Row"
+                    SelectedItem="{Binding SelectedEntry}"
                     SelectionMode="Single">
-
                     <syncfusion:SfDataGrid.Columns>
-                        <syncfusion:GridTemplateColumn>
+                        <syncfusion:GridTemplateColumn
+                            HeaderText=" "
+                            MappingName="Screenshot"
+                            Width="100">
                             <syncfusion:GridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <Image Source="{Binding Screenshot}" Width="50" Height="50" />
+                                    <Canvas>
+                                        <Image
+                                            Width="100"
+                                            Height="70"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Opacity="1"
+                                            Source="{Binding Screenshot}">
+                                        </Image>
+                                    </Canvas>
                                 </DataTemplate>
                             </syncfusion:GridTemplateColumn.CellTemplate>
                         </syncfusion:GridTemplateColumn>
-                        <syncfusion:GridTextColumn FilterRowCondition="Contains" HeaderText="Save" MappingName="DirName" />
-                        <syncfusion:GridTextColumn FilterRowCondition="Contains" HeaderText="LastModified" MappingName="LastModified" />
+                        <syncfusion:GridTemplateColumn
+                            Width="200"
+                            AllowFiltering="True"
+                            FilterRowCondition="Contains"
+                            FilterRowEditorType="TextBox"
+                            ImmediateUpdateColumnFilter="True"
+                            HeaderText="Name"
+                            MappingName="DirName">
+                            <syncfusion:GridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding DirName}" />
+                                </DataTemplate>
+                            </syncfusion:GridTemplateColumn.CellTemplate>
+                        </syncfusion:GridTemplateColumn>
+                        <syncfusion:GridTemplateColumn
+                            HeaderText="Last Modified"
+                            MappingName="LastModified">
+                            <syncfusion:GridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock
+                                        Text="{Binding LastModified}"
+                                        Foreground="{StaticResource Border}" />
+                                </DataTemplate>
+                            </syncfusion:GridTemplateColumn.CellTemplate>
+                        </syncfusion:GridTemplateColumn>
                     </syncfusion:SfDataGrid.Columns>
-
                 </syncfusion:SfDataGrid>
-
             </Grid>
-
-
+            
         </syncfusion:WizardPage>
-
     </syncfusion:WizardControl>
-
-
 </Window>

--- a/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml
@@ -1,0 +1,68 @@
+<Window
+    x:Class="WolvenKit.Views.Dialogs.Windows.SaveGameSelectionDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:local="clr-namespace:WolvenKit.Views.Dialogs"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:others="clr-namespace:WolvenKit.Views.Others"
+    xmlns:reactiveUi="http://reactiveui.net"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    Title="Select Items"
+    Width="800"
+    Height="600"
+    d:DesignHeight="600"
+    d:DesignWidth="800"
+    Background="{StaticResource ContentBackgroundAlt3}"
+    mc:Ignorable="d">
+
+    <syncfusion:WizardControl
+        x:Name="WizardControl"
+        CancelButtonCancelsWindow="True"
+        CancelEnabled="True"
+        FinishButtonClosesWindow="True">
+
+        <syncfusion:WizardPage
+            BackVisibility="Collapsed"
+            HelpVisibility="Collapsed"
+            NextVisibility="Collapsed"
+            PageType="Exterior">
+
+            <Grid>
+                <syncfusion:SfDataGrid
+                    x:Name="SavegameGrid"
+                    Margin="20 5"
+                    AllowFiltering="True"
+                    AllowSorting="True"
+                    AutoGenerateColumns="False"
+                    ColumnSizer="AutoLastColumnFill"
+                    FilterRowPosition="FixedTop"
+                    IsReadOnly="True"
+                    ItemsSource="{Binding SaveGames}"
+                    SelectionMode="Single">
+
+                    <syncfusion:SfDataGrid.Columns>
+                        <syncfusion:GridTemplateColumn>
+                            <syncfusion:GridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Image Source="{Binding Screenshot}" Width="50" Height="50" />
+                                </DataTemplate>
+                            </syncfusion:GridTemplateColumn.CellTemplate>
+                        </syncfusion:GridTemplateColumn>
+                        <syncfusion:GridTextColumn FilterRowCondition="Contains" HeaderText="Save" MappingName="DirName" />
+                        <syncfusion:GridTextColumn FilterRowCondition="Contains" HeaderText="LastModified" MappingName="LastModified" />
+                    </syncfusion:SfDataGrid.Columns>
+
+                </syncfusion:SfDataGrid>
+
+            </Grid>
+
+
+        </syncfusion:WizardPage>
+
+    </syncfusion:WizardControl>
+
+
+</Window>

--- a/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml.cs
@@ -1,11 +1,14 @@
-using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Input;
 using ReactiveUI;
 using Splat;
-using WolvenKit.App.Models;
-using WolvenKit.App.Services;
+using Syncfusion.UI.Xaml.Grid;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.Helpers;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using Window = System.Windows.Window;
 
 namespace WolvenKit.Views.Dialogs.Windows
 {
@@ -19,8 +22,31 @@ namespace WolvenKit.Views.Dialogs.Windows
             InitializeComponent();
 
             ViewModel = Locator.Current.GetService<SaveGameSelectionDialogModel>()!;
-
             DataContext = ViewModel;
+            SaveDataGrid.FilterRowCellRenderers.Add("TextBoxExt", new GridFilterRowTextBoxRendererExt());
+            SaveDataGrid.QueryRowHeight += DataGrid_QueryRowHeight;
+
+            this.WhenActivated(disposables =>
+            {
+                SaveDataGrid.ClearFilters();
+            });
+        }
+
+        public SaveGameSelectionDialog(string currentSaveName) : this()
+        {
+            ViewModel?.SetSelectedSave(currentSaveName);
+
+        }
+
+        private void DataGrid_QueryRowHeight(object sender, QueryRowHeightEventArgs e)
+        {
+            if (e.RowIndex < 2)
+            {
+                return;
+            }
+
+            e.Height = 70;
+            e.Handled = true;
         }
 
         public SaveGameSelectionDialogModel ViewModel { get; set; }
@@ -30,6 +56,18 @@ namespace WolvenKit.Views.Dialogs.Windows
         {
             Owner = owner;
             return ShowDialog();
+        }
+
+        private void WizardPage_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key is not (Key.Enter or Key.Escape))
+            {
+                return;
+            }
+
+            e.Handled = true;
+            DialogResult = e.Key is Key.Enter;
+            Close();
         }
     }
 }

--- a/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/SaveGameSelectionDialog.xaml.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Windows;
+using ReactiveUI;
+using Splat;
+using WolvenKit.App.Models;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs.Windows
+{
+    /// <summary>
+    /// Interaction logic for SaveGameSelectionDialog.xaml
+    /// </summary>
+    public partial class SaveGameSelectionDialog : IViewFor<SaveGameSelectionDialogModel>
+    {
+        public SaveGameSelectionDialog()
+        {
+            InitializeComponent();
+
+            ViewModel = Locator.Current.GetService<SaveGameSelectionDialogModel>()!;
+
+            DataContext = ViewModel;
+        }
+
+        public SaveGameSelectionDialogModel ViewModel { get; set; }
+        object IViewFor.ViewModel { get => ViewModel; set => ViewModel = (SaveGameSelectionDialogModel)value; }
+
+        public bool? ShowDialog(Window owner)
+        {
+            Owner = owner;
+            return ShowDialog();
+        }
+    }
+}

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -65,6 +65,18 @@ namespace WolvenKit.Views.Shell
                     return true;
                 };
 
+                Interactions.ShowSelectSaveView = () =>
+                {
+                    SaveGameSelectionDialog dialog = new();
+
+                    if (dialog.ShowDialog(this) == true)
+                    {
+                        return dialog.ViewModel?.SelectedSave;
+                    }
+
+                    return null;
+                };
+
                 Interactions.ShowMaterialRepositoryView = () =>
                 {
                     MaterialsRepositoryView dialog = new();

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -65,13 +65,13 @@ namespace WolvenKit.Views.Shell
                     return true;
                 };
 
-                Interactions.ShowSelectSaveView = () =>
+                Interactions.ShowSelectSaveView = (string currentSaveGame) =>
                 {
-                    SaveGameSelectionDialog dialog = new();
+                    SaveGameSelectionDialog dialog = new(currentSaveGame);
 
                     if (dialog.ShowDialog(this) == true)
                     {
-                        return dialog.ViewModel?.SelectedSave;
+                        return dialog.ViewModel?.SelectedEntry?.DirName;
                     }
 
                     return null;

--- a/WolvenKit/Views/Shell/RibbonView.xaml
+++ b/WolvenKit/Views/Shell/RibbonView.xaml
@@ -7,6 +7,7 @@
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:shared="clr-namespace:Syncfusion.Windows.Shared;assembly=Syncfusion.Shared.WPF"
     xmlns:shell="clr-namespace:WolvenKit.App.ViewModels.Shell;assembly=WolvenKit.App"
+    xmlns:local="clr-namespace:WolvenKit.Views.Shell"
     x:TypeArguments="shell:RibbonViewModel">
 
     <!--  Resources  -->
@@ -222,7 +223,7 @@
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="ToolbarSaveButton" ToolTip="Save File">
+                <Button x:Name="ToolbarSaveButton" ToolTip="Save Current File">
                     <StackPanel Orientation="Horizontal">
                         <iconPacks:PackIconMaterial
                             Padding="0,1,0,1"
@@ -257,11 +258,11 @@
 
                 <Separator Margin="3" Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                <!--  Pack as REDmod  -->
+                <!-- Button: Pack as REDmod  -->
                 <Button
                     x:Name="ToolbarPackProjectButton"
                     Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}"
-                    ToolTip="Pack as REDmod &amp; create mod package">
+                    ToolTip="Pack as zip file for Nexus upload, REDmod format">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -270,14 +271,14 @@
                                 Kind="Archive"
                                 Style="{StaticResource WolvenKitToolBarButtonIcon}" />
                         </Grid>
-                        <TextBlock Padding="5,0,0,0" Text="Pack as REDmod" />
+                        <TextBlock Padding="5,0,0,0" Text="Create Zip (REDmod)" />
                     </StackPanel>
                 </Button>
 
-                <Button
-                    x:Name="ToolbarPackInstallRedmodButton"
-                    Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}"
-                    ToolTip="Pack as REDmod &amp; install to game">
+                <!-- Button: Install as REDMod -->
+                <Button x:Name="ToolbarPackInstallRedmodButton"
+                        Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        ToolTip="Pack as REDmod &amp; install to game. Not supported by HotReload.">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -300,8 +301,8 @@
 
                 <Separator />
 
-                <!--  Pack as LegacyMod  -->
-                <Button x:Name="ToolbarPackProjectLegacyButton" ToolTip="Pack mod &amp; create mod package">
+                <!-- "Pack" button -->
+                <Button x:Name="ToolbarPackProjectLegacyButton" ToolTip="Pack as zip file for Nexus upload">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -310,11 +311,12 @@
                                 Kind="Archive"
                                 Style="{StaticResource WolvenKitToolBarButtonIcon}" />
                         </Grid>
-                        <TextBlock Padding="5,0,0,0" Text="Pack Mod" />
+                        <TextBlock Padding="5,0,0,0" Text="Create Zip" />
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="ToolbarPackInstallLegacyButton" ToolTip="Pack mod &amp; install to game">
+                <!-- Install button -->
+                <Button x:Name="ToolbarPackInstallLegacyButton" ToolTip="Install mod to game directory">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -337,14 +339,15 @@
 
                 <Separator Margin="3" />
 
+                <!-- Launch Profiles - Added programmatically  -->
                 <Menu x:Name="LaunchMenu">
                     <MenuItem x:Name="LaunchMenuMainItem">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
-                                <Button
-                                    x:Name="LaunchProfileButton"
-                                    Margin="-2,-2,2,-2"
-                                    Style="{StaticResource ButtonChromelessStyle}">
+                                <Button x:Name="LaunchProfileButton"
+                                        ToolTip="Start from launch profile (configure in 'Launch Options')"
+                                        Margin="-2,-2,2,-2"
+                                        Style="{StaticResource ButtonChromelessStyle}">
                                     <StackPanel Orientation="Horizontal">
                                         <Grid>
                                             <iconPacks:PackIconForkAwesome
@@ -355,7 +358,6 @@
                                         </Grid>
                                         <TextBlock x:Name="LaunchProfileText" Padding="5,0,0,0" />
                                     </StackPanel>
-
                                 </Button>
                                 <Separator />
                                 <iconPacks:PackIconCodicons
@@ -370,7 +372,8 @@
 
                         <Separator />
 
-                        <MenuItem x:Name="LaunchOptionsMenuItem" Header="Launch Options">
+                        <!-- Launch Options -->
+                        <MenuItem x:Name="LaunchOptionsMenuItem" Header="{x:Static local:RibbonView.LaunchOptionsString}">
                             <MenuItem.Icon>
                                 <iconPacks:PackIconCodicons
                                     Padding="1"
@@ -384,8 +387,8 @@
 
                 <Separator Margin="3" />
 
-                <Button x:Name="ToolbarHotInstallButton" ToolTip="Pack archives &amp; install directly to hot directory">
-
+                <!-- Button: Hot Reload -->
+                <Button x:Name="ToolbarHotInstallButton" ToolTip="Install to Game Directory (HotReload Plugin required)">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -393,7 +396,6 @@
                                 Foreground="#f44b56"
                                 Kind="Fire"
                                 Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-
                         </Grid>
                         <TextBlock Padding="5,0,0,0" Text="Hot Reload" />
                     </StackPanel>

--- a/WolvenKit/Views/Shell/RibbonView.xaml
+++ b/WolvenKit/Views/Shell/RibbonView.xaml
@@ -255,10 +255,13 @@
                     </StackPanel>
                 </Button>
 
-                <Separator Margin="3" />
+                <Separator Margin="3" Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                 <!--  Pack as REDmod  -->
-                <Button x:Name="ToolbarPackProjectButton" ToolTip="Pack as REDmod &amp; create mod package">
+                <Button
+                    x:Name="ToolbarPackProjectButton"
+                    Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    ToolTip="Pack as REDmod &amp; create mod package">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -271,7 +274,10 @@
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="ToolbarPackInstallRedmodButton" ToolTip="Pack as REDmod &amp; install to game">
+                <Button
+                    x:Name="ToolbarPackInstallRedmodButton"
+                    Visibility="{Binding ShowRedmodInRibbon, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    ToolTip="Pack as REDmod &amp; install to game">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -295,7 +301,7 @@
                 <Separator />
 
                 <!--  Pack as LegacyMod  -->
-                <Button x:Name="ToolbarPackProjectOldButton" ToolTip="Pack mod &amp; create mod package">
+                <Button x:Name="ToolbarPackProjectLegacyButton" ToolTip="Pack mod &amp; create mod package">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -308,7 +314,7 @@
                     </StackPanel>
                 </Button>
 
-                <Button x:Name="ToolbarPackInstallOldButton" ToolTip="Pack mod &amp; install to game">
+                <Button x:Name="ToolbarPackInstallLegacyButton" ToolTip="Pack mod &amp; install to game">
                     <StackPanel Orientation="Horizontal">
                         <Grid>
                             <iconPacks:PackIconForkAwesome
@@ -373,66 +379,6 @@
                             </MenuItem.Icon>
                         </MenuItem>
 
-                    </MenuItem>
-                </Menu>
-
-                <Menu>
-                    <MenuItem
-                        x:Name="MenuHeaderLaunchGame" Header="Launch Game" SubmenuOpened="MenuItem_SubmenuOpened">
-                        <MenuItem.Icon>
-                            <iconPacks:PackIconCodicons
-                                Foreground="{StaticResource WolvenKitYellow}"
-                                Kind="Play"
-                                Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                        </MenuItem.Icon>
-
-                        <!--  launch game normally  -->
-                        <MenuItem
-                            x:Name="MenuItemLaunchGame"
-                            Margin="2,1"
-                            CommandParameter="0"
-                            Header="Launch game"
-                            ToolTip="Launch game normally">
-                            <MenuItem.Icon>
-                                <iconPacks:PackIconCodicons
-                                    Margin="6,0"
-                                    Foreground="{StaticResource WolvenKitYellow}"
-                                    Kind="Play"
-                                    Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-
-                        <!--  launch game and load last save  -->
-                        <MenuItem
-                            x:Name="MenuItemLaunchGameFromLastSave"
-                            Margin="2,1"
-                            CommandParameter="0"
-                            Header="Launch from last save"
-                            ToolTip="Launch game and load last save">
-                            <MenuItem.Icon>
-                                <iconPacks:PackIconCodicons
-                                    Margin="6,0"
-                                    Foreground="{StaticResource WolvenKitYellow}"
-                                    Kind="Play"
-                                    Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-
-                        <!--  launch game from save  -->
-                        <MenuItem
-                            x:Name="MenuItemLaunchGameSave"
-                            Margin="2,1"
-                            Header="Launch game from save..."
-                            ToolTip="Launch Game from savefile">
-                            <MenuItem.Icon>
-                                <iconPacks:PackIconCodicons
-                                    Margin="6,0"
-                                    Foreground="{StaticResource WolvenKitYellow}"
-                                    Kind="Save"
-                                    Style="{StaticResource WolvenKitToolBarButtonIcon}" />
-                            </MenuItem.Icon>
-                            <MenuItem />
-                        </MenuItem>
                     </MenuItem>
                 </Menu>
 

--- a/WolvenKit/Views/Shell/RibbonView.xaml.cs
+++ b/WolvenKit/Views/Shell/RibbonView.xaml.cs
@@ -195,13 +195,6 @@ namespace WolvenKit.Views.Shell
 
         private void ReadGameFiles()
         {
-            // get save files
-            var saveDir = ISettingsManager.GetSaveDirectory();
-            if (!Directory.Exists(saveDir))
-            {
-                return;
-            }
-
             // clear
             foreach (var item in MenuItemLaunchGameSave.Items)
             {
@@ -213,27 +206,14 @@ namespace WolvenKit.Views.Shell
 
             MenuItemLaunchGameSave.Items.Clear();
 
-            var directories = Directory.GetDirectories(saveDir)
-                .Select(folder => new { Folder = folder, Save = Path.Combine(folder, "sav.dat") })
-                .Where(x => File.Exists(x.Save))
-                .Select(x => new
-                {
-                    DirName = new DirectoryInfo(x.Folder).Name,
-                    Screenshot = Path.Combine(x.Folder, "screenshot.png"),
-                    x.Save,
-                    LastModified = new DirectoryInfo(x.Folder).LastWriteTime
-                })
-                .OrderByDescending(x => x.LastModified);
-
-
             // populate items
-            foreach (var dir in directories)
+            foreach (var saveGame in ISettingsManager.GetSaveGames())
             {
                 var imageControl = new Image();
-                var bitmapImage = new BitmapImage(new Uri(dir.Screenshot, UriKind.RelativeOrAbsolute));
+                var bitmapImage = new BitmapImage(new Uri(saveGame.Screenshot, UriKind.RelativeOrAbsolute));
                 imageControl.Source = bitmapImage;
 
-                MenuItem item = new() { Header = dir.DirName, ToolTip = imageControl };
+                MenuItem item = new() { Header = saveGame.DirName, ToolTip = imageControl };
                 item.Click += LaunchSaveItem_Click;
                 MenuItemLaunchGameSave.Items.Add(item);
             }

--- a/WolvenKit/Views/Shell/RibbonView.xaml.cs
+++ b/WolvenKit/Views/Shell/RibbonView.xaml.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
+using HandyControl.Tools.Extension;
 using ReactiveUI;
 using Splat;
 using WolvenKit.App.Models;
@@ -129,20 +130,6 @@ namespace WolvenKit.Views.Shell
 
         private void GetLaunchProfiles()
         {
-            // add default profiles
-            if (_settingsManager.LaunchProfiles is null || _settingsManager.LaunchProfiles.Count == 0)
-            {
-                using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(@"WolvenKit.Resources.launchprofiles.json");
-                var defaultprofiles = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, LaunchProfile>>(stream, new System.Text.Json.JsonSerializerOptions()
-                {
-                    WriteIndented = true,
-                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-                });
-
-                _settingsManager.LaunchProfiles = defaultprofiles;
-                _settingsManager.Save();
-            }
-
             // unsubscribe
             foreach (var obj in LaunchMenuMainItem.Items)
             {
@@ -209,9 +196,7 @@ namespace WolvenKit.Views.Shell
         private void ReadGameFiles()
         {
             // get save files
-            var saveDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                "Saved Games", "CD Projekt Red", "Cyberpunk 2077");
+            var saveDir = ISettingsManager.GetSaveDirectory();
             if (!Directory.Exists(saveDir))
             {
                 return;

--- a/WolvenKit/Views/Shell/RibbonView.xaml.cs
+++ b/WolvenKit/Views/Shell/RibbonView.xaml.cs
@@ -1,29 +1,14 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reactive.Disposables;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media.Imaging;
-using HandyControl.Tools.Extension;
 using ReactiveUI;
 using Splat;
-using WolvenKit.App.Models;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
-using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Core.Services;
-
-enum LaunchGameProfile
-{
-    Directly,
-    FromLastSave,
-    FromSpecificSave,
-}
 
 namespace WolvenKit.Views.Shell
 {
@@ -31,8 +16,8 @@ namespace WolvenKit.Views.Shell
     {
         private readonly ISettingsManager _settingsManager;
         private readonly ILoggerService _loggerService;
-        private readonly IModifierViewStateService _modifierViewStateService;
 
+        public const string LaunchOptionsString = "Launch Options";
         
         public RibbonView()
         {
@@ -42,7 +27,6 @@ namespace WolvenKit.Views.Shell
 
             _settingsManager = Locator.Current.GetService<ISettingsManager>();
             _loggerService = Locator.Current.GetService<ILoggerService>();
-            _modifierViewStateService = Locator.Current.GetService<IModifierViewStateService>();
 
             this.WhenActivated(disposables =>
             {
@@ -77,6 +61,7 @@ namespace WolvenKit.Views.Shell
                         viewModel => viewModel.MainViewModel.PackInstallRedModCommand,
                         view => view.ToolbarPackInstallRedmodButton)
                     .DisposeWith(disposables);
+                
                 // pack legacy mod
                 this.BindCommand(ViewModel,
                         viewModel => viewModel.MainViewModel.PackModCommand,
@@ -87,7 +72,7 @@ namespace WolvenKit.Views.Shell
                         view => view.ToolbarPackInstallLegacyButton)
                     .DisposeWith(disposables);
 
-                // hotreload
+                // HotReload
                 this.BindCommand(ViewModel,
                         viewModel => viewModel.MainViewModel.HotInstallModCommand,
                         view => view.ToolbarHotInstallButton)
@@ -108,6 +93,7 @@ namespace WolvenKit.Views.Shell
                    view => view.LaunchProfileText.Text)
                    .DisposeWith(disposables);
 
+                // Active project: Disable/Enable buttons
                 this.OneWayBind(ViewModel, vm => vm.MainViewModel.ActiveProject,
                     view => view.LaunchMenu.IsEnabled,
                     p => p is not null)
@@ -124,19 +110,18 @@ namespace WolvenKit.Views.Shell
             
         }
 
+            
         private void GetLaunchProfiles()
         {
             // unsubscribe
             foreach (var obj in LaunchMenuMainItem.Items)
             {
-                if (obj is MenuItem menuitem && menuitem.Header is string menuitemHeader)
+                if (obj is not MenuItem { Header: string menuitemHeader } menuitem || menuitemHeader == LaunchOptionsString)
                 {
-                    if (menuitemHeader == "Launch Options")
-                    {
-                        continue;
-                    }
-                    menuitem.Click -= LaunchMenu_MenuItem_Click;
+                    continue;
                 }
+
+                menuitem.Click -= LaunchMenu_MenuItem_Click;
             }
             // delete all except for last two
             var cntToRemove = LaunchMenuMainItem.Items.Count - 2;

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -115,6 +115,8 @@
     <Page Remove="Resources\Styles\CustomBase\**" />
     <Page Remove="Resources\Styles\Custom\**" />
     <Compile Remove="Converters\BooleanConverter.cs" />
+      <Compile Remove="GridVirtualizingCellsControl.xaml.cs"/>
+      <Page Remove="GridVirtualizingCellsControl.xaml"/>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Views\Templates\RedFixedPointEditor.cs" />

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -1762,9 +1762,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\launchprofiles.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </EmbeddedResource>
     <EmbeddedResource Include="Resources\SyntaxHighlighting\JavaScript-DarkMode.xshd" />
     <EmbeddedResource Include="Resources\SyntaxHighlighting\YAML.xshd">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>


### PR DESCRIPTION
Moves "Launch game and load last save" from the title bar into the launch options, where it should be.

closes issue #1486 

- REDMod install and launch options are now hidden from the ribbon, can be brought back via settings
- More launch profiles. If you don't want to use the default ones, you can turn that off via setting as well.
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/dd4e1c93-d3ba-497c-bd20-865e6d9eba03)

- WKit now remembers the last launch profile between restarts
- Changed property descriptions to make clearer what they do
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/be206d3a-42da-4df2-a923-07f83909bfd7)

- You can load a named savegame:
![image](https://github.com/WolvenKit/WolvenKit/assets/965785/0e01c99d-bf84-4ddd-bc4c-496afe6cabc3)


