### PR TITLE
Mesh fix

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -1937,7 +1937,7 @@ namespace WolvenKit.Modkit.RED4
                 Indices = new DataBuffer(indBuffer.ToArray()),
                 MorphOffsets = new DataBuffer(morphBuffer.ToArray()),
                 Vertices = new DataBuffer(vertBuffer.ToArray()),
-                Uv = new DataBuffer(uvBuffer.ToArray()),
+                //Uv = new DataBuffer(uvBuffer.ToArray()),
                 NumVertices = Convert.ToUInt32(mesh.positions.Length),
                 LodMask = 1
             });


### PR DESCRIPTION
# Mesh fix

**Fixed:**
- Disabled UV parameter generation (introduced in ccb65ce ) since its causing issues with mesh seams.

**Notes:**
Normally these buffers contains `TEXCOORD_0` of the meshes, but some values in there are not normalized.
Maybe tackle that topic again later