### PR TITLE
fixed chunk duplication behaviour in groups (shift key)

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -2499,12 +2499,8 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     }
 
 
-    public Task DuplicateChunkAsync()
-    {
-        DuplicateChunk();
-        return Task.CompletedTask;
-    }
-    
+    public Task<ChunkViewModel?> DuplicateChunkAsync(int index) => Task.FromResult(DuplicateChunk(index));
+
     private bool CanDuplicateChunk() => IsInArray && Parent is not null; // TODO RelayCommand check notify
 
     [RelayCommand(CanExecute = nameof(CanDuplicateChunk))]

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -44,6 +44,7 @@ public partial class ChunkViewModel
     [ObservableProperty] private bool _shouldShowCreateExternalMatDef;
 
     [ObservableProperty] private bool _shouldShowDuplicateAsNew;
+    [ObservableProperty] private bool _shouldShowDuplicateInplace;
 
     #endregion
 
@@ -68,7 +69,8 @@ public partial class ChunkViewModel
             IsInArray && !IsShiftKeyPressed &&
             ResolvedData is worldCompiledEffectPlacementInfo or CMeshMaterialEntry;
 
-        ShouldShowDuplicate = !ShouldShowDuplicateAsNew && IsInArray;
+        ShouldShowDuplicateInplace = !ShouldShowDuplicateAsNew && IsInArray && !IsShiftKeyPressed;
+        ShouldShowDuplicate = !ShouldShowDuplicateAsNew && IsInArray && IsShiftKeyPressed;
 
         IsInArrayWithShiftKeyUp = IsInArray && !IsShiftKeyPressed;
         IsInArrayWithShiftKeyDown = IsInArray && IsShiftKeyPressed;

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -390,9 +390,20 @@
                 <!-- Duplicate-->
                 <MenuItem
                     Command="{Binding DuplicateSelectionCommand, Source={x:Reference redTreeView}}"
-                    Header="Duplicate Item(s) in Array/Buffer"
+                    Header="Duplicate in Array/Buffer (append after selection)"
                     IsCheckable="False"
                     Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowDuplicate, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <MenuItem.Icon>
+                        <iconPacks:PackIconMaterial Style="{StaticResource ContextMenuIconStyleMaterial}" Kind="ContentDuplicate" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <!-- Duplicate-->
+                <MenuItem
+                    Command="{Binding DuplicateSelectionInPlaceCommand, Source={x:Reference redTreeView}}"
+                    Header="Duplicate in Array/Buffer"
+                    IsCheckable="False"
+                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowDuplicateInplace, RelativeSource={RelativeSource AncestorType=ContextMenu}, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <MenuItem.Icon>
                         <iconPacks:PackIconMaterial Style="{StaticResource ContextMenuIconStyleMaterial}" Kind="ContentDuplicate" />
                     </MenuItem.Icon>


### PR DESCRIPTION
# fixed chunk duplication behaviour in groups (shift key)
by default, duplicating multiple items will now duplicate them right next to the original. Hold SHIFT to append them at the end of selection.