### PR TITLE
fix(RDTWidgetView): visibility of widgets in canvas

### DIFF
--- a/WolvenKit/Views/Documents/RDTWidgetView.xaml
+++ b/WolvenKit/Views/Documents/RDTWidgetView.xaml
@@ -75,7 +75,7 @@
                         x:Name="WidgetPreview"
                         Style="{ StaticResource WidgetPreviewCanvasStyle }"
                         RenderTransformOrigin="0.5,0.5"
-                        Visibility="{Binding IsPixelGridSnappingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        Visibility="{Binding IsLoaded, Converter={StaticResource BooleanToVisibilityConverter}}"
                         RenderOptions.EdgeMode="Unspecified" />
 
                     <others:LoadingTextControl Grid.Column="0" VisibilityFlag="{Binding IsLoaded}" Small="True" />


### PR DESCRIPTION
# Fix visibility of widgets in canvas of RDTWidgetView

**Implemented:**
Canvas will always show widgets content, when loaded. Toggling snap grid option will only affect the visibility of the snap grid pattern.

**Fixed:**
Closes #1999

**Additional notes:**
I'll write another PR to implement snap grid feature:
- pan shall move the grid
- zoom shall scale the grid
- grid pattern should fit the parent's size