### PR TITLE
meshtools: better error message for missing bones

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -11,6 +11,7 @@ using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
 using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
 using WolvenKit.Modkit.Exceptions;
 using WolvenKit.Modkit.RED4.GeneralStructs;
@@ -711,8 +712,8 @@ namespace WolvenKit.Modkit.RED4.Tools
 
             if (bonesNotFound.Any())
             {
-                throw new Exception(
-                    $"Bones not found in import mesh(es): {string.Join("\n", bonesNotFound)}");
+                throw new WolvenKitException(0x2005,
+                    $"You're trying to import bones into a mesh that doesn't have them. Wolvenkit can't create bones — please remove them in Blender, or import into a different .mesh file.\n{string.Join("\n", bonesNotFound)}");
             }
         }
 

--- a/WolvenKit/Helpers/LogCodeHelper.cs
+++ b/WolvenKit/Helpers/LogCodeHelper.cs
@@ -23,6 +23,8 @@ public static class LogCodeHelper
             "https://wiki.redmodding.org/cyberpunk-2077-modding/modding-guides/textures-and-luts/images-importing-editing-exporting#all-images-must-be-the-same-size");
         s_mapping.Add(0x2004, // morphtarget: no chunks
             "https://wiki.redmodding.org/cyberpunk-2077-modding/modding-guides/npcs/a-new-head-for-v#step-6-optional-disabling-the-character-creator");
+        s_mapping.Add(0x2005, // mesh: bone mismatch
+            "https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators-theory/3d-modelling/troubleshooting-your-mesh-edits#bones-not-found-in-import-mesh-es");
 
         // 3: modKit stuff
 


### PR DESCRIPTION
# meshtools: better error message

![image](https://github.com/user-attachments/assets/2c70f956-7f53-4f4d-9b5b-2695b8091f3f)