### PR TITLE
Add snap grid feature in RDTWidgetView

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTWidgetViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTWidgetViewModel.cs
@@ -25,7 +25,7 @@ public partial class RDTWidgetViewModel : RedDocumentTabViewModel
 
 
     [ObservableProperty] public bool _isLoaded;
-    
+
     [ObservableProperty] private Dictionary<object, inkTextWidget> _textWidgets = new();
 
     [ObservableProperty] private List<string> _styleStates = new();
@@ -52,9 +52,13 @@ public partial class RDTWidgetViewModel : RedDocumentTabViewModel
 
     [ObservableProperty] private bool _isPixelGridSnappingEnabled;
 
+    [ObservableProperty] private double _gridZoom = 1.0;
+
+    [ObservableProperty] private System.Windows.Point _gridOffset = new(0.0, 0.0);
+
     public async Task LoadResources()
     {
-        IsLoaded = false; 
+        IsLoaded = false;
         await Task.Run(async () =>
         {
             var tasks = new List<Task>
@@ -82,7 +86,7 @@ public partial class RDTWidgetViewModel : RedDocumentTabViewModel
             await Task.WhenAll(tasks);
         });
 
-        IsLoaded = true; 
+        IsLoaded = true;
     }
 
     public Task LoadAnimations()

--- a/WolvenKit/Views/Documents/RDTWidgetView.xaml
+++ b/WolvenKit/Views/Documents/RDTWidgetView.xaml
@@ -10,9 +10,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
-    xmlns:types="clr-namespace:WolvenKit.RED4.Types;assembly=WolvenKit.RED4.Types"
     xmlns:others="clr-namespace:WolvenKit.Views.Others"
-    xmlns:converters="clr-namespace:WolvenKit.Converters"
     Margin="0"
     d:DataContext="{d:DesignInstance Type={x:Type documents:RDTWidgetViewModel}}"
     d:DesignHeight="450"
@@ -25,26 +23,30 @@
     <Grid>
         <Grid.Resources>
             <ResourceDictionary>
-                <DrawingBrush x:Key="GridPatternBrush" TileMode="Tile" Viewport="-10,-10,40,40" ViewportUnits="Absolute">
+                <DrawingBrush
+                    x:Key="GridPatternBrush"
+                    TileMode="Tile"
+                    Viewport="0,0,48,48"
+                    ViewportUnits="Absolute">
                     <DrawingBrush.Drawing>
                         <GeometryDrawing>
                             <GeometryDrawing.Geometry>
-                                <RectangleGeometry Rect="0,0,50,50" />
+                                <RectangleGeometry Rect="0,0,48,48" />
                             </GeometryDrawing.Geometry>
+
                             <GeometryDrawing.Pen>
-                                <Pen Brush="{StaticResource WolvenKitCyanShadow25}" Thickness="1" />
+                                <Pen Brush="{StaticResource ForegroundColor}" Thickness="1" />
                             </GeometryDrawing.Pen>
                         </GeometryDrawing>
                     </DrawingBrush.Drawing>
+
+                    <DrawingBrush.Transform>
+                        <TransformGroup>
+                            <ScaleTransform ScaleX="{Binding GridZoom}" ScaleY="{Binding GridZoom}" />
+                            <TranslateTransform X="{Binding GridOffset.X}" Y="{Binding GridOffset.Y}" />
+                        </TransformGroup>
+                    </DrawingBrush.Transform>
                 </DrawingBrush>
-                <Style x:Key="WidgetPreviewCanvasStyle" TargetType="Canvas">
-                    <Setter Property="Background" Value="{StaticResource GridPatternBrush}" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsPixelGridSnappingEnabled}" Value="False">
-                            <Setter Property="Background" Value="{StaticResource ContentBackground}" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
             </ResourceDictionary>
         </Grid.Resources>
         <Grid.ColumnDefinitions>
@@ -73,9 +75,15 @@
                 <Grid>
                     <Canvas
                         x:Name="WidgetPreview"
-                        Style="{ StaticResource WidgetPreviewCanvasStyle }"
-                        RenderTransformOrigin="0.5,0.5"
                         Visibility="{Binding IsLoaded, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        RenderOptions.EdgeMode="Unspecified" />
+
+                    <Canvas
+                        x:Name="WidgetPreviewGrid"
+                        Background="{StaticResource GridPatternBrush}"
+                        Opacity="0.25"
+                        Visibility="{Binding IsPixelGridSnappingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        IsHitTestVisible="False"
                         RenderOptions.EdgeMode="Unspecified" />
 
                     <others:LoadingTextControl Grid.Column="0" VisibilityFlag="{Binding IsLoaded}" Small="True" />

--- a/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTWidgetView.xaml.cs
@@ -185,6 +185,8 @@ namespace WolvenKit.Views.Documents
             var v = start - Mouse.GetPosition(WidgetPreviewCanvas);
             tt.X = Math.Round(origin.X - v.X);
             tt.Y = Math.Round(origin.Y - v.Y);
+
+            ViewModel.GridOffset = new System.Windows.Point(tt.X, tt.Y);
         }
 
         private void WidgetPreview_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -200,26 +202,40 @@ namespace WolvenKit.Views.Documents
                 tt.X = Math.Round(origin.X);
                 tt.Y = Math.Round(origin.Y);
                 WidgetPreviewCanvas.SetCurrentValue(CursorProperty, Cursors.ScrollAll);
+
+                ViewModel.GridOffset = new System.Windows.Point(tt.X, tt.Y);
             }
         }
 
         private void WidgetPreview_MouseWheel(object sender, MouseWheelEventArgs e)
         {
             var transformGroup = (TransformGroup)WidgetPreview.RenderTransform;
-            var transform = (ScaleTransform)transformGroup.Children[0];
+            var scale = (ScaleTransform)transformGroup.Children[0];
             var pan = (TranslateTransform)transformGroup.Children[1];
 
             var zoom = e.Delta > 0 ? 1.189207115 : (1 / 1.189207115);
+            var oldZoom = scale.ScaleX;
+            var newZoom = oldZoom * zoom;
 
-            var CursorPosCanvas = e.GetPosition(WidgetPreviewCanvas);
-            pan.X += Math.Round(-(CursorPosCanvas.X - (WidgetPreviewCanvas.RenderSize.Width / 2.0) - pan.X) * (zoom - 1.0));
-            pan.Y += Math.Round(-(CursorPosCanvas.Y - (WidgetPreviewCanvas.RenderSize.Height / 2.0) - pan.Y) * (zoom - 1.0));
+            if (newZoom is < 0.1 or > 4.0)
+            {
+                return;
+            }
+            var mousePos = e.GetPosition(WidgetPreviewCanvas);
+
+            pan.X = mousePos.X - ((mousePos.X - pan.X) * (newZoom / oldZoom));
+            pan.Y = mousePos.Y - ((mousePos.Y - pan.Y) * (newZoom / oldZoom));
             end.X = pan.X;
             end.Y = pan.Y;
 
-            transform.ScaleX = zoom * transform.ScaleX;
-            transform.ScaleY = transform.ScaleX;
-            UpdateZoomText(transform.ScaleX);
+            zoom *= scale.ScaleX;
+            scale.ScaleX = zoom;
+            scale.ScaleY = zoom;
+
+            ViewModel.GridZoom = zoom;
+            ViewModel.GridOffset = new System.Windows.Point(pan.X, pan.Y);
+
+            UpdateZoomText(zoom);
         }
 
         public void UpdateZoomText(double scale)


### PR DESCRIPTION
# Add snap grid feature in RDTWidgetView

**Implemented:**
- Fill parent element with grid pattern.
- Translate grid on pan event.
- Scale grid on wheel event.
- Zoom based on mouse's position.
- Limit zoom between 10% and 400%.

**Work in progress:**
- [x] use a greyish color to look like surrounding UI.
- ~~add 'level scale' on grid itself, maybe with bigger/smaller rules.~~

**Preview:**
![wkit_feat_snap_grid](https://github.com/user-attachments/assets/7b7e10b7-97f1-4ec5-8c31-e1978cbf820d)