### PR TITLE
Project and appfile actions

### DIFF
--- a/WolvenKit.App/Helpers/UIHelper.cs
+++ b/WolvenKit.App/Helpers/UIHelper.cs
@@ -76,5 +76,7 @@ public static class UIHelper
             pixelsPerDip: 96D).Width);
     }
 
+    public static void SetMaxHeightToScreenHeight(Window window) => window.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
+
     #endregion Methods
 }

--- a/WolvenKit.App/Helpers/UIHelper.cs
+++ b/WolvenKit.App/Helpers/UIHelper.cs
@@ -76,7 +76,8 @@ public static class UIHelper
             pixelsPerDip: 96D).Width);
     }
 
-    public static void SetMaxHeightToScreenHeight(Window window) => window.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
+    public static double GetScreenHeight() => SystemParameters.PrimaryScreenHeight;
+    public static double GetScreenWidth() => SystemParameters.PrimaryScreenWidth;
 
     #endregion Methods
 }

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -738,5 +738,28 @@ public sealed partial class Cp77Project(string location, string name, string mod
 
     [GeneratedRegex(@"((\w+\\\\?)+\w+\.\w+)")]
     private static partial Regex ResourceFilePathsRegex();
+
+    private int _numEmptyFolders = 0;
+
+    public void DeleteEmptyFolders(ILoggerService loggerService)
+    {
+        _numEmptyFolders = 0;
+        DeleteEmptyFolders(ModDirectory);
+        loggerService.Success($"Deleted {_numEmptyFolders} empty folders");
+    }
+
+    private void DeleteEmptyFolders(string directory)
+    {
+        foreach (var subdirectory in Directory.GetDirectories(directory))
+        {
+            DeleteEmptyFolders(subdirectory);
+
+            if (Directory.GetFiles(subdirectory).Length == 0 && Directory.GetDirectories(subdirectory).Length == 0)
+            {
+                _numEmptyFolders += 1;
+                Directory.Delete(subdirectory);
+            }
+        }
+    }
 }
     

--- a/WolvenKit.App/ViewModels/Dialogs/DeleteOrMoveFilesListDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DeleteOrMoveFilesListDialogViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
+using WolvenKit.App.Helpers;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
@@ -9,6 +10,7 @@ public partial class DeleteOrMoveFilesListDialogViewModel : DialogViewModel
     [ObservableProperty] private List<string> _files;
     [ObservableProperty] private string _title;
     [ObservableProperty] private bool _hasFiles;
+    public double MaxHeight = UIHelper.GetScreenHeight() * 0.9;
     public int FilesCount => Files.Count;
     
     public string? MoveToPath { get; set; }

--- a/WolvenKit.App/ViewModels/Dialogs/ShowBrokenReferences.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ShowBrokenReferences.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
+using WolvenKit.App.Helpers;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
@@ -9,6 +10,7 @@ public partial class ShowBrokenReferencesDialogViewModel : DialogViewModel
     [ObservableProperty] private Dictionary<string, List<string>> _references;
     [ObservableProperty] private string _title;
     public int ReferencesCount => References.Count;
+    public double MaxHeight = UIHelper.GetScreenHeight() * 0.9; 
 
     public ShowBrokenReferencesDialogViewModel(string title, Dictionary<string, List<string>> references)
     {

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
@@ -112,9 +112,17 @@ public partial class ChunkViewModel
             return;
         }
 
-        IsHiddenBySearch = !(Value?.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase) == true
-                             || Descriptor?.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase) == true
-                             || StringHelper.StringifyRedType(ResolvedData).Contains(searchBoxText, StringComparison.OrdinalIgnoreCase));
+        var shouldShow = Value?.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase) == true
+                         || Descriptor?.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase) == true
+                         || StringHelper.StringifyRedType(ResolvedData).Contains(searchBoxText, StringComparison.OrdinalIgnoreCase);
+
+        // if it's a ref, search in full depot path
+        shouldShow = shouldShow || (ResolvedData is IRedRef data &&
+                                    data.DepotPath.GetResolvedText()?.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase) == true);
+
+        shouldShow = shouldShow || PropertyType.Name.Contains(searchBoxText, StringComparison.OrdinalIgnoreCase);
+
+        IsHiddenBySearch = !shouldShow;
 
         if (IsHiddenBySearch)
         {

--- a/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml
@@ -8,6 +8,8 @@
     Title="{Binding Title}"
     MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
     MinHeight="{DynamicResource WolvenKitDialogHeight}"
+    MaxHeight="{Binding MaxHeight,
+                        RelativeSource={RelativeSource Self}}"
     SizeToContent="WidthAndHeight"
     WindowStartupLocation="CenterOwner">
     <Grid

--- a/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml.cs
@@ -31,7 +31,6 @@ public partial class DeleteOrMoveFilesListDialogView : IViewFor<DeleteOrMoveFile
     public bool? ShowDialog(Window owner)
     {
         Owner = owner;
-        UIHelper.SetMaxHeightToScreenHeight(owner);
         return ShowDialog();
     }
 

--- a/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/DeleteOrMoveFilesListDialogView.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Data;
 using System.Windows.Input;
 using ReactiveUI;
 using Syncfusion.Windows.Controls.RichTextBoxAdv;
+using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models.ProjectManagement.Project;
 using WolvenKit.App.ViewModels.Dialogs;
@@ -30,6 +31,7 @@ public partial class DeleteOrMoveFilesListDialogView : IViewFor<DeleteOrMoveFile
     public bool? ShowDialog(Window owner)
     {
         Owner = owner;
+        UIHelper.SetMaxHeightToScreenHeight(owner);
         return ShowDialog();
     }
 

--- a/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml
@@ -9,6 +9,8 @@
                     RelativeSource={RelativeSource Self}}"
     MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
     MinHeight="{DynamicResource WolvenKitDialogHeightSmall}"
+    MaxHeight="{Binding MaxHeight,
+                        RelativeSource={RelativeSource Self}}"
     SizeToContent="WidthAndHeight"
     WindowStartupLocation="CenterOwner">
     <Grid

--- a/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml.cs
@@ -25,7 +25,6 @@ public partial class ShowBrokenReferencesDialogView : IViewFor<ShowBrokenReferen
     public bool? ShowDialog(Window owner)
     {
         Owner = owner;
-        UIHelper.SetMaxHeightToScreenHeight(owner);
         return ShowDialog();
     }
 

--- a/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/ShowBrokenReferencesDialogView.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using ReactiveUI;
+using WolvenKit.App.Helpers;
 using WolvenKit.App.ViewModels.Dialogs;
 
 namespace WolvenKit.Views.Dialogs.Windows;
@@ -24,6 +25,7 @@ public partial class ShowBrokenReferencesDialogView : IViewFor<ShowBrokenReferen
     public bool? ShowDialog(Window owner)
     {
         Owner = owner;
+        UIHelper.SetMaxHeightToScreenHeight(owner);
         return ShowDialog();
     }
 

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -538,6 +538,15 @@
                         <templates:IconBox IconPack="Empty" />
                     </MenuItem.Icon>
                 </MenuItem>
+                <MenuItem
+                    Style="{StaticResource ShowAppMenuItemStyle}"
+                    Header="Find unused files in project"
+                    ToolTip="Will filter by extension: Only file extensions used in any references will be considered"
+                    Click="OnFindUnusedProjectFilesClick">
+                    <MenuItem.Icon>
+                        <templates:IconBox IconPack="Empty" />
+                    </MenuItem.Icon>
+                </MenuItem>
 
                 <!-- Select animation path -->
                 <MenuItem

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -192,13 +192,13 @@
                 <Separator />
 
                 <MenuItem
-                    x:Name="ToolbarProjectScanFilepathsButton"
+                    x:Name="ToolbarProjectScanFilePathsButton"
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
                     Header="Scan project for broken file references">
                     <MenuItem.Icon>
                         <local:IconBox
-                            IconPack="Codicons"
-                            Kind="Search"
+                            IconPack="Material"
+                            Kind="FileSearchOutline"
                             Size="{DynamicResource WolvenKitIconTiny}"
                             Foreground="White" />
                     </MenuItem.Icon>
@@ -210,8 +210,8 @@
                     Header="Scan for unused project files">
                     <MenuItem.Icon>
                         <local:IconBox
-                            IconPack="Codicons"
-                            Kind="Search"
+                            IconPack="Material"
+                            Kind="TextSearchVariant"
                             Size="{DynamicResource WolvenKitIconTiny}"
                             Foreground="White" />
                     </MenuItem.Icon>
@@ -220,13 +220,13 @@
                 <MenuItem
                     x:Name="ToolbarProjectDeleteEmptyFoldersButton"
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
-                    Header="Scan for unused project files">
+                    Header="Delete empty folders">
                     <MenuItem.Icon>
                         <local:IconBox
-                            IconPack="Codicons"
-                            Kind="Search"
+                            IconPack="Material"
+                            Kind="FolderRemove"
                             Size="{DynamicResource WolvenKitIconTiny}"
-                            Foreground="White" />
+                            Foreground="{StaticResource WolvenKitRed}" />
                     </MenuItem.Icon>
                 </MenuItem>
 

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -218,6 +218,19 @@
                 </MenuItem>
 
                 <MenuItem
+                    x:Name="ToolbarProjectDeleteEmptyFoldersButton"
+                    Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                    Header="Scan for unused project files">
+                    <MenuItem.Icon>
+                        <local:IconBox
+                            IconPack="Codicons"
+                            Kind="Search"
+                            Size="{DynamicResource WolvenKitIconTiny}"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <MenuItem
                     x:Name="ToolbarProjectRunFileValidationButton"
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
                     Header="Run File Validation on the entire project">

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -78,7 +78,7 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                 .DisposeWith(disposables);
             this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.ScanForBrokenReferencePathsCommand,
-                    view => view.ToolbarProjectScanFilepathsButton)
+                    view => view.ToolbarProjectScanFilePathsButton)
                 .DisposeWith(disposables);
             this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.FindUnusedFilesCommand,

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -85,6 +85,10 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                     view => view.ToolbarProjectFindUnusedFilesButton)
                 .DisposeWith(disposables);
             this.BindCommand(ViewModel,
+                    viewModel => viewModel.MainViewModel.DeleteEmptyFoldersCommand,
+                    view => view.ToolbarProjectDeleteEmptyFoldersButton)
+                .DisposeWith(disposables);
+            this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.RunFileValidationOnProjectCommand,
                     view => view.ToolbarProjectRunFileValidationButton)
                 .DisposeWith(disposables);

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -277,10 +277,12 @@ namespace WolvenKit.Views.Tools
         private void ExpandAllNodes(TreeNode node)
         {
             TreeGrid.ExpandAllNodes(node);
-            if (ViewModel != null)
+            if (ViewModel != null && string.IsNullOrEmpty(_currentFolderQuery))
             {
                 RecursiveStateSave(node.ChildNodes);
             }
+
+            return;
 
             void RecursiveStateSave(TreeNodes childNodes)
             {
@@ -297,11 +299,13 @@ namespace WolvenKit.Views.Tools
 
         private void CollapseAllNodes(TreeNode node)
         {
-            if (ViewModel != null)
+            if (ViewModel != null && string.IsNullOrEmpty(_currentFolderQuery))
             {
                 RecursiveStateSave(node.ChildNodes);
             }
             TreeGrid.CollapseAllNodes(node);
+
+            return;
             void RecursiveStateSave(TreeNodes childNodes)
             {
                 foreach (var childNode in childNodes)
@@ -489,11 +493,11 @@ namespace WolvenKit.Views.Tools
                 }
             }
 
-            if (e.Action != NotifyCollectionChangedAction.Remove || e.OldItems == null)
+            if (e.Action != NotifyCollectionChangedAction.Remove || e.OldItems == null || !string.IsNullOrEmpty(_currentFolderQuery))
             {
                 return;
             }
-
+            
             foreach (var item in e.OldItems)
             {
                 if (item is not TreeNode { Item: FileSystemModel { IsDirectory: true } fileSystemModel })

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -1267,9 +1267,9 @@
 
                 <!-- Delete Everything But Selection -->
                 <MenuItem
+                    Header="Delete All but Selection in Array/Buffer"
                     Command="{Binding Path=PlacementTarget.Tag.DeleteAllButSelectionCommand,
                                       RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                    Header="Delete All but Selection in Array/Buffer"
                     IsCheckable="False">
 
 
@@ -1282,7 +1282,6 @@
                                 <MultiDataTrigger>
                                     <MultiDataTrigger.Conditions>
                                         <Condition Binding="{Binding Path=PlacementTarget.Tag.IsInArray, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
-                                        <Condition Binding="{Binding Path=PlacementTarget.Tag.IsMultipleItemsSelected, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
                                         <Condition Binding="{Binding Path=PlacementTarget.Tag.IsShiftKeyPressed, RelativeSource={RelativeSource AncestorType=ContextMenu}}" Value="True" />
                                     </MultiDataTrigger.Conditions>
                                     <Setter Property="Visibility" Value="Visible" />


### PR DESCRIPTION
# Project and appfile actions

**Implemented:**
- Project: Delete empty folders
- Project explorer: Don't save node expansion states while a search is active
- CVM search: supports depot paths for references and type names
- dialogues: should now be clamped to 90% of screen height (e.g. "find unused files")
