### PR TITLE
Fix non-windows platforms trying to load nt.dll for RtlAreLongPathsEnabled

### DIFF
--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CP77Tools.Commands;
 using CP77Tools.Tasks;
@@ -29,7 +30,7 @@ internal class Program
             return ConsoleFunctions.ERROR_GENERAL_ERROR;
         }
 
-        if (Core.NativeMethods.RtlAreLongPathsEnabled() == 0)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Core.NativeMethods.RtlAreLongPathsEnabled() == 0)
         {
             // TODO: Use logger for that. Tried it as middleware but doesn't get called at all then -.-
             var text = "Long path support is disabled in your OS!" + Environment.NewLine +


### PR DESCRIPTION
**Fixed:**
- WolvenKit.CLI immediately crashing on Linux/macOS due to attempted nt.dll library load

**Additional notes:**
- Linux on average has a PATH_MAX of 4096 but it depends on the filesystem.
- macOS on HFS+ has a PATH_MAX of 1024, APFS has no defined PATH_MAX.

**Fixed Exception:**
```
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'ntdll' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment 
   at WolvenKit.Core.NativeMethods.RtlAreLongPathsEnabled()
   at WolvenKit.CLI.Program.Main(String[] args) in /home/runner/work/WolvenKit/WolvenKit/WolvenKit.CLI/Program.cs:line 32
``` 