### PR TITLE
prevent endless loop during startup

### DIFF
--- a/WolvenKit/Layout/DockStateExtensions.cs
+++ b/WolvenKit/Layout/DockStateExtensions.cs
@@ -5,13 +5,14 @@ namespace WolvenKit.Functionality.Layout
 {
     public static class DockStateExtensions
     {
+        // If there's a distinction between Hidden and AutoHidden, this can lead to endless loops during background initialization
         public static DockState ToDockState(this Syncfusion.Windows.Tools.Controls.DockState sfDockState) =>
             sfDockState switch
             {
                 Syncfusion.Windows.Tools.Controls.DockState.Dock => DockState.Dock,
                 Syncfusion.Windows.Tools.Controls.DockState.Float => DockState.Float,
                 Syncfusion.Windows.Tools.Controls.DockState.Hidden => DockState.Hidden,
-                Syncfusion.Windows.Tools.Controls.DockState.AutoHidden => DockState.AutoHidden,
+                Syncfusion.Windows.Tools.Controls.DockState.AutoHidden => DockState.Hidden,
                 Syncfusion.Windows.Tools.Controls.DockState.Document => DockState.Document,
                 _ => throw new ArgumentOutOfRangeException(nameof(sfDockState), sfDockState, null)
             };


### PR DESCRIPTION
# prevent endless loop during startup

hidden / autohidden would cause an endless refresh loop where the dockState would jump between these two values. Way safer this way.