### PR TITLE
build: disable NuGet audit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,7 @@
 	<PropertyGroup>
 		<EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+		<!-- NOTE: remove after updating vulnerable package dependencies. -->
+		<NuGetAudit>false</NuGetAudit>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
# build: disable NuGet audit

**Implemented:**
- temporarily disable NuGet audit to build project even with vulnerabilities in package dependencies.
- should be removed after upgrading dependencies.