### PR TITLE
Fix rare bug with empty depot path and exporting

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
@@ -10,9 +10,9 @@ namespace WolvenKit.Modkit.RED4.Opus
 {
     public class OpusTools
     {
-        public static OpusInfo? GetOpusInfo(IArchiveManager archiveManager, bool useMod)
+        public static OpusInfo? GetOpusInfo(IArchiveManager archiveManager, bool useProject)
         {
-            var opusInfo = archiveManager.GetGameFile(@"base\sound\soundbanks\sfx_container.opusinfo", false, useMod);
+            var opusInfo = archiveManager.GetGameFile(@"base\sound\soundbanks\sfx_container.opusinfo", false, useProject);
             if (opusInfo == null)
             {
                 return null;
@@ -23,23 +23,23 @@ namespace WolvenKit.Modkit.RED4.Opus
             return new OpusInfo(infoStream);
         }
 
-        public static bool ExportOpusUsingHash(IArchiveManager archiveManager, List<uint> ids, bool useMod, DirectoryInfo rawOutDir)
+        public static bool ExportOpusUsingHash(IArchiveManager archiveManager, List<uint> ids, bool useProject, DirectoryInfo rawOutDir)
         {
-            var info = GetOpusInfo(archiveManager, useMod);
+            var info = GetOpusInfo(archiveManager, useProject);
             if (info != null)
             {
-                return ExportOpusUsingHash(info, archiveManager, ids, useMod, rawOutDir);
+                return ExportOpusUsingHash(info, archiveManager, ids, useProject, rawOutDir);
             }
             return false;
         }
 
-        public static bool ExportOpusUsingHash(OpusInfo info, IArchiveManager archiveManager, List<uint> ids, bool useMod, DirectoryInfo rawOutDir)
+        public static bool ExportOpusUsingHash(OpusInfo info, IArchiveManager archiveManager, List<uint> ids, bool useProject, DirectoryInfo rawOutDir)
         {
             for (uint i = 0; i < info.OpusCount; i++)
             {
                 if (ids.Contains(info.OpusHashes[i]))
                 {
-                    var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{info.PackIndices[i]}.opuspak", false, false);
+                    var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{info.PackIndices[i]}.opuspak", false, useProject);
                     if (opusPak == null)
                     {
                         continue;

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -508,7 +508,7 @@ namespace WolvenKit.Modkit.RED4
 
         public bool IsUncooked(string? depotPath, string destName, string relPath)
         {
-            if (depotPath is not null &&
+            if (!string.IsNullOrEmpty(depotPath) &&
                 destName.StartsWith(depotPath) &&
                 !_uncookedLookup.TryAdd(relPath, 0))
             {


### PR DESCRIPTION
# Fix rare bug with empty depot path and exporting

**Fixed:**
- Rare bug where if depoth path was `""` the Export Tool only worked once per file per session

**Additional notes:**
Un
