### PR TITLE
fix: prevent crash when creating new .ent files

### DIFF
--- a/WolvenKit.RED4/Archive/IO/PreProcessor/entEntityTemplatePreProcessor.cs
+++ b/WolvenKit.RED4/Archive/IO/PreProcessor/entEntityTemplatePreProcessor.cs
@@ -30,7 +30,7 @@ public class entEntityTemplatePreProcessor : IPreProcessor
             rp.Chunks.Add(entEntityTemplate.Entity!);
         }
 
-        foreach (var component in entEntityTemplate.Components)
+        foreach (var component in entEntityTemplate.Components ?? Enumerable.Empty<entIComponent>())
         {
             rp.Chunks.Add(component);
         }


### PR DESCRIPTION
# Fix crash on creating new .ent

Fixes #2448 

Adds a null check to safely handle uninitialized `Components` , allowing new `.ent` files to be created



