### PR TITLE
ResourceRef context menu: Add/Remove dynamic substitution

### DIFF
--- a/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
+++ b/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
@@ -65,7 +65,13 @@ public partial class ArchiveXlHelper
             return staticPath;
         }
 
-        var text = Regex.Replace(staticPath, s_genderPartialRegex, "{gender}");
+        var text = staticPath;
+
+        var match = Regex.Match(staticPath, s_genderPartialRegex);
+        if (match is { Success: true })
+        {
+            text = Regex.Replace(staticPath, s_genderPartialRegex, @"_$1{gender}$3_");
+        }
 
         foreach (var kvp in SubstitutionMap)
         {
@@ -97,7 +103,7 @@ public partial class ArchiveXlHelper
     /// <summary>
     /// Will match w, m, wa, ma, pwa and pma, as long as it's between to underscores.
     /// </summary>
-    private static readonly string s_genderPartialRegex = @"(?<=_)p?([wm])a?(?=[_\.])";
+    private static readonly string s_genderPartialRegex = @"_(p?)([wm])(a?)[._]";
 
     public static bool HasSubstitution(string s) => s_substitutionRegex().IsMatch(s);
 

--- a/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
+++ b/WolvenKit.Modkit/Resources/ArchiveXlHelper.cs
@@ -57,10 +57,30 @@ public partial class ArchiveXlHelper
         return new CResourceReference<IMaterial>(baseMaterialPath.Replace(s_materialWildcard, substitutionValue)[1..]);
 
     }
-    
-    
 
-    private static readonly Dictionary<string, List<string>> s_substitutionMap =
+    public static string MakeDynamic(string staticPath)
+    {
+        if (string.IsNullOrEmpty(staticPath) || HasSubstitution(staticPath))
+        {
+            return staticPath;
+        }
+
+        var text = Regex.Replace(staticPath, s_genderPartialRegex, "{gender}");
+
+        foreach (var kvp in SubstitutionMap)
+        {
+            foreach (var partial in kvp.Value)
+            {
+                text = text.Replace($"_{partial}_", "_{" + kvp.Key + "}_");
+                text = text.Replace($"_{partial}.", "_{" + kvp.Key + "}.");
+            }
+        }
+
+        return $"*{text}";
+    }
+
+
+    public static readonly Dictionary<string, List<string>> SubstitutionMap =
         new()
         {
             { "camera", ["fpp", "tpp"] }, //
@@ -74,8 +94,29 @@ public partial class ArchiveXlHelper
     [GeneratedRegex(@"(?<=\{)\w+(?=\})")]
     private static partial Regex s_substitutionRegex();
 
+    /// <summary>
+    /// Will match w, m, wa, ma, pwa and pma, as long as it's between to underscores.
+    /// </summary>
+    private static readonly string s_genderPartialRegex = @"(?<=_)p?([wm])a?(?=[_\.])";
+
     public static bool HasSubstitution(string s) => s_substitutionRegex().IsMatch(s);
 
+    /// <summary>
+    /// Could the string have substitution? 
+    /// </summary>
+    /// <param name="s"></param>
+    /// <returns></returns>
+    public static bool CouldHaveSubstitution(string s)
+    {
+        if (Regex.IsMatch(s, s_genderPartialRegex))
+        {
+            return true;
+        }
+
+        return SubstitutionMap.SelectMany(kvp => kvp.Value)
+            .Any(partial => s.Contains($"_{partial}_") || s.Contains($"_{partial}."));
+    }
+    
     public static string? GetValuesForInvalidSubstitution(string? s)
     {
         if (s is null || !HasSubstitution(s))
@@ -97,7 +138,7 @@ public partial class ArchiveXlHelper
         
         foreach (Match match in s_substitutionRegex().Matches(s))
         {
-            if (s_substitutionMap.ContainsKey(match.Value))
+            if (SubstitutionMap.ContainsKey(match.Value))
             {
                 continue;
             }
@@ -112,7 +153,7 @@ public partial class ArchiveXlHelper
         
 
         return
-            $"Invalid substitutions used: [{string.Join(',', invalidSubstitutions)}]. Valid substitutions are: [{string.Join(',', s_substitutionMap.Keys)}] ";
+            $"Invalid substitutions used: [{string.Join(',', invalidSubstitutions)}]. Valid substitutions are: [{string.Join(',', SubstitutionMap.Keys)}] ";
     }
 
 
@@ -139,9 +180,9 @@ public partial class ArchiveXlHelper
             }
 
             var (key, value) = (keyValue[0].Replace("&", ""), keyValue[1]);
-            if (!s_substitutionMap.TryGetValue(key, out var values))
+            if (!SubstitutionMap.TryGetValue(key, out var values))
             {
-                result.Add($"Bad key '{key}' ([ {string.Join(", ", s_substitutionMap.Keys)} ])");
+                result.Add($"Bad key '{key}' ([ {string.Join(", ", SubstitutionMap.Keys)} ])");
             }
             else if (!values.Contains(value))
             {

--- a/WolvenKit.sln.DotSettings
+++ b/WolvenKit.sln.DotSettings
@@ -30,6 +30,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mlmask/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mltemplate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modder/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=monowire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=morphtarget/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=onscreens/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=photomode/@EntryIndexedValue">True</s:Boolean>

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml
@@ -103,6 +103,7 @@
             GotFocus="RefreshValidityAndTooltip"
             OnPaste="TrimmingTextbox_OnTextUpdate"
             OnKeyUp="TrimmingTextbox_OnKeyUp"
+            OnFocusLost="TrimmingTextbox_OnFocusLost"
             Tooltip="{Binding Path=TextBoxToolTip}"
             Text="{Binding DepotPath,
                            UpdateSourceTrigger=PropertyChanged,

--- a/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedRefEditor.xaml.cs
@@ -224,6 +224,8 @@ namespace WolvenKit.Views.Editors
 
         private void RefreshValidityAndTooltip(object sender, RoutedEventArgs e)
         {
+            RecalculateFlags();
+            
             if (_settingsManager?.UseValidatingEditor != true || RedRef?.DepotPath == ResourcePath.Empty ||
                 RedRef?.DepotPath.GetResolvedText() is not string filePath || filePath.Trim().IsNullOrEmpty())
             {
@@ -276,6 +278,7 @@ namespace WolvenKit.Views.Editors
         {
             _updateSender = sender;
             _updateTimer.Stop();
+            
             _updateTimer.Start();
         }
 
@@ -295,5 +298,27 @@ namespace WolvenKit.Views.Editors
 
             RefreshValidityAndTooltip(sender, new RoutedEventArgs());
         }
+
+        private void RecalculateFlags()
+        {
+            if (RedRef is null || RedRef.DepotPath == ResourcePath.Empty ||
+                RedRef.DepotPath.GetResolvedText() is not string depotPath)
+            {
+                return;
+            }
+
+            if (ArchiveXlHelper.HasSubstitution(depotPath))
+            {
+                FlagsComboBox.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty,
+                    InternalEnums.EImportFlags.Soft);
+            }
+            else
+            {
+                FlagsComboBox.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty,
+                    InternalEnums.EImportFlags.Default);
+            }
+        }
+
+        private void TrimmingTextbox_OnFocusLost(object sender, EventArgs e) => RecalculateFlags();
     }
 }

--- a/WolvenKit/Views/Templates/TrimmingTextBox.xaml
+++ b/WolvenKit/Views/Templates/TrimmingTextBox.xaml
@@ -37,6 +37,7 @@
                 ScrollViewer.CanContentScroll="False"
                 TextChanged="RealTextBox_OnTextChanged"
                 KeyUp="RealTextBox_OnKeyUp"
+                LostFocus="RealTextBox_OnFocusLost"
                 ContextMenuOpening="RefreshContextMenu"
                 DataObject.Pasting="RealTextBox_OnPasting">
                 <TextBox.ContextMenu>

--- a/WolvenKit/Views/Templates/TrimmingTextBox.xaml
+++ b/WolvenKit/Views/Templates/TrimmingTextBox.xaml
@@ -37,7 +37,66 @@
                 ScrollViewer.CanContentScroll="False"
                 TextChanged="RealTextBox_OnTextChanged"
                 KeyUp="RealTextBox_OnKeyUp"
-                DataObject.Pasting="RealTextBox_OnPasting" />
+                ContextMenuOpening="RefreshContextMenu"
+                DataObject.Pasting="RealTextBox_OnPasting">
+                <TextBox.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem
+                            x:Name="CutMenuItem"
+                            Header="Cut"
+                            Click="Cut_Click" />
+                        <MenuItem
+                            x:Name="CopyMenuItem"
+                            Header="Copy"
+                            Click="Copy_Click" />
+                        <MenuItem
+                            x:Name="PasteMenuItem"
+                            Header="Paste"
+                            Click="Paste_Click" />
+
+                        <Separator x:Name="DynamicSeparator">
+                            <Separator.Style>
+                                <Style
+                                    BasedOn="{StaticResource {x:Type Separator}}"
+                                    TargetType="Separator">
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding ShowMakeDynamic}" Value="False" />
+                                                <Condition Binding="{Binding ShowRemoveDynamic}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Separator.Style>
+                        </Separator>
+
+                        <MenuItem
+                            x:Name="DynamicPathMenuItem"
+                            Header="Add dynamic substitution"
+                            ContextMenuOpening="RefreshContextMenu"
+                            Click="MakeDynamic_Click">
+                            <MenuItem.Style>
+                                <Style
+                                    BasedOn="{StaticResource {x:Type MenuItem}}"
+                                    TargetType="MenuItem">
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding ShowMakeDynamic}" Value="False" />
+                                                <Condition Binding="{Binding ShowRemoveDynamic}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+
+                                </Style>
+                            </MenuItem.Style>
+                        </MenuItem>
+                    </ContextMenu>
+                </TextBox.ContextMenu>
+            </TextBox>
         </Border>
 
         <Grid IsHitTestVisible="False">

--- a/WolvenKit/Views/Templates/TrimmingTextBox.xaml.cs
+++ b/WolvenKit/Views/Templates/TrimmingTextBox.xaml.cs
@@ -67,6 +67,7 @@ namespace WolvenKit.Views.Editors
         }
 
 
+
         private ScrollViewer _scrollViewer;
 
         public TrimmingTextBox() => InitializeComponent();
@@ -90,7 +91,7 @@ namespace WolvenKit.Views.Editors
             StartTrimming.SetCurrentValue(VisibilityProperty, _scrollViewer.HorizontalOffset > 0 ? Visibility.Visible : Visibility.Hidden);
             EndTrimming.SetCurrentValue(VisibilityProperty, Math.Abs(_scrollViewer.ScrollableWidth - _scrollViewer.HorizontalOffset) > 1 ? Visibility.Visible : Visibility.Hidden);
         }
-
+           
         public event EventHandler OnChange;
         private void RealTextBox_OnTextChanged(object sender, TextChangedEventArgs e)
         {
@@ -213,6 +214,14 @@ namespace WolvenKit.Views.Editors
                 _previousValue = Text;
                 RealTextBox.SetCurrentValue(TextBox.TextProperty, s);
             }
+
+            OnFocusLost?.Invoke(this, EventArgs.Empty);
         }
+
+
+        public event EventHandler OnFocusLost;
+
+        private void RealTextBox_OnFocusLost(object sender, RoutedEventArgs e) =>
+            OnFocusLost?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
# ResourceRef context menu: Add/Remove dynamic substitution

Context menu entry will display based on conditional check if the string could support it (check when opening context menu)

![image](https://github.com/user-attachments/assets/b814a7a4-2125-473b-bc20-e07ec09bca6a)
![image](https://github.com/user-attachments/assets/7ca9422b-854f-42c9-8498-57d91c582333)

