### PR TITLE
cybersearch will no longer insist on spaces before > operator

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -836,7 +836,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     private readonly record struct UsedByRefinement(string FilePath) : ISearchRefinement;
 
     // Refinement type matchers
-    private static readonly Regex s_refinementSeparator = new("\\s+>\\s+", s_regexpOpts, s_regexpSafetyTimeout);
+    private static readonly Regex s_refinementSeparator = new("\\s*>\\s*", s_regexpOpts, s_regexpSafetyTimeout);
     private static readonly Regex s_isHashRefinement = new("^h(?:ash)?:(?<numbers>\\d+)$", s_regexpOpts, s_regexpSafetyTimeout);
     private static readonly Regex s_isRegexRefinement = new("^r(?:egexp?)?:(?<pattern>.*)$", s_regexpOpts, s_regexpSafetyTimeout);
 
@@ -1042,6 +1042,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
             return;
         }
 
+        SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
         var searchAsSequentialRefinements =
             s_refinementSeparator
                 .Split(SearchBarText)
@@ -1075,6 +1076,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
             return [];
         }
 
+        SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
         var searchAsSequentialRefinements =
             s_refinementSeparator
                 .Split(SearchBarText)

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -836,7 +836,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     private readonly record struct UsedByRefinement(string FilePath) : ISearchRefinement;
 
     // Refinement type matchers
-    private static readonly Regex s_refinementSeparator = new("\\s*>\\s*", s_regexpOpts, s_regexpSafetyTimeout);
+    private static readonly Regex s_refinementSeparator = new(@"\s*>\s*", s_regexpOpts, s_regexpSafetyTimeout);
     private static readonly Regex s_isHashRefinement = new("^h(?:ash)?:(?<numbers>\\d+)$", s_regexpOpts, s_regexpSafetyTimeout);
     private static readonly Regex s_isRegexRefinement = new("^r(?:egexp?)?:(?<pattern>.*)$", s_regexpOpts, s_regexpSafetyTimeout);
 
@@ -1042,7 +1042,15 @@ public partial class AssetBrowserViewModel : ToolViewModel
             return;
         }
 
-        SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
+        try
+        {
+            SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
+        }
+        catch
+        {
+            // if the thread is busy, I guess we aren't replacing anything
+        }
+        
         var searchAsSequentialRefinements =
             s_refinementSeparator
                 .Split(SearchBarText)
@@ -1076,7 +1084,15 @@ public partial class AssetBrowserViewModel : ToolViewModel
             return [];
         }
 
-        SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
+        try
+        {
+            SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
+        }
+        catch
+        {
+            // if the thread is busy, I guess we aren't replacing anything
+        }
+        
         var searchAsSequentialRefinements =
             s_refinementSeparator
                 .Split(SearchBarText)

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -1041,15 +1041,6 @@ public partial class AssetBrowserViewModel : ToolViewModel
             RightItems.Clear();
             return;
         }
-
-        try
-        {
-            SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
-        }
-        catch
-        {
-            // if the thread is busy, I guess we aren't replacing anything
-        }
         
         var searchAsSequentialRefinements =
             s_refinementSeparator
@@ -1082,15 +1073,6 @@ public partial class AssetBrowserViewModel : ToolViewModel
         {
             RightItems.Clear();
             return [];
-        }
-
-        try
-        {
-            SearchBarText = Regex.Replace(SearchBarText, s_refinementSeparator.ToString(), " > ");
-        }
-        catch
-        {
-            // if the thread is busy, I guess we aren't replacing anything
         }
         
         var searchAsSequentialRefinements =


### PR DESCRIPTION
# cybersearch will no longer insist on spaces before > operator

as discussed in wkit-dev last week :)