### PR TITLE
GarmentSupport fixes

### DIFF
--- a/WolvenKit.Common/Model/Arguments/ImportArgs.cs
+++ b/WolvenKit.Common/Model/Arguments/ImportArgs.cs
@@ -172,6 +172,14 @@ namespace WolvenKit.Common.Model.Arguments
         public bool ImportGarmentSupport { get; set; } = true;
 
         /// <summary>
+        /// Imports garment support data from GLB.
+        /// </summary>
+        [Category("Import Settings")]
+        [Display(Name = "\tIgnore UV param")]
+        [Description("Ignores the Garment Support UV param. Fixes a vanilla bug which creates a seam")]
+        public bool IgnoreGarmentSupportUVParam { get; set; }
+
+        /// <summary>
         /// Use object or node name as mesh name
         /// </summary>
         [Category("Compatibility Settings")]

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -445,7 +445,7 @@ namespace WolvenKit.Modkit.RED4
 
             UpdateSkinningParamCloth(ref meshes, ref cr2w, args);
 
-            UpdateGarmentSupportParameters(meshes, cr2w, args.ImportGarmentSupport);
+            UpdateGarmentSupportParameters(meshes, cr2w, args.ImportGarmentSupport, args.IgnoreGarmentSupportUVParam);
 
             var expMeshes = meshes.Select(_ => RawMeshToRE4Mesh(_, quantScale, quantTrans)).ToList();
 
@@ -1812,7 +1812,7 @@ namespace WolvenKit.Modkit.RED4
             }
         }
 
-        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w, bool importGarmentSupport = true)
+        private static void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CR2WFile cr2w, bool importGarmentSupport = true, bool ignoreGarmentSupportUVParam = true)
         {
             if (importGarmentSupport && cr2w.RootChunk is CMesh cMesh)
             {
@@ -1825,7 +1825,7 @@ namespace WolvenKit.Modkit.RED4
 
                     foreach (var mesh in meshes)
                     {
-                        WriteToGarmentSupportParameters(mesh, garmentMeshBlobChunk, garmentBlobChunk);
+                        WriteToGarmentSupportParameters(mesh, garmentMeshBlobChunk, garmentBlobChunk, ignoreGarmentSupportUVParam);
                     }
                 }
                 else
@@ -1876,7 +1876,7 @@ namespace WolvenKit.Modkit.RED4
             return garmentBlobChunk;
         }
 
-        private static void WriteToGarmentSupportParameters(RawMeshContainer mesh, meshMeshParamGarmentSupport garmentMeshBlobChunk, garmentMeshParamGarment garmentBlobChunk)
+        private static void WriteToGarmentSupportParameters(RawMeshContainer mesh, meshMeshParamGarmentSupport garmentMeshBlobChunk, garmentMeshParamGarment garmentBlobChunk, bool ignoreGarmentSupportUVParam = true)
         {
             ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
             ArgumentNullException.ThrowIfNull(mesh.indices, nameof(mesh));
@@ -1937,7 +1937,7 @@ namespace WolvenKit.Modkit.RED4
                 Indices = new DataBuffer(indBuffer.ToArray()),
                 MorphOffsets = new DataBuffer(morphBuffer.ToArray()),
                 Vertices = new DataBuffer(vertBuffer.ToArray()),
-                Uv = new DataBuffer(uvBuffer.ToArray()),
+                Uv = ignoreGarmentSupportUVParam ? null : new DataBuffer(uvBuffer.ToArray()),
                 NumVertices = Convert.ToUInt32(mesh.positions.Length),
                 LodMask = 1
             });

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -1921,7 +1921,7 @@ namespace WolvenKit.Modkit.RED4
                 }
 
                 uvBw.Write(mesh.texCoords0[v].X);
-                uvBw.Write(mesh.texCoords0[v].Y);
+                uvBw.Write(1 - mesh.texCoords0[v].Y);
             }
 
             foreach (var i in mesh.indices)

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -325,7 +325,7 @@ namespace WolvenKit.Modkit.RED4.Tools
 
                 if (cMesh != null)
                 {
-                    if (!cMesh.Parameters.Select(x => x.Chunk).OfType<meshMeshParamGarmentSupport>().Any())
+                    if (!cMesh.Parameters.Any(x => x.Chunk is meshMeshParamGarmentSupport or garmentMeshParamGarment))
                     {
                         meshesInfo.garmentSupportExists[i] = false;
                     }


### PR DESCRIPTION
# GarmentSupport fixes

**Implemented:**
- Import option to disable UV parameter generation. Fixes an engine bug creating a seam

**Fixed:**
- Fixed UV parameter imported with flipped V
- Fixed an issue where GS wasn't exported if only `garmentMeshParamGarment` was present
