### PR TITLE
put WindowsSdkPackageVersion into .csproj file to fix build error

### DIFF
--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup>
     <InterceptorsPreviewNamespaces>
       $(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
+    <WindowsSdkPackageVersion>10.0.17763.41</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# put WindowsSdkPackageVersion into .csproj file to fix build error

Any reasons not to merge this back? It was the only thing that fixed it for me
