### PR TITLE
Added buttons to filter logs by level

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/LogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/LogViewModel.cs
@@ -39,6 +39,8 @@ public partial class LogViewModel : ToolViewModel
 
     // private readonly ReadOnlyObservableCollection<LogEntry> _logEntries;
     // public ReadOnlyObservableCollection<LogEntry> LogEntries => _logEntries;
+    [ObservableProperty]
+    private bool[] _filterByLevel = { true, true, true, true, true };
 
     private readonly ObservableCollection<ScriptFileViewModel> _scriptFiles = new();
     public CollectionViewSource ScriptFiles { get; } = new();
@@ -80,6 +82,27 @@ public partial class LogViewModel : ToolViewModel
         //     .ObserveOn(RxApp.MainThreadScheduler)
         //     .Bind(out _logEntries)
         //     .Subscribe(OnNext);
+    }
+
+    [RelayCommand]
+    private void ToggleFilterLevel(string index)
+    {
+        if (!int.TryParse(index, out var level))
+        {
+            level = -1;
+        }
+        if (level < 0 || level >= FilterByLevel.Length)
+        {
+            return;
+        }
+        var copy = (bool[])FilterByLevel.Clone();
+
+        copy[level] = !copy[level];
+        if (copy.All(value => !value))
+        {
+            return;
+        }
+        FilterByLevel = copy;
     }
 
     [RelayCommand]

--- a/WolvenKit/Views/Tools/LogView.xaml
+++ b/WolvenKit/Views/Tools/LogView.xaml
@@ -43,108 +43,200 @@
             <converters:NullVisibilityConverter x:Key="NullVisibilityConverter" />
         </Grid.Resources>
 
-        <Grid x:Name="ScriptShortcutGrid"
-              Grid.Row="0"
-              Grid.Column="0">
+        <Grid
+            x:Name="LogViewHeader"
+            Grid.Row="0"
+            Grid.Column="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" MinWidth="240" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="5" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Button
-                x:Name="UpdateButton"
+            <Grid.Resources>
+                <Style x:Key="LogLevelButtonStyle"
+                       TargetType="{x:Type Button}"
+                       BasedOn="{StaticResource WPFButtonStyle}">
+                    <Setter Property="Focusable" Value="False" />
+                    <Setter Property="Margin" Value="0,0,4,0" />
+                    <Setter Property="Padding" Value="6" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="0" />
+
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#10FFFFFF" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Resources>
+
+            <StackPanel
+                x:Name="LogLevelFilter"
                 Grid.Column="0"
-                Margin="0,0,4,0"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                ToolTip="Update scripts"
-                Command="{Binding UpdateScriptsCommand}">
-                <iconPacks:PackIconMaterial
-                    Foreground="White"
-                    Kind="Refresh" />
-            </Button>
+                Margin="4,0,0,0"
+                Orientation="Horizontal"
+                VerticalAlignment="Center">
+                <Button
+                    x:Name="FilterErrorButton"
+                    Style="{StaticResource LogLevelButtonStyle}"
+                    Command="{Binding ToggleFilterLevelCommand}"
+                    CommandParameter="0"
+                    ToolTip="Error">
+                    <iconPacks:PackIconMaterial
+                        Kind="AlphaEBox"
+                        Foreground="{StaticResource WolvenKitRed}" />
+                </Button>
 
-            <ComboBox
-                x:Name="ScriptFileComboBox"
-                Grid.Column="1"
-                Margin="0,0,4,4"
-                ToolTip="Select script"
-                IsEditable="False"
-                IsReadOnly="True"
-                ItemsSource="{Binding ScriptFiles.View}"
-                SelectedItem="{Binding SelectedScriptFile}">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Vertical"
-                                    ToolTip="{Binding HoverInfo}">
-                            <TextBlock Text="{Binding Name}" />
-                            <TextBlock x:Name="Info"
-                                       Text="{Binding SelectInfo}" />
-                        </StackPanel>
+                <Button
+                    x:Name="FilterWarningButton"
+                    Style="{StaticResource LogLevelButtonStyle}"
+                    Command="{Binding ToggleFilterLevelCommand}"
+                    CommandParameter="1"
+                    ToolTip="Warning">
+                    <iconPacks:PackIconMaterial
+                        Kind="AlphaWBox"
+                        Foreground="{StaticResource WolvenKitYellow}" />
+                </Button>
 
-                        <DataTemplate.Triggers>
-                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBoxItem}}"
-                                         Value="{x:Null}">
-                                <Setter TargetName="Info"
-                                        Property="Visibility"
-                                        Value="Collapsed" />
-                            </DataTrigger>
-                        </DataTemplate.Triggers>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-                
-                <ComboBox.GroupStyle>
-                    <GroupStyle>
-                        <GroupStyle.HeaderTemplate>
-                            <DataTemplate>
-                                <Border BorderBrush="White"
-                                        BorderThickness="0,0,0,1"
-                                        Padding="15,0,0,7">
-                                    <StackPanel Orientation="Vertical">
-                                        <TextBlock Text="{Binding Name}"
-                                                   FontSize="14" />
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </GroupStyle.HeaderTemplate>
-                    </GroupStyle>
-                </ComboBox.GroupStyle>
-            </ComboBox>
+                <Button
+                    x:Name="FilterSuccessButton"
+                    Style="{StaticResource LogLevelButtonStyle}"
+                    Command="{Binding ToggleFilterLevelCommand}"
+                    CommandParameter="2"
+                    ToolTip="Success">
+                    <iconPacks:PackIconMaterial
+                        Kind="AlphaSBox"
+                        Foreground="{StaticResource WolvenKitGreen}" />
+                </Button>
 
-            <Button
-                x:Name="RunButton"
+                <Button
+                    x:Name="FilterInfoButton"
+                    Style="{StaticResource LogLevelButtonStyle}"
+                    Command="{Binding ToggleFilterLevelCommand}"
+                    CommandParameter="3"
+                    ToolTip="Normal / Important">
+                    <iconPacks:PackIconMaterial
+                        Kind="AlphaIBox"
+                        Foreground="White" />
+                </Button>
+
+                <Button
+                    Margin="0"
+                    x:Name="FilterDebugButton"
+                    Style="{StaticResource LogLevelButtonStyle}"
+                    Command="{Binding ToggleFilterLevelCommand}"
+                    CommandParameter="4"
+                    ToolTip="Debug">
+                    <iconPacks:PackIconMaterial
+                        Kind="AlphaDBox"
+                        Foreground="{StaticResource WolvenKitPurple}" />
+                </Button>
+            </StackPanel>
+            
+            <Grid
+                x:Name="ScriptShortcutGrid"
                 Grid.Column="2"
-                Margin="0,0,4,0"
-                VerticalAlignment="Top"
-                ToolTip="Reload and run"
-                Command="{Binding RunScriptCommand}"
-                IsEnabled="{Binding CanRunScript}"
-                Visibility="{Binding IsRunningScript, Converter={StaticResource InvertBooleanVisibilityConverter}}">
-                <iconPacks:PackIconMaterial
-                    Foreground="Green"
-                    Kind="Play" />
-            </Button>
+                HorizontalAlignment="Right">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" MinWidth="240" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-            <Button
-                x:Name="StopButton"
-                Grid.Column="3"
-                Margin="0,0,4,0"
-                VerticalAlignment="Top"
-                ToolTip="Stop running script"
-                Command="{Binding StopScriptCommand}"
-                Visibility="{Binding IsRunningScript, Converter={StaticResource BooleanVisibilityConverter}}">
-                <iconPacks:PackIconMaterial
-                    Foreground="{StaticResource WolvenKitRed}"
-                    Kind="Stop" />
-            </Button>
+                <Button
+                    x:Name="UpdateButton"
+                    Grid.Column="0"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Top"
+                    ToolTip="Update scripts"
+                    Command="{Binding UpdateScriptsCommand}">
+                    <iconPacks:PackIconMaterial
+                        Foreground="White"
+                        Kind="Refresh" />
+                </Button>
+
+                <ComboBox
+                    x:Name="ScriptFileComboBox"
+                    Grid.Column="1"
+                    Margin="0,0,4,4"
+                    ToolTip="Select script"
+                    IsEditable="False"
+                    IsReadOnly="True"
+                    ItemsSource="{Binding ScriptFiles.View}"
+                    SelectedItem="{Binding SelectedScriptFile}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Vertical"
+                                        ToolTip="{Binding HoverInfo}">
+                                <TextBlock Text="{Binding Name}" />
+                                <TextBlock x:Name="Info"
+                                           Text="{Binding SelectInfo}" />
+                            </StackPanel>
+
+                            <DataTemplate.Triggers>
+                                <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBoxItem}}"
+                                             Value="{x:Null}">
+                                    <Setter TargetName="Info"
+                                            Property="Visibility"
+                                            Value="Collapsed" />
+                                </DataTrigger>
+                            </DataTemplate.Triggers>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+
+                    <ComboBox.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <Border BorderBrush="White"
+                                            BorderThickness="0,0,0,1"
+                                            Padding="15,0,0,7">
+                                        <StackPanel Orientation="Vertical">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontSize="14" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ComboBox.GroupStyle>
+                </ComboBox>
+
+                <Button
+                    x:Name="RunButton"
+                    Grid.Column="2"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Top"
+                    ToolTip="Reload and run"
+                    Command="{Binding RunScriptCommand}"
+                    IsEnabled="{Binding CanRunScript}"
+                    Visibility="{Binding IsRunningScript, Converter={StaticResource InvertBooleanVisibilityConverter}}">
+                    <iconPacks:PackIconMaterial
+                        Foreground="Green"
+                        Kind="Play" />
+                </Button>
+
+                <Button
+                    x:Name="StopButton"
+                    Grid.Column="3"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Top"
+                    ToolTip="Stop running script"
+                    Command="{Binding StopScriptCommand}"
+                    Visibility="{Binding IsRunningScript, Converter={StaticResource BooleanVisibilityConverter}}">
+                    <iconPacks:PackIconMaterial
+                        Foreground="{StaticResource WolvenKitRed}"
+                        Kind="Stop" />
+                </Button>
+            </Grid>
         </Grid>
 
         <ItemsControl
             Grid.Row="1"
             Grid.Column="0"
-            ItemsSource="{Binding ElementName=uc, Path=LogEntries}"
+            ItemsSource="{Binding ElementName=uc, Path=FilteredLogEntries}"
             ScrollViewer.CanContentScroll="True"
             VirtualizingPanel.ScrollUnit="Pixel"
             KeyUp="LogView_OnKeyUp"

--- a/WolvenKit/Views/Tools/LogView.xaml.cs
+++ b/WolvenKit/Views/Tools/LogView.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -8,6 +10,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Navigation;
 using DynamicData;
+using HandyControl.Tools.Extension;
 using ReactiveUI;
 using Serilog.Events;
 using Splat;
@@ -19,7 +22,7 @@ using WolvenKit.Helpers;
 
 namespace WolvenKit.Views.Tools
 {
-    public record LogEntry(string Message, Uri Uri, Brush TextColor);
+    public record LogEntry(Logtype Level, string Message, Uri Uri, Brush TextColor);
 
     /// <summary>
     /// Interaction logic for LogView.xaml
@@ -30,6 +33,7 @@ namespace WolvenKit.Views.Tools
         private bool _autoscroll = true;
 
         public ObservableCollection<LogEntry> LogEntries { get; set; } = new();
+        public ObservableCollection<LogEntry> FilteredLogEntries { get; set; } = new();
 
         public LogView()
         {
@@ -38,12 +42,57 @@ namespace WolvenKit.Views.Tools
             ViewModel = Locator.Current.GetService<LogViewModel>();
             DataContext = ViewModel;
 
+            LogEntries.CollectionChanged += LogEntries_CollectionChanged;
+
             var sink = Locator.Current.GetService<MySink>();
             _ = sink.Connect()
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Bind(out var _)
                 .DisposeMany()
                 .Subscribe(OnNext);
+
+            this.WhenActivated(disposables =>
+            {
+                this.OneWayBind(ViewModel, vm => vm.FilterByLevel, v => v.FilterErrorButton.Opacity, level => level[0] ? 1.0 : 0.33)
+                    .DisposeWith(disposables);
+                this.OneWayBind(ViewModel, vm => vm.FilterByLevel, v => v.FilterWarningButton.Opacity, level => level[1] ? 1.0 : 0.33)
+                    .DisposeWith(disposables);
+                this.OneWayBind(ViewModel, vm => vm.FilterByLevel, v => v.FilterSuccessButton.Opacity, level => level[2] ? 1.0 : 0.33)
+                    .DisposeWith(disposables);
+                this.OneWayBind(ViewModel, vm => vm.FilterByLevel, v => v.FilterInfoButton.Opacity, level => level[3] ? 1.0 : 0.33)
+                    .DisposeWith(disposables);
+                this.OneWayBind(ViewModel, vm => vm.FilterByLevel, v => v.FilterDebugButton.Opacity, level => level[4] ? 1.0 : 0.33)
+                    .DisposeWith(disposables);
+                this.WhenAnyValue(v => v.ViewModel.FilterByLevel)
+                    .Subscribe(_ => LogEntries_CollectionChanged(null, null))
+                    .DisposeWith(disposables);
+            });
+        }
+
+        private void LogEntries_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            var filtered = LogEntries.Where(log =>
+            {
+                switch (log.Level)
+                {
+                    case Logtype.Error:
+                        return ViewModel.FilterByLevel[0];
+                    case Logtype.Warning:
+                        return ViewModel.FilterByLevel[1];
+                    case Logtype.Success:
+                        return ViewModel.FilterByLevel[2];
+                    case Logtype.Normal:
+                    case Logtype.Important:
+                        return ViewModel.FilterByLevel[3];
+                    case Logtype.Debug:
+                        return ViewModel.FilterByLevel[4];
+                    default:
+                        return true;
+                }
+            });
+
+            FilteredLogEntries.Clear();
+            FilteredLogEntries.AddRange(filtered);
         }
 
         private void ScrollViewer_Loaded(object sender, RoutedEventArgs e) => _scrollViewer = (ScrollViewer)sender;
@@ -90,11 +139,11 @@ namespace WolvenKit.Views.Tools
             var message = item.RenderMessage();
             if (item.Properties.TryGetValue(Core.Constants.InfoCode, out var infoCodeObj) && infoCodeObj is ScalarValue { Value: int infoCode })
             {
-                LogEntries.Add(new LogEntry($"[{item.Timestamp.LocalDateTime}] [{level,-9}] {message}", LogCodeHelper.GetUrl(infoCode), brush));
+                LogEntries.Add(new LogEntry(level, $"[{item.Timestamp.LocalDateTime}] [{level,-9}] {message}", LogCodeHelper.GetUrl(infoCode), brush));
             }
             else
             {
-                LogEntries.Add(new LogEntry($"[{item.Timestamp.LocalDateTime}] [{level,-9}] {message}", null, brush));
+                LogEntries.Add(new LogEntry(level, $"[{item.Timestamp.LocalDateTime}] [{level,-9}] {message}", null, brush));
             }
 
             if (_autoscroll)
@@ -121,7 +170,7 @@ namespace WolvenKit.Views.Tools
             Logtype.Error => (Brush)Application.Current.FindResource("WolvenKitRed"),
             Logtype.Warning => (Brush)Application.Current.FindResource("WolvenKitYellow"),
             Logtype.Debug => (Brush)Application.Current.FindResource("WolvenKitPurple"),
-            Logtype.Success => Brushes.Green,
+            Logtype.Success => (Brush)Application.Current.FindResource("WolvenKitGreen"),
 
             _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
         };


### PR DESCRIPTION
# Added buttons to filter logs by level

**Implemented:**
- Toggles filter by level.
- Ensures at least one level is on.
- Uses `WolvenKitGreen` color resource (ready for #1954).

**Additional notes:**
Closes #1974

![wkit_fix1974_filter_logs](https://github.com/user-attachments/assets/c24d8a89-eba8-4e91-9ea8-8f5b9e2feebf)