### PR TITLE
Scripting: Added `@description` and `@usage` script file headers.

### DIFF
--- a/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
@@ -10,6 +10,8 @@ public class ScriptFileViewModel : ScriptViewModel
 
     public string? Version => _scriptFile.Version;
     public string? Author => _scriptFile.Author;
+    public string? Description => _scriptFile.Description;
+    public string? Usage => _scriptFile.Usage;
 
     public override bool CanExecute => Type == ScriptType.General;
     public override bool CanDelete => Source == ScriptSource.User;

--- a/WolvenKit/Views/Dialogs/ScriptManagerView.xaml
+++ b/WolvenKit/Views/Dialogs/ScriptManagerView.xaml
@@ -126,38 +126,64 @@
                 Grid.Column="1"
                 BorderBrush="#373737"
                 BorderThickness="1">
-                <Grid
-                    MinWidth="250"
-                    Background="{StaticResource ContentBackground}"
-                    IsSharedSizeScope="True">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" SharedSizeGroup="Label" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
+                <ScrollViewer HorizontalScrollBarVisibility="Visible">
+                    <Grid
+                        MinWidth="250"
+                        Background="{StaticResource ContentBackground}"
+                        IsSharedSizeScope="True">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" SharedSizeGroup="Label" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
 
-                    <Label
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Content="Version: " />
-                    <Label
-                        x:Name="VersionLabel"
-                        Grid.Row="0"
-                        Grid.Column="1" />
+                        <Label
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            HorizontalContentAlignment="Right"
+                            Content="Version: " />
+                        <Label
+                            x:Name="VersionLabel"
+                            Grid.Row="0"
+                            Grid.Column="1" />
 
-                    <Label
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        Content="Author: " />
-                    <Label
-                        x:Name="AuthorLabel"
-                        Grid.Row="1"
-                        Grid.Column="1" />
-                </Grid>
+                        <Label
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            HorizontalContentAlignment="Right"
+                            Content="Author: " />
+                        <Label
+                            x:Name="AuthorLabel"
+                            Grid.Row="1"
+                            Grid.Column="1" />
+
+                        <Label
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            HorizontalContentAlignment="Right"
+                            Content="Description: " />
+                        <Label
+                            x:Name="DescriptionLabel"
+                            Grid.Row="2"
+                            Grid.Column="1" />
+
+                        <Label
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            HorizontalContentAlignment="Right"
+                            Content="Usage: " />
+                        <Label
+                            x:Name="UsageLabel"
+                            Grid.Row="3"
+                            Grid.Column="1" />
+                    </Grid>
+                </ScrollViewer>
             </Border>
         </Grid>
 

--- a/WolvenKit/Views/Dialogs/ScriptManagerView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/ScriptManagerView.xaml.cs
@@ -142,14 +142,20 @@ public partial class ScriptManagerView : ReactiveUserControl<ScriptManagerViewMo
     {
         var version = "";
         var author = "";
+        var description = "";
+        var usage = "";
 
         if (e.AddedItems.Count > 0 && e.AddedItems[0] is TreeGridRowInfo { RowData: ScriptFileViewModel scriptFile })
         {
             version = scriptFile.Version;
             author = scriptFile.Author;
+            description = scriptFile.Description;
+            usage = scriptFile.Usage;
         }
 
         VersionLabel.SetCurrentValue(ContentProperty, version);
         AuthorLabel.SetCurrentValue(ContentProperty, author);
+        DescriptionLabel.SetCurrentValue(ContentProperty, description);
+        UsageLabel.SetCurrentValue(ContentProperty, usage);
     }
 }


### PR DESCRIPTION
# Scripting: Added `@description` and `@usage` script file headers.

**Implemented:**
- Added `@description` and `@usage` script file headers. Closes #1936 

Description and Usage blocks are terminated by either a non comment line or the next keyword.

**Example:**
```
// @description
// Line 1 of description
// Line 2 of description
// ...
// Last line of description
// 
// @usage
// Line 1 of usage
// Line 2 of usage
// ...
// Last line of usage
var test = 0;
```

