### PR TITLE
material name: will now update parent display node

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -290,22 +290,42 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             return;
         }
 
-        // expand / collapse "special" children, e.g. if the parent holds no properties we care for
-        if (ResolvedData is not meshMeshAppearance || TVProperties.FirstOrDefault() is not { Name: "chunkMaterials" } tvPropChild)
+        void InitializeChild(ChunkViewModel? tvPropChild)
         {
-            return;
-        }
+            if (tvPropChild?.ResolvedData is not RedDummy)
+            {
+                return;
+            }
 
-        if (tvPropChild.TVProperties.Count == 1 && tvPropChild.TVProperties.FirstOrDefault()?.ResolvedData is RedDummy)
-        {
-            tvPropChild.RecalculateProperties();
             foreach (var chunkViewModel in tvPropChild.TVProperties)
             {
-                chunkViewModel.RecalculateProperties();
+                if (chunkViewModel.ResolvedData is RedDummy)
+                {
+                    chunkViewModel.RecalculateProperties();
+                }
             }
         }
 
-        tvPropChild.IsExpanded = IsExpanded;
+        
+        // expand / collapse "special" children, e.g. if the parent holds no properties we care for
+        switch (ResolvedData)
+        {
+            case meshMeshAppearance when TVProperties.FirstOrDefault() is { Name: "chunkMaterials" } tvPropChild:
+            {
+                InitializeChild(tvPropChild);
+                tvPropChild.IsExpanded = IsExpanded;
+                break;
+            }
+            case CMaterialInstance when GetPropertyChild("values") is ChunkViewModel valueChild:
+            {
+                InitializeChild(valueChild);
+                valueChild.IsExpanded = IsExpanded;
+                break;
+            }
+            default:
+                break;
+        }
+
     }
 
     partial void OnDataChanged(IRedType value)

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Descriptor.cs
@@ -316,14 +316,14 @@ public partial class ChunkViewModel
 
                 break;
             }
-            // animgraph - something is broken here. Why does the orange text go away? Why do I need the try/catch
-            // around the GetNodename?
+            case CMeshMaterialEntry materialEntry:
+                Descriptor = materialEntry.Name.GetResolvedText() ?? "";
+                break;
             // For local and external materials
-            case CMaterialInstance or CResourceAsyncReference<IMaterial> when NodeIdxInParent > -1
-                                                                              && GetRootModel().GetPropertyFromPath("materialEntries")
-                                                                                      ?.ResolvedData is CArray<CMeshMaterialEntry>
-                                                                                  materialEntries &&
-                                                                              materialEntries.Count > NodeIdxInParent:
+            case CMaterialInstance or CResourceAsyncReference<IMaterial>
+                when NodeIdxInParent > -1
+                     && GetRootModel().GetPropertyFromPath("materialEntries")?.ResolvedData is CArray<CMeshMaterialEntry> materialEntries
+                     && materialEntries.Count > NodeIdxInParent:
             {
                 var isLocalMaterial = ResolvedData is CMaterialInstance;
                 var entry = materialEntries[NodeIdxInParent];

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ExpansionStates.cs
@@ -494,4 +494,9 @@ public partial class ChunkViewModel
             chunkViewModel.IsExpanded = false;
         }
     }
+
+    private void ExpandChildNodesByType()
+    {
+        throw new NotImplementedException();
+    }
 }


### PR DESCRIPTION
# ChunkViewModel: value update fixes

- when updating `CMeshMaterialEntry`'s `name`, the entry node's descriptor will update correctly
- when expanding a `CMaterialinstance`, the `values` array will also expand
