### PR TITLE
convenience when copying/moving file on itself

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -792,7 +792,8 @@ namespace WolvenKit.Views.Tools
 
             // We're copying or moving a file on itself - offer rename operation
             if (fileMap.Count == 1 && existingFiles.Count == 1 &&
-                ViewModel?.ActiveProject is Cp77Project project)
+                ViewModel?.ActiveProject is Cp77Project project &&
+                targetDirectory == Path.GetDirectoryName(fileMap.Keys.First()))
             {
                 var filePath = fileMap.Keys.First();
                 var relativePath = filePath.Replace($"{project.ModDirectory}{Path.DirectorySeparatorChar}", "");


### PR DESCRIPTION
# ProjectExplorer: Convenience when copying/moving a file on itself

WKit will ask for a new file name.
- if file name is empty (dialogue cancelled), operation aborts
- if file name is identical, it will create a _copy