### PR TITLE
fixed validating depot path editor

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -399,13 +399,18 @@ public class RED4Controller : ObservableObject, IGameController
         // Shift prevents save game load (CET doesn't initialize
         if (!_modifierService.IsShiftKeyPressed && options.LoadLastSave && ISettingsManager.GetLastSaveName() is string lastSavegame)
         {
-            arguments = $"{arguments} -save={lastSavegame}";
+            arguments = $"{arguments} -save={lastSavegame}";            
         }
         else if (!_modifierService.IsShiftKeyPressed && options.LoadSaveName is string savegame)
         {
             arguments = $"{arguments} -save={savegame}";
         }
-        
+
+        // -save can come from the launch options, or from the user settings 
+        if (arguments.Contains("-save"))
+        {
+            _loggerService.Warning("Warning: Loading a save via start-up options may break CET entity spawn!");
+        }
         try
         {
             Process.Start(new ProcessStartInfo

--- a/WolvenKit.App/Models/FileSystemArchive.cs
+++ b/WolvenKit.App/Models/FileSystemArchive.cs
@@ -71,6 +71,7 @@ public class FileSystemArchive : ICyberGameArchive
         var modDirectory = Project.ModDirectory;
         foreach (var filePath in Directory.EnumerateFiles(modDirectory, "*", SearchOption.AllDirectories))
         {
+            // the full relative path after "archive\", e.g. "base\characters..." 
             var hash = ResourcePath.CalculateHash(filePath[(modDirectory.Length + 1)..]);
 
             result.Add(hash, new FileEntry

--- a/WolvenKit.App/Models/TweakXL.cs
+++ b/WolvenKit.App/Models/TweakXL.cs
@@ -279,7 +279,7 @@ public class TweakXLYamlTypeConverter : IYamlTypeConverter
 
         if (raRef.IsSet)
         {
-            emitter.Emit(new Scalar(raRef.DepotPath.ToString().NotNull()));
+            emitter.Emit(new Scalar(raRef.DepotPath.GetResolvedText().NotNull()));
         }
         else
         {

--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -162,7 +162,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
     private Task OpenImport(ICR2WImport input)
     {
         var depotpath = input.DepotPath;
-        var key = FNV1A64HashAlgorithm.HashString(depotpath.ToString().NotNull());
+        var key = FNV1A64HashAlgorithm.HashString(depotpath.GetResolvedText().NotNull());
 
         return _gameController.GetController().AddFileToModModal(key);
     }

--- a/WolvenKit.App/ViewModels/Documents/RDTInkTextureAtlasViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTInkTextureAtlasViewModel.cs
@@ -134,7 +134,7 @@ public partial class RDTInkTextureAtlasViewModel : RedDocumentTabViewModel
 
         foreach (var part in slot.Parts)
         {
-            var slotViewModel = new InkTextureAtlasMapperViewModel(part, xbm, slot.Texture.DepotPath.ToString().NotNull(),
+            var slotViewModel = new InkTextureAtlasMapperViewModel(part, xbm, slot.Texture.DepotPath.GetResolvedText().NotNull(),
                 Parent.RelativePath, (BitmapSource)Image);
             slotViewModel.PropertyChanged += OnSlotPropertyChanged;
             OverlayItems.Add(slotViewModel);

--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -1501,8 +1501,8 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
         return appMaterials;
     }
 
-    private string GetUniqueMaterialName(string name, CMesh mesh) => mesh.InplaceResources.Count > 0 
-        ? Path.GetFileNameWithoutExtension(mesh.InplaceResources[0].DepotPath.ToString().NotNull()) 
+    private string GetUniqueMaterialName(string name, CMesh mesh) => mesh.InplaceResources.Count > 0
+        ? Path.GetFileNameWithoutExtension(mesh.InplaceResources[0].DepotPath.GetResolvedText().NotNull()) 
         : name;
 
     private Dictionary<string, Material> GetMaterialsFromMesh(CMesh mesh)
@@ -3199,7 +3199,7 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
 
             var text = new BillboardText3D();
             text.TextInfo.Add(
-                new TextInfo(Path.GetFileNameWithoutExtension(desc.Data.DepotPath.ToString()),
+                new TextInfo(Path.GetFileNameWithoutExtension(desc.Data.DepotPath.GetResolvedText()),
                     new SharpDX.Vector3((desc.StreamingBox.Max.X + desc.StreamingBox.Min.X) / 2, (desc.StreamingBox.Max.Z + desc.StreamingBox.Min.Z) / 2, -(desc.StreamingBox.Max.Y + desc.StreamingBox.Min.Y) / 2))
                 {
                     Foreground = SharpDX.Color.Red, Scale = 0.5f
@@ -3209,8 +3209,8 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
             var bbText = new WKBillboardTextModel3D()
             {
                 Geometry = text,
-                Name = Path.GetFileNameWithoutExtension(desc.Data.DepotPath.ToString().NotNull()).Replace("-", "n"),
-                Text = Path.GetFileNameWithoutExtension(desc.Data.DepotPath.ToString().NotNull()),
+                Name = Path.GetFileNameWithoutExtension(desc.Data.DepotPath.GetResolvedText().NotNull()).Replace("-", "n"),
+                Text = Path.GetFileNameWithoutExtension(desc.Data.DepotPath.GetResolvedText().NotNull()),
             };
 
             if (desc.Category == Enums.worldStreamingSectorCategory.Exterior)
@@ -3291,7 +3291,7 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
                 other.Children.Add(bbText);
             }
 
-            sectors.Add(new Sector(Path.GetFileNameWithoutExtension(desc.Data.DepotPath.ToString().NotNull()), bbText)
+            sectors.Add(new Sector(Path.GetFileNameWithoutExtension(desc.Data.DepotPath.GetResolvedText().NotNull()), bbText)
             {
                 DepotPath = desc.Data.DepotPath, NumberOfHandles = desc.NumNodeRanges
             });

--- a/WolvenKit.App/ViewModels/Documents/RDTWidgetViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTWidgetViewModel.cs
@@ -62,7 +62,7 @@ public partial class RDTWidgetViewModel : RedDocumentTabViewModel
 
             foreach (var f in library.ExternalDependenciesForInternalItems)
             {
-                var itemPath = f.DepotPath.ToString().NotNull();
+                var itemPath = f.DepotPath.GetResolvedText().NotNull();
                 if (Path.GetExtension(itemPath) == ".inkatlas")
                 {
                     tasks.Add(LoadInkAtlasAsync(itemPath));

--- a/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ModsViewModel.cs
@@ -213,31 +213,6 @@ public partial class ModsViewModel : PageViewModel
     }
     
     [RelayCommand]
-    private void LaunchGameFromLastSave()
-    {
-        var launchSavegameArg = "";
-        if (ISettingsManager.GetLastSaveName() is string lastSavegame)
-        {
-            launchSavegameArg = $"-save={lastSavegame}";
-        }
-         
-        try
-        {
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = _settings.GetRED4GameLaunchCommand(),
-                Arguments = $"{_settings.GetRED4GameLaunchOptions()} -modded {launchSavegameArg}",
-                ErrorDialog = true,
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.Error("Launch: error launching game! Please check your executable path in Settings.");
-            _logger.Info($"Launch: error debug info: {ex.Message}");
-        }
-    }
-
-    [RelayCommand]
     private void Remove()
     {
         if (SelectedMod is null)

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
@@ -111,7 +111,11 @@ public partial class ChunkViewModel : ObservableObject
                 ExpandAndSelect(child, true);
                 if (child.FindTvPropertyChild("0") is ChunkViewModel grandChild)
                 {
-                    ExpandAndSelect(grandChild, true);
+                    grandChild.IsExpanded = true;
+                    if (grandChild.FindTvPropertyChild("parts") is ChunkViewModel parts)
+                    {
+                        parts.IsExpanded = true;
+                    }
                 }
                 break;
             // .app file

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
@@ -106,6 +106,14 @@ public partial class ChunkViewModel : ObservableObject
             case Multilayer_Setup when FindTvPropertyChild("layers") is ChunkViewModel child:
                 ExpandAndSelect(child, true);
                 break;
+            // .inkatlas
+            case inkTextureAtlas when FindTvPropertyChild("slots") is ChunkViewModel child:
+                ExpandAndSelect(child, true);
+                if (child.FindTvPropertyChild("0") is ChunkViewModel grandChild)
+                {
+                    ExpandAndSelect(grandChild, true);
+                }
+                break;
             // .app file
             case appearanceAppearanceResource when FindTvPropertyChild("appearances") is ChunkViewModel child:
                 ExpandAndSelect(child, false, true);

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -537,10 +537,19 @@ namespace WolvenKit.RED4.CR2W.Archive
 
         public IGameFile? GetGameFile(ResourcePath path, bool includeMods = true, bool includeProject = true)
         {
+            var filePath = (path.GetResolvedText() ?? "").Split(" ").FirstOrDefault() ?? "";
+            var fileHash = ResourcePath.CalculateHash(filePath);
+            
             // check if the file is in the project archive
             if (includeProject && ProjectArchive != null && ProjectArchive.Files.TryGetValue(path, out var projectFile))
             {
                 return projectFile;
+            }
+
+            // check if the file is in the project archive - use hashing algorithm
+            if (includeProject && ProjectArchive != null && ProjectArchive.Files.TryGetValue(fileHash, out var projectFile2))
+            {
+                return projectFile2;
             }
 
             // check if the file is in a mod archive
@@ -548,8 +557,8 @@ namespace WolvenKit.RED4.CR2W.Archive
             {
                 var modFile = GetModArchives()
                     .Select(x => x.Files)
-                    .Where(x => x.ContainsKey(path))
-                    .Select(x => x[path])
+                    .Where(x => x.ContainsKey(path) || x.ContainsKey(fileHash))
+                    .Select(x => x[path] ?? x[fileHash])
                     .FirstOrDefault();
 
                 if (modFile != null)
@@ -561,8 +570,8 @@ namespace WolvenKit.RED4.CR2W.Archive
             // check if the file is in a base archive
             var baseFile = GetGameArchives()
                 .Select(x => x.Files)
-                .Where(x => x.ContainsKey(path))
-                .Select(x => x[path])
+                .Where(x => x.ContainsKey(path) || x.ContainsKey(fileHash))
+                .Select(x => x[path] ?? x[fileHash])
                 .FirstOrDefault();
 
             if (baseFile != null)

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -537,8 +537,7 @@ namespace WolvenKit.RED4.CR2W.Archive
 
         public IGameFile? GetGameFile(ResourcePath path, bool includeMods = true, bool includeProject = true)
         {
-            var filePath = (path.GetResolvedText() ?? "").Split(" ").FirstOrDefault() ?? "";
-            var fileHash = ResourcePath.CalculateHash(filePath);
+            var filePath = path.GetResolvedText() ?? "";
             
             // check if the file is in the project archive
             if (includeProject && ProjectArchive != null && ProjectArchive.Files.TryGetValue(path, out var projectFile))
@@ -546,11 +545,7 @@ namespace WolvenKit.RED4.CR2W.Archive
                 return projectFile;
             }
 
-            // check if the file is in the project archive - use hashing algorithm
-            if (includeProject && ProjectArchive != null && ProjectArchive.Files.TryGetValue(fileHash, out var projectFile2))
-            {
-                return projectFile2;
-            }
+            var fileHash = ResourcePath.CalculateHash(filePath);
 
             // check if the file is in a mod archive
             if (includeMods)

--- a/WolvenKit.Modkit/RED4/Serialization/yaml/TweakTypeConverter.cs
+++ b/WolvenKit.Modkit/RED4/Serialization/yaml/TweakTypeConverter.cs
@@ -263,7 +263,8 @@ namespace WolvenKit.Modkit.RED4.Serialization.yaml
                         }
                         case CResourceAsyncReference<CResource> cres:
                         {
-                            emitter.WriteProperty(nameof(CResourceAsyncReference<CResource>.DepotPath), cres.DepotPath.ToString().NotNull());
+                            emitter.WriteProperty(nameof(CResourceAsyncReference<CResource>.DepotPath),
+                                cres.DepotPath.GetResolvedText().NotNull());
                             break;
                         }
 

--- a/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MaterialTools.cs
@@ -354,7 +354,7 @@ namespace WolvenKit.Modkit.RED4
                     return (null, resultDict, cMaterialInstance.EnableMask);
                 }
 
-                var file = LoadFile(path.ToString().NotNull());
+                var file = LoadFile(path.GetResolvedText().NotNull());
                 if (file.RootChunk is not CMaterialInstance mi)
                 {
                     throw new Exception("Invalid .mi file");
@@ -365,7 +365,7 @@ namespace WolvenKit.Modkit.RED4
             }
             baseMaterials.Reverse();
 
-            var spath = path.ToString().NotNull();
+            var spath = path.GetResolvedText().NotNull();
             CMaterialTemplate mt;
             if (mts.TryGetValue(spath, out var mt1))
             {

--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetTools.cs
@@ -159,8 +159,8 @@ namespace WolvenKit.Modkit.RED4
 
             var names = new string[numTargets];
             var regionNames = new string[numTargets];
-            string baseMesh = morphBlob.BaseMesh.DepotPath.ToString().NotNull();
-            string baseTexture = morphBlob.BaseTexture.DepotPath.ToString().NotNull();
+            string baseMesh = morphBlob.BaseMesh.DepotPath.GetResolvedText().NotNull();
+            string baseTexture = morphBlob.BaseTexture.DepotPath.GetResolvedText().NotNull();
 
             for (var i = 0; i < numTargets; i++)
             {

--- a/WolvenKit.RED4/Archive/IO/PreProcessor/CMeshPreProcessor.cs
+++ b/WolvenKit.RED4/Archive/IO/PreProcessor/CMeshPreProcessor.cs
@@ -165,7 +165,7 @@ public class CMeshPreProcessor : IPreProcessor
         void CheckMaterialProperties(CMaterialInstance material, string materialName)
         {
             // TODO: Make null-proof and use, or delete :D
-            var shaderName = material.BaseMaterial.DepotPath.ToString();
+            var shaderName = material.BaseMaterial.DepotPath.GetResolvedText();
             // We could have a dictionary like
             // {
             //    "metal_base.remt": {

--- a/WolvenKit.RED4/Types/Primitives/Simples/ResourcePath.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/ResourcePath.cs
@@ -142,5 +142,5 @@ public readonly struct ResourcePath : IRedString, IRedPrimitive<string>, IEquata
 
     public string? GetString() => this;
     public override string? ToString() => GetResolvedText();
-    public static bool IsNullOrEmpty([NotNullWhen(false)] ResourcePath path) => path == ResourcePath.Empty ? true : string.IsNullOrEmpty(path.ToString());
+    public static bool IsNullOrEmpty([NotNullWhen(false)] ResourcePath path) => path == ResourcePath.Empty ? true : string.IsNullOrEmpty(path.GetResolvedText());
 }

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
@@ -200,7 +200,7 @@ namespace WolvenKit.Views.Editors
         private void RefreshValidityAndTooltip(object sender, RoutedEventArgs e)
         {
             if (_settingsManager?.UseValidatingEditor != true || RedRef?.DepotPath == ResourcePath.Empty ||
-                RedRef?.ToString() is not string filePath || filePath.Trim().IsNullOrEmpty())
+                RedRef?.DepotPath.GetResolvedText() is not string filePath || filePath.Trim().IsNullOrEmpty())
             {
                 SetCurrentValue(ScopeProperty, FileScope.Unknown);
                 SetCurrentValue(TextBoxToolTipProperty, "Not validating this resource path");
@@ -215,7 +215,7 @@ namespace WolvenKit.Views.Editors
                 return;
             }
 
-            if (!ArchiveXlHelper.HasSubstitution(filePath) && _archiveManager?.GetGameFile(filePath, false, true) is not null)
+            if (!ArchiveXlHelper.HasSubstitution(filePath) && _archiveManager?.GetGameFile(RedRef.DepotPath, false, true) is not null)
             {
                 SetCurrentValue(ScopeProperty, FileScope.GameOrMod);
                 SetCurrentValue(TextBoxToolTipProperty, "Valid depot path (game or same mod)");
@@ -230,7 +230,7 @@ namespace WolvenKit.Views.Editors
                 return;
             }
 
-            if (_archiveManager?.Lookup(filePath, ArchiveManagerScope.Mods).HasValue is true)
+            if (_archiveManager?.Lookup(RedRef.DepotPath, ArchiveManagerScope.Mods).HasValue is true)
             {
                 SetCurrentValue(ScopeProperty, FileScope.OtherMod);
                 SetCurrentValue(TextBoxToolTipProperty, "Valid depot path (another mod)");

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
@@ -215,11 +215,10 @@ namespace WolvenKit.Views.Editors
                 return;
             }
 
-            if (!ArchiveXlHelper.HasSubstitution(filePath) &&
-                _archiveManager?.GetGameFile(filePath, false, true) is not null)
+            if (!ArchiveXlHelper.HasSubstitution(filePath) && _archiveManager?.GetGameFile(filePath, false, true) is not null)
             {
                 SetCurrentValue(ScopeProperty, FileScope.GameOrMod);
-                SetCurrentValue(TextBoxToolTipProperty, "Valid depot path (game or mod)");
+                SetCurrentValue(TextBoxToolTipProperty, "Valid depot path (game or same mod)");
                 return;
             }
 
@@ -231,7 +230,7 @@ namespace WolvenKit.Views.Editors
                 return;
             }
 
-            if (_archiveManager?.GetGameFile(filePath, true, false) is not null)
+            if (_archiveManager?.Lookup(filePath, ArchiveManagerScope.Mods).HasValue is true)
             {
                 SetCurrentValue(ScopeProperty, FileScope.OtherMod);
                 SetCurrentValue(TextBoxToolTipProperty, "Valid depot path (another mod)");


### PR DESCRIPTION
# fixed validating depot path editor's lookup

- added auto-unfolding for inkatlas
- added warning about CET entity spawn when launching with `-save` arg