### PR TITLE
un-dynamify mesh materials

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.MeshFunctions.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.MeshFunctions.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using HelixToolkit.SharpDX.Core;
 using WolvenKit.RED4.Types;
 
 // ReSharper disable once CheckNamespace
@@ -55,5 +58,90 @@ public partial class ChunkViewModel
         }
 
         return entries.TVProperties.ElementAtOrDefault(index);
+    }
+
+    /// <summary>
+    /// Resolves dynamic appearance names and -materials.
+    /// Returns a dictionary of dynamic appearance names with all possible parameters. 
+    /// </summary>
+    /// <example><code>
+    /// { "@neon", [ "red", "blue", "green" ] }
+    /// </code></example>
+    public Dictionary<string, List<string>> UnDynamifyAppearances()
+    {
+        Dictionary<string, List<string>> ret = [];
+
+        if (ResolvedData is not CMesh mesh || GetPropertyChild("appearances") is not ChunkViewModel appearances)
+        {
+            return ret;
+        }
+
+        appearances.CalculatePropertiesRecursive();
+
+        var meshAppearances = mesh.Appearances.Select(m => m.Chunk).OfType<meshMeshAppearance>().ToList();
+        var appearancesWithMaterials = meshAppearances.Where(mA => mA.ChunkMaterials.Count > 0).ToList();
+
+        // if only the first appearance has chunks defined, then the other materials will inherit from the first
+        if (meshAppearances.Count > 1 && appearancesWithMaterials.Count == 1 &&
+            meshAppearances.First() is meshMeshAppearance template &&
+            template.Name.GetString() is string templateName)
+        {
+            var templateChunkMaterials = template.ChunkMaterials.Select(s => s.ToString() ?? "").ToList();
+            foreach (var mA in meshAppearances)
+            {
+                mA.ChunkMaterials.Clear();
+
+                // turn materialName@neon to neon_materialName
+                foreach (var chunkMaterial in templateChunkMaterials.Select(chunk =>
+                             chunk.Replace(templateName, mA.Name)))
+                {
+                    mA.ChunkMaterials.Add(chunkMaterial);
+                }
+            }
+        }
+
+        // now add the dynamic materials to the list
+        foreach (var mA in meshAppearances)
+        {
+            var chunkMaterials = mA.ChunkMaterials
+                .Select(cm => cm.GetString() ?? "")
+                // resolve all dynamic materials, turn red@neon into neon_red
+                .Select(mat =>
+                {
+                    if (!mat.Contains('@'))
+                    {
+                        return mat;
+                    }
+
+                    var nameParts = mat.Split('@');
+                    if (nameParts.Length != 2)
+                    {
+                        return mat;
+                    }
+
+                    ret.TryAdd(nameParts[1], []);
+                    var materialName = $"{nameParts[1]}_{nameParts[0]}";
+                    ret.Get(nameParts[1]).Add(materialName);
+                    return materialName;
+                })
+                .ToList();
+
+            mA.ChunkMaterials.Clear();
+            foreach (var mat in chunkMaterials)
+            {
+                mA.ChunkMaterials.Add(mat);
+            }
+        }
+
+        if (ret.Count != 0)
+        {
+            appearances.RecalculateProperties();
+            foreach (var child in appearances.TVProperties)
+            {
+                child.RecalculateProperties();
+            }
+        }
+
+        return ret;
     }
 }

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -338,6 +338,23 @@
                                          RelativeSource={RelativeSource Self},
                                          Mode=OneWay,
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Header="Un-dynamify materials"
+                    Command="{Binding Path=UnDynamifyMaterialsCommand}"
+                    Click="OnUnDynamifyMaterialsClick">
+                    <MenuItem.Icon>
+                        <templates:IconBox
+                            IconPack="Material"
+                            Kind="ArrowUpBox"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <MenuItem
+                    Style="{StaticResource MenuItemStyle}"
+                    Visibility="{Binding Path=IsEnabled,
+                                         RelativeSource={RelativeSource Self},
+                                         Mode=OneWay,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}"
                     Header="Scroll to material"
                     Command="{Binding Path=ScrollToMaterialCommand}">
                     <MenuItem.Icon>


### PR DESCRIPTION
# un-dynamify mesh materials

**Implemented:**
- can convert dynamic mesh materials into regular materials

before:
![image](https://github.com/user-attachments/assets/1e188cd7-b0c1-4247-93e6-6c9b132ee98d)
![image](https://github.com/user-attachments/assets/68912fe1-3074-4898-8f15-d5866b6793d7)

after:
![image](https://github.com/user-attachments/assets/f2f0c797-79d1-4240-b8d6-cbc3dc37884b)
