### PR TITLE
Added settings to wscript

### DIFF
--- a/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
+++ b/WolvenKit.App/Factories/DocumentViewmodelFactory.cs
@@ -61,7 +61,7 @@ public class DocumentViewmodelFactory : IDocumentViewmodelFactory
             _parserService, _archiveManager, _hookService, _nodeWrapperFactory, _hashService,
             _settingsManager.DefaultEditorDifficultyLevel, isReadOnly);
 
-    public WScriptDocumentViewModel WScriptDocumentViewModel(string path) => new(path, _scriptService);
+    public WScriptDocumentViewModel WScriptDocumentViewModel(string path) => new(path, _scriptService, _loggerService);
 
     public TweakXLDocumentViewModel TweakXLDocumentViewModel(string path) => new(path);
 }

--- a/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptManagerViewModel.cs
@@ -187,15 +187,8 @@ public partial class ScriptManagerViewModel : DialogViewModel
 
     public async Task RunFile(ScriptFileViewModel scriptFile)
     {
-        if (!File.Exists(scriptFile.Path))
-        {
-            return;
-        }
-
-        var code = File.ReadAllText(scriptFile.Path);
-
         GetProjectExplorerViewModel()?.SuspendFileWatcher();
-        await _scriptService.ExecuteAsync(code);
+        await _scriptService.ExecuteAsync(scriptFile.ScriptFile);
         GetProjectExplorerViewModel()?.ResumeFileWatcher();
     }
 

--- a/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WolvenKit.Modkit.Scripting;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+public partial class ScriptSettingsDialogViewModel : DialogViewModel
+{
+    [ObservableProperty]
+    private ScriptFile _scriptFile;
+
+    [ObservableProperty]
+    private SettingsTypeDescriptor _settings;
+
+    public ScriptSettingsDialogViewModel(ScriptFile scriptFile)
+    {
+        _scriptFile = scriptFile;
+        _settings = new SettingsTypeDescriptor(scriptFile.Settings);
+    }
+
+    [RelayCommand]
+    private void Ok() => DialogHandler?.Invoke(this);
+
+    [RelayCommand]
+    private void Cancel() => DialogHandler?.Invoke(this);
+
+    public class SettingsTypeDescriptor : ICustomTypeDescriptor
+    {
+        internal Dictionary<string, SettingsEntry> _settings;
+
+        public SettingsTypeDescriptor(Dictionary<string, SettingsEntry> settingsPreset)
+        {
+            _settings = settingsPreset;
+        }
+
+        public AttributeCollection GetAttributes() => TypeDescriptor.GetAttributes(this, true);
+
+        public string? GetClassName() => TypeDescriptor.GetClassName(this, true);
+
+        public string? GetComponentName() => TypeDescriptor.GetComponentName(this, true);
+
+        public TypeConverter GetConverter() => TypeDescriptor.GetConverter(this, true);
+
+        public EventDescriptor? GetDefaultEvent() => TypeDescriptor.GetDefaultEvent(this, true);
+
+        public PropertyDescriptor? GetDefaultProperty() => TypeDescriptor.GetDefaultProperty(this, true);
+
+        public object? GetEditor(Type editorBaseType) => TypeDescriptor.GetEditor(this, editorBaseType, true);
+
+        public EventDescriptorCollection GetEvents() => TypeDescriptor.GetEvents(this, true);
+
+        public EventDescriptorCollection GetEvents(Attribute[]? attributes) => TypeDescriptor.GetEvents(this, attributes, true);
+
+        public PropertyDescriptorCollection GetProperties()
+        {
+            var modelProperties = new List<SettingsPropertyDescriptor>();
+            foreach (var (_, entry) in _settings)
+            {
+                modelProperties.Add(new SettingsPropertyDescriptor(this, entry.Name, entry.Type, []));
+            }
+
+            return new PropertyDescriptorCollection(modelProperties.ToArray());
+        }
+
+        public PropertyDescriptorCollection GetProperties(Attribute[]? attributes) => TypeDescriptor.GetProperties(this, attributes, true);
+
+        public object? GetPropertyOwner(PropertyDescriptor? pd) => pd != null ? this : null;
+    }
+
+    public class SettingsPropertyDescriptor : PropertyDescriptor
+    {
+        private readonly SettingsTypeDescriptor _typeDescriptor;
+
+        public override Type ComponentType { get; } = typeof(SettingsTypeDescriptor);
+        public override bool IsReadOnly { get; } = false;
+        public override Type PropertyType { get; }
+
+        public override string DisplayName => Name;
+
+        public SettingsPropertyDescriptor(SettingsTypeDescriptor typeDescriptor, string name, Type propertyType, Attribute[]? attrs) : base(name, attrs)
+        {
+            _typeDescriptor = typeDescriptor;
+            PropertyType = propertyType;
+        }
+
+        public override bool CanResetValue(object component) => true;
+
+        public override object? GetValue(object? component) => _typeDescriptor._settings[Name].Value;
+
+        public override void ResetValue(object component)
+        {
+        }
+
+        public override void SetValue(object? component, object? value) => _typeDescriptor._settings[Name].Value = value;
+
+        public override bool ShouldSerializeValue(object component) => false;
+    }
+}

--- a/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ScriptSettingsDialogViewModel.cs
@@ -29,11 +29,11 @@ public partial class ScriptSettingsDialogViewModel : DialogViewModel
 
     public class SettingsTypeDescriptor : ICustomTypeDescriptor
     {
-        internal Dictionary<string, SettingsEntry> _settings;
+        public Dictionary<string, SettingsEntry> Settings;
 
         public SettingsTypeDescriptor(Dictionary<string, SettingsEntry> settingsPreset)
         {
-            _settings = settingsPreset;
+            Settings = settingsPreset;
         }
 
         public AttributeCollection GetAttributes() => TypeDescriptor.GetAttributes(this, true);
@@ -57,7 +57,7 @@ public partial class ScriptSettingsDialogViewModel : DialogViewModel
         public PropertyDescriptorCollection GetProperties()
         {
             var modelProperties = new List<SettingsPropertyDescriptor>();
-            foreach (var (_, entry) in _settings)
+            foreach (var (_, entry) in Settings)
             {
                 modelProperties.Add(new SettingsPropertyDescriptor(this, entry.Name, entry.Type, []));
             }
@@ -88,13 +88,13 @@ public partial class ScriptSettingsDialogViewModel : DialogViewModel
 
         public override bool CanResetValue(object component) => true;
 
-        public override object? GetValue(object? component) => _typeDescriptor._settings[Name].Value;
+        public override object? GetValue(object? component) => _typeDescriptor.Settings[Name].Value;
 
         public override void ResetValue(object component)
         {
         }
 
-        public override void SetValue(object? component, object? value) => _typeDescriptor._settings[Name].Value = value;
+        public override void SetValue(object? component, object? value) => _typeDescriptor.Settings[Name].Value = value;
 
         public override bool ShouldSerializeValue(object component) => false;
     }

--- a/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
@@ -9,7 +9,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Services;
 using WolvenKit.Core.Interfaces;
-using WolvenKit.Helpers;
 using WolvenKit.Modkit.Scripting;
 
 namespace WolvenKit.App.ViewModels.Documents;
@@ -17,10 +16,12 @@ namespace WolvenKit.App.ViewModels.Documents;
 public partial class WScriptDocumentViewModel : DocumentViewModel
 {
     private readonly AppScriptService _scriptService;
+    private readonly ILoggerService _loggerService;
 
-    public WScriptDocumentViewModel(string path, AppScriptService scriptService) : base(path)
+    public WScriptDocumentViewModel(string path, AppScriptService scriptService, ILoggerService loggerService) : base(path)
     {
         _scriptService = scriptService;
+        _loggerService = loggerService;
 
         Extension = "wscript";
 
@@ -67,7 +68,13 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
 
     private bool CanRun() => !_scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanRun))]
-    private async Task Run() => await _scriptService.ExecuteAsync(Text);
+    private async Task Run()
+    {
+        var scriptFile = new ScriptFile(FilePath);
+        scriptFile.Reload(_loggerService);
+
+        await _scriptService.ExecuteAsync(scriptFile);
+    }
 
     private bool CanStop() => _scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanStop))]

--- a/WolvenKit.App/ViewModels/Exporters/CallbackArguments.cs
+++ b/WolvenKit.App/ViewModels/Exporters/CallbackArguments.cs
@@ -1,5 +1,3 @@
-﻿using WolvenKit.Common.Model.Arguments;
+﻿namespace WolvenKit.App.ViewModels.Exporters;
 
-namespace WolvenKit.App.ViewModels.Exporters;
-
-public record class CallbackArguments(ImportExportArgs Arg, string PropertyName);
+public record class CallbackArguments(object Arg, string PropertyName);

--- a/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Scripting/ScriptFileViewModel.cs
@@ -6,21 +6,22 @@ namespace WolvenKit.App.ViewModels.Scripting;
 public class ScriptFileViewModel : ScriptViewModel
 {
     private readonly ISettingsManager _settingsManager;
-    private readonly ScriptFile _scriptFile;
 
-    public string? Version => _scriptFile.Version;
-    public string? Author => _scriptFile.Author;
-    public string? Description => _scriptFile.Description;
-    public string? Usage => _scriptFile.Usage;
+    public ScriptFile ScriptFile { get; }
+
+    public string? Version => ScriptFile.Version;
+    public string? Author => ScriptFile.Author;
+    public string? Description => ScriptFile.Description;
+    public string? Usage => ScriptFile.Usage;
 
     public override bool CanExecute => Type == ScriptType.General;
     public override bool CanDelete => Source == ScriptSource.User;
 
     public ScriptFileViewModel(ISettingsManager settingsManager, ScriptSource source, ScriptFile scriptFile) : base(scriptFile.Name, scriptFile.Path, scriptFile.Type, source)
     {
-        _scriptFile = scriptFile;
         _settingsManager = settingsManager;
-
+        ScriptFile = scriptFile;
+        
         if (!_settingsManager.ScriptStatus!.TryGetValue(Path, out _enabled))
         {
             _enabled = true;

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -1,57 +1,16 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
-using Semver;
-using Microsoft.VisualBasic.FileIO;
-using WolvenKit.App.Controllers;
-using WolvenKit.App.Extensions;
-using WolvenKit.App.Factories;
-using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models;
-using WolvenKit.App.Models.Docking;
-using WolvenKit.App.Models.ProjectManagement;
-using WolvenKit.App.Models.ProjectManagement.Project;
 using WolvenKit.App.Services;
-using WolvenKit.App.ViewModels.Dialogs;
-using WolvenKit.App.ViewModels.Documents;
-using WolvenKit.App.ViewModels.Exporters;
-using WolvenKit.App.ViewModels.HomePage;
-using WolvenKit.App.ViewModels.Importers;
 using WolvenKit.App.ViewModels.Scripting;
-using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Common;
-using WolvenKit.Common.Exceptions;
-using WolvenKit.Common.Extensions;
-using WolvenKit.Common.Services;
-using WolvenKit.Core.Extensions;
-using WolvenKit.Core.Interfaces;
-using WolvenKit.Core.Services;
 using WolvenKit.Helpers;
-using WolvenKit.RED4.Archive;
-using WolvenKit.RED4.Archive.CR2W;
-using WolvenKit.RED4.Archive.IO;
-using WolvenKit.RED4.CR2W;
-using WolvenKit.RED4.Types;
-using FileSystem = Microsoft.VisualBasic.FileIO.FileSystem;
-using NativeMethods = WolvenKit.App.Helpers.NativeMethods;
 
 namespace WolvenKit.App.ViewModels.Shell;
 
@@ -86,8 +45,6 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
             return;
         }
 
-        var code = await File.ReadAllTextAsync(_fileValidationScript.Path);
-
         foreach (var (_, file) in projArchive.Files)
         {
             if (GetRedFile(file) is not { } fileViewModel)
@@ -97,7 +54,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
 
             _loggerService.Info($"Scanning {ActiveProject.GetRelativePath(file.FileName)}");
             ActiveDocument = fileViewModel;
-            await _scriptService.ExecuteAsync(code);
+            await _scriptService.ExecuteAsync(_fileValidationScript.ScriptFile);
         }
 
         // This should never happen, but better safe than sorry
@@ -194,9 +151,8 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
         File.Copy(filePath, destPath);
 
         ActiveDocument = await Open(destPath, EWolvenKitFile.WScript);
-        var code = await File.ReadAllTextAsync(_entSpawnerImportScript.Path);
 
-        await _scriptService.ExecuteAsync(code);
+        await _scriptService.ExecuteAsync(_entSpawnerImportScript.ScriptFile);
 
         ActiveDocument = null;
         try

--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -27,7 +27,7 @@ public partial class ScriptService : ObservableObject
 
     public ScriptService(ILoggerService loggerService) => _loggerService = loggerService;
 
-    public async Task ExecuteAsync(string code, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
+    public async Task ExecuteAsync(ScriptFile scriptFile, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
     {
         if (_mainEngine != null)
         {
@@ -40,10 +40,11 @@ public partial class ScriptService : ObservableObject
         var sw = Stopwatch.StartNew();
 
         _mainEngine = GetScriptEngine(hostObjects, searchPaths);
+        _mainEngine.Script["settings"] = scriptFile.Settings.ToJson();
 
         try
         {
-            await Task.Run(() => _mainEngine.Execute(new DocumentInfo { Category = ModuleCategory.Standard }, code));
+            await Task.Run(() => _mainEngine.Execute(new DocumentInfo { Category = ModuleCategory.Standard }, scriptFile.Content));
         }
         catch (ScriptEngineException ex1)
         {

--- a/WolvenKit/Converters/ValueToDoubleConverter.cs
+++ b/WolvenKit/Converters/ValueToDoubleConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace WolvenKit.Converters;
+
+public class ValueToDoubleConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is int iValue)
+        {
+            return (double)iValue;
+        }
+
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value;
+}

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
@@ -1,0 +1,45 @@
+﻿<reactiveUi:ReactiveUserControl
+    x:Class="WolvenKit.Views.Dialogs.ScriptSettingsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactiveUi="http://reactiveui.net"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:TypeArguments="dialogs:ScriptSettingsDialogViewModel"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="40" />
+            </Grid.RowDefinitions>
+
+            <syncfusion:PropertyGrid
+                Name="SettingsGrid"
+                Width="300"
+                Height="400" />
+
+            <StackPanel
+                Grid.Row="1"
+                Margin="0,0,5,5"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <Button
+                    x:Name="OkButton"
+                    Margin="5"
+                    Padding="12,0"
+                    Background="{StaticResource WolvenKitRed}"
+                    Content="OK" />
+                <Button
+                    x:Name="CancelButton"
+                    Margin="5"
+                    Padding="12,0"
+                    Content="Cancel" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</reactiveUi:ReactiveUserControl>

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    x:Name="uc"
     d:DesignHeight="450"
     d:DesignWidth="800"
     x:TypeArguments="dialogs:ScriptSettingsDialogViewModel"
@@ -18,10 +19,22 @@
                 <RowDefinition Height="40" />
             </Grid.RowDefinitions>
 
+            <Grid.Resources>
+                <Style BasedOn="{StaticResource {x:Type syncfusion:DoubleTextBox}}" TargetType="syncfusion:DoubleTextBox">
+                    <Setter Property="Culture" Value="en-us" />
+                </Style>
+            </Grid.Resources>
+
             <syncfusion:PropertyGrid
                 Name="SettingsGrid"
-                Width="300"
-                Height="400" />
+                Width="600"
+                Height="400"
+                AutoGeneratingPropertyGridItem="SettingsGrid_OnAutoGeneratingPropertyGridItem"
+                ButtonPanelVisibility="Hidden"
+                DescriptionPanelVisibility="Visible"
+                PropertyExpandMode="NestedMode"
+                SearchBoxVisibility="Hidden"
+                SortDirection="{x:Null}" />
 
             <StackPanel
                 Grid.Row="1"

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
@@ -1,6 +1,12 @@
-﻿using System.Reactive.Disposables;
+﻿using System.Collections;
+using System.Reactive.Disposables;
+using System.Threading.Tasks;
 using ReactiveUI;
+using Syncfusion.Windows.PropertyGrid;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.App.ViewModels.Exporters;
+using WolvenKit.Views.Dialogs.Windows;
+using WolvenKit.Views.Exporters;
 
 namespace WolvenKit.Views.Dialogs;
 
@@ -21,5 +27,38 @@ public partial class ScriptSettingsDialog : ReactiveUserControl<ScriptSettingsDi
             this.BindCommand(ViewModel, x => x.CancelCommand, x => x.CancelButton)
                 .DisposeWith(disposables);
         });
+    }
+
+    private void SettingsGrid_OnAutoGeneratingPropertyGridItem(object sender, AutoGeneratingPropertyGridItemEventArgs e)
+    {
+        if (e.OriginalSource is not PropertyItem propertyItem ||
+            sender is not PropertyGrid { SelectedObject: { } args } propertyGrid)
+        {
+            return;
+        }
+
+        if (propertyItem.PropertyType.IsAssignableTo(typeof(IList)))
+        {
+            propertyItem.Editor = new CustomCollectionEditor(InitCollectionEditor, new CallbackArguments(args, propertyItem.DisplayName));
+        }
+    }
+
+    private Task InitCollectionEditor(CallbackArguments args)
+    {
+        if (args.Arg is not ScriptSettingsDialogViewModel.SettingsTypeDescriptor typeDescriptor)
+        {
+            return Task.CompletedTask;
+        }
+
+        var list = typeDescriptor.Settings[args.PropertyName];
+
+        var collectionEditorView = new CollectionEditorView((IList)list.Value, list.InnerType);
+        if (collectionEditorView.ShowDialog() == true)
+        {
+            typeDescriptor.Settings[args.PropertyName].Value = collectionEditorView.ResultList;
+        }
+
+        SettingsGrid.RefreshPropertygrid();
+        return Task.CompletedTask;
     }
 }

--- a/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/ScriptSettingsDialog.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System.Reactive.Disposables;
+using ReactiveUI;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs;
+
+public partial class ScriptSettingsDialog : ReactiveUserControl<ScriptSettingsDialogViewModel>
+{
+    public ScriptSettingsDialog()
+    {
+        InitializeComponent();
+
+        this.WhenActivated(disposables =>
+        {
+            this.Bind(ViewModel, x => x.Settings, x => x.SettingsGrid.SelectedObject)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, x => x.OkCommand, x => x.OkButton)
+                .DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, x => x.CancelCommand, x => x.CancelButton)
+                .DisposeWith(disposables);
+        });
+    }
+}

--- a/WolvenKit/Views/Dialogs/Windows/CollectionEditorView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/CollectionEditorView.xaml
@@ -1,0 +1,148 @@
+﻿<Window
+    x:Class="WolvenKit.Views.Dialogs.Windows.CollectionEditorView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:WolvenKit.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:WolvenKit.Views.Dialogs.Windows"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    Title="CollectionEditorView"
+    Width="800"
+    Height="450"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="20" />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="40" />
+        </Grid.RowDefinitions>
+
+        <Grid.Resources>
+            <converters:ValueToDoubleConverter x:Key="ValueToDoubleConverter" />
+
+            <local:CollectionEditorViewTemplateSelector x:Key="ControlDataTemplateSelector">
+                <local:CollectionEditorViewTemplateSelector.TextTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="20" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBox Grid.Column="0" Text="{Binding Value}" />
+                            <Button
+                                Grid.Column="1"
+                                Click="Remove_OnClick"
+                                Content="-" />
+                        </Grid>
+                    </DataTemplate>
+                </local:CollectionEditorViewTemplateSelector.TextTemplate>
+                <local:CollectionEditorViewTemplateSelector.IntTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="20" />
+                            </Grid.ColumnDefinitions>
+
+                            <syncfusion:DoubleTextBox
+                                Grid.Column="0"
+                                Culture="en-us"
+                                NumberDecimalDigits="0"
+                                Value="{Binding Value, Converter={StaticResource ValueToDoubleConverter}, ConverterParameter=Int32}" />
+                            <Button
+                                Grid.Column="1"
+                                Click="Remove_OnClick"
+                                Content="-" />
+                        </Grid>
+                    </DataTemplate>
+                </local:CollectionEditorViewTemplateSelector.IntTemplate>
+                <local:CollectionEditorViewTemplateSelector.DoubleTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="20" />
+                            </Grid.ColumnDefinitions>
+
+                            <syncfusion:DoubleTextBox
+                                Grid.Column="0"
+                                Culture="en-us"
+                                Value="{Binding Value}" />
+                            <Button
+                                Grid.Column="1"
+                                Click="Remove_OnClick"
+                                Content="-" />
+                        </Grid>
+                    </DataTemplate>
+                </local:CollectionEditorViewTemplateSelector.DoubleTemplate>
+                <local:CollectionEditorViewTemplateSelector.BoolTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="20" />
+                            </Grid.ColumnDefinitions>
+
+                            <CheckBox Grid.Column="0" IsChecked="{Binding Value}" />
+                            <Button
+                                Grid.Column="1"
+                                Click="Remove_OnClick"
+                                Content="-" />
+                        </Grid>
+                    </DataTemplate>
+                </local:CollectionEditorViewTemplateSelector.BoolTemplate>
+            </local:CollectionEditorViewTemplateSelector>
+        </Grid.Resources>
+
+        <ListView
+            x:Name="ListView"
+            Grid.Row="0"
+            ItemTemplateSelector="{StaticResource ControlDataTemplateSelector}">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+        </ListView>
+
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="1"
+            Margin="0,0,5,5"
+            Orientation="Vertical">
+            <Button
+                x:Name="AddButton"
+                Padding="0,6"
+                Click="AddButton_OnClick"
+                Content="+" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="0,0,5,5"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button
+                x:Name="OkButton"
+                Margin="5"
+                Padding="12,0"
+                Background="{StaticResource WolvenKitRed}"
+                Click="OkButton_Click"
+                Content="OK" />
+            <Button
+                x:Name="CancelButton"
+                Margin="5"
+                Padding="12,0"
+                Click="CancelButton_OnClick"
+                Content="Cancel" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/WolvenKit/Views/Dialogs/Windows/CollectionEditorView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/CollectionEditorView.xaml.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WolvenKit.Views.Dialogs.Windows;
+/// <summary>
+/// Interaktionslogik für CollectionEditorView.xaml
+/// </summary>
+public partial class CollectionEditorView : Window
+{
+    private readonly Type _type;
+
+    public List<object> ResultList { get; } = [];
+
+    public CollectionEditorView(IList items, Type type)
+    {
+        InitializeComponent();
+
+        _type = type;
+
+        foreach (var item in items)
+        {
+            ListView.Items.Add(new ValueWrapper(item));
+        }
+    }
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        foreach (var item in ListView.Items)
+        {
+            if (item is not ValueWrapper valueWrapper)
+            {
+                continue;
+            }
+
+            valueWrapper.Convert();
+            ResultList.Add(valueWrapper.Value);
+        }
+
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+
+    private void AddButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        ListView.Items.Add(new ValueWrapper(GetDefault(), _type));
+    }
+
+    private object GetDefault()
+    {
+        if (_type.IsValueType)
+        {
+            return Activator.CreateInstance(_type);
+        }
+
+        if (_type == typeof(string))
+        {
+            return string.Empty;
+        }
+
+        return null;
+    }
+
+    private void Remove_OnClick(object sender, RoutedEventArgs e)
+    {
+        var btn = (Button)sender;
+
+        ListView.Items.Remove(btn.DataContext);
+    }
+
+    public class ValueWrapper
+    {
+        public object Value { get; set; }
+        public Type TargetType { get; }
+
+        public bool IsTargetType => TargetType == Value.GetType();
+
+        public ValueWrapper(object value)
+        {
+            Value = value;
+            TargetType = value.GetType();
+        }
+
+        public ValueWrapper(object value, Type type)
+        {
+            Value = value;
+            TargetType = type;
+        }
+
+        public bool Convert()
+        {
+            if (IsTargetType)
+            {
+                return true;
+            }
+
+            if (Value.GetType() != typeof(string))
+            {
+                Value = Value.ToString();
+            }
+
+            if (TargetType == typeof(int))
+            {
+                if (!int.TryParse((string)Value, out var tmpVal))
+                {
+                    return false;
+                }
+
+                Value = tmpVal;
+                return true;
+            }
+
+            if (TargetType == typeof(double))
+            {
+                if (!double.TryParse((string)Value, CultureInfo.InvariantCulture, out var tmpVal))
+                {
+                    return false;
+                }
+
+                Value = tmpVal;
+                return true;
+            }
+
+            if (TargetType == typeof(bool))
+            {
+                if (!bool.TryParse((string)Value, out var tmpVal))
+                {
+                    return false;
+                }
+
+                Value = tmpVal;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/WolvenKit/Views/Dialogs/Windows/CollectionEditorViewTemplateSelector.cs
+++ b/WolvenKit/Views/Dialogs/Windows/CollectionEditorViewTemplateSelector.cs
@@ -1,0 +1,43 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using static WolvenKit.Views.Dialogs.Windows.CollectionEditorView;
+
+namespace WolvenKit.Views.Dialogs.Windows;
+
+public class CollectionEditorViewTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate TextTemplate { get; set; }
+    public DataTemplate IntTemplate { get; set; }
+    public DataTemplate DoubleTemplate { get; set; }
+    public DataTemplate BoolTemplate { get; set; }
+
+    public override DataTemplate SelectTemplate(object item, DependencyObject container)
+    {
+        if (item is not ValueWrapper valueWrapper)
+        {
+            return base.SelectTemplate(item, container);
+        }
+
+        if (valueWrapper.TargetType == typeof(string))
+        {
+            return TextTemplate;
+        }
+
+        if (valueWrapper.TargetType == typeof(int))
+        {
+            return IntTemplate;
+        }
+
+        if (valueWrapper.TargetType == typeof(double))
+        {
+            return DoubleTemplate;
+        }
+
+        if (valueWrapper.TargetType == typeof(bool))
+        {
+            return BoolTemplate;
+        }
+
+        return TextTemplate;
+    }
+}

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -121,9 +121,7 @@ namespace WolvenKit.Views.Documents
             _isRunning = true;
             try
             {
-                var code = await File.ReadAllTextAsync(_fileValidationScript.Path);
-
-                await _scriptService.ExecuteAsync(code);
+                await _scriptService.ExecuteAsync(_fileValidationScript.ScriptFile);
                 _loggerService.Success("File validation complete!");
             }
             catch

--- a/WolvenKit/Views/Exporters/CustomCollectionEditor.cs
+++ b/WolvenKit/Views/Exporters/CustomCollectionEditor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.ComponentModel;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -8,13 +7,11 @@ using System.Windows.Data;
 using System.Windows.Input;
 using Syncfusion.Windows.PropertyGrid;
 using WolvenKit.App.ViewModels.Exporters;
-using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Controls;
-using WolvenKit.RED4.Types;
 
 namespace WolvenKit.Views.Exporters;
 
-public class CustomCollectionEditor : ITypeEditor
+public class CustomCollectionEditor : BaseTypeEditor
 {
     protected CustomCollectionEditorView _wrappedControl;
 
@@ -27,15 +24,21 @@ public class CustomCollectionEditor : ITypeEditor
         _args = args;
     }
 
-    public object Create(PropertyInfo propertyInfo)
+    public override object Create(PropertyInfo propertyInfo)
     {
         _wrappedControl = new CustomCollectionEditorView(_callback, _args);
         return _wrappedControl;
     }
-    public object Create(PropertyDescriptor PropertyDescriptor) => throw new NotImplementedException();
-    public bool ShouldPropertyGridTryToHandleKeyDown(Key key) => true;
 
-    public void Attach(PropertyViewItem property, PropertyItem info)
+    public override object Create(PropertyDescriptor PropertyDescriptor)
+    {
+        _wrappedControl = new CustomCollectionEditorView(_callback, _args);
+        return _wrappedControl;
+    }
+
+    public override bool ShouldPropertyGridTryToHandleKeyDown(Key key) => true;
+
+    public override void Attach(PropertyViewItem property, PropertyItem info)
     {
         if (info.CanWrite)
         {
@@ -61,5 +64,5 @@ public class CustomCollectionEditor : ITypeEditor
         }
     }
 
-    public void Detach(PropertyViewItem property) => _wrappedControl = null;
+    public override void Detach(PropertyViewItem property) => _wrappedControl = null;
 }

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -150,6 +150,9 @@
                     <DataTemplate DataType="{x:Type dialogVMs:ScriptManagerViewModel}">
                         <dialogs:ScriptManagerView ViewModel="{Binding}" />
                     </DataTemplate>
+                    <DataTemplate DataType="{x:Type dialogVMs:ScriptSettingsDialogViewModel}">
+                        <dialogs:ScriptSettingsDialog ViewModel="{Binding}" />
+                    </DataTemplate>
 
                     <Storyboard x:Key="OverlayFadeIn">
                         <DoubleAnimation

--- a/WolvenKit/Views/Templates/CustomCollectionEditorView.xaml.cs
+++ b/WolvenKit/Views/Templates/CustomCollectionEditorView.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
 using WolvenKit.App.ViewModels.Exporters;
@@ -30,7 +29,14 @@ namespace WolvenKit.Controls
             set => SetValue(ListProperty, value);
         }
         public static readonly DependencyProperty ListProperty = DependencyProperty.Register(
-            nameof(List), typeof(IList), typeof(CustomCollectionEditorView), new PropertyMetadata(null));
+            nameof(List), typeof(IList), typeof(CustomCollectionEditorView), new PropertyMetadata(null, OnListChanged));
+
+        private static void OnListChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var view = (CustomCollectionEditorView)d;
+
+            view.SetText();
+        }
 
         public string Text
         {
@@ -50,9 +56,10 @@ namespace WolvenKit.Controls
 
         private void SetText()
         {
+            var text = "Null";
             if (List is not null)
             {
-                var text = $"[{List.Count}]";
+                text = $"[{List.Count}] ";
                 if (List.Count == 1)
                 {
                     text += $"{List[0]}";
@@ -61,9 +68,8 @@ namespace WolvenKit.Controls
                 {
                     text += $"{List[0]}, ...";
                 }
-
-                SetCurrentValue(TextProperty, text);
             }
+            SetCurrentValue(TextProperty, text);
         }
     }
 }


### PR DESCRIPTION
# Added settings to wscript

**Implemented:**
- WScript settings

**Notes:**
Syntax: `// @setting <varName>:<dataType>` or `// @setting <varName>:<dataType>:<defaultValue>`
Currently supports the following types: `int`, `double`, `string`, `bool` + array `[]` variants

**Example:**
```js
// @setting myIntVar:int
// @setting myIntArrayVar:int[]

// @setting myDoubleVar:double
// @setting myDoubleArrayVar:double[]:1.0,2.5,5.9

// @setting myStringVar:string:"abc"
// @setting myStringArrayVar:string[]:"abc","def","123"

// @setting myBoolVar:bool:true
// @setting myBoolArrayVar:bool[]:true,false,true,true

import * as Logger from 'Logger.wscript';
Logger.Info(settings);
```
