### PR TITLE
ProjectExplorer fixes

### DIFF
--- a/WolvenKit.App/Services/WatcherService.cs
+++ b/WolvenKit.App/Services/WatcherService.cs
@@ -405,7 +405,7 @@ public partial class WatcherService : ObservableObject, IWatcherService
         if (_updateTask != null)
         {
             _updateThreadCancellationTokenSource.Cancel();
-            if (!_updateTask.Wait(1000))
+            if (!_updateTask.IsCanceled && !_updateTask.Wait(1000))
             {
                 throw new Exception();
             }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -1199,7 +1199,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         try
         {
             _projectWatcher.WatchProject(project);
-            _projectWatcher.Refresh();
         }
         catch
         {


### PR DESCRIPTION
# ProjectExplorer fixes

**Fixed:**
- Duplicated `Refresh` call
- Issue with cancelling the WatcherService update task

**Additional notes:**
Fixes #2138 
