### PR TITLE
Make opus uncooking use the --serialize flag

### DIFF
--- a/WolvenKit.CLI/Commands/UncookCommand.cs
+++ b/WolvenKit.CLI/Commands/UncookCommand.cs
@@ -46,7 +46,6 @@ internal class UncookCommand : CommandBase
         AddOption(new Option<string>(new[] { "--mesh-export-material-repo" }, "Location of the material repo, if not specified, it uses the outpath."));
         AddOption(new Option<bool>(new[] { "--mesh-export-lod-filter" }, "Filter out lod models."));
         AddOption(new Option<bool>(new[] { "--mesh-export-experimental-merged-export" }, "[EXPERIMENTAL] Merged mesh export. (Only supports Default or WithMaterials, re-import not supported)"));
-        AddOption(new Option<bool>(new[] { "--opus-dump-json" }, "Dump .opusinfo file as JSON."));
         AddOption(new Option<string>(new[] { "--opus-hashes" }, "Comma-separated list of hashes to export from .opusinfo."));
 
         SetInternalHandler(CommandHandler.Create(Action));

--- a/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/UncookTask.cs
@@ -24,7 +24,6 @@ public record UncookTaskOptions
     public string? meshExportMaterialRepo { get; init; }
     public bool? meshExportLodFilter { get; init; }
     public bool? meshExportExperimentalMergedExport { get; init; }
-    public bool? opusDumpJson { get; init; }
     public List<uint>? opusHashes { get; set; }
     public bool? opusExportAll { get; set; }
 }
@@ -159,7 +158,6 @@ public partial class ConsoleFunctions
         exportArgs.Get<OpusExportArgs>().UseMod = true;
         exportArgs.Get<OpusExportArgs>().SelectedForExport = options.opusHashes ?? [];
         exportArgs.Get<OpusExportArgs>().ExportAll = options.opusExportAll ?? false;
-        exportArgs.Get<OpusExportArgs>().DumpAllToJson = options.opusDumpJson ?? false;
 
         var result = 0;
         foreach (var gameArchive in _archiveManager.Archives.Items)

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -105,7 +105,16 @@ namespace WolvenKit.Modkit.RED4
                 {
                     try
                     {
-                        var jsonOutput = SerializeMainFile(cr2WStream);
+                        string jsonOutput;
+                        if (extension == ".opusinfo")
+                        {
+                            jsonOutput = SerializeOpus(cr2WStream);
+                        }
+                        else
+                        {
+                            jsonOutput = SerializeMainFile(cr2WStream);
+                        }
+
                         var outpath = Path.Combine(outDir.FullName, $"{relFileFullName.Replace('\\', Path.DirectorySeparatorChar)}.json");
                         File.WriteAllText(outpath, jsonOutput);
                         return true;
@@ -785,6 +794,13 @@ namespace WolvenKit.Modkit.RED4
             }
 
             return OpusTools.ExportOpusUsingHash(opusinfo, _archiveManager, opusExportArgs.SelectedForExport, opusExportArgs.UseMod, opusExportArgs.UseProject, rawOutDir);
+        }
+
+
+        private static string SerializeOpus(Stream stream)
+        {
+            var opusinfo = new OpusInfo(stream);
+            return JsonConvert.SerializeObject(opusinfo);
         }
 
         private string SerializeMainFile(Stream redstream)


### PR DESCRIPTION
# $PULL_REQUEST_TITLE

**Implemented:**
- Make opus uncooking use the --serialize flag

**Fixed:**
- Opus uncooking didn't use the --serialize flag, it had it's own flag

**Additional notes:**
closes_issue_number
