### PR TITLE
Fixed importing meshes with ShapeKeys/MorphTargets

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/Structs.cs
@@ -224,4 +224,15 @@ namespace WolvenKit.Modkit.RED4.GeneralStructs
         public string? Type { get; set; }
         public object? Value { get; set; }
     }
+
+    public class MeshExtras
+    {
+        [JsonPropertyName("materialNames")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string[]? MaterialNames { get; set; }
+
+        [JsonPropertyName("targetNames")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string[]? TargetNames { get; set; }
+    };
 }

--- a/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshTools.cs
@@ -1032,19 +1032,18 @@ namespace WolvenKit.Modkit.RED4.Tools
                     node.Skin = skin;
                 }
 
-                var materialNames = mesh.materialNames.Select((name) => name.Split('@').FirstOrDefault() ?? name).ToArray();
-                
+                var meshExtras = new MeshExtras
+                {
+                    MaterialNames = mesh.materialNames.Select((name) => name.Split('@').FirstOrDefault() ?? name).ToArray()
+                };
+
                 if (mesh.garmentMorph.Length > 0)
                 {
-                    string[] arr = ["GarmentSupport"];
-                    var obj = new { materialNames, targetNames = arr };
-                    mes.Extras = JsonSerializer.SerializeToNode(obj, Gltf.SerializationOptions());
+                    meshExtras.TargetNames = ["GarmentSupport"];
                 }
-                else
-                {
-                    var obj = new { materialNames };
-                    mes.Extras = JsonSerializer.SerializeToNode(obj, Gltf.SerializationOptions());
-                }
+
+                mes.Extras = JsonSerializer.SerializeToNode(meshExtras, Gltf.SerializationOptions());
+
                 if (mesh.garmentMorph.Length > 0)
                 {
                     var acc = model.CreateAccessor();


### PR DESCRIPTION
# Fixed importing meshes with ShapeKeys/MorphTargets

**Fixed:**
- Importing a glb with ShapeKeys now checks if it is named "GarmentSupport" before importing it as GarmentSupport

