### PR TITLE
Changed morphTarget normal / tangent to Vec3 instead of Vec4.

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MorphTargetImportTools.cs
@@ -260,8 +260,8 @@ namespace WolvenKit.Modkit.RED4
 
                         // GLTF's RHCS Y up -> Red4 LHCS Z up
                         var zUpPositionDelta = new TargetVec3(positionDelta.X, -positionDelta.Z, positionDelta.Y);
-                        var zUpNormalDelta = new Vec4(normalDelta.X, -normalDelta.Z, normalDelta.Y, 0f);
-                        var zUpTangentDelta = new Vec4(tangentDelta.X, -tangentDelta.Z, tangentDelta.Y, 0f);
+                        var zUpNormalDelta = new Vec3(normalDelta.X, -normalDelta.Z, normalDelta.Y);
+                        var zUpTangentDelta = new Vec3(tangentDelta.X, -tangentDelta.Z, tangentDelta.Y);
 
                         // Quant already converted earlier
                         var zUpQuantizedPositionDelta =
@@ -272,8 +272,8 @@ namespace WolvenKit.Modkit.RED4
 
                         // NB different encoding for position!
                         var positionAs10BitUnsignedInt = Converters.Vec3ToU32(zUpQuantizedPositionDelta, 1);
-                        var normalAs10BitShiftedInt = Converters.Vec4ToU32(zUpNormalDelta);
-                        var tangentAs10BitShiftedInt = Converters.Vec4ToU32(zUpTangentDelta);
+                        var normalAs10BitShiftedInt = Converters.Vec3ToU32(zUpNormalDelta);
+                        var tangentAs10BitShiftedInt = Converters.Vec3ToU32(zUpTangentDelta);
 
                         // 4 + 4 + 4 bytes per diff, no padding
                         diffsWriter.Write(positionAs10BitUnsignedInt);


### PR DESCRIPTION
# MorphTarget import fix

**Fixed:**
- `POSITION` / `TANGENT` using Vec4 instead of Vec3. Needed due to #2076

**Additional notes:**
Fixes #2094 
