### PR TITLE
context menu: show/hide entries based on modifiers

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
@@ -210,19 +210,31 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
     /*
      * Regenerate visual controllers
      */
-    private bool CanRegenerateVisualControllers() => SelectedChunk is { Name: "components", Data: CArray<entIComponent> };
+    private bool CanRegenerateVisualControllers() => ContentType is RedDocumentItemType.Ent ||
+                                                     (ContentType is RedDocumentItemType.App && SelectedChunk is
+                                                         { Name: "components", Data: CArray<entIComponent> });
     
     [RelayCommand(CanExecute = nameof(CanRegenerateVisualControllers))]
-    private void RegenerateVisualControllers() => SelectedChunk?.RegenerateVisualControllerCommand.Execute(null);
+    private void RegenerateVisualControllers()
+    {
+        if (SelectedChunk is { Name: "components", Data: CArray<entIComponent> })
+        {
+            SelectedChunk?.RegenerateVisualControllerCommand.Execute(null);
+            return;
+        }
 
-    private bool CanChangeAnimationComponent() => RootChunk is { };
+        // .ent file
+        RootChunk?.GetPropertyChild("components")?.RegenerateVisualControllerCommand.Execute(null);
+    }
+
+    private bool CanChangeAnimationComponent() => RootChunk?.ResolvedData is appearanceAppearanceResource;
 
     /*
      * Convert to photo mode app
      */
     private bool CanConvertToPhotoModeApp() => RootChunk?.ResolvedData is appearanceAppearanceResource &&
-                                               (FilePath is not string filePath ||
-                                                !SelectPhotoModeAppViewModel.PhotomodeAppPaths.Contains(filePath));
+                                               FilePath is string filePath &&
+                                               !SelectPhotoModeAppViewModel.PhotomodeAppPaths.Contains(filePath);
 
     [RelayCommand(CanExecute = nameof(CanConvertToPhotoModeApp))]
     private void ConvertToPhotoModeApp()

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -2708,7 +2708,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         return RedDocumentTabViewModel.CopiedChunks.All(c => CheckTypeCompatibility(innerType!, c.GetType()) != TypeCompability.None);
     } // TODO RelayCommand check notify
 
-    private bool CanCopyArrayContents() => Properties.Count > 0 && !Properties[0].IsArray;
+    private bool CanCopyArrayContents() => IsArray && Properties.Count > 0 && !Properties[0].IsArray;
 
     [RelayCommand(CanExecute = nameof(CanCopyArrayContents))]
     private void CopyArrayContents()

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -29,14 +30,6 @@ public partial class ChunkViewModel
     
     [ObservableProperty] private bool _shouldShowDuplicate;
 
-    [ObservableProperty] private bool _shouldShowPasteIntoArray;
-
-    [ObservableProperty] private bool _shouldShowOverwriteArray;
-    [ObservableProperty] private bool _shouldShowPasteOverwrite;
-
-    [ObservableProperty] private bool _isInArrayWithShiftKeyDown;
-    [ObservableProperty] private bool _isInArrayWithShiftKeyUp;
-
     [ObservableProperty] private bool _isMaterial;
 
     [ObservableProperty] private bool _isMaterialArray;
@@ -46,7 +39,7 @@ public partial class ChunkViewModel
     [ObservableProperty] private bool _shouldShowDuplicateAsNew;
     [ObservableProperty] private bool _shouldShowDuplicateInplace;
 
-    [ObservableProperty] private bool _isComponentArray;
+    [ObservableProperty] private bool _isMultipleItemsSelected;
 
     #endregion
 
@@ -58,15 +51,9 @@ public partial class ChunkViewModel
         IsCtrlKeyPressed = ModifierViewStateService.IsCtrlBeingHeld;
         IsAltKeyPressed = ModifierViewStateService.IsAltBeingHeld;
 
-        ShouldShowPasteOverwrite = IsInArray && ModifierViewStateService.IsShiftBeingHeldOnly && Tab?.SelectedChunk is not null;
-        ShouldShowOverwriteArray = ShouldShowArrayOps && ((IsArray && IsShiftKeyPressed) ||
-                                                          (IsCtrlKeyPressed && !ShouldShowPasteOverwrite));
-        ShouldShowPasteIntoArray = ShouldShowArrayOps && !(ShouldShowPasteOverwrite || ShouldShowOverwriteArray);
-
         IsMaterial = ResolvedData is CMaterialInstance or CResourceAsyncReference<IMaterial>;
 
         IsMaterialArray = ResolvedData is CArray<IMaterial> or CArray<CResourceAsyncReference<IMaterial>>;
-        IsComponentArray = IsArray && Name == "components";
 
         ShouldShowDuplicateAsNew =
             IsInArray && !IsShiftKeyPressed &&
@@ -75,8 +62,7 @@ public partial class ChunkViewModel
         ShouldShowDuplicateInplace = !ShouldShowDuplicateAsNew && IsInArray && IsShiftKeyPressed;
         ShouldShowDuplicate = !ShouldShowDuplicateAsNew && IsInArray && !IsShiftKeyPressed;
 
-        IsInArrayWithShiftKeyUp = IsInArray && !IsShiftKeyPressed;
-        IsInArrayWithShiftKeyDown = IsInArray && IsShiftKeyPressed;
+        IsMultipleItemsSelected = Parent?.Tab?.SelectedChunks is ObservableCollection<object> chunks && chunks.Count > 1;
     }
 
     public void RefreshCommandStatus()

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -182,20 +182,26 @@
 
             <!-- Appearances: .ent -->
             <Style
-                x:Key="ShowAppearancesMenuItemStyle"
+                x:Key="ShowComponentsAppearancesMenuItemStyle"
                 BasedOn="{StaticResource HasNestedMenuItemStyle}"
                 TargetType="{x:Type MenuItem}">
                 <Setter Property="Visibility" Value="Collapsed" />
-
                 <Style.Triggers>
                     <DataTrigger
-                        Binding="{Binding Path=ContentType,
-                                          UpdateSourceTrigger=PropertyChanged}"
+                        Binding="{Binding Path=ContentType}"
                         Value="{x:Static documents:RedDocumentItemType.App}">
+                        <Setter Property="Header" Value="Appearances" />
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                    <DataTrigger
+                        Binding="{Binding Path=ContentType}"
+                        Value="{x:Static documents:RedDocumentItemType.Ent}">
+                        <Setter Property="Header" Value="Components" />
                         <Setter Property="Visibility" Value="Visible" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
+
 
             <!-- App file: .app -->
             <Style
@@ -502,9 +508,8 @@
             </MenuItem>
 
             <!-- Appearances: .ent -->
-            <MenuItem
-                Style="{StaticResource ShowAppearancesMenuItemStyle}"
-                Header="Appearances">
+            <MenuItem Style="{StaticResource ShowComponentsAppearancesMenuItemStyle}">
+                <!-- Header: Apparances / Components is set in style -->
                 <MenuItem.Icon>
                     <templates:IconBox
                         IconPack="Material"
@@ -514,10 +519,6 @@
 
                 <MenuItem
                     Style="{StaticResource MenuItemStyle}"
-                    Visibility="{Binding Path=IsEnabled,
-                                         RelativeSource={RelativeSource Self},
-                                         Mode=OneWay,
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Header="Regenerate visual controllers"
                     Command="{Binding Path=RegenerateVisualControllersCommand}">
                     <MenuItem.Icon>

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -857,39 +857,6 @@
                     </MenuItem.Icon>
                 </MenuItem>
 
-                <!-- Copy Names -->
-                <MenuItem
-                    Command="{Binding Path=PlacementTarget.Tag.CopyChildNamesCommand,
-                                      RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Copy item names"
-                    IsCheckable="False">
-
-                    <MenuItem.Style>
-                        <Style
-                            BasedOn="{StaticResource WPFMenuItemStyle}"
-                            TargetType="MenuItem">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="True" />
-                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </MultiDataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </MenuItem.Style>
-                    <MenuItem.Icon>
-                        <templates:IconBox
-                            IconPack="Material"
-                            Kind="ContentCopy"
-                            Margin="{DynamicResource WolvenKitMarginTiny}"
-                            Size="{DynamicResource WolvenKitIconMilli}" />
-                    </MenuItem.Icon>
-                </MenuItem>
-
-
                 <!--
                     #########################################################
                     ╔═╗┌─┐┌─┐┬ ┬ ┬ ╔═╗┌─┐┌─┐┌┬┐┌─┐
@@ -939,13 +906,26 @@
 
                 <!-- Copy -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsInArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.CopyChunkCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Copy From Array/Buffer"
                     IsCheckable="False">
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -957,13 +937,27 @@
 
                 <!-- Copy Selection -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsInArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.CopySelectionCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Copy Selection From Array/Buffer"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -975,13 +969,30 @@
 
                 <!-- Paste Selection To Array/Buffer -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowPasteIntoArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.PasteSelectionCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Paste Selection To Array/Buffer"
                     IsCheckable="False">
+
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsCtrlKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
 
                     <MenuItem.Icon>
                         <templates:IconBox
@@ -994,13 +1005,35 @@
 
                 <!-- Overwrite Array/Buffer With Selection -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowOverwriteArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.ClearAndPasteSelectionCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Overwrite Array/Buffer With Selection"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.ShouldShowArrayOpts, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsCtrlKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -1012,13 +1045,26 @@
 
                 <!-- Overwrite Selection With Pasted -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowPasteOverwrite,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.OverwriteSelectionWithPasteCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Overwrite Current With Copied Selection"
                     IsCheckable="False">
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -1030,13 +1076,27 @@
 
                 <!-- Copy Array Contents -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.CopyArrayContentsCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Copy Array Contents"
                     IsCheckable="False">
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -1045,6 +1105,39 @@
                             Size="{DynamicResource WolvenKitIconMilli}" />
                     </MenuItem.Icon>
                 </MenuItem>
+
+                <!-- Copy Names -->
+                <MenuItem
+                    Command="{Binding Path=PlacementTarget.Tag.CopyChildNamesCommand,
+                                      RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                    Header="Copy item names"
+                    IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                    <MenuItem.Icon>
+                        <templates:IconBox
+                            IconPack="Material"
+                            Kind="ContentCopy"
+                            Margin="{DynamicResource WolvenKitMarginTiny}"
+                            Size="{DynamicResource WolvenKitIconMilli}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
 
                 <!-- Paste Handle -->
                 <MenuItem
@@ -1067,14 +1160,30 @@
 
                 <!-- Paste Into Array/Buffer -->
                 <MenuItem
-                    Visibility="{Binding Path=IsEnabled,
-                                         RelativeSource={RelativeSource Self},
-                                         Mode=OneWay,
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.PasteChunkCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Paste Into Array/Buffer"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.ShouldShowArrayOps, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsCtrlKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -1086,13 +1195,28 @@
 
                 <!-- Clear Array/Buffer and Paste -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.ShouldShowOverwriteArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.ClearAndPasteChunkCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Clear Array/Buffer and Paste"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.ShouldShowArrayOps, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsCtrlKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
@@ -1133,13 +1257,28 @@
 
                 <!-- Delete item -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsInArray,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.DeleteItemCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Delete Item in Array/Buffer"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <!-- Old icon Codicons#Remove -->
                         <templates:IconBox
@@ -1153,13 +1292,28 @@
 
                 <!-- Delete Selection -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsInArrayWithShiftKeyUp,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=DeleteSelectionCommand,
                                       Source={x:Reference redTreeView}}"
                     Header="Delete Selection in Array/Buffer"
                     IsCheckable="False">
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <!-- Old icon Codicons#Remove -->
                         <templates:IconBox
@@ -1173,13 +1327,30 @@
 
                 <!-- Delete Everything But Selection -->
                 <MenuItem
-                    Visibility="{Binding Path=PlacementTarget.Tag.IsInArrayWithShiftKeyDown,
-                                         RelativeSource={RelativeSource AncestorType=ContextMenu},
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding Path=PlacementTarget.Tag.DeleteAllButSelectionCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                     Header="Delete All but Selection in Array/Buffer"
                     IsCheckable="False">
+
+
+                    <MenuItem.Style>
+                        <Style
+                            BasedOn="{StaticResource WPFMenuItemStyle}"
+                            TargetType="MenuItem">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+
                     <MenuItem.Icon>
                         <!-- Old icon Codicons#Remove -->
                         <templates:IconBox

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -806,36 +806,6 @@
                     </MenuItem.Icon>
                 </MenuItem>
 
-                <MenuItem
-                    Header="Regenerate visual controllers"
-                    DataContext="{Binding Path=PlacementTarget.Tag,
-                                          RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Command="{Binding Path=RegenerateVisualControllerCommand}">
-                    <MenuItem.Style>
-                        <Style
-                            BasedOn="{StaticResource WPFMenuItemStyle}"
-                            TargetType="MenuItem">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                            <Style.Triggers>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="True" />
-                                        <Condition Binding="{Binding Path=IsCtrlKeyPressed}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </MultiDataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </MenuItem.Style>
-
-                    <MenuItem.Icon>
-                        <templates:IconBox
-                            IconPack="Material"
-                            Kind="CogRefresh"
-                            Foreground="White" />
-                    </MenuItem.Icon>
-                </MenuItem>
-
                 <!-- Generate CRUID -->
                 <MenuItem
                     Visibility="{Binding Path=IsEnabled,


### PR DESCRIPTION
# context menu: show/hide entries based on modifiers

There will no longer be multiple entries with contextual actions, they will now replace each other