### PR TITLE
feat: add quick access to open curve editor

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -30,7 +30,6 @@ using WolvenKit.Common.Services;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
 using WolvenKit.Core.Interfaces;
-using WolvenKit.Core.Services;
 using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.RED4.Archive;
 using WolvenKit.RED4.Archive.Buffer;
@@ -297,7 +296,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             }
         }
 
-        
+
         // expand / collapse "special" children, e.g. if the parent holds no properties we care for
         switch (ResolvedData)
         {
@@ -487,7 +486,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         CalculateProperties();
         return TVProperties.ToList();
     }
-    
+
     // DisplayProperties (for the panel on the right)
     public ObservableCollectionExtended<ChunkViewModel> DisplayProperties => MightHaveChildren() ? Properties : SelfList;
 
@@ -760,8 +759,11 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                                ResolvedPropertyType.IsAssignableTo(typeof(IList))
                                || ResolvedPropertyType.IsAssignableTo(typeof(CR2WList))
                                || ResolvedPropertyType.IsAssignableTo(typeof(RedPackage))));
-    
-    
+
+    public bool IsCurve => (ResolvedPropertyType is not null &&
+                            ResolvedPropertyType.IsAssignableTo(typeof(IRedLegacySingleChannelCurve)));
+
+
     public int PropertyCount
     {
         get
@@ -1500,7 +1502,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     sequenceIndex = (sequenceIndex + 1) % newMaterials.Count;
                 }
             }
-            
+
             appearance.ChunkMaterials = new CArray<CName>();
             foreach (var t in newMaterials)
             {
@@ -2362,7 +2364,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         var gt = propertyType.GetGenericTypeDefinition();
         return (weakHandleOnly && gt == typeof(CWeakHandle<>)) || gt == typeof(CHandle<>);
     }
-    
+
 
 
     public bool PasteHandle(IRedBaseHandle sourceHandle)
@@ -2613,7 +2615,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     private bool CanDuplicateChunk() => IsInArray && Parent is not null; // TODO RelayCommand check notify
 
     [RelayCommand(CanExecute = nameof(CanDuplicateChunk))]
-  
+
     private void DuplicateChunk() => DuplicateChunk(-1);
 
     public ChunkViewModel? DuplicateChunk(int index)
@@ -2641,7 +2643,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         Tab?.Parent.SetIsDirty(true);
 
         var newSibling = Parent.GetChildNode(Math.Min(index, Parent.TVProperties.Count - 1));
-        
+
         // Unless shift key is pressed, we want to regenerate CRUIDs
         if (IsShiftKeyPressed || newSibling is null)
         {
@@ -2672,7 +2674,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         return Task.CompletedTask;
     }
 
-    
+
     [RelayCommand(CanExecute = nameof(CanDuplicateChunk))]
     private void DuplicateAsNewChunk()
     {
@@ -2802,7 +2804,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             .Select(_ => _.Data.NotNull())
             .ToList();
 
-        RedDocumentTabViewModel.ClearCopiedChunks();;
+        RedDocumentTabViewModel.ClearCopiedChunks();
         foreach (var i in fullselection)
         {
             AddToCopiedChunks(i);
@@ -2873,7 +2875,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         try
         {
             var index = insertAtIndex < 0 ? Properties.Count : insertAtIndex;
-            
+
             for (var i = 0; i < copiedData.Count; i++)
             {
                 var e = copiedData[i];
@@ -2903,13 +2905,13 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                 if (PropertyType.IsAssignableTo(typeof(IRedArray)))
                 {
                     // index boundary checking will happen in insertChild
-                    
+
                     if (InsertChild(index, e))
                     {
                         //RDTDataViewModel.CopiedChunk = null;
                     }
                 }
-                
+
                 index++;
             }
         }
@@ -2960,7 +2962,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     [
         "appearances", "externalMaterials"
     ];
-    
+
     public void ForceLoadPropertiesRecursive()
     {
         if (IsHandle(Data, true) && !s_InitializeAnyway.Contains(Parent?.Name ?? ""))
@@ -3448,7 +3450,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         {
             return TypeCompability.None;
         }
-        
+
         if (destType.IsAssignableFrom(srcType))
         {
             return TypeCompability.Assignable;

--- a/WolvenKit/Converters/TreeViewItemTemplateSelector.cs
+++ b/WolvenKit/Converters/TreeViewItemTemplateSelector.cs
@@ -10,10 +10,13 @@ namespace WolvenKit.Converters
     internal class TreeViewItemTemplateSelector : DataTemplateSelector
     {
         public DataTemplate GroupedTemplate { get; set; }
-        public DataTemplate PropertyTemplate { get; set; }
+
+        public DataTemplate CurveTemplate { get; set; }
         public DataTemplate ArrayTemplate { get; set; }
         public DataTemplate HandleTemplate { get; set; }
         public DataTemplate RefTemplate { get; set; }
+
+        public DataTemplate PropertyTemplate { get; set; }
 
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
@@ -22,12 +25,16 @@ namespace WolvenKit.Converters
                 return null;
             }
 
+            // NOTE: don't mess the order, it matters when resolving types below:
             return tvn.Content switch
             {
                 GroupedChunkViewModel gvm => GroupedTemplate,
+
+                ChunkViewModel vm when vm.PropertyType.IsAssignableTo(typeof(IRedLegacySingleChannelCurve)) => CurveTemplate,
                 ChunkViewModel vm when vm.PropertyType.IsAssignableTo(typeof(IList)) => ArrayTemplate,
                 ChunkViewModel vm when vm.PropertyType.IsAssignableTo(typeof(IRedHandle)) => HandleTemplate,
                 ChunkViewModel vm when vm.PropertyType.IsAssignableTo(typeof(IRedRef)) => RefTemplate,
+
                 ChunkViewModel vm => PropertyTemplate,
                 _ => null
             };

--- a/WolvenKit/Views/Templates/RedCurveEditor.xaml
+++ b/WolvenKit/Views/Templates/RedCurveEditor.xaml
@@ -11,9 +11,13 @@
     d:DesignWidth="240"
     d:DesignHeight="48">
     <Grid DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:RedCurveEditor}}}">
+        <!-- Direct access as a field in RedTypeView -->
         <Button
             x:Name="CurveEditorButton"
             Margin="{DynamicResource WolvenKitMarginTinyVertical}"
+            Visibility="{Binding Path=ShowQuickAccess,
+                                 Mode=OneWay,
+                                 Converter={StaticResource InvertBooleanVisibilityConverter}}"
             syncfusion:FocusManagerHelper.FocusedElement="True"
             Click="CurveEditorButton_OnClick">
             <StackPanel Orientation="Horizontal">
@@ -29,6 +33,24 @@
                     VerticalAlignment="Center"
                     Text="Open Curve Editor" />
             </StackPanel>
+        </Button>
+
+        <!-- Quick access in "info top" of RedTypeView -->
+        <Button
+            VerticalAlignment="Center"
+            Background="Transparent"
+            Style="{StaticResource ButtonCustom}"
+            Visibility="{Binding Path=ShowQuickAccess,
+                                 Mode=OneWay,
+                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+            Click="CurveEditorButton_OnClick"
+            ToolTip="Open Curve Editor">
+            <templates:IconBox
+                IconPack="Material"
+                Kind="ChartBellCurve"
+                Margin="{DynamicResource WolvenKitMarginTinyLeft}"
+                Size="{DynamicResource WolvenKitIconMilli}"
+                Foreground="{StaticResource WolvenKitCyan}" />
         </Button>
     </Grid>
 </UserControl>

--- a/WolvenKit/Views/Templates/RedCurveEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedCurveEditor.xaml.cs
@@ -1,6 +1,5 @@
 using System.Windows;
 using System.Windows.Controls;
-using ReactiveUI;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.RED4.Types;
 
@@ -17,6 +16,19 @@ namespace WolvenKit.Views.Editors
         {
             InitializeComponent();
         }
+
+        public bool ShowQuickAccess
+        {
+            get => (bool)GetValue(ShowQuickAccessProperty);
+            set => SetValue(ShowQuickAccessProperty, value);
+        }
+
+        public static readonly DependencyProperty ShowQuickAccessProperty = DependencyProperty.Register(
+            nameof(ShowQuickAccess),
+            typeof(bool),
+            typeof(RedCurveEditor),
+            new PropertyMetadata(false)
+            );
 
         //public IRedLegacySingleChannelCurve RedCurve
         //{

--- a/WolvenKit/Views/Templates/RedTypeView.xaml
+++ b/WolvenKit/Views/Templates/RedTypeView.xaml
@@ -334,6 +334,16 @@
                 </StackPanel>
             </DataTemplate>
 
+            <DataTemplate
+                x:Key="OpenCurveEditorButton"
+                DataType="{x:Type shell:ChunkViewModel}">
+                <editors:RedCurveEditor
+                    Visibility="{Binding Path=IsCurve,
+                                         Mode=OneWay,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}"
+                    ShowQuickAccess="True" />
+            </DataTemplate>
+
             <Style
                 x:Key="PGNameStyle"
                 TargetType="TextBlock">
@@ -1009,28 +1019,38 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="{DynamicResource WolvenKitColumnTiny}" />
                     </Grid.ColumnDefinitions>
 
+                    <!-- Cyan to open/run -->
                     <ContentPresenter
                         Grid.Column="0"
                         Margin="{DynamicResource WolvenKitMarginTinyLeft}"
                         Content="{Binding}"
-                        ContentTemplate="{StaticResource AddToCompiledDataButton}" />
+                        ContentTemplate="{StaticResource OpenCurveEditorButton}" />
+
+                    <!-- Yellow to add/create -->
                     <ContentPresenter
                         Grid.Column="1"
                         Content="{Binding}"
-                        ContentTemplate="{StaticResource AddToArrayButton}" />
+                        ContentTemplate="{StaticResource AddToCompiledDataButton}" />
                     <ContentPresenter
                         Grid.Column="2"
                         Content="{Binding}"
-                        ContentTemplate="{StaticResource AddDynamicProperty}" />
+                        ContentTemplate="{StaticResource AddToArrayButton}" />
                     <ContentPresenter
                         Grid.Column="3"
                         Content="{Binding}"
-                        ContentTemplate="{StaticResource AddHandleButton}" />
+                        ContentTemplate="{StaticResource AddDynamicProperty}" />
                     <ContentPresenter
                         Grid.Column="4"
+                        Content="{Binding}"
+                        ContentTemplate="{StaticResource AddHandleButton}" />
+
+                    <!-- Red to delete/reset -->
+                    <ContentPresenter
+                        Grid.Column="5"
                         Content="{Binding}"
                         ContentTemplate="{StaticResource DeleteAllButton}" />
                 </Grid>

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -10,6 +10,7 @@
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     xmlns:treeViewEngine="clr-namespace:Syncfusion.UI.Xaml.TreeView.Engine;assembly=Syncfusion.SfTreeView.WPF"
     xmlns:templates="clr-namespace:WolvenKit.Views.Templates"
+    xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
     mc:Ignorable="d"
     d:DesignWidth="800"
     d:DesignHeight="450"
@@ -2052,6 +2053,41 @@
                         </Grid>
                     </DataTemplate>
                 </converters:TreeViewItemTemplateSelector.RefTemplate>
+
+                <converters:TreeViewItemTemplateSelector.CurveTemplate>
+                    <DataTemplate>
+                        <Grid
+                            Width="Auto"
+                            HorizontalAlignment="Stretch"
+                            Background="Transparent"
+                            ContextMenu="{StaticResource TreeViewContextMenu}"
+                            Tag="{Binding}"
+                            ToolTip="{Binding Type}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Style="{StaticResource ArrayNameColumnWidth}" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" MinWidth="20" />
+                            </Grid.ColumnDefinitions>
+
+                            <ContentPresenter
+                                Grid.Column="0"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Center"
+                                ContentTemplate="{StaticResource PropertyNameTemplate}" />
+
+                            <ContentPresenter
+                                Grid.Column="1"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Center"
+                                ContentTemplate="{StaticResource PropertyValueTemplate}" />
+
+                            <editors:RedCurveEditor
+                                Grid.Column="2"
+                                Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                                ShowQuickAccess="True" />
+                        </Grid>
+                    </DataTemplate>
+                </converters:TreeViewItemTemplateSelector.CurveTemplate>
             </converters:TreeViewItemTemplateSelector>
         </ResourceDictionary>
     </UserControl.Resources>


### PR DESCRIPTION
# feat: add quick access to open curve editor

**Implemented:**
[feat(RedTypeView): show quick access button to open curve editor](https://github.com/WolvenKit/WolvenKit/commit/00cb03c6826a98d5512710cd1940d2399784d55c)

- reuse RedCurveEditor in "info top" of RedTypeView when type is a IRedLegacySingleChannelCurve.
- add property ShowQuickAccess in RedCurveEditor to either show current button (default) or quick access button.

[feat(RedTreeView): add quick access to open curve editor](https://github.com/WolvenKit/WolvenKit/commit/57af0afe0eb9d6e8043ef50a3166597bdd1e842a)

- add CurveTemplate selector.
- add icon button next to "curveData" rows to open in curve editor.

**Additional notes:**
Closes #2081

**Demo:**
![image](https://github.com/user-attachments/assets/7b870b0e-fe72-451c-bc30-81da361f0406)