### PR TITLE
Delete partsvalues and overrides

### DIFF
--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -583,6 +583,7 @@
                     </MenuItem.Icon>
                 </MenuItem>
 
+                <!-- App file: edit components -->
                 <MenuItem
                     Style="{StaticResource ShowAppMenuItemStyle}"
                     Header="Edit components">
@@ -618,6 +619,21 @@
                                 Foreground="{StaticResource WolvenKitGraphLabel}" />
                         </MenuItem.Icon>
                     </MenuItem>
+                </MenuItem>
+
+                <!-- App file: delete things -->
+                <MenuItem
+                    Style="{StaticResource ShowAppMenuItemStyle}"
+                    Header="Delete...">
+
+                    <MenuItem.Icon>
+                        <templates:IconBox
+                            IconPack="Material"
+                            Kind="Delete..."
+                            Margin="{DynamicResource WolvenKitMarginTiny}"
+                            Size="{DynamicResource WolvenKitIconMilli}"
+                            Foreground="{DynamicResource WolvenKitRed}" />
+                    </MenuItem.Icon>
 
                     <!-- Delete component in all appearances -->
                     <MenuItem
@@ -632,8 +648,33 @@
                         </MenuItem.Icon>
                     </MenuItem>
 
-                </MenuItem>
+                    <!-- Clear PartsOverrides in all appearances -->
+                    <MenuItem
+                        Style="{StaticResource ShowAppMenuItemStyle}"
+                        Header="Clear PartsOverrides"
+                        Click="OnClearPartsOverridesClick">
+                        <MenuItem.Icon>
+                            <templates:IconBox
+                                IconPack="Material"
+                                Kind="PlaylistRemove"
+                                Foreground="{StaticResource WolvenKitRed}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
 
+                    <!-- Clear PartsValues in all appearances -->
+                    <MenuItem
+                        Style="{StaticResource ShowAppMenuItemStyle}"
+                        Header="Clear PartsValues"
+                        Click="OnClearPartsValuesClick">
+                        <MenuItem.Icon>
+                            <templates:IconBox
+                                IconPack="Material"
+                                Kind="PlaylistRemove"
+                                Foreground="{StaticResource WolvenKitRed}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                </MenuItem>
 
                 <!-- Connect to .ent file -->
                 <MenuItem


### PR DESCRIPTION
# .app file: delete partsValues and partsOverrides

... as discussed with psi, these aren't needed for CCXL addition apps, so we should be able to ditch them all at once

![image](https://github.com/user-attachments/assets/4d4fa57b-8a34-4874-be67-83c62856c7ea)
