### PR TITLE
Nuget update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MahApps.Metro" Version="2.4.10" />
     <PackageVersion Include="MahApps.Metro.IconPacks" Version="5.1.0" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.4.5" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="DrawStringLineHeight" Version="1.0.0" />
     <PackageVersion Include="DynamicData" Version="9.0.4" />
-    <PackageVersion Include="EFCore.BulkExtensions" Version="8.1.1" />
+    <PackageVersion Include="EFCore.BulkExtensions.Sqlite" Version="8.1.1" />
     <PackageVersion Include="HandyControls" Version="3.5.3" />
     <PackageVersion Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.25.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,6 @@
     <PackageVersion Include="Nodify" Version="6.6.0" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="PixiEditor.ColorPicker" Version="3.4.1" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
     <PackageVersion Include="ReactiveUI" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,6 @@
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
     <PackageVersion Include="ReactiveUI" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />
-    <PackageVersion Include="ReactiveUI.Events.WPF" Version="15.1.1" />
     <PackageVersion Include="ReactiveUI.Validation" Version="3.0.22" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,52 +8,52 @@
     <PackageVersion Include="AutomaticGraphLayout" Version="1.1.12" />
     <PackageVersion Include="AvalonEdit" Version="6.3.0.90" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Discord.Net" Version="3.16.0" />
+    <PackageVersion Include="Discord.Net" Version="3.17.1" />
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="DrawStringLineHeight" Version="1.0.0" />
-    <PackageVersion Include="DynamicData" Version="9.0.4" />
-    <PackageVersion Include="EFCore.BulkExtensions.Sqlite" Version="8.1.1" />
+    <PackageVersion Include="DynamicData" Version="9.1.1" />
+    <PackageVersion Include="EFCore.BulkExtensions.Sqlite" Version="8.1.2" />
     <PackageVersion Include="HandyControls" Version="3.5.3" />
-    <PackageVersion Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.25.0" />
+    <PackageVersion Include="HelixToolkit.SharpDX.Core.Wpf" Version="2.26.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MahApps.Metro" Version="2.4.10" />
     <PackageVersion Include="MahApps.Metro.IconPacks" Version="5.1.0" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.4.5" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.2" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MouseKeyHook" Version="5.7.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
     <PackageVersion Include="NAudio.Lame" Version="2.1.0" />
     <PackageVersion Include="NAudio.Vorbis" Version="1.5.0" />
     <PackageVersion Include="NVorbis" Version="0.10.5" />
-    <PackageVersion Include="Nodify" Version="6.6.0" />
-    <PackageVersion Include="Octokit" Version="13.0.1" />
+    <PackageVersion Include="Nodify" Version="7.0.1" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="PixiEditor.ColorPicker" Version="3.4.1" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
     <PackageVersion Include="ReactiveUI" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.Events.WPF" Version="15.1.1" />
     <PackageVersion Include="ReactiveUI.Validation" Version="3.0.22" />
-    <PackageVersion Include="Serilog" Version="4.1.0" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
@@ -63,38 +63,38 @@
     <PackageVersion Include="SharpGLTF.Toolkit" Version="1.0.3" />
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Splat" Version="15.2.22" />
-    <PackageVersion Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.2.22" />
-    <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="15.2.22" />
-    <PackageVersion Include="Syncfusion.Edit.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.PropertyGrid.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfAccordion.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfBusyIndicator.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfGrid.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfHubTile.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfImageEditor.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfProgressBar.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfRadialMenu.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfRichTextBoxAdv.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfSkinManager.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfTextInputLayout.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfTreeNavigator.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.SfTreeView.WPF" Version="28.1.37" />
-    <PackageVersion Include="Syncfusion.Themes.MaterialDark.WPF" Version="28.1.37" />
+    <PackageVersion Include="Splat" Version="15.3.1" />
+    <PackageVersion Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
+    <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="15.3.1" />
+    <PackageVersion Include="Syncfusion.Edit.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.PropertyGrid.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfAccordion.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfBusyIndicator.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfGrid.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfHubTile.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfImageEditor.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfProgressBar.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfRadialMenu.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfRichTextBoxAdv.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfSkinManager.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfTextInputLayout.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfTreeNavigator.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.SfTreeView.WPF" Version="28.2.5" />
+    <PackageVersion Include="Syncfusion.Themes.MaterialDark.WPF" Version="28.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.2" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.2" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="WpfAnalyzers" Version="4.1.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="YamlDotNet" Version="16.2.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2">
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="PixiEditor.ColorPicker" Version="3.4.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" />
     <PackageVersion Include="ReactiveUI" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />
     <PackageVersion Include="ReactiveUI.Events.WPF" Version="15.1.1" />

--- a/Tests/WolvenKit.UnitTests/App/Models/ProjectManagement/Project/Cp77ProjectTest.cs
+++ b/Tests/WolvenKit.UnitTests/App/Models/ProjectManagement/Project/Cp77ProjectTest.cs
@@ -44,6 +44,6 @@ public class Cp77ProjectTest
         Assert.Equal(expectedRelativePath, rel);
 
         Assert.Equal(expectedRelativePath, testProject.GetRelativePath(absolutePath));
-        Assert.Equal(absolutePrefix, testProject.GetPrefixPath(absolutePath));
+        Assert.Equal(absolutePrefix, testProject.GetAbsoluteSubDirPath(absolutePath));
     }
 }

--- a/Tests/WolvenKit.Utility/WolvenKit.Utility.csproj
+++ b/Tests/WolvenKit.Utility/WolvenKit.Utility.csproj
@@ -36,7 +36,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Serilog.Sinks.Console" />
   </ItemGroup>

--- a/Tests/WolvenKit.Utility/WolvenKit.Utility.csproj
+++ b/Tests/WolvenKit.Utility/WolvenKit.Utility.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EFCore.BulkExtensions" />
+    <PackageReference Include="EFCore.BulkExtensions.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -492,7 +492,7 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
         (GetAbsoluteSubDirPath(fullPath), GetRelativePath(fullPath));
 
     /// <returns>The absolute path to the subdirectory containing the file, e.g. C:\CyberpunkFiles\...\source\archive</returns>
-    private string GetAbsoluteSubDirPath(string absolutePath)
+    public string GetAbsoluteSubDirPath(string absolutePath)
     {
         if (absolutePath.StartsWith(ModDirectory, StringComparison.Ordinal) ||
             absolutePath.StartsWith(s_relativeModDir))

--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -2,13 +2,10 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using CP77Tools.Commands;
 using CP77Tools.Tasks;
-using Microsoft.Build.Framework;
+using WolvenKit.Common;
 using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Core.Compression;
 

--- a/WolvenKit.CLI/Services/MicrosoftLoggerService.cs
+++ b/WolvenKit.CLI/Services/MicrosoftLoggerService.cs
@@ -1,6 +1,5 @@
 using System;
 using DynamicData;
-using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 using WolvenKit.Common;
 using WolvenKit.Common.Services;

--- a/WolvenKit.CLI/WolvenKit.CLI.csproj
+++ b/WolvenKit.CLI/WolvenKit.CLI.csproj
@@ -43,7 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />

--- a/WolvenKit.Core/Enums.cs
+++ b/WolvenKit.Core/Enums.cs
@@ -330,4 +330,13 @@ namespace WolvenKit.Common
         zh_tw,
         ua_ua
     }
+
+    public enum LoggerVerbosity
+    {
+        Quiet,
+        Minimal,
+        Normal,
+        Detailed,
+        Diagnostic,
+    }
 }

--- a/WolvenKit.Core/Interfaces/ILoggerService.cs
+++ b/WolvenKit.Core/Interfaces/ILoggerService.cs
@@ -1,6 +1,5 @@
 using System;
-using Microsoft.Build.Framework;
-using WolvenKit.Core.Exceptions;
+using WolvenKit.Common;
 
 namespace WolvenKit.Core.Interfaces;
 

--- a/WolvenKit.Core/Services/SerilogWrapper.cs
+++ b/WolvenKit.Core/Services/SerilogWrapper.cs
@@ -1,5 +1,5 @@
 using System;
-using Microsoft.Build.Framework;
+using WolvenKit.Common;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Interfaces;
 

--- a/WolvenKit.Core/WolvenKit.Core.csproj
+++ b/WolvenKit.Core/WolvenKit.Core.csproj
@@ -73,7 +73,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="semver" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
     <PackageReference Include="Serilog" />

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="Nodify" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" />
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="SharpVectors.Wpf" />
     <PackageReference Include="Splat" />
@@ -64,7 +65,6 @@
     <PackageReference Include="Serilog.Sinks.File" />
 
     <PackageReference Include="ReactiveUI" />
-    <PackageReference Include="ReactiveUI.Events.WPF" />
     <PackageReference Include="ReactiveUI.WPF" />
   </ItemGroup>
 
@@ -129,7 +129,7 @@
     <Compile Remove="Converters\BooleanConverter.cs" />
     <Compile Remove="GridVirtualizingCellsControl.xaml.cs" />
     <Page Remove="GridVirtualizingCellsControl.xaml" />
-      <Compile Remove="Converters\BindingProxy.cs"/>
+      <Compile Remove="Converters\BindingProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Views\Templates\RedFixedPointEditor.cs" />


### PR DESCRIPTION
# Nuget update

**Implemented:**
- Custom `LoggerVerbosity` to remove the need of referencing `Microsoft.Build.Framework`
- Replaced `EFCore.BulkExtensions` with `EFCore.BulkExtensions.Sqlite` (Upgrade to EFCore 9.0) 
- Replaced deprecated `ReactiveUI.Events.WPF` with `ReactiveMarbles.ObservableEvents.SourceGenerator`

**Fixed:**
- Build issue introduced with #2098 / 886f03e

**Additional notes:**
Can be squashed
