### PR TITLE
fix search not considering uninitialized nodes

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -563,6 +563,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
         HasActiveSearch = !string.IsNullOrEmpty(searchBoxText);
         foreach (var chunkViewModel in Chunks)
         {
+            chunkViewModel.CalculatePropertiesRecursive();
             chunkViewModel.SetVisibilityStatusBySearchString(searchBoxText);
         }
 

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
@@ -50,6 +50,27 @@ public partial class ChunkViewModel
         RecalculateProperties();
     }
 
+    private bool _isPropertiesInitialized;
+
+    /// <summary>
+    /// If we need a node to be fully initialized (e.g. if we run a search on it) 
+    /// </summary>
+    public void CalculatePropertiesRecursive()
+    {
+        if (_isPropertiesInitialized)
+        {
+            return;
+        }
+
+        _isPropertiesInitialized = true;
+        CalculateProperties();
+        foreach (var child in Properties)
+        {
+            child.CalculatePropertiesRecursive();
+        }
+    }
+
+
     private EditorDifficultyLevelInformation DifficultyLevelFieldInformation { get; set; }
 
     public void SetVisibilityStatusBySearchString(string searchBoxText)
@@ -57,6 +78,13 @@ public partial class ChunkViewModel
         if (ResolvedData is RedDummy || TVProperties.Count == 0)
         {
             CalculateProperties();
+        }
+
+        // some items are still RedDummies even after properties were calculated. Why?
+        if (ResolvedData is RedDummy || TVProperties.Count == 0)
+        {
+            IsHiddenBySearch = true;
+            return;
         }
         
         foreach (var chunkViewModel in TVProperties)


### PR DESCRIPTION
# search & move+refactor

- search will now force cvm initialization if it isn't yet
- refactor action will run again for single files (previously only ran for folders)