### PR TITLE
fix: quest and scenes RDTDataViewModel search

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -565,7 +565,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
         {
             if (ModifierViewStateService.IsShiftBeingHeld)
             {
-                chunkViewModel.CalculatePropertiesRecursive();
+                chunkViewModel.CalculatePropertiesRecursive(0, 1024);
             }
             chunkViewModel.SetVisibilityStatusBySearchString(searchBoxText);
         }


### PR DESCRIPTION
# Fix RDTDataViewModel search for quest and scenes files

**Implemented:**
- Added default count limit parameter to `CalculatePropertiesRecursive`
- Increased limit count for cvm

**Fixed:**
- Broken search within graph trees

**Additional notes:**
Tested against huge scenes such as `base\quest\minor_quests\mq055\scenes\mq055_04_heywood.scene`. Its working kinda of OK.
Id like to add a notification dialog window about unresponsive UI when using search with a "Shift" key held on large files

Before:
![image](https://github.com/user-attachments/assets/eb977905-704a-4cbf-b8f3-2898a738667b)
After:
![image](https://github.com/user-attachments/assets/403b1dbc-8499-4ff2-be42-e7325e5ba359)
![image](https://github.com/user-attachments/assets/d6496fe8-63aa-4683-97c3-28a694145f65)


