### PR TITLE
Add Core to list of published packages

### DIFF
--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -15,7 +15,12 @@ jobs:
       with:
         dotnet-version: 8.x
 
-    # Pack and upload nugets for Types, Modkit and CLI
+    # Pack and upload nugets for Core, Types, Modkit and CLI
+    - run: dotnet pack .\WolvenKit.Core\WolvenKit.Core.csproj
+    - name: Core
+      continue-on-error: true
+      run: dotnet nuget push .\WolvenKit.Core\nupkg\*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+    
     - run: dotnet pack .\WolvenKit.RED4\WolvenKit.RED4.csproj
     - name: RED4
       continue-on-error: true


### PR DESCRIPTION
# Add .Core to list of published packages

**Fixed:**
- Core hasn't been published as a nuget since 2021, making the .RED4 package useless to publish as it requires the .Core project. This simply adds core to the list of published packages, which I assume will fix the issue.

