### PR TITLE
WScript improvements

### DIFF
--- a/WolvenKit.Common/Services/HookService.cs
+++ b/WolvenKit.Common/Services/HookService.cs
@@ -19,7 +19,7 @@ public class HookService : IHookService
     public void OnPreImport(ref RedRelativePath rawRelative, ref GlobalImportArgs args, ref DirectoryInfo? outDir) => _onImportHook?.Invoke(ref rawRelative, ref args, ref outDir);
 
     public void RegisterOnImportFromJson(OnImportFromJsonHook hook) => _onImportFromJsonHook = hook;
-    public void OnImportFromJson(ref string jsonText) => _onImportFromJsonHook?.Invoke(ref jsonText);
+    public void OnImportFromJson(ref string jsonText, string redExtension) => _onImportFromJsonHook?.Invoke(ref jsonText, redExtension);
 
     public void RegisterOnParsingError(OnParsingErrorHook hook) => _onParsingErrorHook = hook;
     public bool OnParsingError(ParsingErrorEventArgs eventData) => _onParsingErrorHook != null && _onParsingErrorHook.Invoke(eventData);
@@ -28,7 +28,7 @@ public class HookService : IHookService
 
     public delegate void OnExportHook(ref FileInfo fileInfo, ref GlobalExportArgs args);
     public delegate void OnPreImportHook(ref RedRelativePath rawRelative, ref GlobalImportArgs args, ref DirectoryInfo? outDir);
-    public delegate void OnImportFromJsonHook(ref string jsonText);
+    public delegate void OnImportFromJsonHook(ref string jsonText, string redExtension);
     public delegate bool OnParsingErrorHook(ParsingErrorEventArgs eventData);
 
     #endregion

--- a/WolvenKit.Common/Services/IHookService.cs
+++ b/WolvenKit.Common/Services/IHookService.cs
@@ -15,7 +15,7 @@ public interface IHookService
     public void OnPreImport(ref RedRelativePath rawRelative, ref GlobalImportArgs args, ref DirectoryInfo? outDir);
 
     public void RegisterOnImportFromJson(OnImportFromJsonHook hook);
-    public void OnImportFromJson(ref string jsonText);
+    public void OnImportFromJson(ref string jsonText, string redExtension);
 
     public void RegisterOnParsingError(OnParsingErrorHook hook);
     public bool OnParsingError(ParsingErrorEventArgs eventData);

--- a/WolvenKit.Modkit/RED4/RedConverter.cs
+++ b/WolvenKit.Modkit/RED4/RedConverter.cs
@@ -117,11 +117,12 @@ namespace WolvenKit.Modkit.RED4
         /// Converts a json string to W2RC file
         /// </summary>
         /// <param name="json"></param>
+        /// <param name="realExtension"></param>
         /// <returns></returns>
         /// <exception cref="InvalidParsingException"></exception>
-        public CR2WFile? ConvertFromJson(string json)
+        public CR2WFile? ConvertFromJson(string json, string realExtension)
         {
-            _hookService.OnImportFromJson(ref json);
+            _hookService.OnImportFromJson(ref json, realExtension);
 
             var dto = RedJsonSerializer.Deserialize<RedFileDto>(json);
 
@@ -162,11 +163,11 @@ namespace WolvenKit.Modkit.RED4
             var text = await File.ReadAllTextAsync(fileInfo.FullName);
 
             // get extension from filename //TODO pass?
-            var filenameWithoutConvertExtension = fileInfo.Name[..^convertExtension.Length /*+ 1*/];
-            var ext = Path.GetExtension(filenameWithoutConvertExtension);
+            var redFileName = Path.GetFileNameWithoutExtension(fileInfo.Name);
+            var redExtension = Path.GetExtension(redFileName);
             var w2rc = textConvertFormat switch
             {
-                ETextConvertFormat.json => ConvertFromJson(text),
+                ETextConvertFormat.json => ConvertFromJson(text, redExtension),
                 _ => throw new NotSupportedException(),
             };
             if (w2rc is null)
@@ -174,7 +175,7 @@ namespace WolvenKit.Modkit.RED4
                 return false;
             }
 
-            var outPath = Path.ChangeExtension(Path.Combine(outputDirInfo.FullName, fileInfo.Name), ext);
+            var outPath = Path.Combine(outputDirInfo.FullName, redFileName);
 
             using var fs2 = new FileStream(outPath, FileMode.Create, FileAccess.ReadWrite);
             using var writer = new CR2WWriter(fs2) { LoggerService = _loggerService };

--- a/WolvenKit.Modkit/Scripting/ScriptFile.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptFile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text.RegularExpressions;
+using NAudio.CoreAudioApi;
 using WolvenKit.Common;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive;
@@ -24,6 +25,7 @@ public partial class ScriptFile
 
     public HookType HookType { get; private set; } = HookType.None;
     public ImmutableList<string> HookExtensions { get; private set; } = null!;
+    public int HookPriority { get; private set; } = 100;
 
     public string? Version { get; private set; }
     public string? Author { get; private set; }
@@ -124,6 +126,15 @@ public partial class ScriptFile
                             hookExtensions.Add(part);
                         }
                         HookExtensions = ImmutableList.Create(hookExtensions.ToArray());
+                        break;
+
+                    case "hook_priority":
+                        if (!int.TryParse(match.Groups[2].Value, out var priority))
+                        {
+                            loggerService?.Error($"Invalid hook priority \"{match.Groups[2].Value}\". Value needs to be an integer");
+                            continue;
+                        }
+                        HookPriority = priority;
                         break;
 
                     case "description":

--- a/WolvenKit.Modkit/Scripting/ScriptFile.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptFile.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text.RegularExpressions;
-using NAudio.CoreAudioApi;
 using WolvenKit.Common;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive;
@@ -24,7 +23,7 @@ public partial class ScriptFile
     public ScriptType Type { get; private set; } = ScriptType.General;
 
     public HookType HookType { get; private set; } = HookType.None;
-    public ImmutableList<string> HookExtensions { get; private set; } = null!;
+    public ImmutableList<string> HookExtensions { get; private set; } = ImmutableList<string>.Empty;
     public int HookPriority { get; private set; } = 100;
 
     public string? Version { get; private set; }
@@ -82,7 +81,7 @@ public partial class ScriptFile
                         }
                         else
                         {
-                            loggerService?.Error($"Could not load \"{Path}\". Field \"type\" is invalid \"{match.Groups[2].Value}\"");
+                            loggerService?.Error($"[WScript] Could not load \"{Path}\". Field \"type\" is invalid \"{match.Groups[2].Value}\"");
                             return false;
                         }
                         break;
@@ -90,12 +89,13 @@ public partial class ScriptFile
                     case "hook_type":
                     case "hook_types":
                         Type = ScriptType.Hook;
+                        HookType = HookType.None;
 
                         foreach (var part in match.Groups[2].Value.Split(','))
                         {
                             if (!Enum.TryParse<HookType>(part, true, out var type))
                             {
-                                loggerService?.Error($"Unknown hook type \"{part}\"");
+                                loggerService?.Error($"[WScript] \"{Name}\" contains an unknown hook type \"{part}\"");
                                 continue;
                             }
 
@@ -113,7 +113,7 @@ public partial class ScriptFile
                                 !Enum.TryParse<ERedExtension>(part, true, out _) &&
                                 !Enum.TryParse<ERawFileFormat>(part, true, out _))
                             {
-                                loggerService?.Error($"Unknown hook extension \"{part}\"");
+                                loggerService?.Error($"[WScript] \"{Name}\" contains an unknown hook extension \"{part}\"");
                                 continue;
                             }
 
@@ -123,7 +123,7 @@ public partial class ScriptFile
                                 break;
                             }
 
-                            hookExtensions.Add(part);
+                            hookExtensions.Add(part.ToLower());
                         }
                         HookExtensions = ImmutableList.Create(hookExtensions.ToArray());
                         break;
@@ -131,7 +131,7 @@ public partial class ScriptFile
                     case "hook_priority":
                         if (!int.TryParse(match.Groups[2].Value, out var priority))
                         {
-                            loggerService?.Error($"Invalid hook priority \"{match.Groups[2].Value}\". Value needs to be an integer");
+                            loggerService?.Error($"[WScript] \"{Name}\" contains an invalid hook priority \"{match.Groups[2].Value}\". Value needs to be an integer");
                             continue;
                         }
                         HookPriority = priority;
@@ -146,7 +146,7 @@ public partial class ScriptFile
                         break;
 
                     default:
-                        loggerService?.Error($"Unknown tag \"{match.Groups[1].Value}\"");
+                        loggerService?.Debug($"[WScript] \"{Name}\" contains an unknown tag \"{match.Groups[1].Value}\"");
                         break;
                 }
             }
@@ -157,17 +157,11 @@ public partial class ScriptFile
             }
         }
 
-        if (Type == ScriptType.Hook)
+        if (Type == ScriptType.Hook && HookType != HookType.None)
         {
-            if (HookType == HookType.None)
-            {
-                loggerService?.Error($"Could not load \"{Path}\". Field \"hook_type(s)\" is not set");
-                return false;
-            }
-
             if (HookExtensions.Count == 0)
             {
-                loggerService?.Error($"Could not load \"{Path}\". Field \"hook_extension(s)\" is not set");
+                loggerService?.Error($"[WScript] Could not load \"{Path}\". Field \"hook_extension(s)\" is not set");
                 return false;
             }
         }
@@ -216,6 +210,7 @@ public partial class ScriptFile
             return false;
         }
 
+        extension = extension.ToLower();
         if (extension.Length > 0 && extension[0] == '.')
         {
             extension = extension[1..];

--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -136,6 +136,7 @@ public partial class ScriptService : ObservableObject
             if (!scriptFile.Reload(_loggerService))
             {
                 _scriptCache.Remove(file, out _);
+                continue;
             }
 
             result.Add(scriptFile);


### PR DESCRIPTION
# WScript improvements

**Implemented:**
- Added `// @hook_type` (see below)
- Added `// @hook_priority` (see below)
- Changed `// @hook_extension` (see below)
- Allow multiple onSave hooks

**Allowed/Added/Changed WScript metadata:**
 - `@hook_type`: `None,Save,Export,PreImport,ImportJson,ParseError` (case-insensitive, no blanks allowed)
 - `@hook_extension`: RedEngine file formats for `Save,Export,ImportJson` or import formats for `PreImport` (case-insensitive, no blanks allowed)
 - `@hook_priority`: if multiple hook script affect the same action. Higher priority executes first. (default prio is 100)

**Additional notes:**
Closes #2174
