### PR TITLE
Remove redundant filewatcher in ScriptManagerViewModel

### DIFF
--- a/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
@@ -5,12 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
-using Splat;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Scripting;
 using WolvenKit.App.ViewModels.Shell;
-using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Modkit.Scripting;
 
@@ -25,29 +23,19 @@ public partial class ScriptManagerViewModel : DialogViewModel
     private readonly ISettingsManager _settingsManager;
     private readonly ILoggerService _loggerService;
 
-    
+
     public ScriptManagerViewModel(AppViewModel appViewModel, AppScriptService scriptService, ISettingsManager settingsManager, ILoggerService loggerService)
     {
         _appViewModel = appViewModel;
         _scriptService = scriptService;
         _settingsManager = settingsManager;
         _loggerService = loggerService;
-        
-        
 
         GetScriptFiles();
     }
 
     public ObservableCollection<ScriptViewModel> Scripts { get; } = new();
 
-    private ProjectExplorerViewModel? _projectExplorerViewModel = null;
-
-    private ProjectExplorerViewModel? GetProjectExplorerViewModel()
-    {
-        _projectExplorerViewModel ??= Locator.Current.GetService<ProjectExplorerViewModel>();
-        return _projectExplorerViewModel;
-    }
-    
     public void AddScript(string fileName, ScriptType type)
     {
         if (string.IsNullOrEmpty(fileName))
@@ -191,12 +179,9 @@ public partial class ScriptManagerViewModel : DialogViewModel
         {
             return;
         }
-
         var code = File.ReadAllText(scriptFile.Path);
 
-        GetProjectExplorerViewModel()?.SuspendFileWatcher();
         await _scriptService.ExecuteAsync(code);
-        GetProjectExplorerViewModel()?.ResumeFileWatcher();
     }
 
     public async Task DeleteFile(ScriptFileViewModel scriptFile)


### PR DESCRIPTION
# Remove redundant filewatcher in ScriptManagerViewModel

**Implemented:**
- [x] Suspend/ResumeFileWatcher is already done by AppScriptService.
- [x] Remove unused dependency ProjectExplorerViewModel.
- [x] Lint and remove unused imports.