### PR TITLE
Search&Replace: removed "ignore case", some fixes

### DIFF
--- a/WolvenKit.App/ViewModels/Dialogs/SearchAndReplaceDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SearchAndReplaceDialogViewModel.cs
@@ -22,10 +22,5 @@ public partial class SearchAndReplaceDialogViewModel() : ObservableObject
     /// <summary>
     ///Ignore case
     /// </summary>
-    [ObservableProperty] private bool _ignoreCase = false;
-
-    /// <summary>
-    ///Ignore case
-    /// </summary>
-    [ObservableProperty] private bool _rememberValues = false;
+    [ObservableProperty] private bool _rememberValues;
 }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1996,10 +1996,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         catch (Exception ex) { _loggerService.Error(ex); }
     }
 
-    public bool SearchAndReplace(string searchText, string replaceText, bool ignoreCase)
-    {
-        return SearchAndReplaceInProperties(searchText, replaceText, ignoreCase);
-    }
+    public bool SearchAndReplace(string searchText, string replaceText) => SearchAndReplaceInternal(searchText, replaceText);
 
     private bool CanCopyHandle() => Data is IRedBaseHandle;   // TODO RelayCommand check notify
     [RelayCommand(CanExecute = nameof(CanCopyHandle))]

--- a/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml
@@ -47,26 +47,24 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
+                    <!-- Search -->
                     <Label Grid.Column="0" Content="Search:" HorizontalAlignment="Left"
                            Background="#252525" BorderThickness="0" />
                     <TextBox x:Name="SearchTextBox" Grid.Column="1" Grid.Row="0" KeyboardNavigation.TabIndex="1"
                              helpers:TextBoxBehavior.FocusGainedSelectAll="True" />
 
+                    <!-- Replace -->
                     <Label Grid.Row="1" Grid.Column="0" Content="Replace:" HorizontalAlignment="Left"
                            Background="#252525" BorderThickness="0" />
                     <TextBox x:Name="ReplaceTextBox" Grid.Column="1" Grid.Row="1" KeyboardNavigation.TabIndex="2"
                              helpers:TextBoxBehavior.FocusGainedSelectAll="True" />
 
-                    <Label Grid.Row="2" Grid.Column="0" Content="Ignore case:" HorizontalAlignment="Left"
-                           Background="#252525" BorderThickness="0" /> <!-- Label for the CheckBox -->
-                    <CheckBox x:Name="IgnoreCaseCheckBox" Grid.Column="1" Grid.Row="2" KeyboardNavigation.TabIndex="3" /> <!-- CheckBox -->
-
-                    <Label Grid.Row="3" Grid.Column="0" Content="Remember:" HorizontalAlignment="Left"
-                           Background="#252525" BorderThickness="0" /> <!-- Label for the CheckBox -->
-                    <CheckBox x:Name="RememberValuesCheckBox" Grid.Column="1" Grid.Row="3" KeyboardNavigation.TabIndex="4" /> <!-- CheckBox -->
+                    <!-- Remember selection -->
+                    <Label Grid.Row="2" Grid.Column="0" Content="Remember:" HorizontalAlignment="Left"
+                           Background="#252525" BorderThickness="0" />
+                    <CheckBox x:Name="RememberValuesCheckBox" Grid.Column="1" Grid.Row="2" KeyboardNavigation.TabIndex="4" /> <!-- CheckBox -->
 
                 </Grid>
             </syncfusion:WizardPage>

--- a/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml.cs
@@ -33,10 +33,6 @@ namespace WolvenKit.Views.Dialogs.Windows
                         x => x.ReplaceTextBox.Text)
                     .DisposeWith(disposables);
                 this.Bind(ViewModel,
-                        x => x.IgnoreCase,
-                        x => x.IgnoreCaseCheckBox.IsChecked)
-                    .DisposeWith(disposables);
-                this.Bind(ViewModel,
                         x => x.RememberValues,
                         x => x.RememberValuesCheckBox.IsChecked)
                     .DisposeWith(disposables);

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -342,10 +342,9 @@ namespace WolvenKit.Views.Tools
 
             var searchText = dialog.ViewModel?.SearchText ?? "";
             var replaceText = dialog.ViewModel?.ReplaceText ?? "";
-            var ignoreCase = dialog.ViewModel?.IgnoreCase ?? false;
 
             var results = selectedChunkViewModels
-                .Select(item => item.SearchAndReplace(searchText, replaceText, ignoreCase))
+                .Select(item => item.SearchAndReplace(searchText, replaceText))
                 .ToList();
 
             var numReplaced = results.Count(r => r == true);


### PR DESCRIPTION
Search and replace: 
- removed "ignore case" checkbox (which did nothing)
- won't abort on "contains" anymore. Also, checking more hashes