### PR TITLE
Clear exported file lookup after export operation

### DIFF
--- a/WolvenKit.App/Helpers/ImportExportHelper.cs
+++ b/WolvenKit.App/Helpers/ImportExportHelper.cs
@@ -169,6 +169,11 @@ public class ImportExportHelper
 
     #endregion RedMod
 
+    /// <summary>
+    /// Clears the lookup table for already exported file.
+    /// </summary>
+    public void ClearFileLookup() => _modTools.ClearFileLookup();
+
     public async Task<bool> Export(FileInfo cr2wFile, GlobalExportArgs args, DirectoryInfo basedir, DirectoryInfo? rawoutdir = null, ECookedFileFormat[]? forcebuffers = null) =>
         await Task.Run(async () =>
         {

--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -454,6 +454,11 @@ public class AppScriptFunctions : ScriptFunctions
     }
 
     /// <summary>
+    /// Clears the lookup for exported depot files.
+    /// </summary>
+    public void ClearExportFileLookup() => _importExportHelper.ClearFileLookup();
+
+    /// <summary>
     /// Exports a list of files as you would with the export tool.
     /// </summary>
     /// <param name="fileList"></param>

--- a/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Exporters/ExportViewModel.cs
@@ -93,6 +93,8 @@ public partial class ExportViewModel : AbstractImportExportViewModel
         var total = 0;
         var successful = 0;
 
+        _importExportHelper.ClearFileLookup();
+
         //prepare a list of failed items
         var failedItems = new List<string>();
 

--- a/WolvenKit.Common/Interfaces/IModTools.cs
+++ b/WolvenKit.Common/Interfaces/IModTools.cs
@@ -74,6 +74,8 @@ namespace WolvenKit.Common.Interfaces
 
         public bool ExportEntity(CR2WFile entFile, CName appearance, FileInfo outfile);
         public bool ExportMaterials(CR2WFile cr2w, FileInfo outfile, MeshExportArgs meshExportArgs);
+
+        public void ClearFileLookup();
     }
 
 }

--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -516,6 +516,11 @@ namespace WolvenKit.Modkit.RED4
             return InternalUncookBuffers(cr2wFile, relPath, outfile, settings, rawOutDir);
         }
 
+        /// <summary>
+        /// Clears the lookup table for already exported file.
+        /// </summary>
+        public void ClearFileLookup() => _uncookedLookup.Clear();
+
         public bool IsUncooked(string? depotPath, string destName, string relPath)
         {
             if (!string.IsNullOrEmpty(depotPath) &&


### PR DESCRIPTION
# Clear exported file lookup after export operation

**Fixed:**
- Due to caching of already exported file (Depot only) which was implemented so CLI doesn't export the same files over and over again, it wasn't possible to export the same file (or files which gets placed in the depot) in the GUI multiples times without restarting. This should be fixed now.

**Notes:**
Also added that to wscript as separate function (`wkit.ClearExportFileLookup()`), so the script author can decide if its wanted or not.
