### PR TITLE
various small UX changes

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -133,12 +133,9 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
     {
         get
         {
-            if (_chunks == null || _chunks.Count == 0)
+            if (_chunks.Count == 0 && _data is not RedDummy)
             {
-                _chunks = _data is null ? new() : new List<ChunkViewModel>
-                {
-                    GenerateChunks()
-                };
+                _chunks.Add(GenerateChunks());
             }
             return _chunks;
         }
@@ -202,7 +199,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
 
     public void LookForReferences(ChunkViewModel cvm)
     {
-        if (cvm.Data is null)
+        if (cvm.Data is RedDummy)
         {
             return;
         }
@@ -221,10 +218,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
             }
         }
 
-        if (LayoutNodes != null)
-        {
-            LayoutNodes();
-        }
+        LayoutNodes?.Invoke();
     }
 
     public void LookForReferences(ChunkViewModel cvm, RedBaseClass data, string xpath)

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -385,27 +385,24 @@ public partial class ChunkViewModel
 
     public void ReplaceComponentChunkMasks(string componentName, CUInt64 chunkMask)
     {
-        if (ResolvedData is not appearanceAppearanceResource appearanceResource || appearanceResource.Appearances.Count == 0)
-        {
-            return;
-        }
-
-        var appearances = appearanceResource.Appearances.Where((handle) => handle.GetValue() is appearanceAppearanceDefinition)
-            .Select(handle => (appearanceAppearanceDefinition)handle.GetValue()!)
-            .Where(appDef => appDef.Components.Count > 0);
-
         var hasChanges = false;
-        foreach (var appDef in appearances)
-        {
-            var component = appDef.Components.FirstOrDefault(comp => comp.Name == componentName);
-            if (component is null || component is not IRedMeshComponent meshComponent)
-            {
-                continue;
-            }
 
-            meshComponent.ChunkMask = chunkMask;
-            GetPropertyChild("appearances", appDef.Name.GetResolvedText() ?? "", "components", componentName)?.RecalculateProperties();
-            hasChanges = true;
+        switch (ResolvedData)
+        {
+            case appearanceAppearanceResource { Appearances.Count: > 0 } appearanceResource:
+            {
+                appearanceResource.Appearances.Where((handle) => handle.GetValue() is appearanceAppearanceDefinition)
+                    .Select(handle => (appearanceAppearanceDefinition)handle.GetValue()!)
+                    .Where(appDef => appDef.Components.Count > 0)
+                    .ToList()
+                    .ForEach(SetAppearanceChunkMask);
+                break;
+            }
+            case appearanceAppearanceDefinition appearance:
+                SetAppearanceChunkMask(appearance);
+                break;
+            default:
+                break;
         }
 
         if (!hasChanges)
@@ -414,6 +411,20 @@ public partial class ChunkViewModel
         }
 
         Tab?.Parent.SetIsDirty(true);
+        return;
+
+        void SetAppearanceChunkMask(appearanceAppearanceDefinition appDef)
+        {
+            var component = appDef.Components.FirstOrDefault(comp => comp.Name == componentName);
+            if (component is not IRedMeshComponent meshComponent)
+            {
+                return;
+            }
+
+            meshComponent.ChunkMask = chunkMask;
+            GetPropertyChild("appearances", appDef.Name.GetResolvedText() ?? "", "components", componentName)?.RecalculateProperties();
+            hasChanges = true;
+        }
     }
     #endregion
 

--- a/WolvenKit/Views/Dialogs/Windows/ChangeComponentChunkMaskDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/ChangeComponentChunkMaskDialog.xaml
@@ -10,7 +10,7 @@
     MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
     MinHeight="{DynamicResource WolvenKitDialogHeightSmall}"
     SizeToContent="WidthAndHeight"
-    FocusManager.FocusedElement="{Binding ElementName=BaseMaterialBox}"
+    FocusManager.FocusedElement="{Binding ElementName=ComponentNameBox}"
     WindowStartupLocation="CenterScreen">
     <Grid
         HorizontalAlignment="Stretch"

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -139,6 +139,7 @@ namespace WolvenKit.Views.Documents
         }
 
         private ChunkViewModel? SelectedChunk => ViewModel?.SelectedChunk;
+        private List<ChunkViewModel> SelectedChunks => ViewModel?.SelectedChunks ?? [];
 
         private ChunkViewModel? RootChunk => ViewModel?.RootChunk;
 
@@ -397,7 +398,7 @@ namespace WolvenKit.Views.Documents
         private void OnChangeChunkMasksClick(object _, RoutedEventArgs e)
         {
             var dialog = new ChangeComponentChunkMaskDialog();
-            if (ViewModel?.RootChunk is not ChunkViewModel cvm || dialog.ShowDialog() != true)
+            if (dialog.ShowDialog() != true)
             {
                 return;
             }
@@ -406,10 +407,18 @@ namespace WolvenKit.Views.Documents
             {
                 return;
             }
-
             var chunkMask = (CUInt64)dialog.ViewModel.ChunkMask;
 
-            cvm.ReplaceComponentChunkMasks(dialog.ViewModel.ComponentName!, chunkMask);
+            var selectedChunks = SelectedChunks;
+            if (selectedChunks.Count == 0 && RootChunk is ChunkViewModel cvm)
+            {
+                selectedChunks.Add(cvm);
+            }
+
+            foreach (var chunkViewModel in SelectedChunks)
+            {
+                chunkViewModel.ReplaceComponentChunkMasks(dialog.ViewModel.ComponentName!, chunkMask);
+            }  
         }
 
         private MenuItem? _openMenu;

--- a/WolvenKit/Views/Templates/RedChunkMaskEditor.xaml
+++ b/WolvenKit/Views/Templates/RedChunkMaskEditor.xaml
@@ -8,15 +8,17 @@
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     mc:Ignorable="d"
     d:DesignWidth="400"
-    d:DesignHeight="100">
+    d:DesignHeight="100"
+    FocusManager.FocusedElement="{Binding ElementName=comboboxadv}">
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:RedChunkMaskEditor}}}">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" MaxWidth="300" />
             <ColumnDefinition Width="{DynamicResource WolvenKitRedEditorHashWidth}" />
         </Grid.ColumnDefinitions>
 
         <syncfusion:ComboBoxAdv
             Name="comboboxadv"
+            Width="300"
             Padding="{DynamicResource WolvenKitMarginTiny}"
             Background="#252525"
             BorderBrush="{StaticResource BorderAlt}"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -1088,10 +1088,7 @@ namespace WolvenKit.Views.Tools
             ViewModel?.ModifierStateService.RefreshModifierStates();
         }
 
-        private void Main_OnKeystateChanged(object sender, KeyEventArgs e)
-        {
-            ViewModel?.ModifierStateService.OnKeystateChanged(e);
-        }
+        private void Main_OnKeystateChanged(object sender, KeyEventArgs e) => ViewModel?.OnKeyStateChanged(e);
 
         private void TreeIcon_Loaded(object sender, RoutedEventArgs e)
         {

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -604,7 +604,7 @@
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding DuplicateSelectionCommand,
                                       Source={x:Reference redTreeView}}"
-                    Header="Duplicate in Array/Buffer (append after selection)"
+                    Header="Duplicate in Array/Buffer"
                     IsCheckable="False">
                     <MenuItem.Icon>
                         <templates:IconBox
@@ -622,7 +622,7 @@
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
                     Command="{Binding DuplicateSelectionInPlaceCommand,
                                       Source={x:Reference redTreeView}}"
-                    Header="Duplicate in Array/Buffer"
+                    Header="Duplicate in Array/Buffer (preserve index)"
                     IsCheckable="False">
                     <MenuItem.Icon>
                         <templates:IconBox

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -378,6 +378,15 @@ namespace WolvenKit.Views.Tools
         {
             var chunks = GetSelectedChunks();
 
+            if (!preserveIndex)
+            {
+                var nodeIndices = chunks.Select(c => c.NodeIdxInParent).Order().ToList();
+                if (nodeIndices.Zip(nodeIndices.Skip(1), (a, b) => b - a).Any(diff => diff != 1))
+                {
+                    preserveIndex = true;
+                }
+            }
+            
 
             var tasks = chunks.Select(cvm => cvm.DuplicateChunkAsync(preserveIndex ? -1 : cvm.NodeIdxInParent + chunks.Count)).ToList();
 
@@ -612,8 +621,8 @@ namespace WolvenKit.Views.Tools
                 case Key.F2 when e.IsUp && CanOpenSearchAndReplaceDialog:
                     OpenSearchAndReplaceDialog();
                     return;
-                case Key.W when e.IsDown && e.KeyboardDevice.Modifiers == ModifierKeys.Control && _appViewModel.ActiveDocument is not null:
-                    _appViewModel.CloseFile(_appViewModel.ActiveDocument);
+                case Key.W when e.IsDown && e.KeyboardDevice.Modifiers == ModifierKeys.Control:
+                    _appViewModel.CloseLastActiveDocument();
                     return;
                 default:
                     _modifierViewStateSvc.OnKeystateChanged(e);


### PR DESCRIPTION
# various small UX changes

- chunk mask replacement in app: dialogue will now be easier to navigate
- ctrl+w: Will also close active document if project browser has focus
- fixed "overwrite with selection" not working if a single item had been copied
- duplicate: fixed tooltips
- duplicate: if non-consecutive items are selected, duplication will happen in-place rather than after the last node