### PR TITLE
Select and run a wscript from Log dock

### DIFF
--- a/WolvenKit.App/Factories/PaneViewModelFactory.cs
+++ b/WolvenKit.App/Factories/PaneViewModelFactory.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using WolvenKit.App.Controllers;
+﻿using WolvenKit.App.Controllers;
 using WolvenKit.App.Helpers;
-using WolvenKit.App.Models.Docking;
 using WolvenKit.App.Services;
-using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Exporters;
 using WolvenKit.App.ViewModels.Importers;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.App.ViewModels.Tools;
-using WolvenKit.Common;
 using WolvenKit.Common.Interfaces;
 using WolvenKit.Common.Services;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Core.Services;
-using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.RED4.CR2W;
 
 namespace WolvenKit.App.Factories;
@@ -35,6 +30,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
     private readonly ITweakDBService _tweakDbService;
     private readonly ILocKeyService _locKeyService;
     private readonly ImportExportHelper _importExportHelper;
+    private readonly AppScriptService _appScriptService;
 
     private readonly PropertiesViewModel _propertiesViewModel;
     private readonly IModifierViewStateService _modifierSvc;
@@ -55,6 +51,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         ILocKeyService locKeyService,
         PropertiesViewModel propertiesViewModel,
         ImportExportHelper importExportHelper,
+        AppScriptService appScriptService,
         IModifierViewStateService modifierSvc
         )
     {
@@ -73,10 +70,11 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         _locKeyService = locKeyService;
         _propertiesViewModel = propertiesViewModel;
         _importExportHelper = importExportHelper;
+        _appScriptService = appScriptService;
         _modifierSvc = modifierSvc;
     }
 
-    public LogViewModel LogViewModel() => new(_loggerService);
+    public LogViewModel LogViewModel() => new(_loggerService, _appScriptService, _settingsManager);
     public ProjectExplorerViewModel ProjectExplorerViewModel(AppViewModel appViewModel)
         => new(appViewModel, _projectManager, _loggerService, _progressService, _modTools,
             _gameController, _pluginService, _settingsManager, _modifierSvc);
@@ -84,10 +82,10 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         => _propertiesViewModel;
     public AssetBrowserViewModel AssetBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _projectManager, _notificationService, _gameController, _archiveManager, _settingsManager, _progressService, _loggerService, _pluginService);
-    public TweakBrowserViewModel TweakBrowserViewModel(AppViewModel appViewModel) 
+    public TweakBrowserViewModel TweakBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _chunkViewmodelFactory, _settingsManager, _notificationService, _projectManager, _loggerService, _tweakDbService, _locKeyService);
     public LocKeyBrowserViewModel LocKeyBrowserViewModel() => new(_projectManager, _loggerService, _progressService, _modTools, _gameController, _archiveManager, _locKeyService);
-    
+
     public ImportViewModel ImportViewModel(AppViewModel appViewModel) => new(appViewModel, _archiveManager, _notificationService, _settingsManager, _loggerService, _projectManager, _progressService, _gameController, _parserService, _importExportHelper);
     public ExportViewModel ExportViewModel(AppViewModel appViewModel) => new(appViewModel, _archiveManager, _notificationService, _settingsManager, _loggerService, _projectManager, _progressService, _importExportHelper);
 

--- a/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using WolvenKit.App.Services;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.Modkit.Scripting;
 
 namespace WolvenKit.App.ViewModels.Scripting;
@@ -13,6 +14,47 @@ public class ScriptFileViewModel : ScriptViewModel
     public string? Description => _scriptFile.Description;
     public string? Usage => _scriptFile.Usage;
 
+    public string Code => _scriptFile.Content;
+
+    public string SelectInfo
+    {
+        get
+        {
+            if (Version != null && Author != null)
+            {
+                return $"v{Version} · {Author}";
+            }
+            else if (Version != null)
+            {
+                return $"v{Version}";
+            }
+            else if (Author != null)
+            {
+                return Author;
+            }
+            return "";
+        }
+    }
+    public string? HoverInfo
+    {
+        get
+        {
+            if (Description != null && Usage != null)
+            {
+                return $"Description:\n{Description}\n\nUsage:\n{Usage}";
+            }
+            else if (Description != null)
+            {
+                return $"Description:\n{Description}";
+            }
+            else if (Usage != null)
+            {
+                return $"Usage:\n{Usage}";
+            }
+            return null;
+        }
+    }
+
     public override bool CanExecute => Type == ScriptType.General;
     public override bool CanDelete => Source == ScriptSource.User;
 
@@ -25,6 +67,11 @@ public class ScriptFileViewModel : ScriptViewModel
         {
             _enabled = true;
         }
+    }
+
+    public bool Reload(ILoggerService? loggerService)
+    {
+        return _scriptFile.Reload(loggerService);
     }
 
     #region INotifyPropertyChanged

--- a/WolvenKit.App/ViewModels/Tools/LogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/LogViewModel.cs
@@ -1,7 +1,18 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Data;
 using System.Windows.Documents;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DynamicData;
 using WolvenKit.App.Models.Docking;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Scripting;
 using WolvenKit.Core.Interfaces;
+using WolvenKit.Modkit.Scripting;
 
 namespace WolvenKit.App.ViewModels.Tools;
 
@@ -23,22 +34,43 @@ public partial class LogViewModel : ToolViewModel
     public const string ToolTitle = "Log";
 
     private readonly ILoggerService _loggerService;
+    private readonly AppScriptService _scriptService;
+    private readonly ISettingsManager _settingsManager;
 
     // private readonly ReadOnlyObservableCollection<LogEntry> _logEntries;
     // public ReadOnlyObservableCollection<LogEntry> LogEntries => _logEntries;
 
-    [ObservableProperty] private FlowDocument _document = new();
+    private readonly ObservableCollection<ScriptFileViewModel> _scriptFiles = new();
+    public CollectionViewSource ScriptFiles { get; } = new();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanRunScript))]
+    private ScriptFileViewModel? _selectedScriptFile;
+
+    public bool CanRunScript => SelectedScriptFile != null;
+
+    [ObservableProperty]
+    private FlowDocument _document = new();
 
     #endregion Fields
 
     public LogViewModel(
-        ILoggerService loggerService
+        ILoggerService loggerService,
+        AppScriptService scriptService,
+        ISettingsManager settingsManager
         ) : base(ToolTitle)
     {
         _loggerService = loggerService;
+        _scriptService = scriptService;
+        _settingsManager = settingsManager;
 
         SetupToolDefaults();
         SideInDockedMode = DockSide.Bottom;
+
+        ScriptFiles.GroupDescriptions.Add(new PropertyGroupDescription("Source"));
+        ScriptFiles.SortDescriptions.Add(new SortDescription("Name", ListSortDirection.Ascending));
+        ScriptFiles.Source = _scriptFiles;
+        GetScriptFiles();
 
         //filter, sort and populate reactive list,
         // _loggerService.Connect() //connect to the cache
@@ -47,6 +79,47 @@ public partial class LogViewModel : ToolViewModel
         //     .Subscribe(OnNext);
     }
 
+    [RelayCommand]
+    private void UpdateScripts()
+    {
+        GetScriptFiles();
+    }
+
+    [RelayCommand]
+    private async Task RunScript()
+    {
+        if (!CanRunScript)
+        {
+            return;
+        }
+        var scriptFile = SelectedScriptFile!;
+
+        if (!File.Exists(scriptFile.Path))
+        {
+            return;
+        }
+        scriptFile.Reload(_loggerService);
+        await _scriptService.ExecuteAsync(scriptFile.Code);
+    }
+
 
     private void SetupToolDefaults() => ContentId = ToolContentId;
+
+    private void GetScriptFiles()
+    {
+        _scriptFiles.Clear();
+        ScanDir(ScriptSource.System, @"Resources\Scripts");
+        ScanDir(ScriptSource.User, ISettingsManager.GetWScriptDir());
+
+        void ScanDir(ScriptSource scriptSource, string path)
+        {
+            var scripts = _scriptService.GetScripts(path)
+                .Where(script => script.Type == ScriptType.General)
+                .Select(script => new ScriptFileViewModel(_settingsManager, scriptSource, script))
+                .ToList();
+
+            _scriptFiles.Add(scripts);
+        }
+    }
+
 }

--- a/WolvenKit/Views/Tools/LogView.xaml
+++ b/WolvenKit/Views/Tools/LogView.xaml
@@ -29,6 +29,11 @@
     </UserControl.Resources>
 
     <Grid x:Name="LogViewGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
@@ -38,7 +43,91 @@
             <converters:NullVisibilityConverter x:Key="NullVisibilityConverter" />
         </Grid.Resources>
 
+        <Grid x:Name="ScriptShortcutGrid"
+              Grid.Row="0"
+              Grid.Column="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" MinWidth="240" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button
+                x:Name="UpdateButton"
+                Grid.Column="0"
+                Margin="0,0,4,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                ToolTip="Update scripts"
+                Command="{Binding UpdateScriptsCommand}">
+                <iconPacks:PackIconMaterial
+                    Foreground="White"
+                    Kind="Refresh" />
+            </Button>
+
+            <ComboBox
+                x:Name="ScriptFileComboBox"
+                Grid.Column="1"
+                Margin="0,0,4,4"
+                ToolTip="Select script"
+                IsEditable="False"
+                IsReadOnly="True"
+                ItemsSource="{Binding ScriptFiles.View}"
+                SelectedItem="{Binding SelectedScriptFile}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical"
+                                    ToolTip="{Binding HoverInfo}">
+                            <TextBlock Text="{Binding Name}" />
+                            <TextBlock x:Name="Info"
+                                       Text="{Binding SelectInfo}" />
+                        </StackPanel>
+
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBoxItem}}"
+                                         Value="{x:Null}">
+                                <Setter TargetName="Info"
+                                        Property="Visibility"
+                                        Value="Collapsed" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+                
+                <ComboBox.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="White"
+                                        BorderThickness="0,0,0,1"
+                                        Padding="15,0,0,7">
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Text="{Binding Name}"
+                                                   FontSize="14" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ComboBox.GroupStyle>
+            </ComboBox>
+
+            <Button
+                x:Name="RunButton"
+                Grid.Column="2"
+                Margin="0,0,4,0"
+                VerticalAlignment="Top"
+                ToolTip="Reload and run"
+                Command="{Binding RunScriptCommand}"
+                IsEnabled="{Binding CanRunScript}">
+                <iconPacks:PackIconMaterial
+                    Foreground="Green"
+                    Kind="Play" />
+            </Button>
+        </Grid>
+
         <ItemsControl
+            Grid.Row="1"
             Grid.Column="0"
             ItemsSource="{Binding ElementName=uc, Path=LogEntries}"
             ScrollViewer.CanContentScroll="True"
@@ -48,7 +137,7 @@
             <ItemsControl.Resources>
                 <DataTemplate DataType="{x:Type tools1:LogEntry}">
                     <Grid HorizontalAlignment="Stretch">
-                        
+
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
@@ -131,7 +220,10 @@
             </ItemsControl.ItemsPanel>
         </ItemsControl>
 
-        <StackPanel Grid.Column="1" Orientation="Vertical">
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="1"
+            Orientation="Vertical">
             <ToggleButton
                 Padding="5"
                 BorderThickness="1"

--- a/WolvenKit/Views/Tools/LogView.xaml.cs
+++ b/WolvenKit/Views/Tools/LogView.xaml.cs
@@ -24,13 +24,13 @@ namespace WolvenKit.Views.Tools
     /// <summary>
     /// Interaction logic for LogView.xaml
     /// </summary>
-    public partial class LogView
+    public partial class LogView : ReactiveUserControl<LogViewModel>
     {
         private ScrollViewer _scrollViewer;
         private bool _autoscroll = true;
 
-        public ObservableCollection<object> LogEntries { get; set; } = new();
-        
+        public ObservableCollection<LogEntry> LogEntries { get; set; } = new();
+
         public LogView()
         {
             InitializeComponent();
@@ -128,10 +128,10 @@ namespace WolvenKit.Views.Tools
 
         private void ClearAll_Click(object sender, RoutedEventArgs e) => LogEntries.Clear();
 
-        private void OpenLogFolder_Click(object sender, RoutedEventArgs e) => 
+        private void OpenLogFolder_Click(object sender, RoutedEventArgs e) =>
             Process.Start(new ProcessStartInfo(ISettingsManager.GetLogsDir()) { UseShellExecute = true });
 
-        private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e) => 
+        private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e) =>
             Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
 
         private void AutoScroll_OnChecked(object sender, RoutedEventArgs e) => _autoscroll = true;
@@ -144,7 +144,7 @@ namespace WolvenKit.Views.Tools
             {
                 return;
             }
-            
+
             Clipboard.SetText($"```{tag}```");
         }
 


### PR DESCRIPTION
# Select and run a wscript from Log dock

**Implemented:**
- [x] Add combobox to list scripts.
- [x] Format item with name, version and author (when present).
- [x] Show tooltip on item with description and usage (when present).
- [x] Group scripts by System/User.
- [x] Only list general scripts (ignore UI/Hook/Lib).
- [x] Add refresh button to update list of scripts.
- [x] Add run button to execute a selected script.
- [x] Reload selected script before running it.
- [x] Disable run button, when no script is selected.

**Additional notes:**
Closes #1932 

**Ideas:**
- Create a single endpoint (e.g. ScriptFileRepository) to keep track of script files, emit updated scripts, trigger reload w/ filesystem... It could be reused in Script Manager and in Log.

**Old demo**
![wkit_script_shortcut_wip](https://github.com/user-attachments/assets/dc7f8c8d-7cee-49cc-835d-3e9e0062ff0a)

