### PR TITLE
feat: improve UI/UX in RDTDataView and descendants

### DIFF
--- a/WolvenKit/Views/Documents/RDTDataView.xaml
+++ b/WolvenKit/Views/Documents/RDTDataView.xaml
@@ -83,6 +83,7 @@
             Grid.Row="0"
             Grid.Column="0"
             Margin="0"
+            HorizontalAlignment="Left"
             ItemsSource="{Binding Chunks}"
             SelectedItem="{Binding SelectedChunk,
                                    Mode=TwoWay}"
@@ -99,6 +100,7 @@
             x:Name="CustomPG"
             Grid.Row="0"
             Grid.Column="2"
+            HorizontalAlignment="Stretch"
             DataContext="{Binding SelectedChunk}"
             ViewModel="{Binding SelectedChunk}"
             ValueChanged="RedTypeView_OnValueChanged" />

--- a/WolvenKit/Views/Templates/RedChunkMaskEditor.xaml
+++ b/WolvenKit/Views/Templates/RedChunkMaskEditor.xaml
@@ -12,17 +12,14 @@
     FocusManager.FocusedElement="{Binding ElementName=comboboxadv}">
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:RedChunkMaskEditor}}}">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" MaxWidth="300" />
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="{DynamicResource WolvenKitRedEditorHashWidth}" />
         </Grid.ColumnDefinitions>
 
         <syncfusion:ComboBoxAdv
             Name="comboboxadv"
-            Width="300"
             Padding="{DynamicResource WolvenKitMarginTiny}"
             Background="#252525"
-            BorderBrush="{StaticResource BorderAlt}"
-            BorderThickness="0,0,1,0"
             FontSize="{DynamicResource WolvenKitFontSubTitle}"
             AllowMultiSelect="True"
             ItemsSource="{Binding BindingCollection,
@@ -33,11 +30,16 @@
                                     UpdateSourceTrigger=PropertyChanged}"
             SelectedValueDelimiter=", " />
 
+        <Border
+            Grid.Column="1"
+            BorderBrush="{StaticResource BorderAlt}"
+            BorderThickness="1,0,0,0" />
+
         <TextBox
             x:Name="TextBox"
             Grid.Column="1"
+            Margin="1,0,0,0"
             Padding="{DynamicResource WolvenKitMarginTiny}"
-            BorderBrush="{StaticResource BorderAlt}"
             FontSize="{DynamicResource WolvenKitFontSubTitle}"
             PreviewTextInput="NumberValidationTextBox"
             Text="{Binding Text,

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml
@@ -146,12 +146,28 @@
             Name="FlagsComboBox"
             Grid.Row="1"
             Grid.Column="1"
-            Grid.ColumnSpan="2"
             Padding="{DynamicResource WolvenKitMarginTiny}"
             FontSize="{DynamicResource WolvenKitFontSubTitle}"
             ItemsSource="{Binding EnumValues}"
             KeyboardNavigation.TabIndex="3"
             SelectedItem="{Binding RedRef.Flags,
                                    Mode=OneWay}" />
+
+        <Border
+            Grid.Row="1"
+            Grid.Column="2"
+            BorderBrush="{StaticResource BorderAlt}"
+            BorderThickness="1,0,0,0" />
+
+        <TextBlock
+            Grid.Row="1"
+            Grid.Column="2"
+            Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+            VerticalAlignment="Center"
+            Foreground="{StaticResource WolvenKitTan}"
+            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+            Text="{Binding TypeName,
+                           UpdateSourceTrigger=PropertyChanged,
+                           Mode=OneWay}" />
     </Grid>
 </UserControl>

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
@@ -8,12 +8,9 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
-using DynamicData.Kernel;
 using HandyControl.Tools.Extension;
 using Splat;
 using WolvenKit.App.Services;
-using WolvenKit.Common;
-using WolvenKit.Common.Extensions;
 using WolvenKit.Modkit.Resources;
 using WolvenKit.RED4.Types;
 
@@ -126,7 +123,7 @@ namespace WolvenKit.Views.Editors
                 }
 
                 return RedRef.DepotPath.GetRedHash().ToString();
-                
+
             }
             set
             {
@@ -140,6 +137,8 @@ namespace WolvenKit.Views.Editors
                 }
             }
         }
+
+        public string TypeName => RedRef.RedType;
 
         private void HashBox_OnPreviewTextInput(object sender, TextCompositionEventArgs e)
         {
@@ -263,7 +262,7 @@ namespace WolvenKit.Views.Editors
             _updateTimer.Stop();
             RefreshValidityAndTooltip(_updateSender, new RoutedEventArgs());
         }
-        
+
         public void TrimmingTextbox_OnKeyUp(object sender, EventArgs e)
         {
             if (e is not KeyEventArgs { Key: Key.Enter or Key.Tab })


### PR DESCRIPTION
# feat: improve UI/UX in RDTDataView and descendants

**Implemented:**
- feat(RedRefEditor): show type name next to flags

**Fixed:**
- fix(RedChunkMaskEditor): revert UI breaking changes
- fix(RDTDataView): horizontal splitter can be moved again

**Additional notes:**
Closes #2124

**Demo:**
![image](https://github.com/user-attachments/assets/dd0e24e8-f6e5-4357-a99a-7badff2b0cbe)