### PR TITLE
added logging about scene graph initialization crash

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -365,8 +365,7 @@ public partial class RedGraph
         }
         else
         {
-            _loggerService?.Error("Scene graph failed to initialize. Check the scene for references to nonexistent resources.");
-            _loggerService?.Error("Possible places: screenplayStore sceneGraph");
+            _loggerService?.Error("Scene graph failed to initialize. Check that the sceneGraph is created.");
         }
 
         foreach (var node in graph.Nodes)


### PR DESCRIPTION
# added logging about scene graph initialization crash

**Implemented:**
- Added log when the sceneGraph was not created. Before that it just silently didn't show up.

**Fixed:**
- Added logging

**Additional notes:**
![image](https://github.com/user-attachments/assets/9d373292-7319-4ff6-b3fd-caccfa3cbd4d)

