### PR TITLE
Fix secor preview not working due to illegal characters in node name

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTMeshViewModel.cs
@@ -2413,7 +2413,7 @@ public partial class RDTMeshViewModel : RedDocumentTabViewModel
         {
             var handle = data.Nodes[handleIndex].NotNull();
             var name = handle.Chunk.NotNull().DebugName.ToString().NotNull();
-            name = "_" + name.Replace("{", "").Replace("}", "").Replace("\\", "_").Replace(".", "_").Replace("!", "").Replace("-", "_") ?? "none";
+            name = "_" + name.Replace(" ", "_").Replace("[", "").Replace("]", "").Replace("{", "").Replace("}", "").Replace("\\", "_").Replace(".", "_").Replace("!", "").Replace("-", "_") ?? "none";
 
             var indexStr = string.Join(", ", transforms.Select(x => buffer.IndexOf(x)));
             var typeStr = handle.Chunk.GetType().Name;


### PR DESCRIPTION
- Just added some more string replace's, to handle some more cases