### PR TITLE
preventing uncaught index out of bound exception

### DIFF
--- a/WolvenKit.RED4/Archive/IO/CR2WReader.File.cs
+++ b/WolvenKit.RED4/Archive/IO/CR2WReader.File.cs
@@ -73,10 +73,16 @@ public partial class CR2WReader
     public EFileReadErrorCodes ReadFile(out CR2WFile? file, bool parseBuffer = true)
     {
         var result = ReadFileInfo(out var info);
-        if (result == EFileReadErrorCodes.NoCr2w || info is null || info.StringDict.Count == 0)
+        if (result == EFileReadErrorCodes.NoCr2w || info is null)
         {
             file = null;
             return EFileReadErrorCodes.NoCr2w;
+        }
+
+        if (info.StringDict.Count == 0)
+        {
+            file = null;
+            return EFileReadErrorCodes.Malformed;
         }
 
         file = new CR2WFile() { Info = info };

--- a/WolvenKit.RED4/Archive/IO/CR2WReader.File.cs
+++ b/WolvenKit.RED4/Archive/IO/CR2WReader.File.cs
@@ -73,13 +73,13 @@ public partial class CR2WReader
     public EFileReadErrorCodes ReadFile(out CR2WFile? file, bool parseBuffer = true)
     {
         var result = ReadFileInfo(out var info);
-        if (result == EFileReadErrorCodes.NoCr2w)
+        if (result == EFileReadErrorCodes.NoCr2w || info is null || info.StringDict.Count == 0)
         {
             file = null;
-            return result;
+            return EFileReadErrorCodes.NoCr2w;
         }
 
-        file = new CR2WFile() { Info = info! };
+        file = new CR2WFile() { Info = info };
 
         if (result == EFileReadErrorCodes.UnsupportedVersion)
         {
@@ -89,17 +89,18 @@ public partial class CR2WReader
         _outputFile = new CR2WFile();
         _parseBuffer = parseBuffer;
 
-        _cr2wFile.Info = info!;
-        _cr2wFile.MetaData.Version = _cr2wFile.Info.FileHeader.version;
-        _cr2wFile.MetaData.BuildVersion = _cr2wFile.Info.FileHeader.buildVersion;
-        _cr2wFile.MetaData.ObjectsEnd = _cr2wFile.Info.FileHeader.objectsEnd;
+        _cr2wFile.Info = info;
+        _cr2wFile.MetaData.Version = info.FileHeader.version;
+        _cr2wFile.MetaData.BuildVersion = info.FileHeader.buildVersion;
+        _cr2wFile.MetaData.ObjectsEnd = info.FileHeader.objectsEnd;
 
         // use 1 as 0 is always empty
-        _cr2wFile.MetaData.HashVersion = IdentifyHash(_cr2wFile.Info.StringDict[1], _cr2wFile.Info.NameInfo[1].hash);
+        _cr2wFile.MetaData.HashVersion = IdentifyHash(info.StringDict[1], info.NameInfo[1].hash);
         if (_cr2wFile.MetaData.HashVersion == EHashVersion.Unknown)
         {
-            throw new Exception();
+            throw new InvalidDataException("Failed to identify hash version");
         }
+       
 
         #region Read Data
 

--- a/WolvenKit.RED4/Archive/IO/Enums.cs
+++ b/WolvenKit.RED4/Archive/IO/Enums.cs
@@ -5,6 +5,7 @@ public enum EFileReadErrorCodes
     NoError,
     NoCr2w,
     UnsupportedVersion,
+    Malformed,
 }
 
 public enum EHashVersion


### PR DESCRIPTION
# preventing uncaught index out of bound exception

Without the length check, line 98 will run into an out-of-bounds exception (which results in no cr2w file being returned)