### PR TITLE
Added settings to wscript, attempt no. 3

### DIFF
--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Scripting;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 
@@ -121,4 +122,6 @@ public static class Interactions
 
     public static Func<(Cp77Project activeProject, ISettingsManager settingsManager), CreatePhotoModeAppViewModel?>
         ShowPhotoModeDialogue { get; set; } = _ => throw new NotImplementedException();
+
+    public static Func<ScriptSettingsDictionary, bool> ShowScriptSettingsView { get; set; } = _ => throw new NotImplementedException();
 }

--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -1053,4 +1053,33 @@ public class AppScriptFunctions : ScriptFunctions
     {
         return _settingsManager.GetVersionNumber();
     }
+
+    /// <summary>
+    /// Shows the settings dialog for the supplied data
+    /// </summary>
+    /// <param name="data">A JavaScript object containing data</param>
+    /// <returns>Returns true when the user changed the settings, otherwise it returns false</returns>
+    public virtual bool ShowSettings(ScriptObject data)
+    {
+        var dict = ScriptSettingsDictionary.FromScriptObject(data);
+        if (dict == null)
+        {
+            _loggerService.Error("Failed to process settings");
+            return false;
+        }
+
+        var success = false;
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            success = Interactions.ShowScriptSettingsView(dict);
+        });
+
+        if (!success)
+        {
+            return false;
+        }
+
+        dict.ToScriptObject(data);
+        return true;
+    }
 }

--- a/WolvenKit.App/Scripting/ScriptSettingsDictionary.cs
+++ b/WolvenKit.App/Scripting/ScriptSettingsDictionary.cs
@@ -1,0 +1,210 @@
+﻿using Microsoft.ClearScript;
+using System.Collections.Generic;
+using System.Collections;
+using System.ComponentModel;
+using System;
+using System.Linq;
+using System.Numerics;
+using WolvenKit.Core.Interfaces;
+
+namespace WolvenKit.App.Scripting;
+
+public class ScriptSettingsDictionary : Dictionary<string, object?>, ICustomTypeDescriptor
+{
+    private ILoggerService? _loggerService;
+
+    public void SetLoggerService(ILoggerService? loggerService) => _loggerService = loggerService;
+
+    #region ICustomTypeDescriptor Members
+
+    public AttributeCollection GetAttributes() => TypeDescriptor.GetAttributes(this, true);
+
+    public string? GetClassName() => TypeDescriptor.GetClassName(this, true);
+
+    public string? GetComponentName() => TypeDescriptor.GetComponentName(this, true);
+
+    public TypeConverter GetConverter() => TypeDescriptor.GetConverter(this, true);
+
+    public EventDescriptor? GetDefaultEvent() => TypeDescriptor.GetDefaultEvent(this, true);
+
+    public PropertyDescriptor? GetDefaultProperty() => TypeDescriptor.GetDefaultProperty(this, true);
+
+    public object? GetEditor(Type editorBaseType) => TypeDescriptor.GetEditor(this, editorBaseType, true);
+
+    public EventDescriptorCollection GetEvents() => TypeDescriptor.GetEvents(this, true);
+
+    public EventDescriptorCollection GetEvents(Attribute[]? attributes) => TypeDescriptor.GetEvents(this, attributes, true);
+
+    public PropertyDescriptorCollection GetProperties()
+    {
+        var entries = this.Select(element =>
+        {
+            var type = element.Value?.GetType() ?? typeof(object);
+
+            return new ScriptSettingsPropertyDescriptor(this, element.Key, element.Key, type, []);
+        });
+        return new PropertyDescriptorCollection(entries.ToArray());
+    }
+
+    public PropertyDescriptorCollection GetProperties(Attribute[]? attributes)
+    {
+        var propList = new ArrayList();
+        var propCollection = (PropertyDescriptor[])propList.ToArray(typeof(PropertyDescriptor));
+        return new PropertyDescriptorCollection(propCollection);
+    }
+
+    public object GetPropertyOwner(PropertyDescriptor? pd) => this;
+
+    #endregion
+
+    #region Converter
+
+    public static ScriptSettingsDictionary? FromScriptObject(ScriptObject scriptObject, ILoggerService? loggerService = null)
+    {
+        if (ConvertValue(scriptObject) is ScriptSettingsDictionary val)
+        {
+            val.SetLoggerService(loggerService);
+
+            return val;
+        }
+
+        return null;
+    }
+
+    private static object? ConvertValue(object? scriptObject)
+    {
+        switch (scriptObject)
+        {
+            case IList array:
+            {
+                var list = new List<object?>();
+                foreach (var item in array)
+                {
+                    list.Add(ConvertValue(item));
+                }
+                return list;
+            }
+
+            case ScriptObject childScriptObject:
+            {
+                var childTarget = new ScriptSettingsDictionary();
+                foreach (var propertyName in childScriptObject.PropertyNames)
+                {
+                    childTarget.Add(propertyName, ConvertValue(childScriptObject[propertyName]));
+                }
+                return childTarget;
+            }
+
+            case bool:
+            case double:
+            case float:
+            case int:
+            case string:
+            case BigInteger:
+                return scriptObject;
+
+            default:
+                throw new NotSupportedException($"Settings type \"{scriptObject?.GetType()}\" is not supported");
+        }
+    }
+
+    public void ToScriptObject(ScriptObject scriptObject)
+    {
+        foreach (var propertyName in scriptObject.PropertyNames)
+        {
+            if (!TryGetValue(propertyName, out var newValue))
+            {
+                continue;
+            }
+
+            switch (scriptObject[propertyName])
+            {
+                case IList array:
+                {
+                    if (newValue is not IList newList)
+                    {
+                        throw new Exception();
+                    }
+
+                    array.Clear();
+                    foreach (var item in newList)
+                    {
+                        array.Add(item);
+                    }
+                    break;
+                }
+
+                case ScriptObject childScriptObject:
+                {
+                    if (newValue is not ScriptSettingsDictionary newChild)
+                    {
+                        throw new Exception();
+                    }
+
+                    newChild.ToScriptObject(childScriptObject);
+                    continue;
+                }
+
+                case bool:
+                case double:
+                case float:
+                case int:
+                case string:
+                case BigInteger:
+                    if (scriptObject[propertyName].GetType() != newValue?.GetType())
+                    {
+                        throw new Exception();
+                    }
+
+                    scriptObject[propertyName] = newValue;
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Settings type \"{scriptObject?.GetType()}\" is not supported");
+            }
+        }
+    }
+
+    #endregion
+}
+
+public class ScriptSettingsPropertyDescriptor : PropertyDescriptor
+{
+    private readonly ScriptSettingsDictionary _parent;
+
+    public ScriptSettingsPropertyDescriptor(ScriptSettingsDictionary parent, string propertyName, string propertyDisplayName, Type propertyType, Attribute[] propertyAttributes) : base(propertyName, propertyAttributes)
+    {
+        _parent = parent;
+
+        PropertyType = propertyType;
+        DisplayName = propertyDisplayName;
+    }
+
+    #region Properties
+
+    public override Type ComponentType => typeof(ScriptSettingsDictionary);
+
+    public override string DisplayName { get; }
+
+    public override bool IsReadOnly => false;
+
+    public override Type PropertyType { get; }
+
+    #endregion
+
+    #region Override members
+
+    public override bool CanResetValue(object component) => true;
+
+    public override object? GetValue(object? component) => _parent[base.Name];
+
+    public override void ResetValue(object component)
+    {
+    }
+
+    public override void SetValue(object? component, object? value) => _parent[Name] = value;
+
+    public override bool ShouldSerializeValue(object component) => false;
+
+    #endregion
+}

--- a/WolvenKit/Views/Dialogs/Windows/ScriptSettingsWindow.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/ScriptSettingsWindow.xaml
@@ -1,0 +1,49 @@
+﻿<Window
+    x:Class="WolvenKit.Views.Dialogs.Windows.ScriptSettingsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    mc:Ignorable="d"
+    Title="ScriptSettingsWindow"
+    Width="800"
+    Height="450">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <syncfusion:PropertyGrid
+            Name="ScriptSettingsPropertyGrid"
+            Grid.Row="0" />
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button
+                x:Name="OkButton"
+                Grid.Column="1"
+                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+                Padding="{DynamicResource WolvenKitMarginSmall}"
+                HorizontalAlignment="Right"
+                Background="{StaticResource WolvenKitRed}"
+                Click="OkButton_OnClick"
+                Content="Save" />
+
+            <Button
+                x:Name="CancelButton"
+                Grid.Column="2"
+                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+                Padding="{DynamicResource WolvenKitMarginSmall}"
+                HorizontalAlignment="Right"
+                Click="CancelButton_OnClick"
+                Content="Cancel" />
+        </Grid>
+    </Grid>
+</Window>

--- a/WolvenKit/Views/Dialogs/Windows/ScriptSettingsWindow.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/ScriptSettingsWindow.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System.Windows;
+using WolvenKit.App.Scripting;
+
+namespace WolvenKit.Views.Dialogs.Windows;
+
+public partial class ScriptSettingsWindow : Window
+{
+    public ScriptSettingsWindow(ScriptSettingsDictionary scriptSettings)
+    {
+        InitializeComponent();
+
+        ScriptSettingsPropertyGrid.SelectedObject = scriptSettings;
+    }
+
+    private void OkButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -137,6 +137,12 @@ namespace WolvenKit.Views.Shell
                     return dialog.ViewModel;
                 };
 
+                Interactions.ShowScriptSettingsView = settings =>
+                {
+                    var dialog = new ScriptSettingsWindow(settings);
+                    return dialog.ShowDialog() == true;
+                };
+
 
                 this.Bind(ViewModel,
                     vm => vm.ActiveDocument,


### PR DESCRIPTION
# Added settings to wscript, attempt no. 3

**Implemented:**
- WScript settings

**Notes:**
Currently supports the following types: `int`, `double`, `string`, `bool `, `BigInteger`+ array `[]` variants

**Example:**
```js
import * as Logger from 'Logger.wscript';

var config = {
	"myIntVar": 5,
	"myIntArrayVar": [6,7,8],
	"myDoubleVar": 3.141,
	"myDoubleArrayVar": [1.0,2.5,5.9],
	"myStringVar": "test",
	"myStringArrayVar": ["abc","def","123"],
	"myBoolVar": false,
	"myBoolArrayVar": [true,false,true,true],
	"myBigIntVar": BigInt(5),
	"myBigIntArrayVar": [BigInt(5), BigInt(4), BigInt(3)]
}

wkit.ShowSettings(config);

Logger.Info(config)
```