### PR TITLE
Trying to prevent "reset layout" bug

### DIFF
--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -220,7 +220,8 @@ namespace WolvenKit.Views.Shell
             {
                 PART_DockingManager.BeginInit(); // Begin batch updates
 
-                using (var reader = XmlReader.Create(filePath)) {              
+                using (var reader = XmlReader.Create(filePath))
+                {              
 
                     var defaultXmlSerializer = DockingManager.CreateDefaultXmlSerializer(typeof(List<DockingParams>));
                     if (!defaultXmlSerializer.CanDeserialize(reader))
@@ -269,7 +270,8 @@ namespace WolvenKit.Views.Shell
                 // Now load layout
                 var isSuccess = false;
 
-                using (var reader = XmlReader.Create(filePath)) {
+                using (var reader = XmlReader.Create(filePath))
+                {
                     isSuccess = PART_DockingManager.LoadDockState(reader);
                 }
 


### PR DESCRIPTION
# Trying to prevent "reset layout" bug

Occasionally, resetting the project layout will reset in the view being covered in... a lot of windows. We know the bug, it's still there (although rarely). 
This is another attempt at preventing it. We'll see if it works, at least things haven't gotten worse.