### PR TITLE
Added settings to wscript

### DIFF
--- a/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
+++ b/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
@@ -61,7 +61,7 @@ public class DocumentViewmodelFactory : IDocumentViewmodelFactory
             _parserService, _archiveManager, _hookService, _nodeWrapperFactory, _hashService,
             _settingsManager.DefaultEditorDifficultyLevel, isReadOnly);
 
-    public WScriptDocumentViewModel WScriptDocumentViewModel(string path) => new(path, _scriptService);
+    public WScriptDocumentViewModel WScriptDocumentViewModel(string path) => new(path, _scriptService, _loggerService);
 
     public TweakXLDocumentViewModel TweakXLDocumentViewModel(string path) => new(path);
 }

--- a/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
@@ -187,15 +187,8 @@ public partial class ScriptManagerViewModel : DialogViewModel
 
     public async Task RunFile(ScriptFileViewModel scriptFile)
     {
-        if (!File.Exists(scriptFile.Path))
-        {
-            return;
-        }
-
-        var code = File.ReadAllText(scriptFile.Path);
-
         GetProjectExplorerViewModel()?.SuspendFileWatcher();
-        await _scriptService.ExecuteAsync(code);
+        await _scriptService.ExecuteAsync(scriptFile.ScriptFile);
         GetProjectExplorerViewModel()?.ResumeFileWatcher();
     }
 

--- a/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WolvenKit.Modkit.Scripting;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+public partial class ScriptSettingsDialogViewModel : DialogViewModel
+{
+    [ObservableProperty]
+    private ScriptFile _scriptFile;
+
+    [ObservableProperty]
+    private SettingsTypeDescriptor _settings;
+
+    public ScriptSettingsDialogViewModel(ScriptFile scriptFile)
+    {
+        _scriptFile = scriptFile;
+        _settings = new SettingsTypeDescriptor(scriptFile.Settings);
+    }
+
+    [RelayCommand]
+    private void Ok() => DialogHandler?.Invoke(this);
+
+    [RelayCommand]
+    private void Cancel() => DialogHandler?.Invoke(this);
+
+    public class SettingsTypeDescriptor : ICustomTypeDescriptor
+    {
+        internal Dictionary<string, SettingsEntry> _settings;
+
+        public SettingsTypeDescriptor(Dictionary<string, SettingsEntry> settingsPreset)
+        {
+            _settings = settingsPreset;
+        }
+
+        public AttributeCollection GetAttributes() => TypeDescriptor.GetAttributes(this, true);
+
+        public string? GetClassName() => TypeDescriptor.GetClassName(this, true);
+
+        public string? GetComponentName() => TypeDescriptor.GetComponentName(this, true);
+
+        public TypeConverter GetConverter() => TypeDescriptor.GetConverter(this, true);
+
+        public EventDescriptor? GetDefaultEvent() => TypeDescriptor.GetDefaultEvent(this, true);
+
+        public PropertyDescriptor? GetDefaultProperty() => TypeDescriptor.GetDefaultProperty(this, true);
+
+        public object? GetEditor(Type editorBaseType) => TypeDescriptor.GetEditor(this, editorBaseType, true);
+
+        public EventDescriptorCollection GetEvents() => TypeDescriptor.GetEvents(this, true);
+
+        public EventDescriptorCollection GetEvents(Attribute[]? attributes) => TypeDescriptor.GetEvents(this, attributes, true);
+
+        public PropertyDescriptorCollection GetProperties()
+        {
+            var modelProperties = new List<SettingsPropertyDescriptor>();
+            foreach (var (_, entry) in _settings)
+            {
+                modelProperties.Add(new SettingsPropertyDescriptor(this, entry.Name, entry.Type, []));
+            }
+
+            return new PropertyDescriptorCollection(modelProperties.ToArray());
+        }
+
+        public PropertyDescriptorCollection GetProperties(Attribute[]? attributes) => TypeDescriptor.GetProperties(this, attributes, true);
+
+        public object? GetPropertyOwner(PropertyDescriptor? pd) => pd != null ? this : null;
+    }
+
+    public class SettingsPropertyDescriptor : PropertyDescriptor
+    {
+        private readonly SettingsTypeDescriptor _typeDescriptor;
+
+        public override Type ComponentType { get; } = typeof(SettingsTypeDescriptor);
+        public override bool IsReadOnly { get; } = false;
+        public override Type PropertyType { get; }
+
+        public override string DisplayName => Name;
+
+        public SettingsPropertyDescriptor(SettingsTypeDescriptor typeDescriptor, string name, Type propertyType, Attribute[]? attrs) : base(name, attrs)
+        {
+            _typeDescriptor = typeDescriptor;
+            PropertyType = propertyType;
+        }
+
+        public override bool CanResetValue(object component) => true;
+
+        public override object? GetValue(object? component) => _typeDescriptor._settings[Name].Value;
+
+        public override void ResetValue(object component)
+        {
+        }
+
+        public override void SetValue(object? component, object? value) => _typeDescriptor._settings[Name].Value = value;
+
+        public override bool ShouldSerializeValue(object component) => false;
+    }
+}

--- a/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
@@ -9,7 +9,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Services;
 using WolvenKit.Core.Interfaces;
-using WolvenKit.Helpers;
 using WolvenKit.Modkit.Scripting;
 
 namespace WolvenKit.App.ViewModels.Documents;
@@ -17,10 +16,12 @@ namespace WolvenKit.App.ViewModels.Documents;
 public partial class WScriptDocumentViewModel : DocumentViewModel
 {
     private readonly AppScriptService _scriptService;
+    private readonly ILoggerService _loggerService;
 
-    public WScriptDocumentViewModel(string path, AppScriptService scriptService) : base(path)
+    public WScriptDocumentViewModel(string path, AppScriptService scriptService, ILoggerService loggerService) : base(path)
     {
         _scriptService = scriptService;
+        _loggerService = loggerService;
 
         Extension = "wscript";
 
@@ -67,7 +68,13 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
 
     private bool CanRun() => !_scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanRun))]
-    private async Task Run() => await _scriptService.ExecuteAsync(Text);
+    private async Task Run()
+    {
+        var scriptFile = new ScriptFile(FilePath);
+        scriptFile.Reload(_loggerService);
+
+        await _scriptService.ExecuteAsync(scriptFile);
+    }
 
     private bool CanStop() => _scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanStop))]

--- a/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
@@ -6,21 +6,22 @@ namespace WolvenKit.App.ViewModels.Scripting;
 public class ScriptFileViewModel : ScriptViewModel
 {
     private readonly ISettingsManager _settingsManager;
-    private readonly ScriptFile _scriptFile;
 
-    public string? Version => _scriptFile.Version;
-    public string? Author => _scriptFile.Author;
-    public string? Description => _scriptFile.Description;
-    public string? Usage => _scriptFile.Usage;
+    public ScriptFile ScriptFile { get; }
+
+    public string? Version => ScriptFile.Version;
+    public string? Author => ScriptFile.Author;
+    public string? Description => ScriptFile.Description;
+    public string? Usage => ScriptFile.Usage;
 
     public override bool CanExecute => Type == ScriptType.General;
     public override bool CanDelete => Source == ScriptSource.User;
 
     public ScriptFileViewModel(ISettingsManager settingsManager, ScriptSource source, ScriptFile scriptFile) : base(scriptFile.Name, scriptFile.Path, scriptFile.Type, source)
     {
-        _scriptFile = scriptFile;
         _settingsManager = settingsManager;
-
+        ScriptFile = scriptFile;
+        
         if (!_settingsManager.ScriptStatus!.TryGetValue(Path, out _enabled))
         {
             _enabled = true;

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -1,57 +1,16 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
-using Semver;
-using Microsoft.VisualBasic.FileIO;
-using WolvenKit.App.Controllers;
-using WolvenKit.App.Extensions;
-using WolvenKit.App.Factories;
-using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models;
-using WolvenKit.App.Models.Docking;
-using WolvenKit.App.Models.ProjectManagement;
-using WolvenKit.App.Models.ProjectManagement.Project;
 using WolvenKit.App.Services;
-using WolvenKit.App.ViewModels.Dialogs;
-using WolvenKit.App.ViewModels.Documents;
-using WolvenKit.App.ViewModels.Exporters;
-using WolvenKit.App.ViewModels.HomePage;
-using WolvenKit.App.ViewModels.Importers;
 using WolvenKit.App.ViewModels.Scripting;
-using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Common;
-using WolvenKit.Common.Exceptions;
-using WolvenKit.Common.Extensions;
-using WolvenKit.Common.Services;
-using WolvenKit.Core.Extensions;
-using WolvenKit.Core.Interfaces;
-using WolvenKit.Core.Services;
 using WolvenKit.Helpers;
-using WolvenKit.RED4.Archive;
-using WolvenKit.RED4.Archive.CR2W;
-using WolvenKit.RED4.Archive.IO;
-using WolvenKit.RED4.CR2W;
-using WolvenKit.RED4.Types;
-using FileSystem = Microsoft.VisualBasic.FileIO.FileSystem;
-using NativeMethods = WolvenKit.App.Helpers.NativeMethods;
 
 namespace WolvenKit.App.ViewModels.Shell;
 
@@ -86,8 +45,6 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
             return;
         }
 
-        var code = await File.ReadAllTextAsync(_fileValidationScript.Path);
-
         foreach (var (_, file) in projArchive.Files)
         {
             if (GetRedFile(file) is not { } fileViewModel)
@@ -97,7 +54,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
 
             _loggerService.Info($"Scanning {ActiveProject.GetRelativePath(file.FileName)}");
             ActiveDocument = fileViewModel;
-            await _scriptService.ExecuteAsync(code);
+            await _scriptService.ExecuteAsync(_fileValidationScript.ScriptFile);
         }
 
         // This should never happen, but better safe than sorry
@@ -194,9 +151,8 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
         File.Copy(filePath, destPath);
 
         ActiveDocument = await Open(destPath, EWolvenKitFile.WScript);
-        var code = await File.ReadAllTextAsync(_entSpawnerImportScript.Path);
 
-        await _scriptService.ExecuteAsync(code);
+        await _scriptService.ExecuteAsync(_entSpawnerImportScript.ScriptFile);
 
         ActiveDocument = null;
         try

--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -27,7 +27,7 @@ public partial class ScriptService : ObservableObject
 
     public ScriptService(ILoggerService loggerService) => _loggerService = loggerService;
 
-    public async Task ExecuteAsync(string code, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
+    public async Task ExecuteAsync(ScriptFile scriptFile, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
     {
         if (_mainEngine != null)
         {
@@ -40,10 +40,11 @@ public partial class ScriptService : ObservableObject
         var sw = Stopwatch.StartNew();
 
         _mainEngine = GetScriptEngine(hostObjects, searchPaths);
+        _mainEngine.Script["settings"] = scriptFile.Settings.ToJson();
 
         try
         {
-            await Task.Run(() => _mainEngine.Execute(new DocumentInfo { Category = ModuleCategory.Standard }, code));
+            await Task.Run(() => _mainEngine.Execute(new DocumentInfo { Category = ModuleCategory.Standard }, scriptFile.Content));
         }
         catch (ScriptEngineException ex1)
         {

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
@@ -1,0 +1,45 @@
+﻿<reactiveUi:ReactiveUserControl
+    x:Class="WolvenKit.Views.Dialogs.ScriptSettingsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactiveUi="http://reactiveui.net"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:TypeArguments="dialogs:ScriptSettingsDialogViewModel"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="40" />
+            </Grid.RowDefinitions>
+
+            <syncfusion:PropertyGrid
+                Name="SettingsGrid"
+                Width="300"
+                Height="400" />
+
+            <StackPanel
+                Grid.Row="1"
+                Margin="0,0,5,5"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <Button
+                    x:Name="OkButton"
+                    Margin="5"
+                    Padding="12,0"
+                    Background="{StaticResource WolvenKitRed}"
+                    Content="OK" />
+                <Button
+                    x:Name="CancelButton"
+                    Margin="5"
+                    Padding="12,0"
+                    Content="Cancel" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</reactiveUi:ReactiveUserControl>

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System.Reactive.Disposables;
+using ReactiveUI;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs;
+
+public partial class ScriptSettingsDialog : ReactiveUserControl<ScriptSettingsDialogViewModel>
+{
+    public ScriptSettingsDialog()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            this.Bind(ViewModel, x => x.Settings, x => x.SettingsGrid.SelectedObject)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, x => x.OkCommand, x => x.OkButton)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, x => x.CancelCommand, x => x.CancelButton)
+                .DisposeWith(disposables);
+        });
+    }
+}

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -121,9 +121,7 @@ namespace WolvenKit.Views.Documents
             _isRunning = true;
             try
             {
-                var code = await File.ReadAllTextAsync(_fileValidationScript.Path);
-
-                await _scriptService.ExecuteAsync(code);
+                await _scriptService.ExecuteAsync(_fileValidationScript.ScriptFile);
                 _loggerService.Success("File validation complete!");
             }
             catch

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -150,6 +150,9 @@
                     <DataTemplate DataType="{x:Type dialogVMs:ScriptManagerViewModel}">
                         <dialogs:ScriptManagerView ViewModel="{Binding}" />
                     </DataTemplate>
+                    <DataTemplate DataType="{x:Type dialogVMs:ScriptSettingsDialogViewModel}">
+                        <dialogs:ScriptSettingsDialog ViewModel="{Binding}" />
+                    </DataTemplate>
 
                     <Storyboard x:Key="OverlayFadeIn">
                         <DoubleAnimation


### PR DESCRIPTION
# Added settings to wscript

**Implemented:**
- WScript settings

**Notes:**
Syntax: `// @setting <varName>:<dataType>` or `// @setting <varName>:<dataType>:<defaultValue>`
Currently supports the following types: `int`, `double`, `string`, `bool`

**Example:**
```js
// @setting myStrVar:string:my def val
// @setting myIntVar:int
// @setting myDoubleVar:double
// @setting myBoolVar:bool:true

import * as Logger from 'Logger.wscript';
Logger.Info(settings);
```
