### PR TITLE
Linux: Remove call to ntdll completely

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -424,7 +424,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     private static void CheckForLongPathSupport()
     {
-        if (Core.NativeMethods.RtlAreLongPathsEnabled() != 0)
+        if (Core.CommonFunctions.AreLongPathsEnabled())
         {
             return;
         }

--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -30,7 +30,7 @@ internal class Program
             return ConsoleFunctions.ERROR_GENERAL_ERROR;
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Core.NativeMethods.RtlAreLongPathsEnabled() == 0)
+        if (!Core.CommonFunctions.AreLongPathsEnabled())
         {
             // TODO: Use logger for that. Tried it as middleware but doesn't get called at all then -.-
             var text = "Long path support is disabled in your OS!" + Environment.NewLine +

--- a/WolvenKit.Core/CommonFunctions.cs
+++ b/WolvenKit.Core/CommonFunctions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using Microsoft.Win32;
 using Semver;
 
 namespace WolvenKit.Core
@@ -99,6 +100,13 @@ namespace WolvenKit.Core
         // Display a byte array in a readable format.
         public static string PrettyByteArray(IEnumerable<byte> array) => array.Aggregate("", (current, t) => current + $"{t:X2}");
 
-
+        public static bool AreLongPathsEnabled()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Registry.GetValue(@"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem", "LongPathsEnabled", 0) is 1;
+            }
+            return true;
+        }
     }
 }

--- a/WolvenKit.Core/NativeMethods.cs
+++ b/WolvenKit.Core/NativeMethods.cs
@@ -14,7 +14,4 @@ public static class NativeMethods
 
     [DllImport("kernel32.dll")]
     internal static extern bool FreeLibrary(IntPtr hModule);
-
-    [DllImport("ntdll")]
-    public static extern byte RtlAreLongPathsEnabled();
 }


### PR DESCRIPTION
# Linux: Remove call to ntdll completely

**Fixed:**
- Fixes problems introduced with df0a03d . Fixes #1989 

**Notes:**
Should be the same bahviour as `RtlAreLongPathsEnabled` does internally