### PR TITLE
Refactored all (CName, NodeRef, ResourcePath, TweakDBID) pools

### DIFF
--- a/Tests/WolvenKit.Utility/DumpInfo.cs
+++ b/Tests/WolvenKit.Utility/DumpInfo.cs
@@ -576,7 +576,6 @@ namespace WolvenKit.Utility
 
             var stringHelper = new TweakDBStringHelper();
             stringHelper.Load(tweakDbStrPath);
-            TweakDBIDPool.ResolveHashHandler = stringHelper.GetString;
 
             using var fh = File.OpenRead(s_tweakDbPath);
             using var reader2 = new TweakDBReader(fh);
@@ -591,11 +590,11 @@ namespace WolvenKit.Utility
             var rts = new Dictionary<string, Dictionary<string, string>>();
             foreach (var (id, value) in tweakDb.Flats)
             {
-                if (id.ResolvedText != null)
+                if (stringHelper.GetString(id) is { } resolvedText)
                 {
-                    if (id.ResolvedText.StartsWith("RTDB"))
+                    if (resolvedText.StartsWith("RTDB"))
                     {
-                        var parts = id.ResolvedText.Split('.');
+                        var parts = resolvedText.Split('.');
 
                         var className = $"gamedata{parts[1]}_Record";
                         if (!rts.ContainsKey(className))

--- a/WolvenKit.Common/Services/TweakDBService.cs
+++ b/WolvenKit.Common/Services/TweakDBService.cs
@@ -5,14 +5,13 @@ using System.IO;
 using System.Threading.Tasks;
 using WolvenKit.Common.Model;
 using WolvenKit.RED4.TweakDB;
-using WolvenKit.RED4.TweakDB.Helper;
 using WolvenKit.RED4.Types;
+using WolvenKit.RED4.Types.Pools;
 
 namespace WolvenKit.Common.Services
 {
     public class TweakDBService : ITweakDBService
     {
-        private static readonly TweakDBStringHelper s_stringHelper = new();
         private static TweakDB s_tweakDb = new();
 
         private bool _isLoading;
@@ -51,8 +50,8 @@ namespace WolvenKit.Common.Services
 
         public static bool Exists(TweakDBID key) => s_tweakDb.Flats.Exists(key) || s_tweakDb.Records.Exists(key);
 
-        public string? GetString(ulong key) => s_stringHelper.GetString(key);
-        public static string? GetStringFromKey(ulong key) => s_stringHelper.GetString(key);
+        public string? GetString(ulong key) => TweakDBIDPool.ResolveHash(key);
+        public static string? GetStringFromKey(ulong key) => TweakDBIDPool.ResolveHash(key);
 
         public static IRedType? GetFlat(TweakDBID tdb) => s_tweakDb.Flats.GetValue((ulong)tdb);
         public static List<TweakDBID>? GetQuery(TweakDBID tdb) => s_tweakDb.Queries.GetQuery((ulong)tdb);

--- a/WolvenKit.Core/Helpers/LookupTable.cs
+++ b/WolvenKit.Core/Helpers/LookupTable.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WolvenKit.Core.Helpers;
+
+public class LookupTable : IEnumerable<KeyValuePair<ulong, string>>
+{
+    private readonly ulong[] _keys;
+    private readonly string[] _values;
+
+    public LookupTable()
+    {
+        _keys = [];
+        _values = [];
+    }
+
+    public LookupTable(IList<ulong> keys, IList<string> values)
+    {
+        if (keys.Count != values.Count)
+        {
+            throw new ArgumentException("Keys and values must have the same length.");
+        }
+
+        _keys = new ulong[keys.Count];
+        _values = new string[keys.Count];
+
+        keys.CopyTo(_keys, 0);
+        values.CopyTo(_values, 0);
+
+        Array.Sort(_keys, _values);
+    }
+
+    public LookupTable(IList<string> values, int maxDegreeOfParallelism, Func<string, ulong> hashFunc)
+    {
+        _keys = new ulong[values.Count];
+        _values = new string[values.Count];
+
+        values.CopyTo(_values, 0);
+
+        if (maxDegreeOfParallelism > 1)
+        {
+            Parallel.For(0, values.Count, new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism }, i =>
+            {
+                _keys[i] = hashFunc(values[i]);
+            });
+        }
+        else
+        {
+            for (var i = 0; i < values.Count; i++)
+            {
+                _keys[i] = hashFunc(values[i]);
+            }
+        }
+
+        Array.Sort(_keys, _values);
+    }
+
+    public bool ContainsKey(ulong key) => Array.BinarySearch(_keys, key) >= 0;
+
+    public bool TryGetValue(ulong key, out string? value)
+    {
+        var index = Array.BinarySearch(_keys, key);
+        if (index < 0)
+        {
+            value = null;
+            return false;
+        }
+        value = _values[index];
+        return true;
+    }
+
+    public IEnumerator<KeyValuePair<ulong, string>> GetEnumerator()
+    {
+        for (var i = 0; i < _keys.Length; i++)
+        {
+            yield return new KeyValuePair<ulong, string>(_keys[i], _values[i]);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/WolvenKit.RED4/Types/Pools/BasePool.cs
+++ b/WolvenKit.RED4/Types/Pools/BasePool.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Concurrent;
+using WolvenKit.Core.Helpers;
+
+namespace WolvenKit.RED4.Types.Pools;
+
+internal class BasePool
+{
+    private LookupTable _nativePool = new();
+    private ConcurrentDictionary<ulong, string> _runtimePool = new();
+
+    private readonly Func<string, string>? _sanitizeStringFunc;
+    private readonly Func<string, ulong> _calculateHashFunc;
+
+    public BasePool(Func<string, string>? sanitizeStringFunc, Func<string, ulong> calculateHashFunc)
+    {
+        _sanitizeStringFunc = sanitizeStringFunc;
+        _calculateHashFunc = calculateHashFunc;
+    }
+
+    private string SanitizeHash(string value) => _sanitizeStringFunc != null ? _sanitizeStringFunc(value) : value;
+
+    public string? ResolveHash(ulong hash)
+    {
+        if (_nativePool.TryGetValue(hash, out var value))
+        {
+            return value;
+        }
+
+        if (_runtimePool.TryGetValue(hash, out value))
+        {
+            return value;
+        }
+
+        return null;
+    }
+
+    public bool IsNative(ulong hash) => _nativePool.ContainsKey(hash);
+    public bool IsNative(string value) => IsNative(_calculateHashFunc(SanitizeHash(value)));
+
+    public bool IsRuntime(ulong hash) => _runtimePool.ContainsKey(hash);
+    public bool IsRuntime(string value) => IsRuntime(_calculateHashFunc(SanitizeHash(value)));
+
+    public (bool newRuntime, ulong hash) AddOrGetHash(string value)
+    {
+        value = SanitizeHash(value);
+
+        var hash = _calculateHashFunc(value);
+
+        var newRuntime = !_nativePool.ContainsKey(hash) && !_runtimePool.ContainsKey(hash);
+        if (newRuntime)
+        {
+            _runtimePool.TryAdd(hash, value);
+        }
+
+        return (newRuntime, hash);
+    }
+
+    public void SetNative(LookupTable values) => _nativePool = values;
+}

--- a/WolvenKit.RED4/Types/Pools/CNamePool.cs
+++ b/WolvenKit.RED4/Types/Pools/CNamePool.cs
@@ -1,73 +1,30 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
-using WolvenKit.Common.FNV1A;
+﻿using WolvenKit.Core.Helpers;
 
 namespace WolvenKit.RED4.Types.Pools;
 
 public static class CNamePool
 {
-    private static readonly ConcurrentDictionary<string, ulong> s_nativePool = new();
-    private static readonly ConcurrentDictionary<ulong, string> s_nativePoolReverse = new();
-
-    private static readonly ConcurrentDictionary<string, ulong> s_pool = new();
-    private static readonly ConcurrentDictionary<ulong, string> s_poolReverse = new();
+    private static readonly BasePool s_pool;
 
     static CNamePool()
     {
-        AddNativeString("None");
+        s_pool = new BasePool(null, CName.CalculateHash);
+        s_pool.SetNative(new LookupTable([0], ["None"]));
     }
 
-    public static string? ResolveHash(ulong hash)
-    {
-        if (s_nativePoolReverse.TryGetValue(hash, out var value))
-        {
-            return value;
-        }
+    public static string? ResolveHash(ulong hash) => s_pool.ResolveHash(hash);
 
-        if (s_poolReverse.TryGetValue(hash, out value))
-        {
-            return value;
-        }
+    public static bool IsNative(string value) => s_pool.IsNative(value);
+    public static bool IsNative(ulong value) => s_pool.IsNative(value);
 
-        return ResolveHashHandler?.Invoke(hash);
-    }
-
-    public static void AddNativeString(string value)
-    {
-        ulong hash = 0;
-        if (value != "None")
-        {
-            hash = CName.CalculateHash(value);
-        }
-
-        s_nativePool.TryAdd(value, hash);
-        s_nativePoolReverse.TryAdd(hash, value);
-    }
+    public static bool IsRuntime(string value) => s_pool.IsRuntime(value);
+    public static bool IsRuntime(ulong value) => s_pool.IsRuntime(value);
 
     public static ulong AddOrGetHash(string value)
     {
-        if (s_nativePool.TryGetValue(value, out var hash))
-        {
-            return hash;
-        }
-
-        if (s_pool.TryGetValue(value, out hash))
-        {
-            return hash;
-        }
-
-        hash = 0;
-        if (value != "None")
-        {
-            hash = FNV1A64HashAlgorithm.HashString(value, Encoding.UTF8, false, true);
-        }
-
-        s_pool.TryAdd(value, hash);
-        s_poolReverse.TryAdd(hash, value);
-
+        var (_, hash) = s_pool.AddOrGetHash(value);
         return hash;
     }
 
-    public delegate string? ExtResolveHash(ulong hash);
-    public static ExtResolveHash? ResolveHashHandler;
+    public static void SetNative(LookupTable lookupTable) => s_pool.SetNative(lookupTable);
 }

--- a/WolvenKit.RED4/Types/Pools/NodeRefPool.cs
+++ b/WolvenKit.RED4/Types/Pools/NodeRefPool.cs
@@ -1,14 +1,54 @@
 ﻿using System.Collections.Concurrent;
 using WolvenKit.Common.FNV1A;
+using WolvenKit.Core.Helpers;
 
-namespace WolvenKit.RED4.Types;
+namespace WolvenKit.RED4.Types.Pools;
 
 public static class NodeRefPool
 {
-    private static readonly ConcurrentDictionary<ulong, string> s_poolReverse = new();
+    private static readonly BasePool s_pool;
+
+    static NodeRefPool()
+    {
+        s_pool = new BasePool(null, s => FNV1A64HashAlgorithm.HashStringWithoutAliases(s));
+    }
+
     private static readonly ConcurrentDictionary<ReadOnlyMemory<char>, ReadOnlyMemory<char>> s_poolAliases = new(MemorySequenceEqualComparator.Instance);
-    
-    public static string? ResolveHash(ulong hash) => s_poolReverse.GetValueOrDefault(hash);
+
+    public static string? ResolveHash(ulong hash) => s_pool.ResolveHash(hash);
+
+    public static bool IsNative(string value) => s_pool.IsNative(value);
+    public static bool IsNative(ulong value) => s_pool.IsNative(value);
+
+    public static bool IsRuntime(string value) => s_pool.IsRuntime(value);
+    public static bool IsRuntime(ulong value) => s_pool.IsRuntime(value);
+
+    public static ulong AddOrGetHash(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return 0;
+        }
+
+        var (newRuntime, hash) = s_pool.AddOrGetHash(value);
+        if (newRuntime)
+        {
+            CacheAliases(value);
+        }
+
+        return hash;
+    }
+
+    public static void SetNative(LookupTable lookupTable)
+    {
+        s_pool.SetNative(lookupTable);
+        foreach (var (_, value) in lookupTable)
+        {
+            CacheAliases(value);
+        }
+    }
+
+    #region Alias
 
     public static ReadOnlyMemory<char>? ResolveAliasToMemory(ReadOnlyMemory<char> aliasName) =>
         s_poolAliases.GetValueOrDefault(aliasName, null);
@@ -25,49 +65,32 @@ public static class NodeRefPool
         return memory != null ? FNV1A64HashAlgorithm.HashStringWithoutAliases(memory.Value.Span) : null;
     }
 
-    public static ulong AddOrGetHash(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return 0;
-        }
-
-        var hash = FNV1A64HashAlgorithm.HashStringWithoutAliases(value);
-
-        // Backwards resolving is already cached
-        if (s_poolReverse.ContainsKey(hash))
-            return hash;
-
-        CacheBackwardsHash(value, hash);
-        CacheAliases(value);
-
-        return hash;
-    }
-
-    private static void CacheBackwardsHash(string value, ulong hash) => s_poolReverse.TryAdd(hash, value);
-    
     private static void CacheAliases(string value)
     {
         if (value[0] != '$' || !value.Contains('#'))
+        {
             return;
+        }
 
         var nextAliasPos = value.IndexOf('#');
 
         if (nextAliasPos == 0)
+        {
             throw new InvalidOperationException("Alias shouldn't be first in the string!");
-        
-        while(nextAliasPos != -1)
+        }
+
+        while (nextAliasPos != -1)
         {
             // We have to handle 2 cases:
             // $/test/#important/123/456 - simple syntax
             // $/test/important;#alias/123/456 - semicolon syntax (named alias)
-            
+
             var semicolonSyntax = value[nextAliasPos - 1] == ';';
-            
+
             var (aliasName, aliasPath) = !semicolonSyntax ?
                 HandleSimpleAlias(value, nextAliasPos) :
                 HandleSemicolonAlias(value, nextAliasPos);
-            
+
             s_poolAliases.TryAdd(aliasName, aliasPath);
 
             nextAliasPos = value.IndexOf('#', nextAliasPos + 1);
@@ -84,25 +107,27 @@ public static class NodeRefPool
         var indexOfSlash = value.IndexOf('/', aliasPosition);
         var nameEndPosition = indexOfSlash != -1 ? indexOfSlash : value.Length;
 
-        var name = memory[(aliasPosition+1)..nameEndPosition];
+        var name = memory[(aliasPosition + 1)..nameEndPosition];
         var path = memory[..nameEndPosition];
 
         return (name, path);
     }
-    
+
     private static (ReadOnlyMemory<char> Name, ReadOnlyMemory<char> Path) HandleSemicolonAlias(string value, int aliasPosition)
     {
         // Handling semicolon syntax
         // $/test/important;#alias/123/456
 
         var memory = value.AsMemory();
-        
+
         var indexOfSlash = value.IndexOf('/', aliasPosition);
         var nameEndPosition = indexOfSlash != -1 ? indexOfSlash : value.Length;
 
-        var name = memory[(aliasPosition+1)..nameEndPosition];
-        var path = memory[..(aliasPosition - 1)]; 
+        var name = memory[(aliasPosition + 1)..nameEndPosition];
+        var path = memory[..(aliasPosition - 1)];
 
         return (name, path);
     }
+
+    #endregion Alias
 }

--- a/WolvenKit.RED4/Types/Pools/ResourcePathPool.cs
+++ b/WolvenKit.RED4/Types/Pools/ResourcePathPool.cs
@@ -1,79 +1,31 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
+﻿using System.Text;
 using WolvenKit.Common.FNV1A;
+using WolvenKit.Core.Helpers;
 
 namespace WolvenKit.RED4.Types.Pools;
 
 public static class ResourcePathPool
 {
-    private static ConcurrentDictionary<string, ulong> s_nativePool = new();
-    private static ConcurrentDictionary<ulong, string> s_nativePoolReverse = new();
+    private static readonly BasePool s_pool;
 
-    private static readonly ConcurrentDictionary<string, ulong> s_pool = new();
-    private static readonly ConcurrentDictionary<ulong, string> s_poolReverse = new();
-
-    public static string? ResolveHash(ulong hash)
+    static ResourcePathPool()
     {
-        if (s_nativePoolReverse.TryGetValue(hash, out var value))
-        {
-            return value;
-        }
-
-        if (s_poolReverse.TryGetValue(hash, out value))
-        {
-            return value;
-        }
-
-        return ResolveHashHandler?.Invoke(hash);
+        s_pool = new BasePool(ResourcePath.SanitizePath, s => FNV1A64HashAlgorithm.HashString(s, Encoding.UTF8, false, true));
     }
 
-    public static bool IsNative(string value) => s_nativePool.ContainsKey(value);
-    public static bool IsNative(ulong value) => s_nativePoolReverse.ContainsKey(value);
+    public static string? ResolveHash(ulong hash) => s_pool.ResolveHash(hash);
 
-    public static bool IsRuntime(string value) => s_pool.ContainsKey(value);
-    public static bool IsRuntime(ulong value) => s_poolReverse.ContainsKey(value);
+    public static bool IsNative(string value) => s_pool.IsNative(value);
+    public static bool IsNative(ulong value) => s_pool.IsNative(value);
 
-    public static void AddNativeString(string value)
-    {
-        var hash = ResourcePath.CalculateHash(value);
-
-        s_nativePool.TryAdd(value, hash);
-        s_nativePoolReverse.TryAdd(hash, value);
-    }
+    public static bool IsRuntime(string value) => s_pool.IsRuntime(value);
+    public static bool IsRuntime(ulong value) => s_pool.IsRuntime(value);
 
     public static ulong AddOrGetHash(string value)
     {
-        var sanitizedValue = ResourcePath.SanitizePath(value);
-
-        if (s_nativePool.TryGetValue(sanitizedValue, out var hash))
-        {
-            return hash;
-        }
-
-        if (s_pool.TryGetValue(sanitizedValue, out hash))
-        {
-            return hash;
-        }
-
-        hash = FNV1A64HashAlgorithm.HashString(sanitizedValue, Encoding.UTF8, false, true);
-
-        s_pool.TryAdd(sanitizedValue, hash);
-        s_poolReverse.TryAdd(hash, sanitizedValue);
-
+        var (_, hash) = s_pool.AddOrGetHash(value);
         return hash;
     }
 
-    public static void SetNative(ConcurrentDictionary<ulong, string> dict)
-    {
-        s_nativePoolReverse = dict;
-        s_nativePool = new ConcurrentDictionary<string, ulong>();
-
-        foreach (var (key, value) in dict)
-        {
-            s_nativePool.GetOrAdd(value, key);
-        }
-    }
-
-    public delegate string? ExtResolveHash(ulong hash);
-    public static ExtResolveHash? ResolveHashHandler;
+    public static void SetNative(LookupTable lookupTable) => s_pool.SetNative(lookupTable);
 }

--- a/WolvenKit.RED4/Types/Pools/TweakDBIDPool.cs
+++ b/WolvenKit.RED4/Types/Pools/TweakDBIDPool.cs
@@ -1,66 +1,29 @@
-﻿using System.Collections.Concurrent;
+﻿using WolvenKit.Core.Helpers;
 
-namespace WolvenKit.RED4.Types;
+namespace WolvenKit.RED4.Types.Pools;
 
 public static class TweakDBIDPool
 {
-    private static ConcurrentDictionary<string, ulong> s_nativePool = new();
-    private static ConcurrentDictionary<ulong, string> s_nativePoolReverse = new();
+    private static readonly BasePool s_pool;
 
-    private static readonly ConcurrentDictionary<string, ulong> s_pool = new();
-    private static readonly ConcurrentDictionary<ulong, string> s_poolReverse = new();
-
-    public static string? ResolveHash(ulong hash)
+    static TweakDBIDPool()
     {
-        if (s_nativePoolReverse.TryGetValue(hash, out var value))
-        {
-            return value;
-        }
-
-        if (s_poolReverse.TryGetValue(hash, out value))
-        {
-            return value;
-        }
-
-        return ResolveHashHandler?.Invoke(hash);
+        s_pool = new BasePool(null, TweakDBID.CalculateHash);
     }
 
-    public static bool IsNative(string value) => s_nativePool.ContainsKey(value);
+    public static string? ResolveHash(ulong hash) => s_pool.ResolveHash(hash);
 
-    public static void AddNativeString(string value)
-    {
-        var hash = TweakDBID.CalculateHash(value);
+    public static bool IsNative(string value) => s_pool.IsNative(value);
+    public static bool IsNative(ulong value) => s_pool.IsNative(value);
 
-        s_nativePool.TryAdd(value, hash);
-        s_nativePoolReverse.TryAdd(hash, value);
-    }
+    public static bool IsRuntime(string value) => s_pool.IsRuntime(value);
+    public static bool IsRuntime(ulong value) => s_pool.IsRuntime(value);
 
     public static ulong AddOrGetHash(string value)
     {
-        if (s_nativePool.TryGetValue(value, out var hash))
-        {
-            return hash;
-        }
-
-        if (s_pool.TryGetValue(value, out hash))
-        {
-            return hash;
-        }
-
-        hash = TweakDBID.CalculateHash(value);
-
-        s_pool.TryAdd(value, hash);
-        s_poolReverse.TryAdd(hash, value);
-
+        var (_, hash) = s_pool.AddOrGetHash(value);
         return hash;
     }
 
-    public static void SetNative(Dictionary<ulong, string> dict)
-    {
-        s_nativePoolReverse = new ConcurrentDictionary<ulong, string>(dict);
-        s_nativePool = new ConcurrentDictionary<string, ulong>(dict.ToDictionary(x => x.Value, x => x.Key));
-    }
-
-    public delegate string? ExtResolveHash(ulong hash);
-    public static ExtResolveHash? ResolveHashHandler;
+    public static void SetNative(LookupTable lookupTable) => s_pool.SetNative(lookupTable);
 }

--- a/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/CName.cs
@@ -33,7 +33,7 @@ public readonly struct CName : IRedString, IRedPrimitive<string>, IEquatable<CNa
     [Obsolete("Use GetRedHash instead")]
     public uint GetOldRedHash() => (uint)(_hash & 0xFFFFFFFF);
 
-    public static ulong CalculateHash(string resourcePath) => FNV1A64HashAlgorithm.HashString(resourcePath);
+    public static ulong CalculateHash(string resourcePath) => resourcePath == "None" ? 0 : FNV1A64HashAlgorithm.HashString(resourcePath);
 
     public static implicit operator CName(string value) => new(CNamePool.AddOrGetHash(value));
     public static implicit operator string?(CName value) => value.GetResolvedText();

--- a/WolvenKit.RED4/Types/Primitives/Simples/NodeRef.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/NodeRef.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using WolvenKit.RED4.Types.Pools;
 
 namespace WolvenKit.RED4.Types;
 

--- a/WolvenKit.RED4/Types/Primitives/Simples/TweakDBID.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/TweakDBID.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using WolvenKit.Core.CRC;
+using WolvenKit.RED4.Types.Pools;
 
 namespace WolvenKit.RED4.Types;
 


### PR DESCRIPTION
# Refactored all (CName, NodeRef, ResourcePath, TweakDBID) pools

**Notes:**
 - Replaced native dictionaries with custom SortedList
 - Removed forward lookup tables
 - Saves round about 550MB RAM in total
