### PR TITLE
(WIP) feat: scene editor workflow improvements

### DIFF
--- a/WolvenKit.App/Helpers/CvmDropdownHelper.cs
+++ b/WolvenKit.App/Helpers/CvmDropdownHelper.cs
@@ -59,7 +59,7 @@ public abstract class CvmDropdownHelper
         IEnumerable<string?> ret = [];
         switch (parent.ResolvedData)
         {
-            case gameJournalPath when cvm.Name is "className" && s_questHandleParentNames.Contains(parent.Name):
+            case gameJournalPath when cvm.Name is "className" && parent.Name is not null && s_questHandleParentNames.Contains(parent.Name):
                 ret = RedTypeHelper.GetExtendingClassNames(typeof(gameJournalEntry));
                 break;
             case entISkinTargetComponent when cvm.Name is "renderingPlaneAnimationParam":
@@ -382,7 +382,7 @@ public abstract class CvmDropdownHelper
             return propOptions;
         }
 
-        return ret.Where(x => !string.IsNullOrEmpty(x)).ToDictionary(x => x!, y => y!);
+        return (ret ?? []).Where(x => !string.IsNullOrEmpty(x)).ToDictionary(x => x!, y => y!);
     }
 
     /// <summary>
@@ -423,15 +423,15 @@ public abstract class CvmDropdownHelper
 
             #region ent 
             appearanceAppearancePart when cvm.Name is ("appearanceResource" or "resource") => true,
-            entSkinnedMeshComponent when s_appearanceNames.Contains(cvm.Name) => true,
+            entSkinnedMeshComponent when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
             entSkinnedMeshComponent when parent.Name == "mesh" => true,
-            entEntityTemplate when s_appearanceNames.Contains(cvm.Name) => true,
+            entEntityTemplate when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
             entTemplateAppearance when cvm.Name is ("appearanceName" or "appearanceResource") => true,
             #endregion
 
             #region app
-            appearanceAppearanceResource when s_appearanceNames.Contains(cvm.Name) => true,
-            IRedRef when cvm.Name is "resource" && cvm.Parent.ResolvedData is appearanceAppearancePart => true,
+            appearanceAppearanceResource when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
+            IRedRef when cvm.Name is "resource" && cvm.Parent?.ResolvedData is appearanceAppearancePart => true,
             #endregion
 
             // tags: ent and app
@@ -512,6 +512,6 @@ public abstract class CvmDropdownHelper
             "effectDefinitions"                     // Effect definitions
         };
         
-        return definitionPaths.Any(defPath => parentPath.Contains(defPath));
+        return definitionPaths.Any(parentPath.Contains);
     }
 }

--- a/WolvenKit.App/Helpers/SceneEditingHelper.cs
+++ b/WolvenKit.App/Helpers/SceneEditingHelper.cs
@@ -1,0 +1,129 @@
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.App.Helpers
+{
+    /// <summary>
+    /// Helper class for scene editing operations
+    /// </summary>
+    public static class SceneEditingHelper
+    {
+        /// <summary>
+        /// Creates a new actor with automatic ID calculation and adds it to the scene
+        /// </summary>
+        /// <param name="sceneResource">The scene to add the actor to</param>
+        /// <param name="actorName">Optional name for the actor</param>
+        /// <param name="entityRef">Optional entity reference</param>
+        /// <returns>The newly created actor</returns>
+        public static scnActorDef CreateAndAddActor(scnSceneResource sceneResource, string? actorName = null, gameEntityReference? entityRef = null)
+        {
+            var actor = new scnActorDef();
+            
+            if (!string.IsNullOrEmpty(actorName))
+            {
+                actor.ActorName = actorName;
+            }
+            
+            if (entityRef != null)
+            {
+                actor.FindActorInWorldParams.ActorRef = entityRef;
+            }
+            
+            sceneResource.AddActor(actor);
+            return actor;
+        }
+        
+        /// <summary>
+        /// Creates a new player actor with automatic ID calculation and adds it to the scene
+        /// </summary>
+        /// <param name="sceneResource">The scene to add the player actor to</param>
+        /// <param name="playerName">Optional name for the player</param>
+        /// <returns>The newly created player actor</returns>
+        public static scnPlayerActorDef CreateAndAddPlayerActor(scnSceneResource sceneResource, string? playerName = null)
+        {
+            var playerActor = new scnPlayerActorDef();
+            
+            if (!string.IsNullOrEmpty(playerName))
+            {
+                playerActor.PlayerName = playerName;
+            }
+            
+            sceneResource.AddPlayerActor(playerActor);
+            return playerActor;
+        }
+        
+        /// <summary>
+        /// Fixes all actor IDs and performer debug symbols in a scene
+        /// This is useful for scenes that were created before automatic ID calculation
+        /// </summary>
+        /// <param name="sceneResource">The scene to fix</param>
+        public static void FixActorIdsAndPerformerSymbols(scnSceneResource sceneResource)
+        {
+            if (sceneResource == null) return;
+            
+            // Clear existing performer symbols
+            sceneResource.DebugSymbols ??= new scnDebugSymbols();
+            sceneResource.DebugSymbols.PerformersDebugSymbols.Clear();
+            
+            uint currentId = 0;
+            
+            // Fix regular actors
+            foreach (var actor in sceneResource.Actors)
+            {
+                actor.ActorId.Id = currentId;
+                
+                // Create performer symbol
+                var performerSymbol = new scnPerformerSymbol
+                {
+                    PerformerId = new scnPerformerId { Id = scnSceneResource.CalculatePerformerId(currentId) },
+                    EntityRef = actor.FindActorInWorldParams?.ActorRef ?? new gameEntityReference { Names = new CArray<CName>() },
+                    EditorPerformerId = new CRUID()
+                };
+                
+                sceneResource.DebugSymbols.PerformersDebugSymbols.Add(performerSymbol);
+                currentId++;
+            }
+            
+            // Fix player actors
+            foreach (var playerActor in sceneResource.PlayerActors)
+            {
+                playerActor.ActorId.Id = currentId;
+                
+                // Create performer symbol
+                var performerSymbol = new scnPerformerSymbol
+                {
+                    PerformerId = new scnPerformerId { Id = scnSceneResource.CalculatePerformerId(currentId) },
+                    EntityRef = new gameEntityReference { Names = new CArray<CName>() },
+                    EditorPerformerId = new CRUID()
+                };
+                
+                sceneResource.DebugSymbols.PerformersDebugSymbols.Add(performerSymbol);
+                currentId++;
+            }
+        }
+        
+        /// <summary>
+        /// Gets the performer ID for a given actor ID
+        /// </summary>
+        /// <param name="actorId">The actor ID</param>
+        /// <returns>The corresponding performer ID</returns>
+        public static uint GetPerformerIdForActor(uint actorId)
+        {
+            return scnSceneResource.CalculatePerformerId(actorId);
+        }
+        
+        /// <summary>
+        /// Gets the actor ID from a performer ID
+        /// </summary>
+        /// <param name="performerId">The performer ID</param>
+        /// <returns>The corresponding actor ID, or null if not a valid actor performer ID</returns>
+        public static uint? GetActorIdFromPerformerId(uint performerId)
+        {
+            // Check if this follows the actor performer pattern: 1 + index * 256
+            if ((performerId - 1) % 256 == 0)
+            {
+                return (performerId - 1) / 256;
+            }
+            return null;
+        }
+    }
+} 

--- a/WolvenKit.App/ViewModels/GraphEditor/ConnectionViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/ConnectionViewModel.cs
@@ -1,7 +1,11 @@
 ﻿namespace WolvenKit.App.ViewModels.GraphEditor;
 
-public class ConnectionViewModel
+using CommunityToolkit.Mvvm.ComponentModel;
+
+public partial class ConnectionViewModel : ObservableObject
 {
+    [ObservableProperty] private bool _isSelected;
+
     public ConnectionViewModel(OutputConnectorViewModel source, InputConnectorViewModel target)
     {
         Source = source;

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -992,7 +992,7 @@ internal class NodeProperties
         return str;
     }
 
-    private static string GetNameFromClass(RedBaseClass? node)
+    public static string GetNameFromClass(RedBaseClass? node)
     {
         string name = "";
 

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -350,6 +350,12 @@ public partial class RedGraph
         Connections.Remove(questConnection);
     }
 
+    public void RemoveQuestConnectionPublic(QuestConnectionViewModel questConnection)
+    {
+        RemoveQuestConnection(questConnection);
+        RefreshCVM(new[] { ((QuestOutputConnectorViewModel)questConnection.Source).Data, ((QuestInputConnectorViewModel)questConnection.Target).Data });
+    }
+
     private void RecalculateQuestSockets(IGraphProvider nodeViewModel)
     {
         if (nodeViewModel is not BaseQuestViewModel phaseNode)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -346,6 +346,11 @@ public partial class RedGraph
         }
     }
 
+    public void RemoveSceneConnectionPublic(SceneConnectionViewModel sceneConnection)
+    {
+        RemoveSceneConnection(sceneConnection);
+    }
+
     public static RedGraph GenerateSceneGraph(string title, scnSceneResource sceneResource)
     {
         var graph = new RedGraph(title, sceneResource);

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -184,7 +184,25 @@ public partial class RedGraph : IDisposable
         GraphStateSave();
     }
 
-    public void RemoveNodes(IList<object> nodes)
+    public void DuplicateNode(NodeViewModel node)
+    {
+        if (!Nodes.Contains(node))
+        {
+            return;
+        }
+
+        if (GraphType == RedGraphType.Scene && node is BaseSceneViewModel sceneNode)
+        {
+            DuplicateSceneNode(sceneNode);
+        }
+
+        if (GraphType == RedGraphType.Quest && node is BaseQuestViewModel questNode)
+        {
+            DuplicateQuestNode(questNode);
+        }
+    }
+
+    public void RemoveNodes(IEnumerable<object> nodes)
     {
         var removableNodes = new List<NodeViewModel>();
         foreach (var node in nodes)

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -25,6 +25,7 @@ using WolvenKit.App.Models.Nodify;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Documents;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes;
 using WolvenKit.App.ViewModels.Tools.EditorDifficultyLevel;
 using WolvenKit.Common.Services;
 using WolvenKit.Core.Exceptions;
@@ -1223,6 +1224,86 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
 
             if (Data is IRedArray arr)
             {
+                // Special handling for scnActorDef arrays - just calculate correct actor ID
+                if (arr.InnerType == typeof(scnActorDef))
+                {
+                    var newActor = new scnActorDef();
+                    
+                    // Calculate the next actor ID based on current array count
+                    uint nextActorId = (uint)arr.Count;
+                    newActor.ActorId.Id = nextActorId;
+                    
+                    InsertChild(-1, newActor);
+                    return;
+                }
+                
+                // Special handling for scnPlayerActorDef arrays - calculate ID continuing after actors
+                if (arr.InnerType == typeof(scnPlayerActorDef) && GetRootModel().ResolvedData is scnSceneResource scene)
+                {
+                    var newPlayerActor = new scnPlayerActorDef();
+                    
+                    // Calculate the next actor ID continuing after regular actors
+                    // Total ID = actors.Count + playerActors.Count
+                    uint nextActorId = (uint)(scene.Actors.Count + arr.Count);
+                    newPlayerActor.ActorId.Id = nextActorId;
+                    
+                    InsertChild(-1, newPlayerActor);
+                    return;
+                }
+                
+                // Special handling for scnPropDef arrays - calculate correct prop ID
+                if (arr.InnerType == typeof(scnPropDef))
+                {
+                    var newProp = new scnPropDef();
+                    
+                    // Calculate the next prop ID based on current array count (0, 1, 2, etc.)
+                    uint nextPropId = (uint)arr.Count;
+                    newProp.PropId.Id = nextPropId;
+                    
+                    InsertChild(-1, newProp);
+                    return;
+                }
+                
+                // Special handling for screenplay lines - itemId: 0, 257, 513, 769, etc.
+                if (arr.InnerType == typeof(scnscreenplayDialogLine))
+                {
+                    var newLine = new scnscreenplayDialogLine();
+                    
+                    // Calculate itemId: 0 + lineIndex * 256
+                    uint itemId = (uint)arr.Count * 256;
+                    newLine.ItemId.Id = itemId;
+                    
+                    InsertChild(-1, newLine);
+                    return;
+                }
+                
+                // Special handling for screenplay options - itemId: 2, 258, 514, 770, etc.
+                if (arr.InnerType == typeof(scnscreenplayChoiceOption))
+                {
+                    var newOption = new scnscreenplayChoiceOption();
+                    
+                    // Calculate itemId: 2 + optionIndex * 256
+                    uint itemId = 2 + (uint)arr.Count * 256;
+                    newOption.ItemId.Id = itemId;
+                    
+                    InsertChild(-1, newOption);
+                    return;
+                }
+                
+                // Special handling for scnPerformerSymbol arrays - just calculate correct performer ID
+                if (arr.InnerType == typeof(scnPerformerSymbol))
+                {
+                    var newPerformer = new scnPerformerSymbol();
+                    
+                    // Calculate the next performer ID based on current array count
+                    // Formula: performerId = 1 + performerIndex * 256
+                    uint performerId = 1 + (uint)arr.Count * 256;
+                    newPerformer.PerformerId.Id = performerId;
+                    
+                    InsertChild(-1, newPerformer);
+                    return;
+                }
+
                 var innerType = arr.InnerType;
                 if (innerType.IsValueType)
                 {

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -734,7 +734,46 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         }
     }
 
-    public string ResolvedType => ResolvedPropertyType is not null ? GetTypeRedName(ResolvedPropertyType) ?? ResolvedPropertyType.Name : "";
+        public string ResolvedType
+    {
+        get
+        {
+            if (ResolvedPropertyType is null)
+            {
+                return "";
+            }
+
+            var baseResolvedType = GetTypeRedName(ResolvedPropertyType) ?? ResolvedPropertyType.Name;
+
+            // Special case for scnQuestNode to show the quest node type in the resolved type
+            if (Data is IRedBaseHandle handle && handle.GetValue() is scnQuestNode questNode)
+            {
+                if (questNode.QuestNode?.Chunk != null)
+                {
+                    var questNodeType = NodeProperties.GetNameFromClass(questNode.QuestNode.Chunk);
+
+                    // Show the condition type for pause condition nodes
+                    if (questNode.QuestNode.Chunk is questPauseConditionNodeDefinition pauseCondition)
+                    {
+                        if (pauseCondition.Condition?.Chunk != null)
+                        {
+                            var conditionType = NodeProperties.GetNameFromClass(pauseCondition.Condition.Chunk);
+
+                            return $"scnQuestNode → {questNodeType} → {conditionType}";
+                        }
+
+                        return $"scnQuestNode → {questNodeType} → <No Condition>";
+                    }
+
+                    return $"scnQuestNode → {questNodeType}";
+                }
+
+                return "scnQuestNode → <No Quest Node>";
+            }
+
+            return baseResolvedType;
+        }
+    }
 
     // Controls if value text is being displayed or not
     public bool TypesDiffer => PropertyType != ResolvedPropertyType;

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1303,6 +1303,19 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     InsertChild(-1, newPerformer);
                     return;
                 }
+                
+                // Special handling for scnCinematicAnimSetSRRefId arrays - auto-assign next available index
+                if (arr.InnerType == typeof(scnCinematicAnimSetSRRefId))
+                {
+                    var newAnimSetRefId = new scnCinematicAnimSetSRRefId();
+                    
+                    // Calculate the next index - start from 0 and increment
+                    uint nextIndex = (uint)arr.Count;
+                    newAnimSetRefId.Id = nextIndex;
+                    
+                    InsertChild(-1, newAnimSetRefId);
+                    return;
+                }
 
                 var innerType = arr.InnerType;
                 if (innerType.IsValueType)

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
@@ -484,7 +484,7 @@ public partial class ChunkViewModel
                     }
                 }
                 break;
-            case scnSceneWorkspotInstanceId sceneWorkspotInstance when sceneWorkspotInstance.Id != 0 && GetRootModel().ResolvedData is scnSceneResource sceneForWorkspot:
+            case scnSceneWorkspotInstanceId sceneWorkspotInstance when GetRootModel().ResolvedData is scnSceneResource sceneForWorkspot:
                  Value = $"{sceneWorkspotInstance.Id}";
                  IsValueExtrapolated = sceneWorkspotInstance.Id != 0;
                  
@@ -507,7 +507,7 @@ public partial class ChunkViewModel
                      }
                  }
                  break;
-            case scnEffectInstanceId scnEffectInstance when scnEffectInstance.Id != 0 && GetRootModel().ResolvedData is scnSceneResource sceneForEffect:
+            case scnEffectInstanceId scnEffectInstance when GetRootModel().ResolvedData is scnSceneResource sceneForEffect:
                 Value = $"{scnEffectInstance.Id}";
                 IsValueExtrapolated = scnEffectInstance.Id != 0;
                 
@@ -527,6 +527,22 @@ public partial class ChunkViewModel
                             var filename = System.IO.Path.GetFileNameWithoutExtension(effectPath);
                             Value = $"{scnEffectInstance.Id}: {filename}";
                         }
+                    }
+                }
+                break;
+            case scnPropId scnPropId when GetRootModel().ResolvedData is scnSceneResource sceneForProp:
+                Value = $"{scnPropId.Id}";
+                IsValueExtrapolated = scnPropId.Id != 0;
+                
+                // Add friendly prop name if available
+                var propDefinition = sceneForProp.Props
+                    .FirstOrDefault(p => p.PropId.Id == scnPropId.Id);
+                if (propDefinition != null)
+                {
+                    var propName = propDefinition.PropName.ToString();
+                    if (!string.IsNullOrEmpty(propName))
+                    {
+                        Value = $"{scnPropId.Id}: {propName}";
                     }
                 }
                 break;

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
@@ -870,8 +870,78 @@ public partial class ChunkViewModel
                 Value = scnWorkspotSymbol.WsEditorEventId.ToString();
                 IsValueExtrapolated = scnWorkspotSymbol.WsEditorEventId != 0;
                 break;
+            case scnCinematicAnimSetSRRefId cinematicAnimSetRefId when GetRootModel().ResolvedData is scnSceneResource sceneForAnimSetRef:
+                var animSetId = cinematicAnimSetRefId.Id;
+                Value = ((uint)animSetId).ToString();
+                
+                // Try to show the animation set file name if available
+                var animSetIdValue = (uint)animSetId;
+                if (sceneForAnimSetRef.ResouresReferences?.CinematicAnimSets != null && 
+                    animSetIdValue < sceneForAnimSetRef.ResouresReferences.CinematicAnimSets.Count)
+                {
+                    var animSet = sceneForAnimSetRef.ResouresReferences.CinematicAnimSets[(int)animSetIdValue];
+                    var animSetPath = animSet.AsyncAnimSet.DepotPath.GetResolvedText();
+                    
+                    if (!string.IsNullOrEmpty(animSetPath))
+                    {
+                        var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
+                        Value = $"{animSetIdValue}: {filename}.anims";
+                        IsValueExtrapolated = true;
+                    }
+                }
+                break;
             case scnCinematicAnimSetSRRefId cinematicAnimSetRefId:
+                // Fallback case when not in a scene context
                 Value = cinematicAnimSetRefId.Id.ToString();
+                break;
+            case scnLipsyncAnimSetSRRefId lipsyncAnimSetRefId when GetRootModel().ResolvedData is scnSceneResource sceneForLipsyncAnimSetRef:
+                var lipsyncAnimSetId = lipsyncAnimSetRefId.Id;
+                Value = ((uint)lipsyncAnimSetId).ToString();
+                
+                // Try to show the lipsync animation set file name if available
+                var lipsyncAnimSetIdValue = (uint)lipsyncAnimSetId;
+                if (sceneForLipsyncAnimSetRef.ResouresReferences?.LipsyncAnimSets != null && 
+                    lipsyncAnimSetIdValue < sceneForLipsyncAnimSetRef.ResouresReferences.LipsyncAnimSets.Count)
+                {
+                    var animSet = sceneForLipsyncAnimSetRef.ResouresReferences.LipsyncAnimSets[(int)lipsyncAnimSetIdValue];
+                    var animSetPath = animSet.AsyncRefLipsyncAnimSet.DepotPath.GetResolvedText();
+                    
+                    if (!string.IsNullOrEmpty(animSetPath))
+                    {
+                        var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
+                        Value = $"{lipsyncAnimSetIdValue}: {filename}.anims";
+                        IsValueExtrapolated = true;
+                    }
+                }
+                break;
+            case scnLipsyncAnimSetSRRefId lipsyncAnimSetRefId:
+                // Fallback case when not in a scene context
+                Value = lipsyncAnimSetRefId.Id.ToString();
+                break;
+
+            case scnDynamicAnimSetSRRefId dynamicAnimSetRefId when GetRootModel().ResolvedData is scnSceneResource sceneForDynamicAnimSetRef:
+                var dynamicAnimSetId = dynamicAnimSetRefId.Id;
+                Value = ((uint)dynamicAnimSetId).ToString();
+                
+                // Try to show the dynamic animation set file name if available
+                var dynamicAnimSetIdValue = (uint)dynamicAnimSetId;
+                if (sceneForDynamicAnimSetRef.ResouresReferences?.DynamicAnimSets != null && 
+                    dynamicAnimSetIdValue < sceneForDynamicAnimSetRef.ResouresReferences.DynamicAnimSets.Count)
+                {
+                    var animSet = sceneForDynamicAnimSetRef.ResouresReferences.DynamicAnimSets[(int)dynamicAnimSetIdValue];
+                    var animSetPath = animSet.AsyncAnimSet.DepotPath.GetResolvedText();
+                    
+                    if (!string.IsNullOrEmpty(animSetPath))
+                    {
+                        var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
+                        Value = $"{dynamicAnimSetIdValue}: {filename}.anims";
+                        IsValueExtrapolated = true;
+                    }
+                }
+                break;
+            case scnDynamicAnimSetSRRefId dynamicAnimSetRefId:
+                // Fallback case when not in a scene context
+                Value = dynamicAnimSetRefId.Id.ToString();
                 break;
             case scnlocSignature locSignature:
                 Value = locSignature.Val.ToString();

--- a/WolvenKit.RED4/Types/Classes/scnActorDef.cs
+++ b/WolvenKit.RED4/Types/Classes/scnActorDef.cs
@@ -205,5 +205,47 @@ namespace WolvenKit.RED4.Types
 		}
 
 		partial void PostConstruct();
+		
+		/// <summary>
+		/// Sets up the actor with automatic ID calculation and creates corresponding performer debug symbol
+		/// </summary>
+		/// <param name="sceneResource">The scene resource to add this actor to</param>
+		public void InitializeInScene(scnSceneResource sceneResource)
+		{
+			if (sceneResource == null) return;
+			
+			// Calculate the next actor ID (0, 1, 2, etc.)
+			uint nextActorId = (uint)sceneResource.Actors.Count;
+			ActorId.Id = nextActorId;
+			
+			// Create performer debug symbol with calculated performer ID
+			// Formula: performerId = 1 + actorIndex * 256
+			uint performerId = 1 + nextActorId * 256;
+			
+			var performerSymbol = new scnPerformerSymbol
+			{
+				PerformerId = new scnPerformerId { Id = performerId },
+				EntityRef = new gameEntityReference
+				{
+					Names = FindActorInWorldParams?.ActorRef?.Names ?? new CArray<CName>()
+				},
+				EditorPerformerId = new CRUID()
+			};
+			
+			// Transfer entityRef from actor to performer symbol
+			if (FindActorInWorldParams?.ActorRef != null)
+			{
+				performerSymbol.EntityRef = FindActorInWorldParams.ActorRef;
+			}
+			
+			// Ensure debug symbols exist
+			if (sceneResource.DebugSymbols == null)
+			{
+				sceneResource.DebugSymbols = new scnDebugSymbols();
+			}
+			
+			// Add the performer symbol to debug symbols
+			sceneResource.DebugSymbols.PerformersDebugSymbols.Add(performerSymbol);
+		}
 	}
 }

--- a/WolvenKit.RED4/Types/Classes/scnPlayerActorDef.cs
+++ b/WolvenKit.RED4/Types/Classes/scnPlayerActorDef.cs
@@ -170,5 +170,47 @@ namespace WolvenKit.RED4.Types
 		}
 
 		partial void PostConstruct();
+		
+		/// <summary>
+		/// Sets up the player actor with automatic ID calculation and creates corresponding performer debug symbol
+		/// </summary>
+		/// <param name="sceneResource">The scene resource to add this player actor to</param>
+		public void InitializeInScene(scnSceneResource sceneResource)
+		{
+			if (sceneResource == null) return;
+			
+			// Calculate the next actor ID considering both regular actors and player actors
+			uint nextActorId = (uint)(sceneResource.Actors.Count + sceneResource.PlayerActors.Count);
+			ActorId.Id = nextActorId;
+			
+			// Create performer debug symbol with calculated performer ID
+			// Formula: performerId = 1 + actorIndex * 256
+			uint performerId = 1 + nextActorId * 256;
+			
+			var performerSymbol = new scnPerformerSymbol
+			{
+				PerformerId = new scnPerformerId { Id = performerId },
+				EntityRef = new gameEntityReference
+				{
+					Names = new CArray<CName>()
+				},
+				EditorPerformerId = new CRUID()
+			};
+			
+			// Set up default player entity reference if not already set
+			if (string.IsNullOrEmpty(PlayerName))
+			{
+				PlayerName = "Player";
+			}
+			
+			// Ensure debug symbols exist
+			if (sceneResource.DebugSymbols == null)
+			{
+				sceneResource.DebugSymbols = new scnDebugSymbols();
+			}
+			
+			// Add the performer symbol to debug symbols
+			sceneResource.DebugSymbols.PerformersDebugSymbols.Add(performerSymbol);
+		}
 	}
 }

--- a/WolvenKit.RED4/Types/Classes/scnSceneResource.cs
+++ b/WolvenKit.RED4/Types/Classes/scnSceneResource.cs
@@ -234,5 +234,54 @@ namespace WolvenKit.RED4.Types
 		}
 
 		partial void PostConstruct();
+		
+		/// <summary>
+		/// Adds an actor to the scene with automatic ID calculation and performer debug symbol creation
+		/// </summary>
+		/// <param name="actor">The actor to add</param>
+		public void AddActor(scnActorDef actor)
+		{
+			if (actor == null) return;
+			
+			// Initialize the actor with automatic ID and performer symbol
+			actor.InitializeInScene(this);
+			
+			// Add to actors collection
+			Actors.Add(actor);
+		}
+		
+		/// <summary>
+		/// Adds a player actor to the scene with automatic ID calculation and performer debug symbol creation
+		/// </summary>
+		/// <param name="playerActor">The player actor to add</param>
+		public void AddPlayerActor(scnPlayerActorDef playerActor)
+		{
+			if (playerActor == null) return;
+			
+			// Initialize the player actor with automatic ID and performer symbol
+			playerActor.InitializeInScene(this);
+			
+			// Add to player actors collection
+			PlayerActors.Add(playerActor);
+		}
+		
+		/// <summary>
+		/// Gets the next available actor ID
+		/// </summary>
+		/// <returns>The next actor ID that should be used</returns>
+		public uint GetNextActorId()
+		{
+			return (uint)(Actors.Count + PlayerActors.Count);
+		}
+		
+		/// <summary>
+		/// Calculates the performer ID for a given actor index
+		/// </summary>
+		/// <param name="actorIndex">The actor index (0, 1, 2, etc.)</param>
+		/// <returns>The corresponding performer ID (1, 257, 513, etc.)</returns>
+		public static uint CalculatePerformerId(uint actorIndex)
+		{
+			return 1 + actorIndex * 256;
+		}
 	}
 }

--- a/WolvenKit/Converters/RedEditorTemplateSelector.cs
+++ b/WolvenKit/Converters/RedEditorTemplateSelector.cs
@@ -21,6 +21,7 @@ namespace WolvenKit.Converters
         public DataTemplate RedVectorColorEditor { get; set; }
         public DataTemplate FilterableDropdownCNameEditor { get; set; }
         public DataTemplate FilterableDropdownRedRefEditor { get; set; }
+        public DataTemplate FilterableDropdownIntegerEditor { get; set; }
         public DataTemplate RedColorPicker { get; set; }
         public DataTemplate RedCurveEditor { get; set; }
         public DataTemplate RedCurvePointEditor { get; set; }
@@ -78,6 +79,8 @@ namespace WolvenKit.Converters
                 return FilterableDropdownCNameEditor;
                 
             }
+
+
 
             if (vm.PropertyType.IsAssignableTo(typeof(TweakDBID)))
             {
@@ -138,6 +141,11 @@ namespace WolvenKit.Converters
 
             if (vm.PropertyType.IsAssignableTo(typeof(IRedInteger)))
             {
+                if (CvmDropdownHelper.HasDropdownOptions(vm))
+                {
+                    return FilterableDropdownIntegerEditor;
+                }
+                
                 return RedIntegerEditor;
             }
 

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -160,7 +160,9 @@
                         Target="{Binding Target.Anchor}"
                         TargetOffset="7,0"
                         TargetOffsetMode="Static"
-                        IsSelectable="True">
+                        IsSelectable="True"
+                        IsSelected="{Binding IsSelected}"
+                        MouseRightButtonDown="Connection_OnRightClick">
                         <nodify:Connection.Style>
                             <Style TargetType="{x:Type nodify:BaseConnection}">
                                 <Setter Property="Cursor" Value="Hand" />

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -294,6 +294,7 @@ public partial class GraphEditorView : UserControl
             node.ContextMenu.Items.Add(new Separator());
         }
 
+        node.ContextMenu.Items.Add(CreateMenuItem("Duplicate Node", "ContentDuplicate", "WolvenKitYellow", () => Source.DuplicateNode(nvm)));
         node.ContextMenu.Items.Add(CreateMenuItem("Remove Node", "Delete", "WolvenKitRed", () => Source.RemoveNode(nvm)));
 
         node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -399,6 +399,9 @@ public partial class GraphEditorView : UserControl
                         Source.RemoveSceneConnectionPublic(sceneConnection);
                     }
                 }
+                
+                Editor.SelectedItems.Clear();
+                connectionViewModel.IsSelected = false;
             });
             
             contextMenu.Items.Add(deleteMenuItem);

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -19,6 +19,8 @@ using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.Views.Templates;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 
 namespace WolvenKit.Views.GraphEditor;
 /// <summary>
@@ -366,4 +368,44 @@ public partial class GraphEditorView : UserControl
     #endregion
 
     private void Node_OnMouseDoubleClick(object sender, MouseButtonEventArgs e) => RaiseEvent(new RoutedEventArgs(NodeDoubleClickEvent));
+
+    private void Connection_OnRightClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is Connection connection && connection.DataContext is ConnectionViewModel connectionViewModel && Source != null)
+        {
+            // Clear other selections and select this connection to highlight it
+            Editor.SelectedItems.Clear();
+            Editor.SelectedItems.Add(connectionViewModel);
+            
+            // Also set the IsSelected property on the view model for binding
+            connectionViewModel.IsSelected = true;
+            
+            var contextMenu = new ContextMenu();
+            
+            var deleteMenuItem = CreateMenuItem("Delete Connection", "Delete", "WolvenKitRed", () =>
+            {
+                if (Source.GraphType == RedGraphType.Quest)
+                {
+                    if (connectionViewModel is QuestConnectionViewModel questConnection)
+                    {
+                        Source.RemoveQuestConnectionPublic(questConnection);
+                    }
+                }
+                else if (Source.GraphType == RedGraphType.Scene)
+                {
+                    if (connectionViewModel is SceneConnectionViewModel sceneConnection)
+                    {
+                        Source.RemoveSceneConnectionPublic(sceneConnection);
+                    }
+                }
+            });
+            
+            contextMenu.Items.Add(deleteMenuItem);
+            
+            connection.ContextMenu = contextMenu;
+            contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
+            
+            e.Handled = true;
+        }
+    }
 }

--- a/WolvenKit/Views/Templates/RedTypeView.xaml
+++ b/WolvenKit/Views/Templates/RedTypeView.xaml
@@ -465,6 +465,12 @@
                     </DataTemplate>
                 </converters:RedEditorTemplateSelector.FilterableDropdownRedRefEditor>
 
+                <converters:RedEditorTemplateSelector.FilterableDropdownIntegerEditor>
+                    <DataTemplate>
+                        <editors:ScnActorIdDropdown DataContext="{Binding}" />
+                    </DataTemplate>
+                </converters:RedEditorTemplateSelector.FilterableDropdownIntegerEditor>
+
 
                 <converters:RedEditorTemplateSelector.RedNodeRefEditor>
                     <DataTemplate>

--- a/WolvenKit/Views/Templates/ScnActorIdDropdown.xaml
+++ b/WolvenKit/Views/Templates/ScnActorIdDropdown.xaml
@@ -1,0 +1,30 @@
+<UserControl
+    x:Class="WolvenKit.Views.Editors.ScnActorIdDropdown"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:editors="clr-namespace:WolvenKit.Views.Editors">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="5" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        
+        <!-- Actor dropdown -->
+        <ComboBox
+            x:Name="ActorDropdown"
+            Grid.Row="0"
+            Height="{StaticResource WolvenKitTabHeight}"
+            DisplayMemberPath="Key"
+            SelectedValuePath="Value"
+            SelectionChanged="ActorDropdown_SelectionChanged" />
+        
+        <!-- Current value display -->
+        <TextBlock
+            x:Name="CurrentValueText"
+            Grid.Row="2"
+            Text="Current ID: 0"
+            VerticalAlignment="Center"
+            Margin="5" />
+    </Grid>
+</UserControl> 

--- a/WolvenKit/Views/Templates/ScnActorIdDropdown.xaml.cs
+++ b/WolvenKit/Views/Templates/ScnActorIdDropdown.xaml.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using Splat;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.Views.Editors
+{
+    public partial class ScnActorIdDropdown : UserControl
+    {
+        private readonly DocumentTools _documentTools;
+        private bool _isUpdatingFromCode = false;
+
+        public ScnActorIdDropdown()
+        {
+            _documentTools = Locator.Current.GetService<DocumentTools>();
+            InitializeComponent();
+            
+            this.DataContextChanged += OnDataContextChanged;
+            this.Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            SetupIntegerEditor();
+            PopulateDropdown();
+            UpdateDropdownSelection();
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (IsLoaded)
+            {
+                SetupIntegerEditor();
+                PopulateDropdown();
+                UpdateDropdownSelection();
+            }
+        }
+
+        private void SetupIntegerEditor()
+        {
+            // Update the current value display
+            if (DataContext is ChunkViewModel { Data: IRedInteger integerData })
+            {
+                var currentValue = integerData switch
+                {
+                    CUInt32 cuint32 => ((uint)cuint32).ToString(),
+                    CInt32 cint32 => ((int)cint32).ToString(),
+                    CUInt16 cuint16 => ((ushort)cuint16).ToString(),
+                    CInt16 cint16 => ((short)cint16).ToString(),
+                    CUInt8 cuint8 => ((byte)cuint8).ToString(),
+                    CInt8 cint8 => ((sbyte)cint8).ToString(),
+                    _ => "0"
+                };
+                CurrentValueText.SetCurrentValue(TextBlock.TextProperty, $"Current ID: {currentValue}");
+            }
+        }
+
+        private void PopulateDropdown()
+        {
+            if (DataContext is not ChunkViewModel cvm)
+                return;
+
+            var options = CvmDropdownHelper.GetDropdownOptions(cvm, _documentTools, false);
+            if (options.Count > 0)
+            {
+                ActorDropdown.SetCurrentValue(ItemsControl.ItemsSourceProperty, options.ToList());
+            }
+        }
+
+        private void UpdateDropdownSelection()
+        {
+            if (DataContext is not ChunkViewModel { Data: IRedInteger integerData })
+                return;
+
+            _isUpdatingFromCode = true;
+            
+            var currentValue = integerData switch
+            {
+                CUInt32 cuint32 => ((uint)cuint32).ToString(),
+                CInt32 cint32 => ((int)cint32).ToString(),
+                CUInt16 cuint16 => ((ushort)cuint16).ToString(),
+                CInt16 cint16 => ((short)cint16).ToString(),
+                CUInt8 cuint8 => ((byte)cuint8).ToString(),
+                CInt8 cint8 => ((sbyte)cint8).ToString(),
+                _ => ""
+            };
+
+            ActorDropdown.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedValueProperty, currentValue);
+            _isUpdatingFromCode = false;
+        }
+
+        private void ActorDropdown_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isUpdatingFromCode || ActorDropdown.SelectedValue is not string selectedValue)
+                return;
+
+            if (DataContext is not ChunkViewModel cvm || cvm.Data is not IRedInteger integerData)
+                return;
+
+            if (uint.TryParse(selectedValue, out var newValue))
+            {
+                // Update the integer value based on the type
+                switch (integerData)
+                {
+                    case CUInt32:
+                        cvm.Data = (CUInt32)newValue;
+                        break;
+                    case CInt32:
+                        cvm.Data = (CInt32)(int)newValue;
+                        break;
+                    case CUInt16:
+                        cvm.Data = (CUInt16)(ushort)newValue;
+                        break;
+                    case CInt16:
+                        cvm.Data = (CInt16)(short)newValue;
+                        break;
+                    case CUInt8:
+                        cvm.Data = (CUInt8)(byte)newValue;
+                        break;
+                    case CInt8:
+                        cvm.Data = (CInt8)(sbyte)newValue;
+                        break;
+                }
+                
+                // Update the display
+                CurrentValueText.SetCurrentValue(TextBlock.TextProperty, $"Current ID: {selectedValue}");
+            }
+        }
+    }
+} 


### PR DESCRIPTION
WIP: Scene editing workflow improvements

I've been making some scenes from scratch and implementing some ideas for workflow improvements to make scene editing in general easier. Changes include:

GraphEditor:

- Right click to duplicate node
- Right click to delete connection

![image](https://github.com/user-attachments/assets/bec8ba20-f43b-4e06-923b-738e5ae0e8d7)
![image](https://github.com/user-attachments/assets/5a545730-03d4-4147-88be-a4c47127d6b7)


Tree/Document View:

- Automatic index assignment on creation for actors, performers, props, dialogs
- Dropdown selector UI for actors, performers, props, dialogs, animation resources
- Some minor UI improvements like displaying questNode in scnQuestNode

![image](https://github.com/user-attachments/assets/8ab195fd-4d2c-4f1a-ae3f-afa8b1ba2953)

![image](https://github.com/user-attachments/assets/3912dd21-f695-4d62-970a-1b928fa58534)
![image](https://github.com/user-attachments/assets/7f820c91-ef34-4eac-a4bf-c4a4ae4f2c9b)
