### PR TITLE
Better dialog support

### DIFF
--- a/WolvenKit.App/Services/IDialogService.cs
+++ b/WolvenKit.App/Services/IDialogService.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using System;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// Provides methods to display dialogs and modals in the application.
+/// </summary>
+public interface IDialogService
+{
+    /// <summary>
+    /// Displays a dialog for the specified view model.
+    /// </summary>
+    /// <param name="viewModel">The view model for the dialog.</param>
+    /// <returns>A nullable boolean indicating the result of the dialog.</returns>
+    public bool? ShowDialog(DialogExtViewModel viewModel);
+
+    /// <summary>
+    /// Displays a dialog for the specified view model and executes a callback upon completion.
+    /// </summary>
+    /// <typeparam name="T">The type of the view model, which must inherit from <see cref="DialogExtViewModel"/>.</typeparam>
+    /// <param name="viewModel">The view model for the dialog.</param>
+    /// <param name="callback">The callback to execute upon completion.</param>
+    public void ShowDialog<T>(T viewModel, Action<T> callback) where T : DialogExtViewModel;
+
+    /// <summary>
+    /// Displays a dialog for the specified view model and executes an asynchronous callback upon completion.
+    /// </summary>
+    /// <typeparam name="T">The type of the view model, which must inherit from <see cref="DialogExtViewModel"/>.</typeparam>
+    /// <param name="viewModel">The view model for the dialog.</param>
+    /// <param name="callback">The asynchronous callback to execute upon completion.</param>
+    public void ShowDialog<T>(T viewModel, Func<T, Task> callback) where T : DialogExtViewModel;
+
+    /// <summary>
+    /// Displays a modal dialog for the specified view model.
+    /// </summary>
+    /// <param name="viewModel">The view model for the modal dialog.</param>
+    public void ShowModal(DialogExtViewModel viewModel);
+
+    /// <summary>
+    /// Displays a modal dialog for the specified view model and executes a callback upon completion.
+    /// </summary>
+    /// <typeparam name="T">The type of the view model, which must inherit from <see cref="DialogExtViewModel"/>.</typeparam>
+    /// <param name="viewModel">The view model for the modal dialog.</param>
+    /// <param name="callback">The callback to execute upon completion.</param>
+    public void ShowModal<T>(T viewModel, Action<T> callback) where T : DialogExtViewModel;
+
+    /// <summary>
+    /// Displays a modal dialog for the specified view model and executes an asynchronous callback upon completion.
+    /// </summary>
+    /// <typeparam name="T">The type of the view model, which must inherit from <see cref="DialogExtViewModel"/>.</typeparam>
+    /// <param name="viewModel">The view model for the modal dialog.</param>
+    /// <param name="callback">The asynchronous callback to execute upon completion.</param>
+    public void ShowModal<T>(T viewModel, Func<T, Task> callback) where T : DialogExtViewModel;
+}

--- a/WolvenKit.App/ViewModels/Dialogs/DialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogViewModel.cs
@@ -1,5 +1,6 @@
-using System.Windows.Input;
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
+using WolvenKit.App.Services;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
@@ -7,12 +8,36 @@ public abstract class DialogViewModel : ObservableObject
 {
     public delegate void DialogHandlerDelegate(DialogViewModel? sender);
     public DialogHandlerDelegate? DialogHandler { get; set; }
-
-    //public abstract ICommand OkCommand { get; }
-    //public abstract ICommand CancelCommand { get; }
 }
 
 public abstract class DialogWindowViewModel : ObservableObject
 {
 
+}
+
+/// <summary>
+/// Base class for dialog view models used with <see cref="IDialogService"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Close"/> needs to be called to close the dialog.
+/// </para>
+/// </remarks>
+// Keep that as extra class for now. Can be renamed when all DialogViewModel/DialogWindowViewModel are migrated.
+public abstract class DialogExtViewModel : ObservableObject
+{
+    /// <summary>
+    /// Gets or sets the title of the dialog.
+    /// </summary>
+    public string Title { get; protected set; } = string.Empty;
+
+    /// <summary>
+    /// Occurs when the dialog is closed.
+    /// </summary>
+    public event EventHandler? Closed;
+
+    /// <summary>
+    /// Closes the dialog.
+    /// </summary>
+    protected void Close() => Closed?.Invoke(this, EventArgs.Empty);
 }

--- a/WolvenKit.App/ViewModels/Dialogs/SoundModdingViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SoundModdingViewModel.cs
@@ -18,7 +18,7 @@ using WolvenKit.Modkit.RED4.Sounds;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
-public partial class SoundModdingViewModel : DialogViewModel
+public partial class SoundModdingViewModel : DialogExtViewModel
 {
     private readonly INotificationService _notificationService;
     private readonly ILoggerService _logger;
@@ -140,6 +140,7 @@ public partial class SoundModdingViewModel : DialogViewModel
     {
         if (_projectManager.ActiveProject is null)
         {
+            Close();
             return;
         }
 
@@ -198,10 +199,16 @@ public partial class SoundModdingViewModel : DialogViewModel
             File.WriteAllText(modInfoJsonPath, jsonString);
             _notificationService.Success($"Saved sound configuration to {modInfoJsonPath}");
         }
+
+        Close();
     }
 
     [RelayCommand]
-    private void Cancel() => FileHandler?.Invoke(null);
+    private void Cancel()
+    {
+        FileHandler?.Invoke(null);
+        Close();
+    }
 
     [RelayCommand]
     private void Add()

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -80,6 +80,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     private readonly Cr2WTools _cr2WTools;
     private readonly TemplateFileTools _templateFileTools;
     private readonly ProjectResourceTools _projectResourceTools;
+    private readonly IDialogService _dialogService;
 
     // expose to view
     public ISettingsManager SettingsManager { get; init; }
@@ -109,7 +110,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         DocumentTools documentTools,
         Cr2WTools cr2WTools,
         TemplateFileTools templateFileTools,
-        ProjectResourceTools projectResourceTools
+        ProjectResourceTools projectResourceTools,
+        IDialogService dialogService
     )
     {
         _documentViewmodelFactory = documentViewmodelFactory;
@@ -132,6 +134,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         _cr2WTools = cr2WTools;
         _templateFileTools = templateFileTools;
         _projectResourceTools = projectResourceTools;
+        _dialogService = dialogService;
 
         _fileValidationScript = _scriptService.GetScripts().ToList()
             .Where(s => s.Name == "run_FileValidation_on_active_tab")
@@ -1122,29 +1125,13 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     private bool CanShowSoundModdingTool() => !IsDialogShown && ActiveProject != null;
     [RelayCommand(CanExecute = nameof(CanShowSoundModdingTool))]
-    private async Task ShowSoundModdingTool()
+    private void ShowSoundModdingTool()
     {
         var vm = _dialogViewModelFactory.SoundModdingViewModel();
         if (vm != null)
         {
-            vm.FileHandler = OpenSoundModdingView;
-            await SetActiveDialog(vm);
+            _dialogService.ShowModal(vm);
         }
-
-        //var vm = new SoundModdingViewModel
-        //{
-        //    FileHandler = OpenSoundModdingView
-        //};
-    }
-
-    private async Task OpenSoundModdingView(SoundModdingViewModel? file)
-    {
-        CloseModalCommand.Execute(null);
-        if (file == null)
-        {
-            return;
-        }
-        await Task.CompletedTask;
     }
 
     private bool CanShowScriptManager() => !IsDialogShown;

--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -68,6 +68,8 @@ namespace WolvenKit
                     services.AddSingleton<ILoggerService, SerilogWrapper>();                    // can this be transient?
                     services.AddSingleton<ITweakDBService, TweakDBService>();
 
+                    services.AddSingleton<IDialogService, DialogService>();
+
                     // scripting
                     services.AddSingleton<IHookService, AppHookService>();
                     services.AddSingleton<AppScriptService>();
@@ -105,7 +107,7 @@ namespace WolvenKit
                     #region shell
 
                     services.AddSingleton<AppViewModel>();
-                    services.AddTransient<IViewFor<AppViewModel>, MainView>();
+                    services.AddSingleton<IViewFor<AppViewModel>, MainView>();
 
                     services.AddTransient<RibbonViewModel>();
                     services.AddTransient<IViewFor<RibbonViewModel>, RibbonView>();

--- a/WolvenKit/Services/DialogService.cs
+++ b/WolvenKit/Services/DialogService.cs
@@ -1,0 +1,217 @@
+﻿using Splat;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System;
+using System.Windows;
+using Microsoft.Xaml.Behaviors;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.Views.Dialogs.Windows;
+using WolvenKit.Views.Shell;
+
+namespace WolvenKit.Services;
+
+/// <summary>
+/// Provides methods to display dialogs and modals in the application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service is a behavior that is attached to the <see cref="MainView"/> to display dialogs and modals.
+/// </para>
+/// <para>
+/// To use it, the ViewModel needs to be registered in the <see cref="GenericHost"/>.
+/// <code>
+/// <![CDATA[
+/// services.AddTransient<IViewFor<TViewModel>, TView>();
+/// ]]>
+/// </code>
+/// </para>
+/// <para>
+/// ShowDialog supports both <see cref="Window"/> and <see cref="UserControl"/> as Views.
+/// ShowModal supports only <see cref="UserControl"/> as Views.
+/// </para>
+/// </remarks>
+public class DialogService : Behavior<MainView>, IDialogService
+{
+    protected override void OnAttached()
+    {
+        // Pass down AssociatedObject to the DialogService registered in the Locator
+
+        var realService = Locator.Current.GetService<IDialogService>();
+        if (realService is not Behavior<MainView> realBehavior)
+        {
+            throw new Exception();
+        }
+
+        if (ReferenceEquals(this, realService))
+        {
+            return;
+        }
+
+        realBehavior.Attach(AssociatedObject);
+    }
+
+    private UserControl GetUserControl(DialogExtViewModel viewModel)
+    {
+        var view = ReactiveUI.ViewLocator.Current.ResolveView(viewModel);
+        if (view == null)
+        {
+            throw new Exception($"View for \"{viewModel.GetType().Name}\" could not be found!");
+        }
+
+        view.ViewModel ??= viewModel;
+
+        if (view is UserControl userControl)
+        {
+            return userControl;
+        }
+
+        throw new Exception($"View for \"{viewModel.GetType().Name}\" needs to be \"UserControl\"!");
+    }
+
+    private Window GetWindow(DialogExtViewModel viewModel)
+    {
+        var view = ReactiveUI.ViewLocator.Current.ResolveView(viewModel);
+        if (view == null)
+        {
+            throw new Exception($"View for \"{viewModel.GetType().Name}\" could not be found!");
+        }
+
+        view.ViewModel ??= viewModel;
+
+        if (view is Window window)
+        {
+            window.Owner = AssociatedObject;
+
+            return window;
+        }
+
+        if (view is UserControl userControl)
+        {
+            window = new DialogWindow(userControl)
+            {
+                Owner = AssociatedObject
+            };
+
+            return window;
+        }
+
+        throw new Exception($"View for \"{viewModel.GetType().Name}\" needs to be \"Window\" or \"UserControl\"!");
+    }
+
+    /// <inheritdoc />
+    public bool? ShowDialog(DialogExtViewModel viewModel)
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            throw new Exception();
+        }
+
+        return GetWindow(viewModel).ShowDialog();
+    }
+
+    /// <inheritdoc />
+    public void ShowDialog<T>(T viewModel, Action<T> callback) where T : DialogExtViewModel
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            return;
+        }
+
+        GetWindow(viewModel).ShowDialog();
+
+        callback(viewModel);
+    }
+
+    /// <inheritdoc />
+    public void ShowDialog<T>(T viewModel, Func<T, Task> callback) where T : DialogExtViewModel
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            return;
+        }
+
+        GetWindow(viewModel).ShowDialog();
+
+        callback(viewModel);
+    }
+
+    /// <inheritdoc />
+    public void ShowModal(DialogExtViewModel viewModel)
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            return;
+        }
+
+        var userControl = GetUserControl(viewModel);
+
+        EventHandler eventHandler = null;
+        eventHandler = (sender, args) =>
+        {
+            viewModel.Closed -= eventHandler;
+
+            AssociatedObject.ViewModel.IsDialogShown = false;
+            AssociatedObject.ViewModel.ShouldDialogShow = false;
+        };
+        viewModel.Closed += eventHandler;
+
+        AssociatedObject.ModalContent.SetCurrentValue(ContentControl.ContentProperty, userControl);
+        AssociatedObject.ViewModel.IsDialogShown = true;
+        AssociatedObject.ViewModel.ShouldDialogShow = true;
+    }
+
+    /// <inheritdoc />
+    public void ShowModal<T>(T viewModel, Action<T> callback) where T : DialogExtViewModel
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            return;
+        }
+
+        var userControl = GetUserControl(viewModel);
+
+        EventHandler eventHandler = null;
+        eventHandler = (sender, args) =>
+        {
+            viewModel.Closed -= eventHandler;
+
+            AssociatedObject.ViewModel.IsDialogShown = false;
+            AssociatedObject.ViewModel.ShouldDialogShow = false;
+
+            callback(viewModel);
+        };
+        viewModel.Closed += eventHandler;
+
+        AssociatedObject.ModalContent.SetCurrentValue(ContentControl.ContentProperty, userControl);
+        AssociatedObject.ViewModel.IsDialogShown = true;
+        AssociatedObject.ViewModel.ShouldDialogShow = true;
+    }
+
+    /// <inheritdoc />
+    public void ShowModal<T>(T viewModel, Func<T, Task> callback) where T : DialogExtViewModel
+    {
+        if (AssociatedObject.ViewModel == null)
+        {
+            return;
+        }
+
+        var userControl = GetUserControl(viewModel);
+
+        EventHandler eventHandler = null;
+        eventHandler = async void (sender, args) =>
+        {
+            viewModel.Closed -= eventHandler;
+
+            AssociatedObject.ViewModel.IsDialogShown = false;
+            AssociatedObject.ViewModel.ShouldDialogShow = false;
+
+            await callback(viewModel);
+        };
+        viewModel.Closed += eventHandler;
+
+        AssociatedObject.ModalContent.SetCurrentValue(ContentControl.ContentProperty, userControl);
+        AssociatedObject.ViewModel.IsDialogShown = true;
+        AssociatedObject.ViewModel.ShouldDialogShow = true;
+    }
+}

--- a/WolvenKit/Views/Dialogs/Windows/DialogWindow.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/DialogWindow.xaml
@@ -1,0 +1,10 @@
+﻿<Window
+    x:Class="WolvenKit.Views.Dialogs.Windows.DialogWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="DialogWindow"
+    Width="800"
+    Height="450" />

--- a/WolvenKit/Views/Dialogs/Windows/DialogWindow.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/DialogWindow.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using ReactiveUI;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs.Windows
+{
+    /// <summary>
+    /// A wrapper window to show UserControls as dialogs. Used by <see cref="DialogService"/>.
+    /// </summary>
+    public partial class DialogWindow : Window
+    {
+        public DialogWindow(UserControl content)
+        {
+            InitializeComponent();
+
+            Content = content;
+            SizeToContent = SizeToContent.WidthAndHeight;
+
+            if (content is IViewFor { ViewModel: DialogExtViewModel dialogViewModel })
+            {
+                Title = dialogViewModel.Title;
+                dialogViewModel.Closed += DialogViewModel_Closed;
+            }
+        }
+
+        private void DialogViewModel_Closed(object sender, System.EventArgs e)
+        {
+            var viewModel = (DialogExtViewModel)sender;
+            viewModel.Closed -= DialogViewModel_Closed;
+
+            Close();
+        }
+    }
+}

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -126,9 +126,6 @@
                     <DataTemplate DataType="{x:Type dialogVMs:NewFileViewModel}">
                         <dialogs:NewFileView ViewModel="{Binding}" />
                     </DataTemplate>
-                    <DataTemplate DataType="{x:Type dialogVMs:SoundModdingViewModel}">
-                        <dialogs:SoundModdingView ViewModel="{Binding}" />
-                    </DataTemplate>
                     <DataTemplate DataType="{x:Type dialogVMs:TypeSelectorDialogViewModel}">
                         <dialogs:TypeSelectorDialog ViewModel="{Binding}" />
                     </DataTemplate>

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -10,6 +10,8 @@
     xmlns:shell="clr-namespace:WolvenKit.Views.Shell"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     xmlns:syncfusionskin="clr-namespace:Syncfusion.SfSkinManager;assembly=Syncfusion.SfSkinManager.WPF"
+    xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+    xmlns:services="clr-namespace:WolvenKit.Services"
     Title="{Binding Title}"
     MinWidth="960"
     MinHeight="600"
@@ -29,6 +31,10 @@
     UseLayoutRounding="True"
     UseNativeChrome="True">
     <!-- TextBlock Text="{Binding Title}" FontSize="{Binding TitileFontSize}" VerticalAlignment="Center" Margin="10,0,0,0" Opacity="{Binding Opacity, ElementName=ModalOverlay}"/ -->
+    <b:Interaction.Behaviors>
+        <services:DialogService />
+    </b:Interaction.Behaviors>
+
     <syncfusion:ChromelessWindow.Resources>
         <shell:MyObservableCollection x:Key="leftHeaderItems">
             <shell:MenuBarView />
@@ -374,7 +380,9 @@
                                 Margin="20,10"
                                 FontSize="{DynamicResource WolvenKitFontMedium}"
                                 Text="Loading..." />
-                            <ContentControl Content="{Binding ActiveDialog}" />
+                            <ContentControl
+                                x:Name="ModalContent"
+                                Content="{Binding ActiveDialog}" />
                             <Border
                                 BorderBrush="{StaticResource BorderAlt}"
                                 BorderThickness="1"


### PR DESCRIPTION
# Better dialog support

**Implemented:**
- Better dialog support

**Fixed:**
- Changed `IViewFor<AppViewModel>` to a static service. Solves issue where the service locator would create new instances of `MainView` though we only have one (the main Window)

**Additional notes:**
Propose to merge it as is and migrate the current logic step by step so it can be used for new dialogs/modals directly.
Added migration of the `SoundModdingViewModel` modal as an example.

Not sure yet, how we should handle MessageBoxes in the future though...
