### PR TITLE
Fix importing opuspaks not producing new opuspaks

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
@@ -128,7 +128,7 @@ namespace WolvenKit.Modkit.RED4.Opus
             p?.WaitForExit();
         }
 
-        public void WriteOpusToPak(MemoryStream opus, ref Stream pak, uint hash, MemoryStream wav)
+        public Stream WriteOpusToPak(MemoryStream opus, Stream pak, uint hash, MemoryStream wav)
         {
             var br = new BinaryReader(pak);
             pak.Position = 0;
@@ -179,7 +179,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                 }
             }
 
-            pak = ms;
+            return ms;
             //File.WriteAllBytes(@"C:\Users\Abhinav\Desktop\mod\sfx_container_1280.opuspak",ms.ToArray());
         }
 

--- a/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
@@ -128,7 +128,7 @@ namespace WolvenKit.Modkit.RED4.Opus
             p?.WaitForExit();
         }
 
-        public void WriteOpusToPak(MemoryStream opus, Stream pak, uint hash, MemoryStream wav)
+        public void WriteOpusToPak(MemoryStream opus, ref Stream pak, uint hash, MemoryStream wav)
         {
             var br = new BinaryReader(pak);
             pak.Position = 0;

--- a/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
@@ -155,7 +155,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                         modDictionary.Add(pakIdx, modStream);
                     }
                             
-                    info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(name.Replace("opus", "wav"))));
+                    info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), ref modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(name.Replace("opus", "wav"))));
                 }
             }
 

--- a/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
@@ -155,7 +155,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                         modDictionary.Add(pakIdx, modStream);
                     }
                             
-                    info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), ref modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(name.Replace("opus", "wav"))));
+                    modDictionary[pakIdx] = info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(name.Replace("opus", "wav"))));
                 }
             }
 


### PR DESCRIPTION
# Fix missing ref keyword breaking opuspak/wav import

**Fixed:**
- Importing .wav files to opuspaks "broke" the whole opuspak

**Additional notes:**
I don't know if it still builds :D
