### PR TITLE
fix(AnimExport): Fixed wrong array size for SIMD alligned buffers.

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSIMD.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSIMD.cs
@@ -154,7 +154,7 @@ namespace WolvenKit.Modkit.RED4.Animation
                 evalAlignedPositions[i] = br.ReadSingle();
             }
 
-            var scalesForFrame = new Vec3[animBufSimd.NumFrames, animBufSimd.NumJoints];
+            var scalesForFrame = new Vec3[animBufSimd.NumFrames, numJointsSimdAligned];
             if (animBufSimd.IsScaleConstant)
             {
                 // I guess these are aligned too?


### PR DESCRIPTION
# Fixed wrong array size for SIMD alligned buffers.

**Fixed:**
- Fixed wrong array size for SIMD alligned buffers. Fixes #1137 