### PR TITLE
exception fixes and CVM context menu performance

### DIFF
--- a/WolvenKit.App/Factories/ChunkViewmodelFactory.cs
+++ b/WolvenKit.App/Factories/ChunkViewmodelFactory.cs
@@ -28,7 +28,6 @@ public class ChunkViewmodelFactory(
     IAppArchiveManager archiveManager,
     ITweakDBService tweakDbService,
     ILocKeyService locKeyService,
-    IModifierViewStateService modifierViewStateService,
     Red4ParserService parserService,
     CRUIDService cruidService)
     : IChunkViewmodelFactory, IFactory<ChunkViewModel>
@@ -46,7 +45,6 @@ public class ChunkViewmodelFactory(
             archiveManager,
             tweakDbService,
             locKeyService,
-            modifierViewStateService,
             parserService,
             cruidService,
             editorDifficultyLevel,
@@ -66,7 +64,6 @@ public class ChunkViewmodelFactory(
             archiveManager,
             tweakDbService,
             locKeyService,
-            modifierViewStateService,
             parserService,
             cruidService,
             editorDifficultyLevel,
@@ -85,7 +82,6 @@ public class ChunkViewmodelFactory(
             archiveManager,
             tweakDbService,
             locKeyService,
-            modifierViewStateService,
             parserService,
             cruidService,
             editorDifficultyLevel, 

--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -61,11 +61,11 @@ public static partial class ArchiveXlHelper
         {
             return [depotPath];
         }
-        
-        // If the key is not in the dictionary, throw an exception
+
+        // If the key is not in the dictionary, return an empty array. This will result in a warning.
         if (!s_keysAndValues.TryGetValue(key, out var substitutionList))
         {
-            throw new Exception($"Key {key} not found in dictionary");
+            return [];
         }
 
         // For each value of this key, replace the key in the string with the value and recursively call the function

--- a/WolvenKit.App/Services/ModifierViewStateService.cs
+++ b/WolvenKit.App/Services/ModifierViewStateService.cs
@@ -95,6 +95,9 @@ public partial class ModifierViewStateService() : ObservableObject, IModifierVie
     public static bool IsCtrlBeingHeld => Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl);
     public static bool IsAltBeingHeld => Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt);
     public static bool IsNoModifierBeingHeld => !IsShiftBeingHeld && !IsCtrlBeingHeld && !IsAltBeingHeld;
+    public static bool IsShiftBeingHeldOnly => IsShiftBeingHeld && !IsCtrlBeingHeld && !IsAltBeingHeld;
+    public static bool IsCtrlBeingHeldOnly => !IsShiftBeingHeld && IsCtrlBeingHeld && !IsAltBeingHeld;
+    public static bool IsAltBeingHeldOnly => !IsShiftBeingHeld && !IsCtrlBeingHeld && IsAltBeingHeld;
 
     private readonly Dictionary<Key, bool> _keyStates = [];
 

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -69,7 +69,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     private readonly ILocKeyService _locKeyService;
     private readonly Red4ParserService _parserService;
     private readonly CRUIDService _cruidService;
-    private readonly IModifierViewStateService _modifierViewStateService;
 
     private static readonly List<string> s_hiddenProperties = new()
     {
@@ -107,7 +106,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         IAppArchiveManager archiveManager,
         ITweakDBService tweakDbService,
         ILocKeyService locKeyService,
-        IModifierViewStateService modifierViewStateService,
         Red4ParserService parserService,
         CRUIDService cruidService,
         EditorDifficultyLevel editorLevel,
@@ -127,7 +125,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         _locKeyService = locKeyService;
         _parserService = parserService;
         _cruidService = cruidService;
-        _modifierViewStateService = modifierViewStateService;
 
         _appViewModel = appViewModel;
         _data = data;
@@ -135,8 +132,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         _propertyName = name;
         _displayName = name;
         IsReadOnly = isReadOnly;
-
-        _modifierViewStateService.ModifierStateChanged += OnModifierChanged;
 
         _currentEditorDifficultyLevel = editorLevel;
         DifficultyLevelFieldInformation = EditorDifficultyLevelFieldFactory.GetInstance(editorLevel);
@@ -177,7 +172,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         IAppArchiveManager archiveManager,
         ITweakDBService tweakDbService,
         ILocKeyService locKeyService,
-        IModifierViewStateService modifierViewStateService,
         Red4ParserService parserService,
         CRUIDService cruidService,
         EditorDifficultyLevel editorDifficultyLevel, 
@@ -185,7 +179,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         ) 
         : this(data, nameof(RDTDataViewModel), appViewModel,
             chunkViewmodelFactory, tabViewmodelFactory, hashService, loggerService, projectManager,
-            gameController, settingsManager, archiveManager, tweakDbService, locKeyService, modifierViewStateService, parserService,
+            gameController, settingsManager, archiveManager, tweakDbService, locKeyService, parserService,
             cruidService, editorDifficultyLevel, null, isReadOnly)
     {
         _tab = tab;
@@ -204,7 +198,6 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         IAppArchiveManager archiveManager,
         ITweakDBService tweakDbService,
         ILocKeyService locKeyService,
-        IModifierViewStateService modifierViewStateService,
         Red4ParserService parserService,
         CRUIDService cruidService,
         EditorDifficultyLevel editorDifficultyLevel, 
@@ -212,7 +205,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         ) 
         : this(export, nameof(ReferenceSocket), appViewModel,
               chunkViewmodelFactory, tabViewmodelFactory, hashService, loggerService, projectManager,
-              gameController, settingsManager, archiveManager, tweakDbService, locKeyService, modifierViewStateService, parserService,
+              gameController, settingsManager, archiveManager, tweakDbService, locKeyService, parserService,
               cruidService, editorDifficultyLevel, null, isReadOnly
               )
     {

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
+using WolvenKit.App.Services;
 using WolvenKit.Common;
 using WolvenKit.RED4.Types;
 
@@ -48,15 +49,13 @@ public partial class ChunkViewModel
 
     #region methods
 
-    private void OnModifierChanged() => RefreshContextMenuFlags();
-
     public void RefreshContextMenuFlags()
     {
-        IsShiftKeyPressed = _modifierViewStateService.IsShiftKeyPressed;
-        IsCtrlKeyPressed = _modifierViewStateService.IsCtrlKeyPressed;
-        IsAltKeyPressed = _modifierViewStateService.IsAltKeyPressed;
+        IsShiftKeyPressed = ModifierViewStateService.IsShiftBeingHeld;
+        IsCtrlKeyPressed = ModifierViewStateService.IsCtrlBeingHeld;
+        IsAltKeyPressed = ModifierViewStateService.IsAltBeingHeld;
 
-        ShouldShowPasteOverwrite = IsInArray && _modifierViewStateService.IsShiftKeyPressedOnly && Tab?.SelectedChunk is not null;
+        ShouldShowPasteOverwrite = IsInArray && ModifierViewStateService.IsShiftBeingHeldOnly && Tab?.SelectedChunk is not null;
         ShouldShowOverwriteArray = ShouldShowArrayOps && ((IsArray && IsShiftKeyPressed) ||
                                                           (IsCtrlKeyPressed && !ShouldShowPasteOverwrite));
         ShouldShowPasteIntoArray = ShouldShowArrayOps && !(ShouldShowPasteOverwrite || ShouldShowOverwriteArray);

--- a/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
+++ b/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
@@ -88,8 +88,13 @@ public partial class ArchiveXlHelper
             return "string must start with '*'";
         }
 
-        List<string> invalidSubstitutions = [];
+        if (s.Contains(s_materialWildcard))
+        {
+            return null;
+        }
 
+        List<string> invalidSubstitutions = [];
+        
         foreach (Match match in s_substitutionRegex().Matches(s))
         {
             if (s_substitutionMap.ContainsKey(match.Value))
@@ -104,6 +109,7 @@ public partial class ArchiveXlHelper
         {
             return null;
         }
+        
 
         return
             $"Invalid substitutions used: [{string.Join(',', invalidSubstitutions)}]. Valid substitutions are: [{string.Join(',', s_substitutionMap.Keys)}] ";

--- a/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/SearchAndReplaceDialogView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Input;
@@ -11,6 +12,8 @@ namespace WolvenKit.Views.Dialogs.Windows
     {
         private static string s_lastSearch = "";
         private static string s_lastReplace = "";
+
+        public static bool IsInstanceOpen { get; private set; }
         
         public SearchAndReplaceDialog()
         {
@@ -50,6 +53,7 @@ namespace WolvenKit.Views.Dialogs.Windows
         public bool? ShowDialog(Window owner)
         {
             Owner = owner;
+            IsInstanceOpen = true;
             return ShowDialog();
         }
 
@@ -105,6 +109,12 @@ namespace WolvenKit.Views.Dialogs.Windows
             e.Handled = true;
             DialogResult = true;
             Close();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            IsInstanceOpen = false;
+            base.OnClosed(e);
         }
 
         private void WizardControl_OnFinish(object sender, RoutedEventArgs e) => SaveLastSelection();


### PR DESCRIPTION
# exception fixes and CVM context menu performance

**Fixed:**
- hopefully fixes #2006 - CVM's context menu is now much faster
- dynamic path validation will no longer throw an exception for {material} wildcards in depot paths