### PR TITLE
Fixed nugets not including required files

### DIFF
--- a/WolvenKit.Common/WolvenKit.Common.csproj
+++ b/WolvenKit.Common/WolvenKit.Common.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>8.15.1</Version>
+    <Version>8.15.1.1</Version>
     <Platforms>x64</Platforms>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	<NoWarn>NU5100;NU5104</NoWarn>
   </PropertyGroup>
 
 
@@ -38,11 +39,30 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="lib\texconv.dll">
+	<Content Include="lib\DirectXTexNet.dll">
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+	</Content>
+	<Content Include="lib\texconv.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Pack>true</Pack>
-      <PackagePath>lib\net6.0</PackagePath>
+	  <PackagePath>contentFiles\any\any\lib;content\lib</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
+	<Content Include="lib\DirectXTexNetImpl.dll">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\lib;content\lib</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+	</Content>
+	<Content Include="lib\Ijwhost.dll">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\lib;content\lib</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+	</Content>
+	<Content Include="lib\COPYING">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\lib;content\lib</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+	</Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -68,15 +88,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="lib\DirectXTexNetImpl.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="lib\Ijwhost.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="lib\COPYING">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="Resources\tweakdb.str">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>

--- a/WolvenKit.Core/WolvenKit.Core.csproj
+++ b/WolvenKit.Core/WolvenKit.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>8.15.1</Version>
+    <Version>8.15.1.1</Version>
     <Platforms>x64</Platforms>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <Nullable>enable</Nullable>
@@ -24,6 +24,7 @@
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageOutputPath>./nupkg</PackageOutputPath>
+	<NoWarn>NU5100</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
@@ -38,26 +39,36 @@
 
 
   <ItemGroup>
-    <ContentWithTargetPath Include="lib\kraken.dll">
+    <Content Include="lib\kraken.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>kraken.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\libkraken.so">
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+    <Content Include="lib\libkraken.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>libkraken.so</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\libkraken.dylib">
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+    <Content Include="lib\libkraken.dylib">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>libkraken.dylib</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\wwtools.dll">
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+    <Content Include="lib\wwtools.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>wwtools.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\libwwtools.so">
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+    <Content Include="lib\libwwtools.so">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>libwwtools.so</TargetPath>
-    </ContentWithTargetPath>
+	  <PackagePath>contentFiles\any\any;content</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/WolvenKit.Modkit/WolvenKit.Modkit.csproj
+++ b/WolvenKit.Modkit/WolvenKit.Modkit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>8.15.1</VersionPrefix>
+    <VersionPrefix>8.15.1.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
@@ -49,15 +49,23 @@
   <ItemGroup>
     <Content Include="opus-tools\opusdec.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\opus-tools;content\opus-tools</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <Content Include="opus-tools\opusenc.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\opus-tools;content\opus-tools</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <Content Include="opus-tools\opusinfo.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\opus-tools;content\opus-tools</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
     <Content Include="Resources\soundEvents.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <PackagePath>contentFiles\any\any\Resources;content\Resources</PackagePath>
+	  <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>
 


### PR DESCRIPTION
# Fixed nugets not including required files

Could also use `<PackagePath>lib\net8.0</PackagePath>` for dlls placed in the main dir, but won't work for other files (json, so, ...)

Also included `;content`. Only used in (really) old csprojects (before nuget 3.3 was introduced). Not sure if we need to keep it. (Also duplicates these files in the nuget)

`<NoWarn>NU5104</NoWarn>` can be removed as soon as the nuget update is done. Thats just for the prerelease version of SharpGltf we currently use.

Also bumped version so we can release them.
