### PR TITLE
feat: add copy relative path button in treegrid

### DIFF
--- a/WolvenKit/Themes/App.Styles.xaml
+++ b/WolvenKit/Themes/App.Styles.xaml
@@ -34,6 +34,8 @@
     <Color x:Key="WolvenKitPurpleColor">CornflowerBlue</Color>
     <Color x:Key="WolvenKitDarkPinkColor">#AA336A</Color>
     <Color x:Key="WolvenKitTanColor">#D0A467</Color>
+    <Color x:Key="WolvenKitOrangeColor">#FFA359</Color>
+    <Color x:Key="WolvenKitOrangeShadowColor">#8C5A31</Color>
 
     <Color x:Key="WolvenKitCyanShadow50Color">#7F4D8C9A</Color>
     <Color x:Key="WolvenKitCyanShadow25Color">#203a40</Color>
@@ -69,6 +71,8 @@
     <SolidColorBrush x:Key="WolvenKitPurple" Color="{StaticResource WolvenKitPurpleColor}" />
     <SolidColorBrush x:Key="WolvenKitDarkPink" Color="{StaticResource WolvenKitDarkPinkColor}" />
     <SolidColorBrush x:Key="WolvenKitTan" Color="{StaticResource WolvenKitTanColor}" />
+    <SolidColorBrush x:Key="WolvenKitOrange" Color="{StaticResource WolvenKitOrangeColor}" />
+    <SolidColorBrush x:Key="WolvenKitOrangeShadow" Color="{StaticResource WolvenKitOrangeShadowColor}" />
 
     <SolidColorBrush x:Key="WolvenKitRed50" Color="#7FDF2935" />
     <SolidColorBrush x:Key="WolvenKitRedShadow50" Color="{StaticResource WolvenKitRedShadow50Color}" />

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -471,11 +471,32 @@
                         VerticalAlignment="Center"
                         Text="{Binding Path=Name}" />
 
-                    <!-- Open in Windows Explorer - Open file - Delete -->
+                    <!-- Copy relative path - Open in Windows Explorer - Open file - Delete -->
                     <StackPanel
                         Grid.Column="2"
                         Background="{StaticResource ContentBackground}"
                         Orientation="Horizontal">
+                        
+                        <!-- Copy relative path-->
+                        <helpers:TreeGridButton
+                            BorderBrush="{StaticResource WolvenKitOrange}"
+                            Style="{StaticResource WolvenKitTreeGridButtonDirectory}"
+                            Command="{Binding ViewModel.CopyRelPathCommand,
+                                                   RelativeSource={RelativeSource FindAncestor,
+                                                 AncestorType={x:Type local:ProjectExplorerView}}}"
+                            CommandParameter="{Binding}"
+                            HoverBackground="{StaticResource WolvenKitOrangeShadow}"
+                            ToolTip="Copy relative path to game file">
+                            <helpers:TreeGridButton.Content>
+                                <templates:IconBox
+                                      IconPack="Material"
+                                      Kind="ContentCopy"
+                                      Size="{DynamicResource WolvenKitIconNano}"
+                                      Foreground="#222"
+                                      Loaded="TreeIcon_Loaded" />
+                            </helpers:TreeGridButton.Content>
+                        </helpers:TreeGridButton>
+                        
                         <!-- Open in Explorer -->
                         <helpers:TreeGridButton
                             BorderBrush="{StaticResource WolvenKitYellow}"


### PR DESCRIPTION
Copy relative path button added in treegridbuttons next to "open in explorer, open file, and delete" buttons as a QoL addition.

Screenshot:
![image](https://github.com/user-attachments/assets/a100188b-a37e-4507-b6fa-4b46946bdce0)
