### PR TITLE
Export fixes

### DIFF
--- a/WolvenKit.CLI/Commands/ExportCommand.cs
+++ b/WolvenKit.CLI/Commands/ExportCommand.cs
@@ -4,7 +4,9 @@ using System.IO;
 using CP77Tools.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using WolvenKit.Common;
+using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Core.Interfaces;
 
 namespace CP77Tools.Commands;
@@ -40,6 +42,13 @@ internal class ExportCommand : CommandBase
         if (path is null || path.Length < 1)
         {
             logger.Error("Please fill in an input path.");
+            return ConsoleFunctions.ERROR_BAD_ARGUMENTS;
+        }
+
+        var meshExportArgs = serviceProvider.GetService<IOptions<MeshExportArgs>>();
+        if (meshExportArgs?.Value is { withMaterials: true } && gamepath == null)
+        {
+            logger.Error("Exporting mesh files with materials requires \"--gamepath\" to be set");
             return ConsoleFunctions.ERROR_BAD_ARGUMENTS;
         }
 

--- a/WolvenKit.CLI/Commands/UncookCommand.cs
+++ b/WolvenKit.CLI/Commands/UncookCommand.cs
@@ -16,7 +16,7 @@ namespace CP77Tools.Commands;
 
 internal class UncookCommand : CommandBase
 {
-    private const string s_description = "Target an archive to uncook files fom.";
+    private const string s_description = "Target an archive to uncook files from.";
     private const string s_name = "uncook";
     public UncookCommand() : base(s_name, s_description)
     {

--- a/WolvenKit.Modkit/RED4/Tools/Common/MaterialExtractor.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/MaterialExtractor.cs
@@ -279,6 +279,13 @@ public class MaterialExtractor
                 var status = TryFindFile2(parentFile, cMaterialInstance.BaseMaterial, out var result);
                 if (status is FindFileResult.NoCR2W or FindFileResult.FileNotFound || result.File!.RootChunk is not IMaterial childMaterial)
                 {
+                    if (Equals(DefaultMaterials.DefaultMaterialTemplateFile, parentFile) &&
+                        Equals(DefaultMaterials.DefaultMaterialInstance, material) &&
+                        Equals(materialName, dynamicMaterialName))
+                    {
+                        throw new Exception("Default material is missing!");
+                    }
+
                     // If there's anything wrong with the file, we're falling back to the default material 
                     (mergedMaterial, template) =
                         MergeMaterialChain(DefaultMaterials.DefaultMaterialTemplateFile, DefaultMaterials.DefaultMaterialInstance,


### PR DESCRIPTION
# Export fixes

**Implemented:**
- Requiring `--gamepath` for cli export if meshExportArgs.withMaterials is set

**Fixed:**
- StackOverflow while using the material extractor and no archives (or wrong) are loaded

**Additional notes:**
Fixes #2279
