### PR TITLE
inkatlas dialog: more improvements

### DIFF
--- a/WolvenKit.App/Helpers/InkatlasImageGenerator.cs
+++ b/WolvenKit.App/Helpers/InkatlasImageGenerator.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.Interfaces.Extensions;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Types;
 
@@ -91,7 +92,7 @@ public static class InkatlasImageGenerator
                 (
                     file,
                     paddedImage,
-                    Path.GetFileNameWithoutExtension(file),
+                    Path.GetFileNameWithoutExtension(file).ToFileName(),
                     originalWidth,
                     originalHeight
                 ));
@@ -190,6 +191,11 @@ public static class InkatlasImageGenerator
         foreach (var imgData in images)
         {
             imgData.Image.Dispose();
+        }
+
+        if (parts.Count == 1)
+        {
+            parts[0].Name = "icon";
         }
 
         return parts;
@@ -343,7 +349,7 @@ public static class InkatlasImageGenerator
     {
         public AtlasPart(string name) => Name = name;
 
-        public string Name { get; init; }
+        public string Name { get; set; }
         public Rectangle PixelRect { get; init; }
         public RectangleF UvRect { get; init; }
     }

--- a/WolvenKit.App/Helpers/InkatlasImageGenerator.cs
+++ b/WolvenKit.App/Helpers/InkatlasImageGenerator.cs
@@ -256,7 +256,10 @@ public static class InkatlasImageGenerator
             }
             else
             {
-                grid.Add(currentRow);
+                if (currentRow.Count > 0)
+                {
+                    grid.Add(currentRow);
+                }
                 currentRow = [imageData];
                 currentWidth = width;
             }

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -915,8 +915,8 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
 
     /// <summary>
     /// Gets all folders under a given directory as list. Defaults to mod directory.
-    /// </summary>
     /// <param name="subdirParam">Pass <see cref="ModDirectory"/>, <see cref="ResourcesDirectory"/>, <see cref="RawDirectory"/></param>
+    /// </summary>
     public List<string> GetAllFolders(string? subdirParam)
     {
         var filesToSearch = ModFiles;

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -912,5 +912,32 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
             }
         }
     }
+
+    /// <summary>
+    /// Gets all folders under a given directory as list. Defaults to mod directory.
+    /// </summary>
+    /// <param name="subdirParam">Pass <see cref="ModDirectory"/>, <see cref="ResourcesDirectory"/>, <see cref="RawDirectory"/></param>
+    public List<string> GetAllFolders(string? subdirParam)
+    {
+        var filesToSearch = ModFiles;
+        var subdirectory = subdirParam ?? ModDirectory;
+
+        if (subdirectory == RawDirectory)
+        {
+            filesToSearch = RawFiles;
+        }
+        else if (subdirectory == ResourcesDirectory)
+        {
+            filesToSearch = ResourceFiles;
+        }
+
+        return filesToSearch
+            .Select(Path.GetDirectoryName)
+            .Where(f => f is not null && f != subdirectory &&
+                        Directory.Exists(Path.Combine(subdirectory, f)))
+            .Select(f => f!)
+            .Distinct()
+            .ToList();
+    }
 }
     

--- a/WolvenKit.App/ViewModels/Dialogs/AddInkatlasDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/AddInkatlasDialogViewModel.cs
@@ -1,29 +1,32 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using WolvenKit.App.Models.ProjectManagement.Project;
-using WolvenKit.App.Services;
+using WolvenKit.Interfaces.Extensions;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
 public partial class AddInkatlasDialogViewModel : ObservableObject
 {
-    public AddInkatlasDialogViewModel(Cp77Project project) => ProjectFolders =
-        project.ModFiles // get all folders in mod files
-            .Select(Path.GetDirectoryName)
-            .Where(f => f is not null && f != project.ModDirectory &&
-                        Directory.Exists(Path.Combine(project.ModDirectory, f)))
-            .Select(f => f!)
-            .Distinct()
-            .ToDictionary<string, string>(x => x);
+    public AddInkatlasDialogViewModel(Cp77Project project)
+    {
+        // Dropdown menu should have all folders in mod directory available
+        ProjectFolders = project.GetAllFolders(project.ModDirectory).ToDictionary<string, string>(x => x);
+
+        InkatlasFileName = $"{project.Name}_icons";
+    }
 
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(RelativePath))
+        switch (e.PropertyName)
         {
-            RelativePath = RelativePath.ToLower();
+            case nameof(RelativePath):
+                RelativePath = RelativePath.ToFileName();
+                break;
+            case nameof(InkatlasFileName):
+                InkatlasFileName = InkatlasFileName.ToFileName().Replace(".inkatlas", "");
+                break;
         }
 
         base.OnPropertyChanged(e);
@@ -44,7 +47,7 @@ public partial class AddInkatlasDialogViewModel : ObservableObject
     /// <summary>
     /// name for inkatlas file
     /// </summary>
-    [ObservableProperty] private string _inkatlasFileName = "icons";
+    [ObservableProperty] private string _inkatlasFileName = "";
 
     /// <summary>
     /// Tile width

--- a/WolvenKit.App/ViewModels/Dialogs/AddInkatlasDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/AddInkatlasDialogViewModel.cs
@@ -22,7 +22,7 @@ public partial class AddInkatlasDialogViewModel : ObservableObject
         switch (e.PropertyName)
         {
             case nameof(RelativePath):
-                RelativePath = RelativePath.ToFileName();
+                RelativePath = RelativePath.ToFilePath();
                 break;
             case nameof(InkatlasFileName):
                 InkatlasFileName = InkatlasFileName.ToFileName().Replace(".inkatlas", "");

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
@@ -446,8 +446,7 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
             && FilePath?.RelativePath(new DirectoryInfo(modDir)) is string activeFilePath
             && Path.GetDirectoryName(activeFilePath) is string dirName && !string.IsNullOrEmpty(dirName))
         {
-            // we're in a .mi file
-            if (!useTextureSubfolder)
+            if (!useTextureSubfolder || dirName.Contains("textures"))
             {
                 destFolder = dirName;
             }
@@ -460,14 +459,7 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
             {
                 // if the folder contains more than one .mesh file, add a subdirectory inside "textures"
                 var fileName = Path.GetFileName(CurrentTab.FilePath.Split('.').FirstOrDefault() ?? "").ToFileName();
-                if (!dirName.Contains("textures"))
-                {
-                    destFolder = Path.Combine(dirName, "textures", fileName);
-                }
-                else
-                {
-                    destFolder = Path.Combine(dirName, fileName);
-                }
+                destFolder = Path.Combine(dirName, fileName);
             }
         }
 

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
@@ -460,7 +460,14 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
             {
                 // if the folder contains more than one .mesh file, add a subdirectory inside "textures"
                 var fileName = Path.GetFileName(CurrentTab.FilePath.Split('.').FirstOrDefault() ?? "").ToFileName();
-                destFolder = Path.Combine(dirName, "textures", fileName);
+                if (!dirName.Contains("textures"))
+                {
+                    destFolder = Path.Combine(dirName, "textures", fileName);
+                }
+                else
+                {
+                    destFolder = Path.Combine(dirName, fileName);
+                }
             }
         }
 

--- a/WolvenKit.Core/Extensions/StringExtensions.cs
+++ b/WolvenKit.Core/Extensions/StringExtensions.cs
@@ -135,18 +135,6 @@ namespace WolvenKit.Interfaces.Extensions
 
         public static bool IsEmptyOrEndsWith(this string target, string value) =>
             target == "" || target.EndsWith(value);
-
-
-        private static char[]? s_invalidFileNameChars = null;
-
-        /// <summary>
-        /// Separate method to avoid SYSLIB1045 warning
-        /// </summary>
-        private static char[] GetInvalidFileNameChars()
-        {
-            s_invalidFileNameChars ??= Path.GetInvalidFileNameChars();
-            return s_invalidFileNameChars;
-        }
         
         /// <summary>
         /// Generates redengine friendly file path. 
@@ -158,9 +146,8 @@ namespace WolvenKit.Interfaces.Extensions
         /// Generates redengine friendly file name 
         /// </summary>
         public static string ToFileName(this string target) =>
-            new string(target.Where(c => GetInvalidFileNameChars().Contains(c)).ToArray()).Trim()
+            new string(target.Where(c => Path.GetInvalidFileNameChars().Contains(c)).ToArray()).Trim()
                 .Replace(" ", "_").ToLower();
-
 
         /// <summary>
         /// Capitalizes each word in the string, replacing underscores with spaces

--- a/WolvenKit.Core/Extensions/StringExtensions.cs
+++ b/WolvenKit.Core/Extensions/StringExtensions.cs
@@ -136,16 +136,35 @@ namespace WolvenKit.Interfaces.Extensions
         public static bool IsEmptyOrEndsWith(this string target, string value) =>
             target == "" || target.EndsWith(value);
 
-#pragma warning disable SYSLIB1045
-        // Generated regex attribute means the class can't be abstract anymore
+
+        private static char[]? s_invalidFileNameChars = null;
+
+        /// <summary>
+        /// Separate method to avoid SYSLIB1045 warning
+        /// </summary>
+        private static char[] GetInvalidFileNameChars()
+        {
+            s_invalidFileNameChars ??= Path.GetInvalidFileNameChars();
+            return s_invalidFileNameChars;
+        }
+        
+        /// <summary>
+        /// Generates redengine friendly file path. 
+        /// </summary>
+        public static string ToFilePath(this string target) => string.Join(Path.DirectorySeparatorChar,
+            target.Split(Path.DirectorySeparatorChar).Select(s => s.ToFileName()));
+
         /// <summary>
         /// Generates redengine friendly file name 
         /// </summary>
         public static string ToFileName(this string target) =>
-            new string(target.Where(c => !Path.GetInvalidFileNameChars().Contains(c)).ToArray()).Trim()
+            new string(target.Where(c => GetInvalidFileNameChars().Contains(c)).ToArray()).Trim()
                 .Replace(" ", "_").ToLower();
-#pragma warning restore SYSLIB1045
 
+
+        /// <summary>
+        /// Capitalizes each word in the string, replacing underscores with spaces
+        /// </summary>
         public static string ToHumanFriendlyString(this string? target) =>
             string.IsNullOrEmpty(target) ? "" : target.Replace("_", " ").CapitalizeEachWord();
     }

--- a/WolvenKit/Views/Dialogs/Windows/AddInkatlasDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/AddInkatlasDialog.xaml
@@ -7,7 +7,7 @@
     xmlns:helpers="clr-namespace:WolvenKit.Functionality.Helpers"
     xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-    Title="AddInkatklasDialog"
+    Title="Generate new inkatlas"
     Width="{StaticResource WolvenKitDialogWidth}"
     MinWidth="{StaticResource WolvenKitDialogWidthSmall}"
     MinHeight="{StaticResource WolvenKitDialogHeightSmall}"
@@ -85,19 +85,9 @@
                                           UpdateSourceTrigger=PropertyChanged}"
                         SelectedOption="{Binding RelativePath,
                                                  Mode=TwoWay}"
+                        IsInline="True"
                         KeyboardNavigation.TabIndex="1" />
 
-                    <!-- new component name -->
-                    <Label
-                        Grid.Row="2"
-                        Grid.Column="0"
-                        Width="{StaticResource WolvenKitLabelWidthMedium}"
-                        Margin="{StaticResource WolvenKitMarginTinyBottom}"
-                        HorizontalAlignment="Left"
-                        Background="#252525"
-                        BorderThickness="0"
-                        Content="Icon folder"
-                        KeyboardNavigation.TabIndex="3" />
 
                     <TextBox
                         x:Name="RelativePathBox"

--- a/WolvenKit/Views/Dialogs/Windows/AddInkatlasDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/AddInkatlasDialog.xaml.cs
@@ -14,7 +14,7 @@ public partial class AddInkatlasDialog : IViewFor<AddInkatlasDialogViewModel>
 {
     private static string s_lastSourceFolder = "";
     private static string s_lastRelativePath = "";
-    private static string s_lastFileName = "inkatlas";
+    private static string s_lastFileName = "";
     private static int s_lastTileWidth = 0;
     private static int s_lastTileHeight = 0;
 

--- a/WolvenKit/Views/Templates/FilterableDropdownMenu.xaml
+++ b/WolvenKit/Views/Templates/FilterableDropdownMenu.xaml
@@ -8,78 +8,111 @@
     FocusManager.FocusedElement="{Binding ElementName=FilterTextBox}">
     <Grid>
         <Grid.Resources>
-            <ResourceDictionary>
+            <ResourceDictionary xmlns:editors="clr-namespace:WolvenKit.Views.Editors">
                 <ResourceDictionary.MergedDictionaries>
                     <hc:ThemeResources />
                     <hc:Theme />
                 </ResourceDictionary.MergedDictionaries>
-                <Style TargetType="{x:Type Label}" BasedOn="{StaticResource WolvenkitDialogLabelStyleMedium}">
-                </Style>
+                <Style
+                    BasedOn="{StaticResource WolvenkitDialogLabelStyleMedium}"
+                    TargetType="{x:Type Label}" />
                 <Style TargetType="{x:Type Grid}">
-                    <Setter Property="Background" Value="{StaticResource BackgroundColor_Control}"></Setter>
+                    <Setter Property="Background" Value="{StaticResource BackgroundColor_Control}" />
                 </Style>
                 <converters:IntToVisibilityConverterInverted x:Key="IntToVisibilityConverterInverted" />
             </ResourceDictionary>
+
         </Grid.Resources>
 
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="{StaticResource WolvenKitDialogLabelColumnWidthMedium}" />
             <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="5" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="5" />
+            <RowDefinition Height="2" />
+            <RowDefinition x:Name="dropdownRow" Height="Auto" />
+            <RowDefinition x:Name="spacerRow2" Height="2" />
         </Grid.RowDefinitions>
 
         <!-- ====================================== -->
-        <!--                Label                   -->
+        <!-- Label -->
         <!-- ====================================== -->
         <Label
             Grid.Row="0"
             Grid.Column="0"
+            Width="{StaticResource WolvenKitLabelWidthMedium}"
             HorizontalAlignment="Left"
             Background="#252525"
             BorderThickness="0"
-            Width="{StaticResource WolvenKitLabelWidthMedium}"
             Content="{Binding Label}" />
 
-        <!-- ====================================== -->
-        <!--               Filter                   -->
-        <!-- ====================================== -->
+
+        <!-- Filter and Dropdown - StackPanel for inline mode -->
+        <StackPanel
+            x:Name="inlinePanel"
+            Grid.Row="0"
+            Grid.Column="1"
+            Visibility="{Binding IsInline,
+                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+            Orientation="Horizontal">
+            <TextBox
+                x:Name="FilterTextBox"
+                Width="150"
+                Margin="0,0,5,0"
+                Foreground="{StaticResource ForegroundColor_Grey_Dark}"
+                helpers:TextBoxBehavior.TripleClickSelectAll="True"
+                KeyboardNavigation.TabIndex="1"
+                Text="{Binding FilterText,
+                               UpdateSourceTrigger=PropertyChanged}" />
+
+            <ComboBox
+                x:Name="Dropdown"
+                Height="{StaticResource WolvenKitTabHeight}"
+                MinWidth="150"
+                ItemsSource="{Binding FilteredOptions,
+                                      Mode=OneWay}"
+                KeyboardNavigation.TabIndex="2"
+                SelectedValuePath="Value"
+                DisplayMemberPath="Key"
+                SelectedValue="{Binding SelectedOption}" />
+        </StackPanel>
+
+
+        <!-- Original layout elements (with x:Name for toggling) -->
         <TextBox
-            x:Name="FilterTextBox"
+            x:Name="originalFilterTextBox"
             Grid.Row="0"
             Grid.Column="1"
             Margin="0"
             Foreground="{StaticResource ForegroundColor_Grey_Dark}"
+            Visibility="{Binding IsInline,
+                                 Converter={StaticResource InvertBooleanVisibilityConverter}}"
             helpers:TextBoxBehavior.TripleClickSelectAll="True"
             KeyboardNavigation.TabIndex="1"
             Text="{Binding FilterText,
                            UpdateSourceTrigger=PropertyChanged}" />
 
-        <!-- Placeholder text -->
         <TextBlock
+            x:Name="originalPlaceholder"
             Grid.Row="0"
             Grid.Column="1"
-            Text="Filter"
             Style="{StaticResource WolvenkitPlaceholderStyle}"
-            Visibility="{Binding ElementName=FilterTextBox,
+            Visibility="{Binding ElementName=originalFilterTextBox,
                                  Path=Text.Length,
-                                 Converter={StaticResource IntToVisibilityConverterInverted}}" />
+                                 Converter={StaticResource IntToVisibilityConverterInverted}}"
+            Text="Filter" />
 
-        <!-- ====================================== -->
-        <!--             Dropdown                   -->
-        <!-- ====================================== -->
         <ComboBox
-            x:Name="Dropdown"
+            x:Name="originalDropdown"
             Grid.Row="2"
             Grid.Column="1"
             Height="{StaticResource WolvenKitTabHeight}"
+            Visibility="{Binding IsInline,
+                                 Converter={StaticResource InvertBooleanVisibilityConverter}}"
             ItemsSource="{Binding FilteredOptions,
                                   Mode=OneWay}"
-
             KeyboardNavigation.TabIndex="2"
             SelectedValuePath="Value"
             DisplayMemberPath="Key"

--- a/WolvenKit/Views/Templates/FilterableDropdownMenu.xaml.cs
+++ b/WolvenKit/Views/Templates/FilterableDropdownMenu.xaml.cs
@@ -31,6 +31,21 @@ namespace WolvenKit.Views.Editors
             DataContext = this;
         }
 
+        #region properties
+
+        public bool IsInline
+        {
+            get => (bool)GetValue(IsInlineProperty);
+            set => SetValue(IsInlineProperty, value);
+        }
+
+        public static readonly DependencyProperty IsInlineProperty =
+            DependencyProperty.Register(
+                nameof(IsInline),
+                typeof(bool),
+                typeof(FilterableDropdownMenu),
+                new PropertyMetadata(false, OnPropertyChangedCallback));
+        
         public string Key
         {
             get => (string)GetValue(KeyProperty);
@@ -124,6 +139,8 @@ namespace WolvenKit.Views.Editors
                 typeof(FilterableDropdownMenu),
                 new PropertyMetadata(null, OnPropertyChangedCallback));
 
+        #endregion
+        
         private void UpdateFilteredOptions()
         {
             if (Options == null)
@@ -155,6 +172,10 @@ namespace WolvenKit.Views.Editors
             {
                 case (nameof(Options)) or (nameof(FilterText)):
                     UpdateFilteredOptions();
+                    break;
+                case nameof(IsInline) when IsInline:
+                    dropdownRow.SetCurrentValue(Grid.HeightProperty, 0.0);
+                    spacerRow2.SetCurrentValue(Grid.HeightProperty, 0.0);
                     break;
             }
 


### PR DESCRIPTION
# inkatlas dialog: more improvements

![image](https://github.com/user-attachments/assets/f8ab0587-3465-4617-995c-bb77062e60cc)
- Some UI improvements (inkatlas folder path doesn't look like two different fields anymore)
- everything will be forced to lowercase in the backend
- if you import a single png, the inkatlas part will always be named `icon`
