### PR TITLE
feat: Rename scnAnimName unks

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -36,25 +36,42 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>
                         {
                             animNameObj = handle.GetValue() as scnAnimName;
                         }
-                        if (animNameObj != null && animNameObj.Unk1 != null && animNameObj.Unk1.Count > 0)
+                        
+                        if (animNameObj != null)
                         {
-                            var animCName = animNameObj.Unk1[0];
-                            if (animCName != CName.Empty)
+                            var animNameType = (WolvenKit.RED4.Types.Enums.scnAnimNameType)animNameObj.Type;
+                            if (animNameType == WolvenKit.RED4.Types.Enums.scnAnimNameType.direct || animNameType == WolvenKit.RED4.Types.Enums.scnAnimNameType.dynamic)
                             {
-                                string? animNameString = animCName.GetResolvedText();
-                                if (!string.IsNullOrEmpty(animNameString))
+                                if (animNameObj.AnimNames != null && animNameObj.AnimNames.Count > 0)
                                 {
-                                    const int maxLen = 35;
-                                    string displayAnimName = animNameString;
-                                    if (displayAnimName.Length > maxLen)
+                                    var animCName = animNameObj.AnimNames[0];
+                                    if (animCName != CName.Empty)
                                     {
-                                        displayAnimName = displayAnimName.Substring(0, maxLen) + "...";
+                                        string? animNameString = animCName.GetResolvedText();
+                                        if (!string.IsNullOrEmpty(animNameString))
+                                        {
+                                            const int maxLen = 35;
+                                            string displayAnimName = animNameString;
+                                            if (displayAnimName.Length > maxLen)
+                                            {
+                                                displayAnimName = displayAnimName.Substring(0, maxLen) + "...";
+                                            }
+                                            animSuffix = displayAnimName;
+                                        }
+                                        else { animSuffix = "[unresolved]"; }
                                     }
-                                    animSuffix = displayAnimName;
                                 }
-                                else { animSuffix = "[unresolved]"; }
+                            }
+                            else if (animNameType == WolvenKit.RED4.Types.Enums.scnAnimNameType.reference || animNameType == WolvenKit.RED4.Types.Enums.scnAnimNameType.container)
+                            {
+                                if (animNameObj.ReferenceIndices != null && animNameObj.ReferenceIndices.Count > 0)
+                                {
+                                    var indices = string.Join(", ", animNameObj.ReferenceIndices.Select(x => x.ToString()));
+                                    animSuffix = $"{(animNameType.ToString())} Ref Idx: {indices}";
+                                }
                             }
                         }
+
                         detailSuffix = $" ({performerName} - Anim: {animSuffix})";
                     }
                     break;

--- a/WolvenKit.RED4/Types/ClassesExt/Appendix/scnAnimName.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/Appendix/scnAnimName.cs
@@ -6,17 +6,17 @@ namespace WolvenKit.RED4.Types;
 
 public partial class scnAnimName : IRedAppendix
 {
-    [RED("unk1")]
+    [RED("animNames")]
     [REDProperty(IsIgnored = true)]
-    public CArray<CName> Unk1
+    public CArray<CName> AnimNames
     {
         get => GetPropertyValue<CArray<CName>>();
         set => SetPropertyValue<CArray<CName>>(value);
     }
 
-    [RED("unk2")]
+    [RED("referenceIndices")]
     [REDProperty(IsIgnored = true)]
-    public CArray<CUInt16> Unk2
+    public CArray<CUInt16> ReferenceIndices
     {
         get => GetPropertyValue<CArray<CUInt16>>();
         set => SetPropertyValue<CArray<CUInt16>>(value);
@@ -24,8 +24,8 @@ public partial class scnAnimName : IRedAppendix
 
     partial void PostConstruct()
     {
-        Unk1 = new CArray<CName>();
-        Unk2 = new CArray<CUInt16>();
+        AnimNames = new CArray<CName>();
+        ReferenceIndices = new CArray<CUInt16>();
     }
 
     public void Read(Red4Reader reader, uint size)
@@ -39,18 +39,18 @@ public partial class scnAnimName : IRedAppendix
 
         if (Type == Enums.scnAnimNameType.reference || Type == Enums.scnAnimNameType.container)
         {
-            Unk2 = new CArray<CUInt16>();
+            ReferenceIndices = new CArray<CUInt16>();
             for (int i = 0; i < cnt; i++)
             {
-                Unk2.Add(reader.BaseReader.ReadUInt16());
+                ReferenceIndices.Add(reader.BaseReader.ReadUInt16());
             }
         }
         else
         {
-            Unk1 = new CArray<CName>();
+            AnimNames = new CArray<CName>();
             for (int i = 0; i < cnt; i++)
             {
-                Unk1.Add(reader.ReadCName());
+                AnimNames.Add(reader.ReadCName());
             }
         }
     }
@@ -59,14 +59,14 @@ public partial class scnAnimName : IRedAppendix
     {
         if (Type == Enums.scnAnimNameType.reference || Type == Enums.scnAnimNameType.container)
         {
-            foreach (var val in Unk2)
+            foreach (var val in ReferenceIndices)
             {
                 writer.Write(val);
             }
         }
         else
         {
-            foreach (var val in Unk1)
+            foreach (var val in AnimNames)
             {
                 writer.Write(val);
             }


### PR DESCRIPTION
# Rename scnAnimName unks

This change adds labels for the unk1 and unk2 properties within the `scnAnimName` class (The serialization/node wrapper logic is unchanged), we already knew the type and the usage logic in the node wrapper was added by @JakubMarecek last year. This change just adds the labels to the fields:

- Renamed `scnAnimName.unk1` to `AnimNames` (CArray<CName>)
- Renamed `scnAnimName.unk2` to `ReferenceIndices` (CArray<CUInt16>)

Also fixes a bug in the GraphEditor which will now show all animation types (direct, reference, container, etc.) 