### PR TITLE
View: exposing save/delete default layout

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
@@ -38,6 +38,8 @@ public partial class MenuBarViewModel : ObservableObject
         
         MainViewModel.DockedViewVisibleChanged += MainViewModel_OnDockedViewVisibleChanged;
         SettingsManager.PropertyChanged += SettingsManager_PropertyChanged;
+
+        appViewModel.PropertyChanged += AppViewModel_PropertyChanged;
     }
 
     private void SettingsManager_PropertyChanged(object? sender, PropertyChangedEventArgs e) =>
@@ -151,4 +153,16 @@ public partial class MenuBarViewModel : ObservableObject
 
         MainViewModel.GetToolViewModel<LocKeyBrowserViewModel>().IsVisible = value;
     }
+
+    [ObservableProperty] private bool? _hasOpenProject;
+
+    private void AppViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        HasOpenProject ??= MainViewModel.ActiveProject != null;
+        if (e.PropertyName == nameof(AppViewModel.ActiveProject))
+        {
+            HasOpenProject = true;
+        }
+    }        
+    
 }

--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -87,14 +87,14 @@ namespace WolvenKit.Views.Shell
 
         #region methods
 
-        public void SaveLayout()
+        public void SaveLayout(bool saveAsDefault = false)
         {
             if (ItemsSource == null)
             {
                 return;
             }
 
-            if (DataContext is AppViewModel { ActiveProject: { } project })
+            if (!saveAsDefault && DataContext is AppViewModel { ActiveProject: { } project })
             {
                 SaveLayout(Path.Combine(project.ProjectDirectory, "layout.xml"));
             }
@@ -103,7 +103,7 @@ namespace WolvenKit.Views.Shell
                 SaveLayout(Path.Combine(ISettingsManager.GetAppData(), "DockStates.xml"));
             }
         }
-
+        
         private void SaveLayout(string filePath)
         {
             var tmpPath = Path.ChangeExtension(filePath, ".tmp");
@@ -164,6 +164,19 @@ namespace WolvenKit.Views.Shell
             }
         }
 
+        public void ResetDefaultLayout()
+        {
+            var appDataLayoutPath = Path.Combine(ISettingsManager.GetAppData(), "DockStates.xml");
+            if (!File.Exists(appDataLayoutPath))
+            {
+                _logger.Info("You don't have a custom default layout");
+                return;
+            }
+
+            File.Delete(appDataLayoutPath);
+            _logger.Success("Your custom default layout was reset");
+        }        
+        
         public void LoadDefaultLayout()
         {
             if (DataContext is AppViewModel { ActiveProject: { } project })

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -51,7 +51,7 @@ namespace WolvenKit.Views.Shell
             
             this.WhenActivated(disposables =>
             {
-                Disposable.Create(dockingAdapter.SaveLayout).DisposeWith(disposables);
+                Disposable.Create(() => dockingAdapter.SaveLayout()).DisposeWith(disposables);
 
                 Interactions.ShowConfirmation = ShowConfirmation;
                 Interactions.ShowQuestionYesNo = ShowQuestionYesNo;

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -485,30 +485,73 @@
 
                 <Separator />
 
+                <!-- sub-menu "default layout" -->
                 <MenuItem
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
-                    Click="SaveLayoutToProject"
-                    Header="Save Layout to Project">
-                    <MenuItem.Icon>
-                        <local:IconBox
-                            IconPack="Codicons"
-                            Kind="Save"
-                            Size="{DynamicResource WolvenKitIconTiny}" />
-                    </MenuItem.Icon>
-                </MenuItem>
+                    Header="Layout">
 
-                <MenuItem
-                    Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
-                    Click="SetLayoutToDefault"
-                    Header="Reset Layout">
                     <MenuItem.Icon>
                         <local:IconBox
-                            IconPack="MaterialDesign"
-                            Kind="Refresh"
+                            IconPack="Empty"
                             Size="{DynamicResource WolvenKitIconTiny}" />
                     </MenuItem.Icon>
+
+
+                    <MenuItem
+                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                        IsEnabled="{Binding HasOpenProject}"
+                        Click="SaveLayoutToProject"
+                        Header="Save Layout to Project">
+                        <MenuItem.Icon>
+                            <local:IconBox
+                                IconPack="Codicons"
+                                Kind="Save"
+                                Size="{DynamicResource WolvenKitIconTiny}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <MenuItem
+                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                        IsEnabled="{Binding HasOpenProject}"
+                        Click="SetLayoutToDefault"
+                        Header="Reset Project Layout">
+                        <MenuItem.Icon>
+                            <local:IconBox
+                                IconPack="MaterialDesign"
+                                Kind="Refresh"
+                                Size="{DynamicResource WolvenKitIconTiny}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <Separator />
+
+                    <MenuItem
+                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                        Click="SaveCurrentLayoutToDefault"
+                        Header="Save Default Layout">
+                        <MenuItem.Icon>
+                            <local:IconBox
+                                IconPack="MaterialDesign"
+                                Kind="Save"
+                                Size="{DynamicResource WolvenKitIconTiny}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <MenuItem
+                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                        Click="ResetDefaultLayout"
+                        Header="Reset Default Layout">
+                        <MenuItem.Icon>
+                            <local:IconBox
+                                IconPack="MaterialDesign"
+                                Kind="ResetTv"
+                                Size="{DynamicResource WolvenKitIconTiny}" />
+                        </MenuItem.Icon>
+                    </MenuItem>
                 </MenuItem>
             </MenuItem>
+
+
 
             <!-- Tools -->
             <MenuItem

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -1,8 +1,10 @@
+using System.IO;
 using System.Reactive.Disposables;
 using System.Windows;
 using ReactiveUI;
 using Splat;
 using WolvenKit.App.Interaction;
+using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
 
 namespace WolvenKit.Views.Shell;
@@ -258,5 +260,9 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
 
     private void SetLayoutToDefault(object sender, RoutedEventArgs e) => DockingAdapter.G_Dock.LoadDefaultLayout();
     private void SaveLayoutToProject(object sender, RoutedEventArgs e) => DockingAdapter.G_Dock.SaveLayout();
+
+    private void ResetDefaultLayout(object sender, RoutedEventArgs e) => DockingAdapter.G_Dock.ResetDefaultLayout();
+
+    private void SaveCurrentLayoutToDefault(object sender, RoutedEventArgs e) => DockingAdapter.G_Dock.SaveLayout(true);
     private void GenerateMaterialRepoButton_Click(object sender, RoutedEventArgs e) => Interactions.ShowMaterialRepositoryView();
 }


### PR DESCRIPTION
# View: Default layout
 
- You can now save or delete the default layout from the view menu (previously, you could only save default layout by saving the project layout without an open project)
- The project layout operations are disabled while no project is opened

![image](https://github.com/user-attachments/assets/f8d135ac-d3f9-4cf4-a4ed-28d41ae7533f)
![image](https://github.com/user-attachments/assets/2b3b3a21-7260-43d1-96da-694f785a8d82)
