### PR TITLE
Add OpusPak/OpusInfo support to CLI

### DIFF
--- a/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
@@ -233,7 +233,7 @@ public partial class ExportViewModel : AbstractImportExportViewModel
         }
 
 
-        var info = OpusTools.GetOpusInfo(_archiveManager, opusExportArgs.UseMod);
+        var info = OpusTools.GetOpusInfo(_archiveManager, opusExportArgs.UseProject);
         if (info == null)
         {
             return;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
@@ -256,7 +256,7 @@ public partial class ChunkViewModel
                 IsValueExtrapolated = true;
                 break;
             case questFactsDBCondition condition:
-                switch (condition.Type.GetValue())
+                switch (condition.Type?.GetValue())
                 {
                     case questVarComparison_ConditionType type:
                         Value = $"{type.ComparisonType.ToEnumString()}: {type.FactName}";

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -65,7 +65,11 @@ namespace WolvenKit.Common.Model.Arguments
         [Display(Name = "Dump all information inside OpusInfo to a JSON.")]
         public bool DumpAllToJson { get; set; }
 
-        public override string ToString() => $"Wem Files | Use Modified OpusInfo :  {UseProject} | Selected :  {SelectedForExport.Count}";
+        [Browsable(false)]
+        [Description("Required for CLI uncooking.")]
+        public bool UseMod { get; set; }
+
+        public override string ToString() => $"Use Modified OpusInfo: {UseProject} | Selected: {SelectedForExport.Count}";
     }
 
     /// <summary>

--- a/WolvenKit.Common/Model/Arguments/ExportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ExportArgs.cs
@@ -41,23 +41,31 @@ namespace WolvenKit.Common.Model.Arguments
 
     public class OpusExportArgs : ExportArgs
     {
-        private bool _useMod;
+        private bool _useProject;
         private List<uint> _selectedForExport = new();
 
         [Category("Export Settings")]
         [Display(Name = "Use Modified OpusInfo")]
-        [Description("If selected modified OpusInfo and paks within the Mod Project are used. If unchecked the original OpusInfo and paks will be exported.")]
+        [Description("If selected, modified OpusInfo and paks within the Mod Project are used. If unchecked the original OpusInfo and paks will be exported.")]
         [WkitScriptAccess()]
-        public bool UseMod { get => _useMod; set => SetProperty(ref _useMod, value); }
+        public bool UseProject { get => _useProject; set => SetProperty(ref _useProject, value); }
 
-        [Category("Export Settings")]
+        [Category("OpusPak settings")]
+        [Display(Name = "Hashes to Export")]
+        [Description("Which hashes should be exported.")]
         public List<uint> SelectedForExport { get => _selectedForExport; set => SetProperty(ref _selectedForExport, value); }
 
-        [Category("Export Settings")]
-        [Display(Name = "Dump all information inside OpusInfo to Json.")]
+        [Category("OpusPak settings")]
+        [Display(Name = "Export all")]
+        [Description("If checked, ignores the above list and exports ALL of the sounds in OpusPaks as .opus (no .wav). WARNING: May taky a considerable time and resources!")]
+        [Browsable(false)]
+        public bool ExportAll { get; set; }
+
+        [Category("Miscellaneous")]
+        [Display(Name = "Dump all information inside OpusInfo to a JSON.")]
         public bool DumpAllToJson { get; set; }
 
-        public override string ToString() => $"Wem Files | Use Modified OpusInfo :  {UseMod} | Selected :  {SelectedForExport.Count}";
+        public override string ToString() => $"Wem Files | Use Modified OpusInfo :  {UseProject} | Selected :  {SelectedForExport.Count}";
     }
 
     /// <summary>
@@ -358,7 +366,7 @@ namespace WolvenKit.Common.Model.Arguments
         /// String Override to display info in datagrid.
         /// </summary>
         /// <returns>String</returns>
-        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")}, Additive Anims Relative: { AdditiveRelativeToLocalTransform }, Root Motion: {incRootMotion}";
+        public override string ToString() => $"{(IsBinary ? "glb" : "gltf")}, Additive Anims Relative: {AdditiveRelativeToLocalTransform}, Root Motion: {incRootMotion}";
     }
 
     /// <summary>

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using WolvenKit.Common;
@@ -23,6 +24,9 @@ public record UncookTaskOptions
     public string? meshExportMaterialRepo { get; init; }
     public bool? meshExportLodFilter { get; init; }
     public bool? meshExportExperimentalMergedExport { get; init; }
+    public bool? opusDumpJson { get; init; }
+    public List<uint>? opusHashes { get; set; }
+    public bool? opusExportAll { get; set; }
 }
 
 public partial class ConsoleFunctions
@@ -151,6 +155,11 @@ public partial class ConsoleFunctions
 
         exportArgs.Get<GeneralExportArgs>().MaterialRepositoryPath = string.IsNullOrEmpty(options.meshExportMaterialRepo) ? outDir.FullName : options.meshExportMaterialRepo;
         exportArgs.Get<MeshExportArgs>().MaterialRepo = string.IsNullOrEmpty(options.meshExportMaterialRepo) ? outDir.FullName : options.meshExportMaterialRepo;
+
+        exportArgs.Get<OpusExportArgs>().UseMod = true;
+        exportArgs.Get<OpusExportArgs>().SelectedForExport = options.opusHashes ?? [];
+        exportArgs.Get<OpusExportArgs>().ExportAll = options.opusExportAll ?? false;
+        exportArgs.Get<OpusExportArgs>().DumpAllToJson = options.opusDumpJson ?? false;
 
         var result = 0;
         foreach (var gameArchive in _archiveManager.Archives.Items)

--- a/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
@@ -91,17 +91,18 @@ namespace WolvenKit.Modkit.RED4.Opus
 
         //public OpusInfo() => OpusCount = 0;
 
-        public void WriteAllOpusFromPaks(Stream[] opuspaks, DirectoryInfo outdir) // thou shall not be used
+        public void WriteAllOpusFromPak(int pakIndex, Stream opuspak, DirectoryInfo outdir)
         {
-            var brs = new BinaryReader[opuspaks.Length];
-            for (var i = 0; i < opuspaks.Length; i++)
-            {
-                brs[i] = new BinaryReader(opuspaks[i]);
-            }
+            var br = new BinaryReader(opuspak);
             for (uint i = 0; i < OpusCount; i++)
             {
-                opuspaks[PackIndices[i]].Position = OpusOffsets[i] + RiffOpusOffsets[i];
-                var bytes = brs[PackIndices[i]].ReadBytes(Convert.ToInt32(OpusStreamLengths[i] - RiffOpusOffsets[i]));
+                if (PackIndices[i] != pakIndex)
+                {
+                    continue;
+                }
+
+                opuspak.Position = OpusOffsets[i] + RiffOpusOffsets[i];
+                var bytes = br.ReadBytes(Convert.ToInt32(OpusStreamLengths[i] - RiffOpusOffsets[i]));
                 var name = OpusHashes[i] + ".opus";
                 File.WriteAllBytes(Path.Combine(outdir.FullName, name), bytes);
             }

--- a/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
@@ -3,10 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using DynamicData.Kernel;
 using WolvenKit.Common;
-using WolvenKit.Common.FNV1A;
 
 namespace WolvenKit.Modkit.RED4.Opus
 {
@@ -25,7 +22,7 @@ namespace WolvenKit.Modkit.RED4.Opus
             return new OpusInfo(infoStream);
         }
 
-        public static IEnumerable<double> ExportAllOpus(OpusInfo info, IArchiveManager archiveManager, bool useProject, DirectoryInfo rawOutDir)
+        public static IEnumerable<double> ExportAllOpus(OpusInfo info, IArchiveManager archiveManager, bool useMod, bool useProject, DirectoryInfo rawOutDir)
         {
             var maxPak = info.PackIndices.Last();
             double progress;
@@ -34,7 +31,7 @@ namespace WolvenKit.Modkit.RED4.Opus
             {
                 progress = (i + 1) / (double)maxPak;
 
-                var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{i}.opuspak", false, useProject);
+                var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{i}.opuspak", useMod, useProject);
                 if (opusPak != null)
                 {
                     var ms = new MemoryStream();
@@ -46,13 +43,13 @@ namespace WolvenKit.Modkit.RED4.Opus
             }
         }
 
-        public static bool ExportOpusUsingHash(OpusInfo info, IArchiveManager archiveManager, List<uint> ids, bool useProject, DirectoryInfo rawOutDir)
+        public static bool ExportOpusUsingHash(OpusInfo info, IArchiveManager archiveManager, List<uint> ids, bool useMod, bool useProject, DirectoryInfo rawOutDir)
         {
             for (uint i = 0; i < info.OpusCount; i++)
             {
                 if (ids.Contains(info.OpusHashes[i]))
                 {
-                    var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{info.PackIndices[i]}.opuspak", false, useProject);
+                    var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{info.PackIndices[i]}.opuspak", useMod, useProject);
                     if (opusPak == null)
                     {
                         continue;

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -770,8 +770,9 @@ namespace WolvenKit.Modkit.RED4
 
             if (opusExportArgs.ExportAll)
             {
+                _loggerService.Warning("Exporting all sounds from OpusPaks, this may take a while!");
                 // NOTE: Hijacked the progress service here because it takes a while
-                foreach (var progress in OpusTools.ExportAllOpus(opusinfo, _archiveManager, opusExportArgs.UseProject, rawOutDir))
+                foreach (var progress in OpusTools.ExportAllOpus(opusinfo, _archiveManager, opusExportArgs.UseMod, opusExportArgs.UseProject, rawOutDir))
                 {
                     _progressService.Report(progress);
                 }
@@ -783,7 +784,7 @@ namespace WolvenKit.Modkit.RED4
                 return true;
             }
 
-            return OpusTools.ExportOpusUsingHash(opusinfo, _archiveManager, opusExportArgs.SelectedForExport, opusExportArgs.UseProject, rawOutDir);
+            return OpusTools.ExportOpusUsingHash(opusinfo, _archiveManager, opusExportArgs.SelectedForExport, opusExportArgs.UseMod, opusExportArgs.UseProject, rawOutDir);
         }
 
         private string SerializeMainFile(Stream redstream)

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -768,12 +768,22 @@ namespace WolvenKit.Modkit.RED4
                 File.WriteAllText(Path.Combine(rawOutDir.FullName, relPath + ".json"), JsonConvert.SerializeObject(opusinfo));
             }
 
+            if (opusExportArgs.ExportAll)
+            {
+                // NOTE: Hijacked the progress service here because it takes a while
+                foreach (var progress in OpusTools.ExportAllOpus(opusinfo, _archiveManager, opusExportArgs.UseProject, rawOutDir))
+                {
+                    _progressService.Report(progress);
+                }
+                return true;
+            }
+
             if (opusExportArgs.SelectedForExport.Count == 0)
             {
                 return true;
             }
 
-            return OpusTools.ExportOpusUsingHash(opusinfo, _archiveManager, opusExportArgs.SelectedForExport, opusExportArgs.UseMod, rawOutDir);
+            return OpusTools.ExportOpusUsingHash(opusinfo, _archiveManager, opusExportArgs.SelectedForExport, opusExportArgs.UseProject, rawOutDir);
         }
 
         private string SerializeMainFile(Stream redstream)


### PR DESCRIPTION
# Add OpusPak/OpusInfo support to CLI

**Implemented:**
- Exporting of all sounds from OpusInfo/Paks (hidden in GUI)
- Options to configure the `uncook` command for OpusInfo
- Alcohol into my bloodstream

**Additional notes:**
Closes #1909 
Depends on #1914 
Also is waiting for #1913



