### PR TITLE
fix(LogView): improve responsiveness

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -2364,6 +2364,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         // LogView
         resources["WolvenKitLogScriptMinWidth"] = 240 * _uiScalePercentage;
         resources["WolvenKitLogLineMinHeight"] = 16 * _uiScalePercentage;
+        resources["WolvenKitLogBreakpointWidth"] = 504 * _uiScalePercentage;
 
         // BackStageView
         resources["WolvenKitBackStageBgMargin"] = new Thickness(5, 55, 5, 5).Mul(_uiScalePercentage);

--- a/WolvenKit/Themes/App.Sizes.xaml
+++ b/WolvenKit/Themes/App.Sizes.xaml
@@ -141,6 +141,7 @@
     <!-- LogView -->
     <system:Double x:Key="WolvenKitLogScriptMinWidth">240</system:Double>
     <system:Double x:Key="WolvenKitLogLineMinHeight">16</system:Double>
+    <system:Double x:Key="WolvenKitLogBreakpointWidth">504</system:Double>
 
     <!-- BackStageView -->
     <Thickness x:Key="WolvenKitBackStageBgMargin">5,55,5,5</Thickness>
@@ -188,7 +189,7 @@
     <system:Double x:Key="WolvenKitDialogHeightMedium">600</system:Double>
     <system:Double x:Key="WolvenKitDialogWidthLarge">1024</system:Double>
     <system:Double x:Key="WolvenKitDialogHeightLarge">768</system:Double>
-    
+
     <GridLength x:Key="WolvenKitDialogLabelColumnWidth">112</GridLength>
     <GridLength x:Key="WolvenKitDialogLabelColumnWidthMedium">140</GridLength>
     <GridLength x:Key="WolvenKitDialogLabelColumnWidthLarge">180</GridLength>
@@ -196,9 +197,9 @@
     <system:Double x:Key="WolvenKitLabelWidth">112</system:Double>
     <system:Double x:Key="WolvenKitLabelWidthMedium">140</system:Double>
     <system:Double x:Key="WolvenKitLabelWidthLarge">180</system:Double>
-    
+
     <system:Double x:Key="WolvenKitDialogSammySize">40</system:Double>
-    
+
     <!-- FirstSetupView -->
     <system:Double x:Key="WolvenKitFirstSetupWidth">720</system:Double>
     <system:Double x:Key="WolvenKitFirstSetupHeight">278</system:Double>

--- a/WolvenKit/Views/Tools/LogView.xaml
+++ b/WolvenKit/Views/Tools/LogView.xaml
@@ -15,7 +15,9 @@
     d:DataContext="{d:DesignInstance Type=tools:LogViewModel}"
     d:DesignWidth="800"
     d:DesignHeight="450"
-    x:Name="uc">
+    x:Name="uc"
+    MinWidth="348"
+    SizeChanged="LogView_OnSizeChanged">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -38,6 +40,22 @@
 
         <Grid.Resources>
             <converters:NullVisibilityConverter x:Key="NullVisibilityConverter" />
+
+            <Style
+                x:Key="LogLevelButtonStyle"
+                BasedOn="{StaticResource WPFButtonStyle}"
+                TargetType="{x:Type Button}">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Focusable" Value="False" />
+                <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="#10FFFFFF" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
         </Grid.Resources>
 
         <Grid
@@ -45,33 +63,16 @@
             Grid.Row="0"
             Grid.Column="0">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="{DynamicResource WolvenKitColumnTiny}" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-
-            <Grid.Resources>
-                <Style
-                    x:Key="LogLevelButtonStyle"
-                    BasedOn="{StaticResource WPFButtonStyle}"
-                    TargetType="{x:Type Button}">
-                    <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="BorderThickness" Value="0" />
-                    <Setter Property="Focusable" Value="False" />
-                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
-
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#10FFFFFF" />
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </Grid.Resources>
 
             <StackPanel
                 x:Name="LogLevelFilter"
                 Grid.Column="0"
                 Margin="{DynamicResource WolvenKitMarginTinyLeft}"
+                HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Orientation="Horizontal">
                 <Button
@@ -131,7 +132,6 @@
 
                 <Button
                     x:Name="FilterDebugButton"
-                    Margin="0"
                     Style="{StaticResource LogLevelButtonStyle}"
                     Command="{Binding ToggleFilterLevelCommand}"
                     CommandParameter="4"
@@ -151,7 +151,7 @@
                 Margin="{DynamicResource WolvenKitMarginTinyBottom}"
                 HorizontalAlignment="Right">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" MinWidth="240" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
@@ -363,6 +363,7 @@
         </ItemsControl>
 
         <StackPanel
+            x:Name="LogPanelButtons"
             Grid.Row="1"
             Grid.Column="1"
             Orientation="Vertical">

--- a/WolvenKit/Views/Tools/LogView.xaml.cs
+++ b/WolvenKit/Views/Tools/LogView.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Media;
 using System.Windows.Navigation;
 using DynamicData;
 using HandyControl.Tools.Extension;
+using MahApps.Metro.Controls;
 using ReactiveUI;
 using Serilog.Events;
 using Splat;
@@ -199,11 +200,6 @@ namespace WolvenKit.Views.Tools
 
         private void ScrollToBottom_OnClick(object sender, RoutedEventArgs e) => _scrollViewer?.ScrollToBottom();
 
-        private void LogView_OnKeyUp(object sender, KeyEventArgs e)
-        {
-            // TODO: Implement scrolling and copy
-        }
-
         private void ScrollViewer_OnKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.PageUp)
@@ -213,6 +209,46 @@ namespace WolvenKit.Views.Tools
             else if (e.Key == Key.PageDown)
             {
                 _scrollViewer?.PageDown();
+            }
+        }
+
+        private void LogView_OnKeyUp(object sender, KeyEventArgs e)
+        {
+            // TODO: Implement scrolling and copy
+        }
+
+        private void LogView_OnSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            var breakpoint = (double)FindResource("WolvenKitLogBreakpointWidth");
+
+            if (e.NewSize.Width > breakpoint && LogLevelFilter.Orientation != Orientation.Horizontal)
+            {
+                LogPanelButtons.Children.Remove(LogLevelFilter);
+                LogViewHeader.Children.Add(LogLevelFilter);
+
+                LogLevelFilter.SetCurrentValue(Grid.ColumnProperty, 0);
+                LogLevelFilter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Left);
+                LogLevelFilter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Center);
+                LogLevelFilter.SetCurrentValue(StackPanel.OrientationProperty, Orientation.Horizontal);
+                ChangeMargin((Thickness)FindResource("WolvenKitMarginTinyRight"));
+            }
+            else if (e.NewSize.Width <= breakpoint && LogLevelFilter.Orientation != Orientation.Vertical)
+            {
+                LogViewHeader.Children.Remove(LogLevelFilter);
+                LogPanelButtons.Children.Add(LogLevelFilter);
+
+                LogLevelFilter.ClearValue(Grid.ColumnProperty);
+                LogLevelFilter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Center);
+                LogLevelFilter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Top);
+                LogLevelFilter.SetCurrentValue(StackPanel.OrientationProperty, Orientation.Vertical);
+                ChangeMargin((Thickness)FindResource("WolvenKitMarginTinyTop"));
+            }
+
+            return;
+
+            void ChangeMargin(Thickness margin)
+            {
+                LogLevelFilter.FindChildren<Button>().ForEach(button => button.SetCurrentValue(MarginProperty, margin));
             }
         }
     }


### PR DESCRIPTION
# fix(LogView): improve responsiveness

**Implemented:**
- move "filter by level" buttons in the right panel, vertically, when width is to small to fit filters and script buttons.
- add a minimum width to render the LogView.
- refactor LogView_ event callbacks to be grouped together.
- scaling at 150% is good enough as-is.

**Additional notes:**
Closes #2199

**Demo:**
Scale at 100%
![2025-01-16_WKit_LogView](https://github.com/user-attachments/assets/fb809386-7fe7-4651-b3ca-8b3940926740)