### PR TITLE
cvm: fixed an exception and an index offset

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1531,7 +1531,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             {
                 var sequenceIndex = GetIndexOfFirstNonRepeatingMaterial(newMaterials.Select(m => m.GetResolvedText() ?? "").ToList());
 
-                while (newMaterials.Count < numSubmeshes)
+                while (newMaterials.Count < numSubmeshes && sequenceIndex < newMaterials.Count + 1)
                 {
                     newMaterials.Add(newMaterials[sequenceIndex]);
                     wasAdded = true;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -99,7 +99,7 @@ public partial class ChunkViewModel
         var oldName = entry.Name;
         var newName = await Interactions.ShowInputBoxAsync("Rename material", oldName.GetResolvedText() ?? "");
 
-        if (string.IsNullOrEmpty(newName.Trim()))
+        if (string.IsNullOrWhiteSpace(newName))
         {
             return;
         }

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -156,11 +156,13 @@ public partial class ChunkViewModel
         }
 
         var newIdx = await Interactions.ShowInputBoxAsync("New material index", $"{NodeIdxInParent}");
-        if (!int.TryParse(newIdx, out var newIndex))
+        if (!int.TryParse(newIdx, out var newIndex) || newIndex < 0 || newIndex >= materialEntries.Count)
         {
             return;
         }
 
+        newIndex += 1;
+        
         entryCvm.MoveChild(newIndex, entryDefinition);
         Parent.MoveChild(newIndex, this);
 

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.ContextMenu.cs
@@ -99,6 +99,11 @@ public partial class ChunkViewModel
         var oldName = entry.Name;
         var newName = await Interactions.ShowInputBoxAsync("Rename material", oldName.GetResolvedText() ?? "");
 
+        if (string.IsNullOrEmpty(newName.Trim()))
+        {
+            return;
+        }
+
         entry.Name = (CName)newName;
 
         Tab?.Parent?.SetIsDirty(true);


### PR DESCRIPTION
# cvm: fixed an exception and an index offset

**Fixed**
- When using "Move to index" command for material entries, the index offset will now correctly be considered
- "Adjust submesh count" will no longer throw an OutOfBounds-exception