### PR TITLE
fix(ProjectExplorer): scrollbar no longer showing ontop of buttons

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -363,7 +363,9 @@
             </ContextMenu>
 
             <DataTemplate x:Key="TreeGridCellTemplate">
-                <Grid>
+                <Grid
+                    Margin="{DynamicResource WolvenKitMarginRight}"
+                    HorizontalAlignment="Stretch">
                     <Grid.Resources>
                         <Style
                             x:Key="WolvenKitTreeGridButton"
@@ -532,11 +534,6 @@
                                     Loaded="TreeIcon_Loaded" />
                             </helpers:TreeGridButton.Content>
                         </helpers:TreeGridButton>
-
-                        <helpers:TreeGridButton
-                            Width="0"
-                            Margin="{DynamicResource WolvenKitMarginSmallBottom}"
-                            Style="{StaticResource WolvenKitTreeGridButtonDirectory}" />
                     </StackPanel>
                 </Grid>
             </DataTemplate>


### PR DESCRIPTION
# fix(ProjectExplorer): scrollbar no longer showing ontop of buttons

**Implemented:**
- add margin to the right to prevent missclick between delete button and scrollbar.
- improve drawing of quick access buttons to be the same on all rows.

**Demo:**
![image](https://github.com/user-attachments/assets/3fbe6d53-b6a9-4bcb-b983-caa799979389)