### PR TITLE
feat(CurveEditor): improve contrast ratio

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1002,7 +1002,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
                     File.Move(absolutePath, destPath);
                 }
-               
+
             }
             catch
             {

--- a/WolvenKit/Themes/App.Styles.xaml
+++ b/WolvenKit/Themes/App.Styles.xaml
@@ -42,6 +42,11 @@
     <Color x:Key="WolvenKitYellowShadow50Color">#7FABA108</Color>
     <Color x:Key="WolvenKitYellowShadow25Color">#7F403c09</Color>
 
+    <Color x:Key="WolvenKitGraphGridColor">#0DFFFFFF</Color>
+    <Color x:Key="WolvenKitGraphAxisColor">Black</Color>
+    <Color x:Key="WolvenKitGraphLabelColor">White</Color>
+    <Color x:Key="WolvenKitGraphCurveColor">White</Color>
+
     <!-- Brushes -->
     <SolidColorBrush x:Key="CustomSliderForegroundBrush" Color="#FF1E91EA" />
     <SolidColorBrush x:Key="CustomSliderBackgroundBrush" Color="#55ffffff" />
@@ -99,6 +104,12 @@
 
     <SolidColorBrush x:Key="BackgroundColor_Button_Inactive" Color="#969696" />
     <SolidColorBrush x:Key="BackgroundColor_Button_Active" Color="#313131" />
+
+    <!-- Graph and Curve Editors -->
+    <SolidColorBrush x:Key="WolvenKitGraphGrid" Color="{StaticResource WolvenKitGraphGridColor}" />
+    <SolidColorBrush x:Key="WolvenKitGraphAxis" Color="{StaticResource WolvenKitGraphAxisColor}" />
+    <SolidColorBrush x:Key="WolvenKitGraphLabel" Color="{StaticResource WolvenKitGraphLabelColor}" />
+    <SolidColorBrush x:Key="WolvenKitGraphCurve" Color="{StaticResource WolvenKitGraphCurveColor}" />
 
     <Style
         x:Key="WolvenKitTabControl"

--- a/WolvenKit/Views/Templates/CurveEditorWindow.xaml
+++ b/WolvenKit/Views/Templates/CurveEditorWindow.xaml
@@ -221,7 +221,7 @@
 
                                             <GeometryDrawing.Pen>
                                                 <Pen
-                                                    Brush="Gray"
+                                                    Brush="{StaticResource WolvenKitGraphGrid}"
                                                     Thickness="1" />
                                             </GeometryDrawing.Pen>
                                         </GeometryDrawing>
@@ -235,8 +235,8 @@
                             x:Name="CanvasLinearCurve"
                             Visibility="Collapsed">
                             <Path
-                                Stroke="Black"
-                                StrokeThickness="1">
+                                Stroke="{StaticResource WolvenKitGraphCurve}"
+                                StrokeThickness="2">
                                 <Path.Data>
                                     <GeometryGroup>
                                         <PathGeometry>
@@ -262,8 +262,8 @@
                             x:Name="CanvasQuadraticCurve"
                             Visibility="Collapsed">
                             <Path
-                                Stroke="Black"
-                                StrokeThickness="1">
+                                Stroke="{StaticResource WolvenKitGraphCurve}"
+                                StrokeThickness="2">
                                 <Path.Data>
                                     <GeometryGroup>
                                         <PathGeometry>
@@ -289,8 +289,8 @@
                             x:Name="CanvasCubicCurve"
                             Visibility="Collapsed">
                             <Path
-                                Stroke="Black"
-                                StrokeThickness="1">
+                                Stroke="{StaticResource WolvenKitGraphCurve}"
+                                StrokeThickness="2">
                                 <Path.Data>
                                     <GeometryGroup>
                                         <PathGeometry>

--- a/WolvenKit/Views/Templates/CurveEditorWindow.xaml.cs
+++ b/WolvenKit/Views/Templates/CurveEditorWindow.xaml.cs
@@ -376,7 +376,6 @@ namespace WolvenKit.Views.Editors
             {
                 var p = new Ellipse
                 {
-                    Stroke = Brushes.Black,
                     Fill = GetPointColor(generalizedPoint),
                     Width = pointSize,
                     Height = pointSize,
@@ -450,7 +449,7 @@ namespace WolvenKit.Views.Editors
                 var xaxisPath = new Path
                 {
                     StrokeThickness = 2,
-                    Stroke = Brushes.Black,
+                    Stroke = (SolidColorBrush)FindResource("WolvenKitGraphAxis"),
                     Data = xaxisGeom
                 };
 
@@ -495,7 +494,7 @@ namespace WolvenKit.Views.Editors
                 var yaxisPath = new Path
                 {
                     StrokeThickness = 2,
-                    Stroke = Brushes.Black,
+                    Stroke = (SolidColorBrush)FindResource("WolvenKitGraphAxis"),
                     Data = yaxisGeom
                 };
 
@@ -503,13 +502,14 @@ namespace WolvenKit.Views.Editors
             }
         }
 
-        private static void DrawLabels(Panel can, string text, Point location, double fontSize, HorizontalAlignment halign, VerticalAlignment valign)
+        private void DrawLabels(Panel can, string text, Point location, double fontSize, HorizontalAlignment halign, VerticalAlignment valign)
         {
             // Make the label.
             var label = new Label
             {
                 Content = text,
                 FontSize = fontSize,
+                Foreground = (SolidColorBrush)FindResource("WolvenKitGraphLabel"),
                 Background = Brushes.Transparent,
                 BorderBrush = Brushes.Transparent
             };


### PR DESCRIPTION
# feat(CurveEditor): improve contrast ratio

**Implemented:**
- remove point's outline
- increase curve's line width, change to white color
- add color resources with `WolvenKitGraph...` name

**Fixed:**
- see [feedback](https://github.com/WolvenKit/WolvenKit/issues/1957#issuecomment-2566686742). Issue in itself is related to the same view but for others, bigger changes (so not closing here).

**Demo:**
Screenshot at 100%. Currently line width (grid + axis + curve) are not responsive, but point's size is. Can a 4K user try it and let me know if it would benefit UI scaling?

![image](https://github.com/user-attachments/assets/fcbb5c63-e3ed-4604-9d65-e98677787cee)