### PR TITLE
fix: "Open in new tab" checking wrong property for already opened files

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1407,7 +1407,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     {
         foreach (var file in DockedViews.OfType<IDocumentViewModel>())
         {
-            if (file.FilePath is null || file.FilePath != path)
+            if (file is not RedDocumentViewModel redDocumentViewModel || redDocumentViewModel.RelativePath != path)
             {
                 continue;
             }


### PR DESCRIPTION
# fix: "Open in new tab" checking wrong property for already opened files

**Fixed:**
- "Open in new tab" checking wrong property for already opened files

Did check the full path before. Now checks the relative path.