### PR TITLE
feat: improve scene graph readability by detailing scnSectionNode events

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 using WolvenKit.RED4.Types;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
 
@@ -16,18 +18,259 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>
         int counter = 1;
         foreach (var eventClass in events)
         {
-            string evName = eventClass?.Chunk?.GetType().Name!;
+            string evName = eventClass?.Chunk?.GetType().Name ?? "UnknownEvent";
+            string detailSuffix = "";
 
             if (eventClass?.Chunk is scneventsSocket evSocket)
             {
-                evName += " - Name: " + evSocket.OsockStamp.Name.ToString()! + ", Ordinal: " + evSocket.OsockStamp.Ordinal.ToString()!;
+                detailSuffix = " - Name: " + evSocket.OsockStamp.Name.ToString() + ", Ordinal: " + evSocket.OsockStamp.Ordinal.ToString();
+            }
+            else if (eventClass?.Chunk is scnPlaySkAnimEvent playSkAnimEvent)
+            {
+                scnAnimName? animNameObj = null;
+                if (playSkAnimEvent.AnimName is CHandle<scnAnimName> handle)
+                {
+                    animNameObj = handle.GetValue() as scnAnimName;
+                }
+                if (animNameObj != null && animNameObj.Unk1 != null && animNameObj.Unk1.Count > 0)
+                {
+                    var animCName = animNameObj.Unk1[0];
+                    if (animCName != CName.Empty)
+                    {
+                        string? animNameString = animCName.GetResolvedText();
+                        if (!string.IsNullOrEmpty(animNameString))
+                        {
+                            const int maxLen = 35;
+                            string displayAnimName = animNameString;
+                            if (displayAnimName.Length > maxLen)
+                            {
+                                displayAnimName = displayAnimName.Substring(0, maxLen) + "...";
+                            }
+                            detailSuffix = $" ({displayAnimName})";
+                        }
+                        else { detailSuffix = " ([unresolved animName])"; }
+                    }
+                }
+            }
+            else if (eventClass?.Chunk is scnDialogLineEvent dialogLineEvent)
+            {
+                if (dialogLineEvent.ScreenplayLineId != null && 
+                    scnSceneResource?.LocStore != null && 
+                    scnSceneResource.LocStore.VdEntries != null && 
+                    scnSceneResource.LocStore.VpEntries != null)
+                {
+                    CUInt32 screenplayId = dialogLineEvent.ScreenplayLineId.Id;
+                    var screenplayLine = scnSceneResource.ScreenplayStore?.Lines?.FirstOrDefault(line => line.ItemId?.Id == screenplayId);
+
+                    if (screenplayLine != null && screenplayLine.LocstringId != null)
+                    {
+                        CRUID locstringRuid = screenplayLine.LocstringId.Ruid;
+                        string? dialogueText = null;
+                        bool foundText = false;
+
+                        var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.db_db;
+                        var vdEntryPreferred = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId == preferredLocaleId);
+
+                        if (vdEntryPreferred != null && vdEntryPreferred.VariantId != null)
+                        {
+                            CRUID targetVariantRuid = vdEntryPreferred.VariantId.Ruid;
+                            var vpEntry = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == targetVariantRuid);
+                            if (vpEntry != null)
+                            {
+                                dialogueText = vpEntry.Content;
+                                if (!string.IsNullOrEmpty(dialogueText))
+                                {
+                                    foundText = true;
+                                }
+                            }
+                        }
+
+                        if (!foundText)
+                        {
+                            var vdEntryFallback = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId != preferredLocaleId);
+                            if (vdEntryFallback != null && vdEntryFallback.VariantId != null)
+                            {
+                                CRUID fallbackVariantRuid = vdEntryFallback.VariantId.Ruid;
+                                var vpEntryFallback = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == fallbackVariantRuid);
+                                if (vpEntryFallback != null)
+                                {
+                                    dialogueText = vpEntryFallback.Content;
+                                    if (!string.IsNullOrEmpty(dialogueText))
+                                    {
+                                        foundText = true;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (foundText && !string.IsNullOrEmpty(dialogueText))
+                        {
+                            const int maxLen = 40;
+                            string displayDialogue = dialogueText;
+                            if (displayDialogue.Length > maxLen)
+                            {
+                                displayDialogue = displayDialogue.Substring(0, maxLen) + "...";
+                            }
+                            detailSuffix = $" (\"{displayDialogue}\")";
+                        }
+                        else
+                        {
+                            detailSuffix = $" (RUID {locstringRuid} - empty)";
+                        }
+                    }
+                    else
+                    {
+                        detailSuffix = $" (ID {screenplayId} - missing refs)";
+                    }
+                }
+            }
+            else if (eventClass?.Chunk is scnLookAtEvent lookAtEvent)
+            {
+                if (lookAtEvent.BasicData?.Basic != null && scnSceneResource != null)
+                {
+                    var basicLookAtData = lookAtEvent.BasicData.Basic;
+                    string performerName = ResolvePerformerName(basicLookAtData.PerformerId.Id, scnSceneResource);
+                    string targetName = "UnknownTarget";
+
+                    var targetTypeEnum = (Enums.scnLookAtTargetType)basicLookAtData.TargetType;
+                    switch (targetTypeEnum) 
+                    {
+                        case Enums.scnLookAtTargetType.Actor:
+                            // Use TargetPerformerId when TargetType is Actor
+                            if (basicLookAtData.TargetPerformerId != null)
+                            {
+                                targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
+                            }
+                            else
+                            {
+                                targetName = "Performer: [Null ID]"; // Fallback if TargetPerformerId is null
+                            }
+                            break;
+                        case Enums.scnLookAtTargetType.Prop:
+                             if (basicLookAtData.TargetPropId != null)
+                             {
+                                var propDef = scnSceneResource.Props?.FirstOrDefault(p => p.PropId?.Id == basicLookAtData.TargetPropId.Id);
+                                if (propDef != null)
+                                {
+                                    targetName = $"Prop: {propDef.PropName} [{basicLookAtData.TargetPropId.Id}]";
+                                }
+                                else
+                                { 
+                                    targetName = $"Prop: Unknown [{basicLookAtData.TargetPropId.Id}]";
+                                }
+                             }
+                             else
+                             {
+                                targetName = "Prop: [Null ID]";
+                             }
+                            break;
+                        default:
+                             // Check StaticTarget first (assuming non-default means it's used)
+                             if (basicLookAtData.StaticTarget.X != 0 || basicLookAtData.StaticTarget.Y != 0 || basicLookAtData.StaticTarget.Z != 0)
+                             {
+                                targetName = $"Position: ({basicLookAtData.StaticTarget.X:F1}, {basicLookAtData.StaticTarget.Y:F1}, {basicLookAtData.StaticTarget.Z:F1})";
+                             }
+                             // Then check TargetPerformerId 
+                             else if (basicLookAtData.TargetPerformerId != null && 
+                                basicLookAtData.TargetPerformerId.Id != 4294967040)
+                             {
+                                 targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
+                                 targetName += " (as Performer)";
+                             }
+                             // Then check TargetSlot
+                             else if (basicLookAtData.TargetSlot != CName.Empty) 
+                             {
+                                 targetName = $"Slot: {basicLookAtData.TargetSlot.GetResolvedText() ?? "?"}";
+                             }
+                             // Final fallback
+                             else
+                             {
+                                 targetName = $"Unknown ({targetTypeEnum})";
+                             }
+                             break;
+                    }
+                    detailSuffix = $" ({performerName} -> {targetName})";
+                }
+            }
+            else if (eventClass?.Chunk is scneventsVFXEvent vfxEvent)
+            {
+                string actionName = vfxEvent.Action.ToString(); // Get enum string representation
+                string effectName = "[No Effect]";
+                if (vfxEvent.EffectEntry != null && vfxEvent.EffectEntry.EffectName != CName.Empty)
+                {
+                    effectName = vfxEvent.EffectEntry.EffectName.GetResolvedText() ?? "[unresolved]";
+                }
+                detailSuffix = $" ({actionName}: {effectName})";
             }
 
-            Details["#" + counter.ToString() + " " + eventClass?.Chunk?.StartTime.ToString() + "ms"] = evName;
+            string fullEventName = evName + detailSuffix;
+
+            Details["#" + counter.ToString() + " " + eventClass?.Chunk?.StartTime.ToString() + "ms"] = fullEventName;
             counter++;
         }
 
-        Title += NodeProperties.SetNameFromNotablePoints(scnSectionNode.NodeId.Id, scnSceneResource);
+        if (scnSceneResource != null)
+        {
+            Title += NodeProperties.SetNameFromNotablePoints(scnSectionNode.NodeId.Id, scnSceneResource);
+        }
+    }
+
+    // Helper method to resolve performer IDs to names using BITMASK encoding
+    private string ResolvePerformerName(CUInt32 performerIdCUint32, scnSceneResource sceneResource)
+    {
+        uint performerId = performerIdCUint32; // Implicit conversion
+
+        // Handle potential 'None' or special values
+        if (performerId == uint.MaxValue || performerId == 4294967040 || performerId == 0) return "None [0]";
+
+        var names = new List<string>();
+        for (int actorIndex = 0; actorIndex < 16; actorIndex++) // Check up to 16 actors
+        {
+            if (((performerId >> actorIndex) & 1) == 1)
+            {
+                string resolvedName = $"Idx {actorIndex}?";
+
+                if (sceneResource?.Actors != null && actorIndex < sceneResource.Actors.Count)
+                {
+                     var actorDef = sceneResource.Actors[actorIndex];
+                     if (actorDef != null)
+                     {
+                         var playerActorDef = sceneResource.PlayerActors?.FirstOrDefault(p => p.ActorId?.Id == actorDef.ActorId?.Id);
+                         if(playerActorDef != null)
+                         {
+                             string playerName = playerActorDef.PlayerName;
+                             string? playerNameStr = playerName;
+                             if (string.IsNullOrEmpty(playerNameStr)) playerNameStr = "Player";
+                             resolvedName = $"{playerNameStr} [{actorIndex}]";
+                         }
+                         else
+                         {
+                             string actorName = actorDef.ActorName;
+                             string? actorNameStr = actorName;
+                             resolvedName = $"{actorNameStr ?? "Unnamed"} [{actorIndex}]";
+                         }
+                     }
+                     else
+                     {
+                          resolvedName = $"Idx {actorIndex} (Null Def)";
+                     }
+                }
+                 names.Add(resolvedName);
+            }
+        }
+
+        if (names.Count > 0)
+        {
+            string joinedNames = string.Join(", ", names);
+            const int maxTotalLen = 50;
+            if (joinedNames.Length > maxTotalLen)
+            {
+                joinedNames = joinedNames.Substring(0, maxTotalLen) + "...";
+            }
+            return joinedNames;
+        }
+
+        return $"Unknown [{performerId}]";
     }
 
     internal override void GenerateSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -21,411 +21,427 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>
             string evName = eventClass?.Chunk?.GetType().Name ?? "UnknownEvent";
             string detailSuffix = "";
 
-            if (eventClass?.Chunk is scneventsSocket evSocket)
+            switch (eventClass?.Chunk)
             {
-                detailSuffix = " - Name: " + evSocket.OsockStamp.Name.ToString() + ", Ordinal: " + evSocket.OsockStamp.Ordinal.ToString();
-            }
-            else if (eventClass?.Chunk is scnPlaySkAnimEvent playSkAnimEvent)
-            {
-                string performerName = ResolvePerformerName(playSkAnimEvent.Performer.Id, scnSceneResource);
-                string animSuffix = "[No Anim]";
-                
-                scnAnimName? animNameObj = null;
-                if (playSkAnimEvent.AnimName is CHandle<scnAnimName> handle)
-                {
-                    animNameObj = handle.GetValue() as scnAnimName;
-                }
-                if (animNameObj != null && animNameObj.Unk1 != null && animNameObj.Unk1.Count > 0)
-                {
-                    var animCName = animNameObj.Unk1[0];
-                    if (animCName != CName.Empty)
+                case scneventsSocket evSocket:
+                    detailSuffix = " - Name: " + evSocket.OsockStamp.Name.ToString() + ", Ordinal: " + evSocket.OsockStamp.Ordinal.ToString();
+                    break;
+                case scnPlaySkAnimEvent playSkAnimEvent:
                     {
-                        string? animNameString = animCName.GetResolvedText();
-                        if (!string.IsNullOrEmpty(animNameString))
+                        string performerName = ResolvePerformerName(playSkAnimEvent.Performer.Id, scnSceneResource);
+                        string animSuffix = "[No Anim]";
+
+                        scnAnimName? animNameObj = null;
+                        if (playSkAnimEvent.AnimName is CHandle<scnAnimName> handle)
                         {
-                            const int maxLen = 35;
-                            string displayAnimName = animNameString;
-                            if (displayAnimName.Length > maxLen)
-                            {
-                                displayAnimName = displayAnimName.Substring(0, maxLen) + "...";
-                            }
-                            animSuffix = displayAnimName;
+                            animNameObj = handle.GetValue() as scnAnimName;
                         }
-                        else { animSuffix = "[unresolved]"; }
-                    }
-                }
-                detailSuffix = $" ({performerName} - Anim: {animSuffix})";
-            }
-            else if (eventClass?.Chunk is scnDialogLineEvent dialogLineEvent)
-            {
-                if (dialogLineEvent.ScreenplayLineId != null && 
-                    scnSceneResource?.LocStore != null && 
-                    scnSceneResource.LocStore.VdEntries != null && 
-                    scnSceneResource.LocStore.VpEntries != null)
-                {
-                    CUInt32 screenplayId = dialogLineEvent.ScreenplayLineId.Id;
-                    var screenplayLine = scnSceneResource.ScreenplayStore?.Lines?.FirstOrDefault(line => line.ItemId?.Id == screenplayId);
-
-                    if (screenplayLine != null && screenplayLine.LocstringId != null)
-                    {
-                        CRUID locstringRuid = screenplayLine.LocstringId.Ruid;
-                        string? dialogueText = null;
-                        bool foundText = false;
-
-                        var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.db_db;
-                        var vdEntryPreferred = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId == preferredLocaleId);
-
-                        if (vdEntryPreferred != null && vdEntryPreferred.VariantId != null)
+                        if (animNameObj != null && animNameObj.Unk1 != null && animNameObj.Unk1.Count > 0)
                         {
-                            CRUID targetVariantRuid = vdEntryPreferred.VariantId.Ruid;
-                            var vpEntry = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == targetVariantRuid);
-                            if (vpEntry != null)
+                            var animCName = animNameObj.Unk1[0];
+                            if (animCName != CName.Empty)
                             {
-                                dialogueText = vpEntry.Content;
-                                if (!string.IsNullOrEmpty(dialogueText))
+                                string? animNameString = animCName.GetResolvedText();
+                                if (!string.IsNullOrEmpty(animNameString))
                                 {
-                                    foundText = true;
-                                }
-                            }
-                        }
-
-                        if (!foundText)
-                        {
-                            var vdEntryFallback = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId != preferredLocaleId);
-                            if (vdEntryFallback != null && vdEntryFallback.VariantId != null)
-                            {
-                                CRUID fallbackVariantRuid = vdEntryFallback.VariantId.Ruid;
-                                var vpEntryFallback = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == fallbackVariantRuid);
-                                if (vpEntryFallback != null)
-                                {
-                                    dialogueText = vpEntryFallback.Content;
-                                    if (!string.IsNullOrEmpty(dialogueText))
+                                    const int maxLen = 35;
+                                    string displayAnimName = animNameString;
+                                    if (displayAnimName.Length > maxLen)
                                     {
-                                        foundText = true;
+                                        displayAnimName = displayAnimName.Substring(0, maxLen) + "...";
+                                    }
+                                    animSuffix = displayAnimName;
+                                }
+                                else { animSuffix = "[unresolved]"; }
+                            }
+                        }
+                        detailSuffix = $" ({performerName} - Anim: {animSuffix})";
+                    }
+                    break;
+                case scnDialogLineEvent dialogLineEvent:
+                    {
+                        if (dialogLineEvent.ScreenplayLineId != null &&
+                            scnSceneResource?.LocStore != null &&
+                            scnSceneResource.LocStore.VdEntries != null &&
+                            scnSceneResource.LocStore.VpEntries != null)
+                        {
+                            CUInt32 screenplayId = dialogLineEvent.ScreenplayLineId.Id;
+                            var screenplayLine = scnSceneResource.ScreenplayStore?.Lines?.FirstOrDefault(line => line.ItemId?.Id == screenplayId);
+
+                            if (screenplayLine != null && screenplayLine.LocstringId != null)
+                            {
+                                CRUID locstringRuid = screenplayLine.LocstringId.Ruid;
+                                string? dialogueText = null;
+                                bool foundText = false;
+
+                                var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.db_db;
+                                var vdEntryPreferred = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId == preferredLocaleId);
+
+                                if (vdEntryPreferred != null && vdEntryPreferred.VariantId != null)
+                                {
+                                    CRUID targetVariantRuid = vdEntryPreferred.VariantId.Ruid;
+                                    var vpEntry = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == targetVariantRuid);
+                                    if (vpEntry != null)
+                                    {
+                                        dialogueText = vpEntry.Content;
+                                        if (!string.IsNullOrEmpty(dialogueText))
+                                        {
+                                            foundText = true;
+                                        }
                                     }
                                 }
-                            }
-                        }
 
-                        if (foundText && !string.IsNullOrEmpty(dialogueText))
-                        {
-                            const int maxLen = 40;
-                            string displayDialogue = dialogueText;
-                            if (displayDialogue.Length > maxLen)
-                            {
-                                displayDialogue = displayDialogue.Substring(0, maxLen) + "...";
-                            }
-                            detailSuffix = $" (\"{displayDialogue}\")";
-                        }
-                        else
-                        {
-                            detailSuffix = $" (RUID {locstringRuid} - empty)";
-                        }
-                    }
-                    else
-                    {
-                        detailSuffix = $" (ID {screenplayId} - missing refs)";
-                    }
-                }
-            }
-            else if (eventClass?.Chunk is scnLookAtEvent lookAtEvent)
-            {
-                if (lookAtEvent.BasicData?.Basic != null && scnSceneResource != null)
-                {
-                    var basicLookAtData = lookAtEvent.BasicData.Basic;
-                    string performerName = ResolvePerformerName(basicLookAtData.PerformerId.Id, scnSceneResource);
-                    string targetName = "UnknownTarget";
+                                if (!foundText)
+                                {
+                                    var vdEntryFallback = scnSceneResource.LocStore.VdEntries.FirstOrDefault(vd => vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId != preferredLocaleId);
+                                    if (vdEntryFallback != null && vdEntryFallback.VariantId != null)
+                                    {
+                                        CRUID fallbackVariantRuid = vdEntryFallback.VariantId.Ruid;
+                                        var vpEntryFallback = scnSceneResource.LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == fallbackVariantRuid);
+                                        if (vpEntryFallback != null)
+                                        {
+                                            dialogueText = vpEntryFallback.Content;
+                                            if (!string.IsNullOrEmpty(dialogueText))
+                                            {
+                                                foundText = true;
+                                            }
+                                        }
+                                    }
+                                }
 
-                    var targetTypeEnum = (WolvenKit.RED4.Types.Enums.scnLookAtTargetType)basicLookAtData.TargetType;
-                    switch (targetTypeEnum) 
-                    {
-                        case WolvenKit.RED4.Types.Enums.scnLookAtTargetType.Actor:
-                            // Use TargetPerformerId when TargetType is Actor
-                            if (basicLookAtData.TargetPerformerId != null)
-                            {
-                                targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
+                                if (foundText && !string.IsNullOrEmpty(dialogueText))
+                                {
+                                    const int maxLen = 40;
+                                    string displayDialogue = dialogueText;
+                                    if (displayDialogue.Length > maxLen)
+                                    {
+                                        displayDialogue = displayDialogue.Substring(0, maxLen) + "...";
+                                    }
+                                    detailSuffix = $" (\"{displayDialogue}\")";
+                                }
+                                else
+                                {
+                                    detailSuffix = $" (RUID {locstringRuid} - empty)";
+                                }
                             }
                             else
                             {
-                                targetName = "Performer: [Null ID]";
+                                detailSuffix = $" (ID {screenplayId} - missing refs)";
                             }
-                            break;
-                        case WolvenKit.RED4.Types.Enums.scnLookAtTargetType.Prop:
-                             if (basicLookAtData.TargetPropId != null)
-                             {
-                                var propDef = scnSceneResource.Props?.FirstOrDefault(p => p.PropId?.Id == basicLookAtData.TargetPropId.Id);
-                                if (propDef != null)
-                                {
-                                    targetName = $"Prop: {propDef.PropName} [{basicLookAtData.TargetPropId.Id}]";
-                                }
-                                else
-                                { 
-                                    targetName = $"Prop: Unknown [{basicLookAtData.TargetPropId.Id}]";
-                                }
-                             }
-                             else
-                             {
-                                targetName = "Prop: [Null ID]";
-                             }
-                            break;
-                        default:
-                             // Check StaticTarget first (assuming non-default means it's used)
-                             if (basicLookAtData.StaticTarget.X != 0 || basicLookAtData.StaticTarget.Y != 0 || basicLookAtData.StaticTarget.Z != 0)
-                             {
-                                targetName = $"Position: ({basicLookAtData.StaticTarget.X:F1}, {basicLookAtData.StaticTarget.Y:F1}, {basicLookAtData.StaticTarget.Z:F1})";
-                             }
-                             // Then check TargetPerformerId 
-                             else if (basicLookAtData.TargetPerformerId != null && 
-                                basicLookAtData.TargetPerformerId.Id != 4294967040)
-                             {
-                                 targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
-                                 targetName += " (as Performer)";
-                             }
-                             // Then check TargetSlot
-                             else if (basicLookAtData.TargetSlot != CName.Empty) 
-                             {
-                                 targetName = $"Slot: {basicLookAtData.TargetSlot.GetResolvedText() ?? "?"}";
-                             }
-                             else
-                             {
-                                 targetName = $"Unknown ({targetTypeEnum})";
-                             }
-                             break;
+                        }
                     }
-                    detailSuffix = $" ({performerName} -> {targetName})";
-                }
-            }
-            else if (eventClass?.Chunk is scneventsVFXEvent vfxEvent)
-            {
-                string actionName = vfxEvent.Action.ToString();
-                string effectName = "[No Effect]";
-                if (vfxEvent.EffectEntry != null && vfxEvent.EffectEntry.EffectName != CName.Empty)
-                {
-                    effectName = vfxEvent.EffectEntry.EffectName.GetResolvedText() ?? "[unresolved]";
-                }
-                detailSuffix = $" ({actionName}: {effectName})";
-            }
-            else if (eventClass?.Chunk is scnChangeIdleAnimEvent idleAnimEvent)
-            {
-                string performerName = ResolvePerformerName(idleAnimEvent.Performer.Id, scnSceneResource);
-                string idleAnim = "[None]";
-                if (idleAnimEvent.IdleAnimName != CName.Empty)
-                {
-                    idleAnim = idleAnimEvent.IdleAnimName.GetResolvedText() ?? "[unresolved]";
-                }
-                
-                string facialAnim = "[None]";
-                if (idleAnimEvent.BakedFacialTransition != null)
-                {
-                    var facialCName = CName.Empty;
-                    if (idleAnimEvent.BakedFacialTransition.ToIdleFemale != CName.Empty)
+                    break;
+                case scnLookAtEvent lookAtEvent:
                     {
-                        facialCName = idleAnimEvent.BakedFacialTransition.ToIdleFemale;
+                        if (lookAtEvent.BasicData?.Basic != null && scnSceneResource != null)
+                        {
+                            var basicLookAtData = lookAtEvent.BasicData.Basic;
+                            string performerName = ResolvePerformerName(basicLookAtData.PerformerId.Id, scnSceneResource);
+                            string targetName = "UnknownTarget";
+
+                            var targetTypeEnum = (WolvenKit.RED4.Types.Enums.scnLookAtTargetType)basicLookAtData.TargetType;
+                            switch (targetTypeEnum)
+                            {
+                                case WolvenKit.RED4.Types.Enums.scnLookAtTargetType.Actor:
+                                    // Use TargetPerformerId when TargetType is Actor
+                                    if (basicLookAtData.TargetPerformerId != null)
+                                    {
+                                        targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
+                                    }
+                                    else
+                                    {
+                                        targetName = "Performer: [Null ID]";
+                                    }
+                                    break;
+                                case WolvenKit.RED4.Types.Enums.scnLookAtTargetType.Prop:
+                                    if (basicLookAtData.TargetPropId != null)
+                                    {
+                                        var propDef = scnSceneResource.Props?.FirstOrDefault(p => p.PropId?.Id == basicLookAtData.TargetPropId.Id);
+                                        if (propDef != null)
+                                        {
+                                            targetName = $"Prop: {propDef.PropName} [{basicLookAtData.TargetPropId.Id}]";
+                                        }
+                                        else
+                                        {
+                                            targetName = $"Prop: Unknown [{basicLookAtData.TargetPropId.Id}]";
+                                        }
+                                    }
+                                    else
+                                    {
+                                        targetName = "Prop: [Null ID]";
+                                    }
+                                    break;
+                                default:
+                                    // Check StaticTarget first (assuming non-default means it's used)
+                                    if (basicLookAtData.StaticTarget.X != 0 || basicLookAtData.StaticTarget.Y != 0 || basicLookAtData.StaticTarget.Z != 0)
+                                    {
+                                        targetName = $"Position: ({basicLookAtData.StaticTarget.X:F1}, {basicLookAtData.StaticTarget.Y:F1}, {basicLookAtData.StaticTarget.Z:F1})";
+                                    }
+                                    // Then check TargetPerformerId
+                                    else if (basicLookAtData.TargetPerformerId != null &&
+                                       basicLookAtData.TargetPerformerId.Id != 4294967040)
+                                    {
+                                        targetName = ResolvePerformerName(basicLookAtData.TargetPerformerId.Id, scnSceneResource);
+                                        targetName += " (as Performer)";
+                                    }
+                                    // Then check TargetSlot
+                                    else if (basicLookAtData.TargetSlot != CName.Empty)
+                                    {
+                                        targetName = $"Slot: {basicLookAtData.TargetSlot.GetResolvedText() ?? "?"}";
+                                    }
+                                    else
+                                    {
+                                        targetName = $"Unknown ({targetTypeEnum})";
+                                    }
+                                    break;
+                            }
+                            detailSuffix = $" ({performerName} -> {targetName})";
+                        }
                     }
-                    else if (idleAnimEvent.BakedFacialTransition.ToIdleMale != CName.Empty)
+                    break;
+                case scneventsVFXEvent vfxEvent:
                     {
-                        facialCName = idleAnimEvent.BakedFacialTransition.ToIdleMale;
+                        string actionName = vfxEvent.Action.ToString();
+                        string effectName = "[No Effect]";
+                        if (vfxEvent.EffectEntry != null && vfxEvent.EffectEntry.EffectName != CName.Empty)
+                        {
+                            effectName = vfxEvent.EffectEntry.EffectName.GetResolvedText() ?? "[unresolved]";
+                        }
+                        detailSuffix = $" ({actionName}: {effectName})";
                     }
-                    
-                    if (facialCName != CName.Empty)
+                    break;
+                case scnChangeIdleAnimEvent idleAnimEvent:
                     {
-                        facialAnim = facialCName.GetResolvedText() ?? "[unresolved]";
-                    }
-                }
-                
-                // Conditionally add parts to the suffix
-                var parts = new List<string>();
-                parts.Add($"Performer: {performerName}");
-                if (idleAnim != "[None]") parts.Add($"Idle: {idleAnim}");
-                if (facialAnim != "[None]") parts.Add($"Face: {facialAnim}");
-                
-                if (parts.Count > 1)
-                {
-                    detailSuffix = $" ({string.Join(", ", parts)})";
-                }
-                else
-                {
-                    detailSuffix = $" ({performerName})";
-                }
-            }
-            else if (eventClass?.Chunk is scnIKEvent ikEvent)
-            {
-                string performerName = "[No Performer]";
-                if (ikEvent.IkData?.Basic?.PerformerId != null && scnSceneResource != null)
-                {
-                    performerName = ResolvePerformerName(ikEvent.IkData.Basic.PerformerId.Id, scnSceneResource);
-                }
+                        string performerName = ResolvePerformerName(idleAnimEvent.Performer.Id, scnSceneResource);
+                        string idleAnim = "[None]";
+                        if (idleAnimEvent.IdleAnimName != CName.Empty)
+                        {
+                            idleAnim = idleAnimEvent.IdleAnimName.GetResolvedText() ?? "[unresolved]";
+                        }
 
-                string chainName = "[No Chain]";
-                if (ikEvent.IkData?.ChainName != null && ikEvent.IkData.ChainName != CName.Empty)
-                {
-                    chainName = ikEvent.IkData.ChainName.GetResolvedText() ?? "[unresolved]";
-                }
-                
-                detailSuffix = $" ({performerName} - Chain: {chainName})";
-            }
-            else if (eventClass?.Chunk is scneventsAttachPropToPerformer attachEvent)
-            {
-                string propName = "[No Prop]";
-                if (attachEvent.PropId != null && scnSceneResource?.Props != null)
-                {
-                    var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachEvent.PropId.Id);
-                    if (propDef != null)
+                        string facialAnim = "[None]";
+                        if (idleAnimEvent.BakedFacialTransition != null)
+                        {
+                            var facialCName = CName.Empty;
+                            if (idleAnimEvent.BakedFacialTransition.ToIdleFemale != CName.Empty)
+                            {
+                                facialCName = idleAnimEvent.BakedFacialTransition.ToIdleFemale;
+                            }
+                            else if (idleAnimEvent.BakedFacialTransition.ToIdleMale != CName.Empty)
+                            {
+                                facialCName = idleAnimEvent.BakedFacialTransition.ToIdleMale;
+                            }
+
+                            if (facialCName != CName.Empty)
+                            {
+                                facialAnim = facialCName.GetResolvedText() ?? "[unresolved]";
+                            }
+                        }
+
+                        var suffixParts = new List<string>();
+                        if (idleAnim != "[None]") suffixParts.Add($"Idle: {idleAnim}");
+                        if (facialAnim != "[None]") suffixParts.Add($"Face: {facialAnim}");
+
+                        if (suffixParts.Count > 0)
+                        {
+                            detailSuffix = $" ({performerName} - {string.Join(", ", suffixParts)})";
+                        }
+                        else
+                        {
+                            detailSuffix = $" ({performerName})";
+                        }
+                    }
+                    break;
+                case scnIKEvent ikEvent:
                     {
-                        string? pName = propDef.PropName;
-                        propName = pName ?? "Unnamed";
+                        string performerName = "[No Performer]";
+                        if (ikEvent.IkData?.Basic?.PerformerId != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(ikEvent.IkData.Basic.PerformerId.Id, scnSceneResource);
+                        }
+
+                        string chainName = "[No Chain]";
+                        if (ikEvent.IkData?.ChainName != null && ikEvent.IkData.ChainName != CName.Empty)
+                        {
+                            chainName = ikEvent.IkData.ChainName.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        detailSuffix = $" ({performerName} - Chain: {chainName})";
                     }
-                    else
-                    { 
-                        propName = $"Unknown [{attachEvent.PropId.Id}]";
-                    }
-                }
-
-                string performerName = "[No Performer]";
-                if (attachEvent.PerformerId != null && scnSceneResource != null)
-                {
-                    performerName = ResolvePerformerName(attachEvent.PerformerId.Id, scnSceneResource);
-                }
-
-                string slotName = "[No Slot]";
-                if (attachEvent.Slot != CName.Empty)
-                {
-                    slotName = attachEvent.Slot.GetResolvedText() ?? "[unresolved]";
-                }
-
-                detailSuffix = $" (Prop: {propName} -> Performer: {performerName} at Slot: {slotName})";
-            }
-            else if (eventClass?.Chunk is scneventsAttachPropToWorld attachWorldEvent)
-            {
-                string propName = "[No Prop]";
-                if (attachWorldEvent.PropId != null && scnSceneResource?.Props != null)
-                {
-                    var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachWorldEvent.PropId.Id);
-                    if (propDef != null)
+                    break;
+                case scneventsAttachPropToPerformer attachEvent:
                     {
-                         string? pName = propDef.PropName;
-                         propName = pName ?? "Unnamed";
+                        string propName = "[No Prop]";
+                        if (attachEvent.PropId != null && scnSceneResource?.Props != null)
+                        {
+                            var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachEvent.PropId.Id);
+                            if (propDef != null)
+                            {
+                                string? pName = propDef.PropName;
+                                propName = pName ?? "Unnamed";
+                            }
+                            else
+                            {
+                                propName = $"Unknown [{attachEvent.PropId.Id}]";
+                            }
+                        }
+
+                        string performerName = "[No Performer]";
+                        if (attachEvent.PerformerId != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(attachEvent.PerformerId.Id, scnSceneResource);
+                        }
+
+                        string slotName = "[No Slot]";
+                        if (attachEvent.Slot != CName.Empty)
+                        {
+                            slotName = attachEvent.Slot.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        detailSuffix = $" (Prop: {propName} -> Performer: {performerName} at Slot: {slotName})";
                     }
-                    else 
-                    { 
-                        propName = $"Unknown [{attachWorldEvent.PropId.Id}]";
-                    }
-                }
-                 detailSuffix = $" (Prop: {propName} -> World)";
-            }
-            else if (eventClass?.Chunk is scneventsAttachPropToNode attachNodeEvent)
-            {
-                string propName = "[No Prop]";
-                if (attachNodeEvent.PropId != null && scnSceneResource?.Props != null)
-                {
-                    var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachNodeEvent.PropId.Id);
-                    if (propDef != null)
+                    break;
+                case scneventsAttachPropToWorld attachWorldEvent:
                     {
-                         string? pName = propDef.PropName;
-                         propName = pName ?? "Unnamed";
+                        string propName = "[No Prop]";
+                        if (attachWorldEvent.PropId != null && scnSceneResource?.Props != null)
+                        {
+                            var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachWorldEvent.PropId.Id);
+                            if (propDef != null)
+                            {
+                                string? pName = propDef.PropName;
+                                propName = pName ?? "Unnamed";
+                            }
+                            else
+                            {
+                                propName = $"Unknown [{attachWorldEvent.PropId.Id}]";
+                            }
+                        }
+                        detailSuffix = $" (Prop: {propName} -> World)";
                     }
-                    else 
-                    { 
-                        propName = $"Unknown [{attachNodeEvent.PropId.Id}]";
-                    }
-                }
-                string nodeRef = attachNodeEvent.NodeRef != NodeRef.Empty 
-                                 ? attachNodeEvent.NodeRef.GetRedHash().ToString("X") 
-                                 : "[No Node]";
-                 detailSuffix = $" (Prop: {propName} -> Node: {nodeRef})";
-            }
-            else if (eventClass?.Chunk is scneventsEquipItemToPerformer equipEvent)
-            {
-                string performerName = "[No Performer]";
-                if (equipEvent.PerformerId != null && scnSceneResource != null)
-                {
-                    performerName = ResolvePerformerName(equipEvent.PerformerId.Id, scnSceneResource);
-                }
-
-                string itemName = "[No Item]";
-                if (equipEvent.ItemId != TweakDBID.Empty)
-                {
-                    itemName = equipEvent.ItemId.GetResolvedText() ?? "[unresolved]";
-                }
-
-                string slotName = "[No Slot]";
-                if (equipEvent.SlotId != TweakDBID.Empty)
-                {
-                    slotName = equipEvent.SlotId.GetResolvedText() ?? "[unresolved]";
-                }
-
-                detailSuffix = $" (Performer: {performerName}, Item: {itemName}, Slot: {slotName})";
-            }
-            else if (eventClass?.Chunk is scnAudioEvent audioEvent)
-            {
-                string performerName = "[No Performer]";
-                if (audioEvent.Performer != null && scnSceneResource != null)
-                {
-                    performerName = ResolvePerformerName(audioEvent.Performer.Id, scnSceneResource);
-                }
-
-                string audioName = "[No Audio Name]";
-                if (audioEvent.AudioEventName != CName.Empty)
-                {
-                    audioName = audioEvent.AudioEventName.GetResolvedText() ?? "[unresolved]";
-                }
-                
-                detailSuffix = $" ({performerName} - Audio: {audioName})";
-            }
-            else if (eventClass?.Chunk is scnGameplayTransitionEvent gameplayTransitionEvent)
-            {
-                 string performerName = "[No Performer]";
-                 if (gameplayTransitionEvent.Performer != null && scnSceneResource != null)
-                 {
-                     performerName = ResolvePerformerName(gameplayTransitionEvent.Performer.Id, scnSceneResource);
-                 }
-                 
-                 string vehState = gameplayTransitionEvent.VehState.ToEnumString();
-                 
-                 detailSuffix = $" ({performerName} - VehState: {vehState})";
-            }
-            else if (eventClass?.Chunk is scneventsSetAnimFeatureEvent setAnimFeatureEvent)
-            {
-                 string actorName = "[No Actor]";
-                 if (setAnimFeatureEvent.ActorId != null && scnSceneResource != null)
-                 {
-                     actorName = ResolvePerformerName(setAnimFeatureEvent.ActorId.Id, scnSceneResource); // Re-use ResolvePerformerName for actor IDs
-                 }
-
-                 string featureName = "[No Feature Name]";
-                 if (setAnimFeatureEvent.AnimFeatureName != CName.Empty)
-                 {
-                     featureName = setAnimFeatureEvent.AnimFeatureName.GetResolvedText() ?? "[unresolved]";
-                 }
-
-                 string featureType = "[No Feature Type]";
-                 if (setAnimFeatureEvent.AnimFeature is CHandle<animAnimFeature> handle)
-                 {
-                    var featureInstance = handle.GetValue() as animAnimFeature;
-                    if (featureInstance != null) 
+                    break;
+                case scneventsAttachPropToNode attachNodeEvent:
                     {
-                        featureType = featureInstance.GetType().Name; 
+                        string propName = "[No Prop]";
+                        if (attachNodeEvent.PropId != null && scnSceneResource?.Props != null)
+                        {
+                            var propDef = scnSceneResource.Props.FirstOrDefault(p => p.PropId?.Id == attachNodeEvent.PropId.Id);
+                            if (propDef != null)
+                            {
+                                string? pName = propDef.PropName;
+                                propName = pName ?? "Unnamed";
+                            }
+                            else
+                            {
+                                propName = $"Unknown [{attachNodeEvent.PropId.Id}]";
+                            }
+                        }
+                        string nodeRef = attachNodeEvent.NodeRef != NodeRef.Empty
+                                         ? attachNodeEvent.NodeRef.GetRedHash().ToString("X")
+                                         : "[No Node]";
+                        detailSuffix = $" (Prop: {propName} -> Node: {nodeRef})";
                     }
-                    else
+                    break;
+                case scneventsEquipItemToPerformer equipEvent:
                     {
-                        featureType = "[Invalid Handle]";
-                    }
-                 }
-                 else if (setAnimFeatureEvent.AnimFeature != null) // Fallback if it's not a Handle for some reason
-                 {
-                    featureType = setAnimFeatureEvent.AnimFeature.GetType().Name;
-                 }
+                        string performerName = "[No Performer]";
+                        if (equipEvent.PerformerId != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(equipEvent.PerformerId.Id, scnSceneResource);
+                        }
 
-                 detailSuffix = $" ({actorName} - {featureType}: {featureName})";
-            }
-            else if (eventClass?.Chunk is scnUnmountEvent unmountEvent)
-            {
-                string performerName = "[No Performer]";
-                if (unmountEvent.Performer != null && scnSceneResource != null)
-                {
-                    performerName = ResolvePerformerName(unmountEvent.Performer.Id, scnSceneResource);
-                }
-                detailSuffix = $" ({performerName})";
+                        string itemName = "[No Item]";
+                        if (equipEvent.ItemId != TweakDBID.Empty)
+                        {
+                            itemName = equipEvent.ItemId.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        string slotName = "[No Slot]";
+                        if (equipEvent.SlotId != TweakDBID.Empty)
+                        {
+                            slotName = equipEvent.SlotId.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        detailSuffix = $" (Performer: {performerName}, Item: {itemName}, Slot: {slotName})";
+                    }
+                    break;
+                case scnAudioEvent audioEvent:
+                    {
+                        string performerName = "[No Performer]";
+                        if (audioEvent.Performer != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(audioEvent.Performer.Id, scnSceneResource);
+                        }
+
+                        string audioName = "[No Audio Name]";
+                        if (audioEvent.AudioEventName != CName.Empty)
+                        {
+                            audioName = audioEvent.AudioEventName.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        detailSuffix = $" ({performerName} - Audio: {audioName})";
+                    }
+                    break;
+                case scnGameplayTransitionEvent gameplayTransitionEvent:
+                    {
+                        string performerName = "[No Performer]";
+                        if (gameplayTransitionEvent.Performer != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(gameplayTransitionEvent.Performer.Id, scnSceneResource);
+                        }
+
+                        string vehState = gameplayTransitionEvent.VehState.ToEnumString();
+
+                        detailSuffix = $" ({performerName} - VehState: {vehState})";
+                    }
+                    break;
+                case scneventsSetAnimFeatureEvent setAnimFeatureEvent:
+                    {
+                        string actorName = "[No Actor]";
+                        if (setAnimFeatureEvent.ActorId != null && scnSceneResource != null)
+                        {
+                            actorName = ResolvePerformerName(setAnimFeatureEvent.ActorId.Id, scnSceneResource);
+                        }
+
+                        string featureName = "[No Feature Name]";
+                        if (setAnimFeatureEvent.AnimFeatureName != CName.Empty)
+                        {
+                            featureName = setAnimFeatureEvent.AnimFeatureName.GetResolvedText() ?? "[unresolved]";
+                        }
+
+                        string featureType = "[No Feature Type]";
+                        if (setAnimFeatureEvent.AnimFeature is CHandle<animAnimFeature> handle)
+                        {
+                           var featureInstance = handle.GetValue() as animAnimFeature;
+                           if (featureInstance != null)
+                           {
+                               featureType = featureInstance.GetType().Name;
+                           }
+                           else
+                           {
+                               featureType = "[Invalid Handle]";
+                           }
+                        }
+                        else if (setAnimFeatureEvent.AnimFeature != null)
+                        {
+                           featureType = setAnimFeatureEvent.AnimFeature.GetType().Name;
+                        }
+
+                        detailSuffix = $" ({actorName} - {featureType}: {featureName})";
+                    }
+                    break;
+                 case scnUnmountEvent unmountEvent:
+                    {
+                        string performerName = "[No Performer]";
+                        if (unmountEvent.Performer != null && scnSceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(unmountEvent.Performer.Id, scnSceneResource);
+                        }
+                        detailSuffix = $" ({performerName})";
+                    }
+                    break;
+                default:
+                    break;
             }
 
             string fullEventName = evName + detailSuffix;
@@ -440,7 +456,7 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>
         }
     }
 
-    // Helper method to resolve performer IDs to names using INDEX encoding (Revised Player Logic)
+    // Helper method to resolve performer IDs to names using index encoding
     private string ResolvePerformerName(CUInt32 performerIdCUint32, scnSceneResource? sceneResource)
     {
         uint performerId = performerIdCUint32;

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -356,6 +356,77 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>
 
                 detailSuffix = $" (Performer: {performerName}, Item: {itemName}, Slot: {slotName})";
             }
+            else if (eventClass?.Chunk is scnAudioEvent audioEvent)
+            {
+                string performerName = "[No Performer]";
+                if (audioEvent.Performer != null && scnSceneResource != null)
+                {
+                    performerName = ResolvePerformerName(audioEvent.Performer.Id, scnSceneResource);
+                }
+
+                string audioName = "[No Audio Name]";
+                if (audioEvent.AudioEventName != CName.Empty)
+                {
+                    audioName = audioEvent.AudioEventName.GetResolvedText() ?? "[unresolved]";
+                }
+                
+                detailSuffix = $" ({performerName} - Audio: {audioName})";
+            }
+            else if (eventClass?.Chunk is scnGameplayTransitionEvent gameplayTransitionEvent)
+            {
+                 string performerName = "[No Performer]";
+                 if (gameplayTransitionEvent.Performer != null && scnSceneResource != null)
+                 {
+                     performerName = ResolvePerformerName(gameplayTransitionEvent.Performer.Id, scnSceneResource);
+                 }
+                 
+                 string vehState = gameplayTransitionEvent.VehState.ToEnumString();
+                 
+                 detailSuffix = $" ({performerName} - VehState: {vehState})";
+            }
+            else if (eventClass?.Chunk is scneventsSetAnimFeatureEvent setAnimFeatureEvent)
+            {
+                 string actorName = "[No Actor]";
+                 if (setAnimFeatureEvent.ActorId != null && scnSceneResource != null)
+                 {
+                     actorName = ResolvePerformerName(setAnimFeatureEvent.ActorId.Id, scnSceneResource); // Re-use ResolvePerformerName for actor IDs
+                 }
+
+                 string featureName = "[No Feature Name]";
+                 if (setAnimFeatureEvent.AnimFeatureName != CName.Empty)
+                 {
+                     featureName = setAnimFeatureEvent.AnimFeatureName.GetResolvedText() ?? "[unresolved]";
+                 }
+
+                 string featureType = "[No Feature Type]";
+                 if (setAnimFeatureEvent.AnimFeature is CHandle<animAnimFeature> handle)
+                 {
+                    var featureInstance = handle.GetValue() as animAnimFeature;
+                    if (featureInstance != null) 
+                    {
+                        featureType = featureInstance.GetType().Name; 
+                    }
+                    else
+                    {
+                        featureType = "[Invalid Handle]";
+                    }
+                 }
+                 else if (setAnimFeatureEvent.AnimFeature != null) // Fallback if it's not a Handle for some reason
+                 {
+                    featureType = setAnimFeatureEvent.AnimFeature.GetType().Name;
+                 }
+
+                 detailSuffix = $" ({actorName} - {featureType}: {featureName})";
+            }
+            else if (eventClass?.Chunk is scnUnmountEvent unmountEvent)
+            {
+                string performerName = "[No Performer]";
+                if (unmountEvent.Performer != null && scnSceneResource != null)
+                {
+                    performerName = ResolvePerformerName(unmountEvent.Performer.Id, scnSceneResource);
+                }
+                detailSuffix = $" ({performerName})";
+            }
 
             string fullEventName = evName + detailSuffix;
 

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.App.ViewModels.Documents;
@@ -120,7 +121,11 @@ public partial class RedGraph
 
     private BaseSceneViewModel WrapSceneNode(scnSceneGraphNode node)
     {
-        var sceneResource = (scnSceneResource)_data;
+        if (!(_data is scnSceneResource sceneResource))
+        {
+            _loggerService?.Error($"RedGraph internal data is not scnSceneResource, cannot create node wrappers correctly.");
+            sceneResource = new scnSceneResource();
+        }
 
         BaseSceneViewModel nodeWrapper;
         if (node is scnAndNode andNode)
@@ -209,7 +214,6 @@ public partial class RedGraph
         }
         else
         {
-            // shouldn't happen, just for failsafe
             nodeWrapper = new scnSceneGraphNodeWrapper(node);
         }
 

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -36,7 +36,11 @@ public partial class GraphEditorView : UserControl
             return;
         }
 
-        view.Dispatcher.BeginInvoke(new Action(() => UpdateView(view)), DispatcherPriority.ContextIdle);
+        view.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            UpdateView(view);
+            view.Source?.ArrangeNodes();
+        }), DispatcherPriority.ContextIdle);
     }
 
     private static void UpdateView(GraphEditorView view)


### PR DESCRIPTION
# Feat: improve scene graph readability by detailing scnSectionNode events in GraphEditorView

![Frame 1 (3)](https://github.com/user-attachments/assets/945fbe8a-ee74-40d1-86a5-166d4069a018)

Exposes more useful metadata for events in `scnSectionNode` within the Graph Editor

Section nodes orchestrate animations, dialogue events, VFX, attachments, and other events within a scene so they can get quite complicated. Previously, it was difficult to understand the purpose of a `scnSectionNode` by just looking at it in the graph editor, as it only displayed the raw event type names. This means it takes a lot of time to figure out a scene's flow, especially for larger scenes.

This PR changes `scnSectionNodeWrapper` to extract and display more meaningful metadata for commonly used event types directly within the node's details in the Graph Editor view to improves the usability and readability of scene graphs

Specifically, the following event types now display richer information:

-   **`scnPlaySkAnimEvent`**: Shows the target Performer and the Animation Name.
-   **`scnDialogLineEvent`**: Displays the actual dialogue text (truncated for brevity). Note: This text is sourced from embedded localization data (`LocStore`) within the scene resource itself, which more frequently uses Polish than English (but it is still useful somewhat than having nothing). I could maybe look at a complete localization key lookup but I fear that might be quite a heavy operation esp for large graphs when loading the graph editor. Maybe for a future PR.
-   **`scnLookAtEvent`**: Indicates the Performer and the Target (Actor, Prop, Position, or Slot).
-   **`scneventsVFXEvent`**: Shows the VFX Action (e.g., Play, Stop) and the Effect Name.
-   **`scnChangeIdleAnimEvent`**: Displays the Performer, Idle Animation Name, and Facial Animation Name.
-   **`scnIKEvent`**: Shows the Performer and the IK Chain Name involved.
-   **`scneventsAttachPropToPerformer`**: Details the Prop being attached, the target Performer, and the attachment Slot Name.
-   **`scneventsAttachPropToWorld`**: Shows the Prop being attached to the world.
-   **`scneventsAttachPropToNode`**: Shows the Prop being attached and the target Node Reference.
-  **`scneventsEquipItemToPerformer`**: Shows the Item (and slot) being equipped to the performer 




