### PR TITLE
fix(AppViewModel): fix refresh behavior for object spawner JSON imports

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -232,5 +232,8 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
         {
             _loggerService.Error($"Failed to delete {filePath}. This file is no longer needed.");
         }
+
+        // Check for and reload any modified streaming sector or related files that are currently open
+        ReloadChangedFiles();
     }
 }


### PR DESCRIPTION
# Fix refresh behavior for object spawner JSON imports

Currently File > Import > Import object spawner .json won't reload modified sector files that might be affected by the import script. This change adds the file change detection check after import to prompt users to reload any modified files that are currently open


