### PR TITLE
renamed "delete empty submeshes"

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
@@ -130,7 +130,7 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
     }
 
 
-    [NotifyCanExecuteChangedFor(nameof(DeleteEmptySubmeshesCommand))]
+    [NotifyCanExecuteChangedFor(nameof(AdjustSubmeshCountCommand))]
     [NotifyCanExecuteChangedFor(nameof(DeleteDuplicateEntriesCommand))]
     [NotifyCanExecuteChangedFor(nameof(RegenerateVisualControllersCommand))]
     [NotifyCanExecuteChangedFor(nameof(DeleteUnusedMaterialsCommand))]
@@ -269,14 +269,14 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
      */
     private bool _isEmptySubmeshesDeleted;
 
-    private bool CanDeleteEmptySubmeshes() =>
+    private bool CanAdjustSubmeshCount() =>
         !_isEmptySubmeshesDeleted && ContentType is RedDocumentItemType.Mesh && !_isEmptySubmeshesDeleted;
 
-    [RelayCommand(CanExecute = nameof(CanDeleteEmptySubmeshes))]
-    private void DeleteEmptySubmeshes()
+    [RelayCommand(CanExecute = nameof(CanAdjustSubmeshCount))]
+    private void AdjustSubmeshCount()
     {
         _isEmptySubmeshesDeleted = true;
-        RootChunk?.DeleteEmptySubmeshesCommand.Execute(null);
+        RootChunk?.AdjustSubmeshCountCommand.Execute(null);
     }
 
     /*

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -480,13 +480,13 @@
                     Visibility="{Binding Path=IsEnabled,
                                          RelativeSource={RelativeSource Self},
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Header="Delete empty submeshes"
-                    Command="{Binding Path=DeleteEmptySubmeshesCommand}">
+                    Header="Adjust submesh counts"
+                    Command="{Binding Path=AdjustSubmeshCountCommand}">
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Material"
-                            Kind="DatabaseMinus"
-                            Foreground="{StaticResource WolvenKitRed}" />
+                            Kind="LayersTriple"
+                            Foreground="White" />
                     </MenuItem.Icon>
                 </MenuItem>
 


### PR DESCRIPTION
# renamed "delete empty submeshes"

can now also generate missing chunk materials, thus stopping all those annoying warnings.