### PR TITLE
Logs a nice message when interrupting a wscript

### DIFF
--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -51,7 +51,15 @@ public partial class ScriptService : ObservableObject
         }
         catch (Exception ex2)
         {
-            _loggerService?.Error(ex2);
+            if (ex2.Message == "Script execution interrupted by host" ||
+                ex2.Message == "Script execution was interrupted")
+            {
+                _loggerService?.Info("User interrupted execution of script");
+            }
+            else
+            {
+                _loggerService?.Error(ex2);
+            }
         }
 
         if (_mainEngine != null)


### PR DESCRIPTION
# Logs a nice message when interrupting a wscript

**Implemented:**
- Catches exception when script engine interrupts execution.
- Shows a nice log instead of an exception's stacktrace:
> User interrupted execution of script

![image](https://github.com/user-attachments/assets/ea4ead7f-3d58-4c9d-ab92-4827ac627967)