### PR TITLE
fix incorrect renaming behavior leading to exceptions and data loss

### DIFF
--- a/WolvenKit.App/Helpers/ProjectResourceTools.cs
+++ b/WolvenKit.App/Helpers/ProjectResourceTools.cs
@@ -383,7 +383,9 @@ public class ProjectResourceTools
 
         if (!sourceIsDirectory)
         {
-            if (File.Exists(destAbsPath))
+            // do operations regardless if old filename is new filename as a temp extension is used so no risk of data loss, avoids the popup showing up when only the case is changed
+            bool sourceIsTarget = sourceAbsPath.ToLower() == destAbsPath.ToLower();
+            if (File.Exists(destAbsPath) && !sourceIsTarget)
             {
                 var response = await Interactions.ShowMessageBoxAsync(
                     $"Do you want to overwrite the existing file {destRelPath}?",
@@ -412,7 +414,7 @@ public class ProjectResourceTools
                 File.Move(sourceInRaw, destAbsPath.Replace("archive", "raw"), true);
             }
             
-            
+            _loggerService.Info($"Moved {sourceRelPath} to {destRelPath}");
         }
         else
         {
@@ -421,7 +423,9 @@ public class ProjectResourceTools
              */
             try
             {
-                if (Directory.Exists(destAbsPath) && Directory.EnumerateFiles(destAbsPath).Any())
+                // do operations regardless if old directory is new directory as a temp folder is used so no risk of data loss, avoids the popup showing up when only the case is changed
+                bool sourceIsTarget = sourceAbsPath.ToLower() == destAbsPath.ToLower();
+                if (Directory.Exists(destAbsPath) && Directory.EnumerateFiles(destAbsPath, "*", SearchOption.AllDirectories).Any() && !sourceIsTarget)
                 {
                     var response = await Interactions.ShowMessageBoxAsync(
                         $"Directory {destRelPath} already exists and is not empty. Do you want to overwrite existing files?",

--- a/WolvenKit.Common/Tools/FileHelper.cs
+++ b/WolvenKit.Common/Tools/FileHelper.cs
@@ -92,56 +92,8 @@ public class FileHelper
         var destDirTemp = $"{destDirAbsPath}_temp";
         try
         {
-            // source dir is an empty directory
-            if (Directory.Exists(sourceDirAbsPath) && !Directory.EnumerateFileSystemEntries(sourceDirAbsPath).Any())
-            {
-                if (!Directory.Exists(destDirAbsPath))
-                {
-                    Directory.CreateDirectory(destDirAbsPath);
-                }
-
-                Directory.Delete(sourceDirAbsPath);
-                return;
-            } 
-            
-            // Ensure the destination directory exists
-            if (!Directory.Exists(destDirTemp))
-            {
-                Directory.CreateDirectory(destDirTemp);
-            }
-
-            // Move all files
-            var files = Directory.GetFiles(sourceDirAbsPath, "*", SearchOption.AllDirectories);
-            foreach (var file in files)
-            {
-                var relativePath = Path.GetRelativePath(sourceDirAbsPath, file);
-                var destFile = Path.Combine(destDirAbsPath, relativePath);
-                var destDir = Path.GetDirectoryName(destFile);
-                
-                if (destDir is not null && !Directory.Exists(destDir))
-                {
-                    Directory.CreateDirectory(destDir);
-                }
-
-                // renaming file.ext to File.ext will delete it, so rename it to .tmp first
-                File.Move(file, $"{destFile}.tmp", true);
-                File.Move($"{destFile}.tmp", destFile, true);
-            }
-
-            // Move all directories by recursively calling this method
-            var directories = Directory.GetDirectories(sourceDirAbsPath, "*", SearchOption.AllDirectories);
-            foreach (var directory in directories)
-            {
-                var relativePath = Path.GetRelativePath(sourceDirAbsPath, directory);
-                var destSubDirAbsPath = Path.Combine(destDirAbsPath, relativePath);
-                MoveRecursively(directory, destSubDirAbsPath, overwrite, logger);
-            }
-
-            // recursive delete the source directory - all our files are in destDirTemp
-            Directory.Delete(sourceDirAbsPath, true);
-
+            Directory.Move(sourceDirAbsPath, destDirTemp);
             Directory.Move(destDirTemp, destDirAbsPath);
-
         }
         catch (IOException e)
         {


### PR DESCRIPTION
# fix incorrect renaming behavior leading to exceptions and data loss

**Fixed:**
- folder content deletion if the only change was case
- exceptions thrown when renaming due to folders being created twice
- temp folders not being removed when renaming
- skips popup asking for overwrite if source path is new path (to handle only the case changing, as that is a safe operation and doesn't overwrite anything due to temp folders)
- added logging when a single file is renamed to be consistent with folder renaming
- fix folders being incorrectly treated as empty if it only had nested files and none directly in the folder 

**Additional notes:**
closes #2268
