### PR TITLE
feat: add quest editor

### DIFF
--- a/WolvenKit.App/Helpers/CollectionViewHelper.cs
+++ b/WolvenKit.App/Helpers/CollectionViewHelper.cs
@@ -103,6 +103,21 @@ namespace WolvenKit.App.Helpers
             };
         }
 
+        // Quest Phase specific filters
+        public static Func<ChunkViewModel, bool> CreateQuestNodePropertiesFilter()
+        {
+            return chunk => chunk.Name == "graph";
+        }
+
+        public static Func<ChunkViewModel, bool> CreateQuestPhaseResourcesFilter()
+        {
+            return chunk => 
+            {
+                return chunk.Name == "phasePrefabs" || 
+                       chunk.Name == "inplacePhases";
+            };
+        }
+
         // Legacy filters for backward compatibility
         public static Func<ChunkViewModel, bool> CreateActorsFilter() => CreateActorsAndPropsFilter();
         public static Func<ChunkViewModel, bool> CreatePerformersFilter() => CreateAssetLibraryFilter();

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
@@ -49,6 +49,8 @@ namespace WolvenKit.App.ViewModels.Documents
         
         public int TotalNodes => CalculateTotalNodes();
         
+        public int TotalPhaseNodes => CalculatePhaseNodes();
+        
         public int TotalPhasePrefabs => _questPhaseData.PhasePrefabs?.Count ?? 0;
         
         public int TotalInplacePhases => _questPhaseData.InplacePhases?.Count ?? 0;
@@ -173,14 +175,60 @@ namespace WolvenKit.App.ViewModels.Documents
                     total += CountNodesInPhaseGraph(phasePrefab);
                 }
             }
+
+            // Count nodes in phase nodes within the graph
+            if (_questPhaseData.Graph?.Chunk?.Nodes != null)
+            {
+                foreach (var nodeHandle in _questPhaseData.Graph.Chunk.Nodes)
+                {
+                    if (nodeHandle.Chunk is questPhaseNodeDefinition phaseNode)
+                    {
+                        // Count nodes in phase graphs
+                        if (phaseNode.PhaseGraph?.Chunk != null)
+                        {
+                            total += phaseNode.PhaseGraph.Chunk.Nodes?.Count ?? 0;
+                        }
+
+                        // Count nodes in phase instance prefabs
+                        if (phaseNode.PhaseInstancePrefabs != null)
+                        {
+                            foreach (var instancePrefab in phaseNode.PhaseInstancePrefabs)
+                            {
+                                total += CountNodesInPrefab(instancePrefab);
+                            }
+                        }
+                    }
+                }
+            }
+            
+            return total;
+        }
+
+        private int CalculatePhaseNodes()
+        {
+            int total = 0;
+            
+            // Count phase nodes in the main graph
+            if (_questPhaseData.Graph?.Chunk?.Nodes != null)
+            {
+                total += _questPhaseData.Graph.Chunk.Nodes.Count(
+                    nodeHandle => nodeHandle.Chunk is questPhaseNodeDefinition);
+            }
             
             return total;
         }
 
         private int CountNodesInPhaseGraph(questQuestPrefabEntry phasePrefab)
         {
-            // This would need to be implemented based on how phase prefabs contain nested graphs
-            // For now, return 0 - this can be expanded when we understand the phase structure better
+            // Count nodes in phase prefabs - this is a simplified implementation
+            // In a full implementation, we might need to load the referenced resource
+            return 0;
+        }
+
+        private int CountNodesInPrefab(questQuestPrefabEntry prefab)
+        {
+            // Count nodes in prefabs - this is a simplified implementation
+            // In a full implementation, we might need to load the referenced resource
             return 0;
         }
 

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
@@ -29,6 +29,9 @@ namespace WolvenKit.App.ViewModels.Documents
         public RDTDataViewModel RDTViewModel { get; }
         public RedGraph MainGraph { get; }
         public ObservableCollection<QuestPhaseTabDefinition> Tabs { get; } = new();
+        
+        // Navigation history for nested graphs
+        public ObservableCollection<RedGraph> History { get; } = new();
 
         [ObservableProperty]
         private QuestPhaseTabDefinition? _selectedTab;
@@ -93,6 +96,9 @@ namespace WolvenKit.App.ViewModels.Documents
                 MainGraph.DocumentViewModel = parent;
             }
 
+            // Initialize navigation history with the main graph
+            History.Add(MainGraph);
+            
             CreateTabs();
             
             // Set the first tab as selected

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Data;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Factories;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.RED4.Types;
+using Splat;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
+using WolvenKit.Core.Extensions;
+using System.IO;
+
+namespace WolvenKit.App.ViewModels.Documents
+{
+    public partial class QuestPhaseGraphViewModel : RedDocumentTabViewModel, IDisposable
+    {
+        private bool _disposed = false;
+        private readonly ILoggerService? _logger = Locator.Current.GetService<ILoggerService>();
+        private readonly questQuestPhaseResource _questPhaseData;
+
+        public RDTDataViewModel RDTViewModel { get; }
+        public RedGraph MainGraph { get; }
+        public ObservableCollection<QuestPhaseTabDefinition> Tabs { get; } = new();
+
+        [ObservableProperty]
+        private QuestPhaseTabDefinition? _selectedTab;
+
+        [ObservableProperty]
+        private object? _selectedTabContent;
+
+        [ObservableProperty]
+        private bool _isGraphLoading = true;
+
+        public override ERedDocumentItemType DocumentItemType => ERedDocumentItemType.MainFile;
+
+        // Quest phase statistics properties
+        public string FileName => Path.GetFileNameWithoutExtension(Parent?.Header ?? "Unknown");
+        
+        public int TotalNodes => CalculateTotalNodes();
+        
+        public int TotalPhasePrefabs => _questPhaseData.PhasePrefabs?.Count ?? 0;
+        
+        public int TotalInplacePhases => _questPhaseData.InplacePhases?.Count ?? 0;
+
+        public QuestPhaseGraphViewModel(questQuestPhaseResource data, RedDocumentViewModel parent, IChunkViewmodelFactory chunkViewmodelFactory, INodeWrapperFactory nodeWrapperFactory)
+            : base(parent, "Quest Phase Editor")
+        {
+            _questPhaseData = data;
+            
+            var appViewModel = Locator.Current.GetService<AppViewModel>() ?? throw new ArgumentNullException(nameof(AppViewModel));
+            var settingsManager = Locator.Current.GetService<ISettingsManager>() ?? throw new ArgumentNullException(nameof(ISettingsManager));
+            var gameController = Locator.Current.GetService<IGameControllerFactory>() ?? throw new ArgumentNullException(nameof(IGameControllerFactory));
+
+            RDTViewModel = new RDTDataViewModel(data, parent, appViewModel, chunkViewmodelFactory, settingsManager, gameController);
+            
+            // Create MainGraph - handle cases where graph might be null
+            try
+            {
+                if (data.Graph?.Chunk != null)
+                {
+                    MainGraph = RedGraph.GenerateQuestGraph(parent.Header, data.Graph.Chunk, nodeWrapperFactory);
+                    
+                    // Set document reference for property change syncing
+                    MainGraph.DocumentViewModel = parent;
+
+                    // Ensure all nodes have DocumentViewModel reference for dirty tracking
+                    foreach (var node in MainGraph.Nodes)
+                    {
+                        node.DocumentViewModel = parent;
+                    }
+                }
+                else
+                {
+                    _logger?.Warning($"Quest phase file '{parent.Header}' has no graph data. Creating empty graph.");
+                    // Create an empty graph as fallback
+                    MainGraph = new RedGraph(parent.Header, data);
+                    MainGraph.DocumentViewModel = parent;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error($"Failed to create quest phase graph for '{parent.Header}': {ex.Message}");
+                // Create an empty graph as fallback
+                MainGraph = new RedGraph(parent.Header, data);
+                MainGraph.DocumentViewModel = parent;
+            }
+
+            CreateTabs();
+            
+            // Set the first tab as selected
+            SelectedTab = Tabs.FirstOrDefault();
+
+            if (SelectedTab != null)
+            {
+                UpdateTabContent(SelectedTab);
+            }
+        }
+
+        public void SetGraphLoaded()
+        {
+            IsGraphLoading = false;
+        }
+
+        private void CreateTabs()
+        {
+            // Create tab definitions for quest phase
+            Tabs.Add(new QuestPhaseTabDefinition
+            {
+                Header = "Node Properties",
+                Icon = "SitemapOutline",
+                Filter = CollectionViewHelper.CreateQuestNodePropertiesFilter()
+            });
+
+            Tabs.Add(new QuestPhaseTabDefinition
+            {
+                Header = "Phase Resources",
+                Icon = "PackageVariantClosed",
+                Filter = CollectionViewHelper.CreateQuestPhaseResourcesFilter()
+            });
+        }
+
+        private void UpdateTabContent(QuestPhaseTabDefinition tab)
+        {
+            var rootChunk = RDTViewModel.GetRootChunk();
+            if (rootChunk == null)
+            {
+                _logger?.Warning($"[PANEL] No root chunk found for tab '{tab.Header}'");
+                SelectedTabContent = null;
+                return;
+            }
+
+            if (!rootChunk.TVProperties.Any())
+            {
+                rootChunk.CalculateProperties();
+            }
+
+            foreach (var cvm in rootChunk.TVProperties)
+            {
+                if (tab.Filter(cvm))
+                {
+                    cvm.CalculateProperties();
+                }
+            }
+
+            var list = new List<ChunkViewModel>(rootChunk.TVProperties.Where(c => tab.Filter(c)));
+            SelectedTabContent = list;
+        }
+
+        private int CalculateTotalNodes()
+        {
+            int total = _questPhaseData.Graph?.Chunk?.Nodes?.Count ?? 0;
+            
+            // Add nodes from phase prefabs (nested graphs)
+            if (_questPhaseData.PhasePrefabs != null)
+            {
+                foreach (var phasePrefab in _questPhaseData.PhasePrefabs)
+                {
+                    // Count nodes in nested phase graphs
+                    total += CountNodesInPhaseGraph(phasePrefab);
+                }
+            }
+            
+            return total;
+        }
+
+        private int CountNodesInPhaseGraph(questQuestPrefabEntry phasePrefab)
+        {
+            // This would need to be implemented based on how phase prefabs contain nested graphs
+            // For now, return 0 - this can be expanded when we understand the phase structure better
+            return 0;
+        }
+
+        partial void OnSelectedTabChanged(QuestPhaseTabDefinition? value)
+        {
+            if (value == null) return;
+            UpdateTabContent(value);
+        }
+
+        // Override Unload to ensure disposal when tab is closed
+        public override void Unload()
+        {
+            Dispose();
+            base.Unload();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~QuestPhaseGraphViewModel()
+        {
+            Dispose(false);
+        }
+    }
+} 

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseTabDefinition.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseTabDefinition.cs
@@ -1,0 +1,12 @@
+using System;
+using WolvenKit.App.ViewModels.Shell;
+
+namespace WolvenKit.App.ViewModels.Documents
+{
+    public class QuestPhaseTabDefinition
+    {
+        public string Header { get; set; } = string.Empty;
+        public string Icon { get; set; } = string.Empty;
+        public Func<ChunkViewModel, bool> Filter { get; set; } = _ => false;
+    }
+} 

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -339,6 +339,19 @@ public partial class RedDocumentViewModel : DocumentViewModel
             return;
         }
 
+        if (cls is questQuestPhaseResource questPhaseResource)
+        {
+            var combinedQuestPhaseTab = new QuestPhaseGraphViewModel(questPhaseResource, this, _chunkViewmodelFactory, _nodeWrapperFactory);
+            TabItemViewModels.Insert(0, combinedQuestPhaseTab);
+
+            if (_globals.Value.ENABLE_NODE_EDITOR)
+            {
+                TabItemViewModels.Add(new RDTGraphViewModel2(questPhaseResource, this, _nodeWrapperFactory));
+            }
+
+            return;
+        }
+
         if (_globals.Value.ENABLE_NODE_EDITOR && cls is graphGraphResource)
         {
             TabItemViewModels.Add(new RDTGraphViewModel2(cls, this, _nodeWrapperFactory));

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
@@ -113,6 +113,23 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
     }
 
     /// <summary>
+    /// Override RefreshFromData for quest nodes to avoid breaking connections
+    /// Quest nodes don't need socket regeneration during property sync
+    /// </summary>
+    public override void RefreshFromData()
+    {
+        // Update title
+        UpdateTitle();
+        OnPropertyChanged(nameof(Title));
+        
+        // DON'T regenerate sockets for quest nodes
+        OnPropertyChanged(nameof(Data));
+        
+        // Refresh details
+        RefreshDetails();
+    }
+
+    /// <summary>
     /// Populate quest node details into the provided dictionary
     /// </summary>
     protected virtual void PopulateDetailsInto(Dictionary<string, string> details)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
@@ -5,6 +5,9 @@ using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.RED4.Types;
+using System.Reflection;
+using System.Linq;
+using System;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 
@@ -14,6 +17,11 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
 
     public Brush Background { get; protected set; }
     public Brush ContentBackground { get; protected set; }
+
+    /// <summary>
+    /// Whether this node is a player node (has refLocalPlayer set to true)
+    /// </summary>
+    public bool IsPlayerNode { get; protected set; }
 
     protected BaseQuestViewModel(graphGraphNodeDefinition graphGraphNodeDefinition) : base(graphGraphNodeDefinition)
     {
@@ -26,12 +34,195 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
         {
             UniqueId = (uint)graphGraphNodeDefinition.GetHashCode();
         }
+        
+        // Detect if this is a player node
+        DetectPlayerNode(graphGraphNodeDefinition);
+        
         Title = FormatQuestNodeName(graphGraphNodeDefinition.GetType().Name);
         Background = GetBackgroundForNodeType(graphGraphNodeDefinition);
         ContentBackground = GetContentBackgroundForNodeType(graphGraphNodeDefinition);
         
         // Check if this is a simple node type that should have uniform colors
         UpdateBackgroundsBasedOnNodeType(graphGraphNodeDefinition);
+    }
+
+    /// <summary>
+    /// Detect if this node is a player node (has refLocalPlayer set to true anywhere in its structure)
+    /// </summary>
+    private void DetectPlayerNode(graphGraphNodeDefinition graphGraphNodeDefinition)
+    {
+        try
+        {
+            // Exclude organizational/logical nodes that don't need player labels
+            if (graphGraphNodeDefinition is questPhaseNodeDefinition or
+                questDeletionMarkerNodeDefinition or
+                questCheckpointNodeDefinition or
+                questLogicalHubNodeDefinition or
+                questLogicalAndNodeDefinition or
+                questLogicalXorNodeDefinition or
+                questFactsDBManagerNodeDefinition or
+                questSceneNodeDefinition)
+            {
+                IsPlayerNode = false;
+                return;
+            }
+            
+            // Check for player node patterns recursively with visited set to prevent infinite loops
+            var visited = new HashSet<object>();
+            IsPlayerNode = CheckForPlayerNodeRecursively(graphGraphNodeDefinition, visited);
+        }
+        catch (System.Exception)
+        {
+            // If detection fails, assume it's not a player node
+            IsPlayerNode = false;
+        }
+    }
+
+    /// <summary>
+    /// Recursively check an object for player node indicators
+    /// </summary>
+    protected bool CheckForPlayerNodeRecursively(object obj, HashSet<object> visited)
+    {
+        if (obj == null) return false;
+        
+        // Prevent infinite recursion by checking if we've already visited this object
+        if (!visited.Add(obj)) return false;
+
+        // Check questUniversalRef for refLocalPlayer
+        if (obj is questUniversalRef universalRef && universalRef.RefLocalPlayer == true)
+        {
+            return true;
+        }
+
+        // Check gameEntityReference for player references
+        if (obj is gameEntityReference entityRef)
+        {
+            // Check if reference contains player identifier
+            var resolvedText = entityRef.Reference.GetResolvedText()!;
+            if (!string.IsNullOrEmpty(resolvedText) && 
+                (resolvedText.Contains("player", StringComparison.OrdinalIgnoreCase) ||
+                 resolvedText == "#player"))
+            {
+                return true;
+            }
+            
+            // Check dynamic entity unique name for player
+            var dynamicEntityName = entityRef.DynamicEntityUniqueName.GetResolvedText();
+            if (!string.IsNullOrEmpty(dynamicEntityName) &&
+                dynamicEntityName.Contains("player", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        // Check specific quest condition types that commonly have player flags
+        if (obj is questTriggerCondition triggerCondition && triggerCondition.IsPlayerActivator == true)
+        {
+            return true;
+        }
+
+        // Check various quest node types that have specific player flags
+        if (obj is questNodeDefinition questNode)
+        {
+            return CheckQuestNodeForPlayerFlags(questNode, visited);
+        }
+
+        // For IRedBaseHandle, check the contained value
+        if (obj is IRedBaseHandle handle)
+        {
+            var handleValue = handle.GetValue();
+            if (handleValue != null)
+            {
+                return CheckForPlayerNodeRecursively(handleValue, visited);
+            }
+        }
+
+        // For collections, check each item
+        if (obj is System.Collections.IEnumerable enumerable and not string)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item != null)
+                {
+                    if (CheckForPlayerNodeRecursively(item, visited))
+                        return true;
+                }
+            }
+        }
+
+        // For RedBaseClass objects, check all properties
+        if (obj is RedBaseClass redObj)
+        {
+            return CheckRedBaseClassForPlayerFlags(redObj, visited);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Check quest node definitions for player-related flags
+    /// </summary>
+    private bool CheckQuestNodeForPlayerFlags(questNodeDefinition questNode, HashSet<object> visited)
+    {
+        // Check common quest node types that have player-specific properties
+        switch (questNode)
+        {
+            case questPauseConditionNodeDefinition pauseCondNode:
+                if (pauseCondNode.Condition?.Chunk != null && CheckForPlayerNodeRecursively(pauseCondNode.Condition.Chunk, visited))
+                    return true;
+                break;
+                
+            case questConditionNodeDefinition condNode:
+                if (condNode.Condition?.Chunk != null && CheckForPlayerNodeRecursively(condNode.Condition.Chunk, visited))
+                    return true;
+                break;
+        }
+
+        // Check all properties of the quest node recursively (but avoid circular references)
+        return CheckRedBaseClassForPlayerFlags(questNode, visited);
+    }
+
+    /// <summary>
+    /// Check RedBaseClass properties for player flags
+    /// </summary>
+    private bool CheckRedBaseClassForPlayerFlags(RedBaseClass obj, HashSet<object> visited)
+    {
+        var type = obj.GetType();
+        var properties = type.GetProperties();
+        
+        foreach (var prop in properties)
+        {
+            try
+            {
+                // Skip properties that might cause issues
+                if (prop.Name == "Chunk" || prop.Name == "Parent") continue;
+                
+                var value = prop.GetValue(obj);
+                if (value != null)
+                {
+                    // Check for specific player-related properties
+                    if (prop.Name.Contains("Player", System.StringComparison.OrdinalIgnoreCase) ||
+                        prop.Name.Contains("refLocalPlayer", System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (value is CBool boolValue && boolValue == true)
+                        {
+                            return true;
+                        }
+                    }
+                    
+                    // Recursively check the property value
+                    if (CheckForPlayerNodeRecursively(value, visited))
+                        return true;
+                }
+            }
+            catch (System.Exception)
+            {
+                // Skip properties that cause exceptions
+                continue;
+            }
+        }
+        
+        return false;
     }
 
     /// <summary>
@@ -45,14 +236,16 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
             typeName = typeName[5..];
         }
 
-        // Remove common suffixes
+        // Remove "NodeDefinition" suffix
         if (typeName.EndsWith("NodeDefinition"))
         {
             typeName = typeName[..^14];
         }
-        else if (typeName.EndsWith("Node"))
+
+        // Remove "Definition" suffix
+        if (typeName.EndsWith("Definition"))
         {
-            typeName = typeName[..^4];
+            typeName = typeName[..^10];
         }
 
         return typeName;
@@ -110,6 +303,10 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
         // Also refresh the title in case it depends on the data
         UpdateTitle();
         OnPropertyChanged(nameof(Title));
+        
+        // Re-detect player node status in case the data changed
+        DetectPlayerNode((graphGraphNodeDefinition)Data);
+        OnPropertyChanged(nameof(IsPlayerNode));
     }
 
     /// <summary>
@@ -118,6 +315,9 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
     /// </summary>
     public override void RefreshFromData()
     {
+        // Re-detect player node status in case the data changed
+        DetectPlayerNode((graphGraphNodeDefinition)Data);
+        
         // Update title
         UpdateTitle();
         OnPropertyChanged(nameof(Title));
@@ -150,11 +350,11 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
     /// </summary>
     protected override void UpdateTitle()
     {
-        if (Data is questNodeDefinition questNode)
-        {
-            var formattedName = FormatQuestNodeName(questNode.GetType().Name);
-            Title = formattedName;
-        }
+        // Format quest node titles properly  
+        Title = FormatQuestNodeName(Data.GetType().Name);
+        
+        // Also notify about player node properties in case they changed
+        OnPropertyChanged(nameof(IsPlayerNode));
     }
 
     private void UpdateBackgroundsBasedOnNodeType(graphGraphNodeDefinition node)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConnectionViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConnectionViewModel.cs
@@ -1,10 +1,14 @@
 ﻿using WolvenKit.RED4.Types;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 
 
-public class QuestConnectionViewModel : ConnectionViewModel
+public partial class QuestConnectionViewModel : ConnectionViewModel
 {
+    [ObservableProperty]
+    private int _pathType = 2; // Default to "live" path (2), dead-end is 1
+    
     public graphGraphConnectionDefinition ConnectionDefinition { get; }
 
     public QuestConnectionViewModel(OutputConnectorViewModel source, InputConnectorViewModel target, graphGraphConnectionDefinition connectionDefinition) : base(source, target)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -38,6 +38,13 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
         {
             Details.Add("Filename", Path.GetFileName(_castedData.PhaseResource.DepotPath.GetResolvedText())!);
         }
+        
+        // Add node count for the phase
+        var nodeCount = GetPhaseNodeCount();
+        if (nodeCount > 0)
+        {
+            Details.Add("Total Nodes", nodeCount.ToString());
+        }
     }
 
     private void GenerateSubGraph()
@@ -126,4 +133,35 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
     }
 
     internal override void CreateDefaultSockets() => CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
+
+    /// <summary>
+    /// Get the total count of nodes in this phase graph
+    /// </summary>
+    private int GetPhaseNodeCount()
+    {
+        // Check embedded graph first
+        if (_castedData.PhaseGraph?.Chunk != null)
+        {
+            return _castedData.PhaseGraph.Chunk.Nodes?.Count ?? 0;
+        }
+        
+        // Check external phase resource
+        if (_castedData.PhaseResource.DepotPath != ResourcePath.Empty)
+        {
+            try
+            {
+                var cr2w = _archiveManager.GetCR2WFile(_castedData.PhaseResource.DepotPath);
+                if (cr2w is { RootChunk: questQuestPhaseResource res } && res.Graph?.Chunk != null)
+                {
+                    return res.Graph.Chunk.Nodes?.Count ?? 0;
+                }
+            }
+            catch (Exception)
+            {
+                // Silently fail if we can't load the resource
+            }
+        }
+        
+        return 0;
+    }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -145,6 +145,194 @@ public partial class RedGraph
         return questNode;
     }
 
+    /// <summary>
+    /// Replace a quest node with a deletion marker node that preserves all connections
+    /// </summary>
+    /// <param name="node">The quest node to replace with a deletion marker</param>
+    private void ReplaceNodeWithQuestDeletionMarkerInternal(BaseQuestViewModel node)
+    {
+        if (_data is not graphGraphDefinition graphDefinition)
+        {
+            _loggerService?.Error("Cannot replace quest node with deletion marker: not a quest graph");
+            return;
+        }
+
+        if (node.Data is questDeletionMarkerNodeDefinition)
+        {
+            _loggerService?.Warning("Cannot replace a deletion marker with another deletion marker");
+            return;
+        }
+
+        if (node.Data is not questNodeDefinition originalQuestNode)
+        {
+            _loggerService?.Error("Cannot replace non-quest node with quest deletion marker");
+            return;
+        }
+
+        // 1. Create a quest deletion marker with the same ID as the node being replaced
+        var deletionMarker = new questDeletionMarkerNodeDefinition
+        {
+            Id = originalQuestNode.Id
+        };
+
+        // 2. Store the ID of the deleted node
+        deletionMarker.DeletedNodeIds.Add(originalQuestNode.Id);
+
+        // 3. Create a node wrapper for the deletion marker (this will create default sockets)
+        var markerWrapper = new questDeletionMarkerNodeDefinitionWrapper(deletionMarker);
+        markerWrapper.Location = node.Location;
+        markerWrapper.DocumentViewModel = DocumentViewModel;
+
+        // 4. Generate the default sockets for the deletion marker (CutDestination, In, Out)
+        markerWrapper.CreateDefaultSockets();
+        markerWrapper.GenerateSockets();
+
+        // 5. Remove the original node from the graph data
+        for (var i = graphDefinition.Nodes.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(graphDefinition.Nodes[i].Chunk, node.Data))
+            {
+                graphDefinition.Nodes.RemoveAt(i);
+                break;
+            }
+        }
+
+        // 6. Add the deletion marker node to the graph data
+        graphDefinition.Nodes.Add(new CHandle<graphGraphNodeDefinition>(deletionMarker));
+
+        // 7. Replace the node in the UI
+        var nodeIndex = Nodes.IndexOf(node);
+        if (nodeIndex >= 0)
+        {
+            Nodes[nodeIndex] = markerWrapper;
+        }
+        else
+        {
+            Nodes.Remove(node);
+            Nodes.Add(markerWrapper);
+        }
+
+        // 8. Map connections from original node to deletion marker's default sockets
+        MapConnectionsToStandardSockets(originalQuestNode, markerWrapper);
+
+        // 9. Update properties in the nodes collection
+        if (GetQuestNodesChunkViewModel() is { } nodes)
+        {
+            nodes.RecalculateProperties();
+        }
+
+        // Save graph state and mark document as dirty
+        GraphStateSave();
+        DocumentViewModel?.SetIsDirty(true);
+
+        _loggerService?.Info($"Replaced quest node {node.UniqueId} with a deletion marker");
+    }
+
+    /// <summary>
+    /// Maps connections from the original node to the deletion marker's standard sockets (In, Out, CutDestination)
+    /// </summary>
+    /// <param name="originalNode">The original node that was replaced</param>
+    /// <param name="markerWrapper">The deletion marker wrapper with default sockets</param>
+    private void MapConnectionsToStandardSockets(questNodeDefinition originalNode, questDeletionMarkerNodeDefinitionWrapper markerWrapper)
+    {
+        // Get the deletion marker's default sockets
+        var markerInSocket = markerWrapper.Input.FirstOrDefault(s => s.Name == "In") as QuestInputConnectorViewModel;
+        var markerOutSocket = markerWrapper.Output.FirstOrDefault(s => s.Name == "Out") as QuestOutputConnectorViewModel;
+        var markerCutDestSocket = markerWrapper.Input.FirstOrDefault(s => s.Name == "CutDestination") as QuestInputConnectorViewModel;
+
+        if (markerInSocket == null || markerOutSocket == null || markerCutDestSocket == null)
+        {
+            _loggerService?.Error("Failed to find deletion marker's default sockets");
+            return;
+        }
+
+        // Process each socket from the original node
+        foreach (var originalSocketHandle in originalNode.Sockets)
+        {
+            var originalSocket = originalSocketHandle.Chunk;
+            if (originalSocket == null) continue;
+
+            // Process each connection from this socket
+            foreach (var connectionHandle in originalSocket.Connections.ToList())
+            {
+                var connection = connectionHandle.Chunk;
+                if (connection == null) continue;
+
+                // Determine if this is an input or output connection from the original node's perspective
+                bool isInputConnection = ReferenceEquals(connection.Destination.Chunk, originalSocket);
+                bool isOutputConnection = ReferenceEquals(connection.Source.Chunk, originalSocket);
+
+                if (isInputConnection)
+                {
+                    // Connection coming TO the original node -> redirect to deletion marker's In socket
+                    // (unless it's a CutDestination type, then use CutDestination socket)
+                    var targetSocket = markerInSocket; // Default to In socket
+                    if (originalSocket is questSocketDefinition questSocket && questSocket.Type == Enums.questSocketType.CutDestination)
+                    {
+                        targetSocket = markerCutDestSocket;
+                    }
+                    
+                    connection.Destination = new CWeakHandle<graphGraphSocketDefinition>(targetSocket.Data);
+                    
+                    // Remove from original socket and add to new socket
+                    originalSocket.Connections.Remove(connectionHandle);
+                    targetSocket.Data.Connections.Add(connectionHandle);
+                }
+                else if (isOutputConnection)
+                {
+                    // Connection going FROM the original node -> redirect from deletion marker's Out socket
+                    connection.Source = new CWeakHandle<graphGraphSocketDefinition>(markerOutSocket.Data);
+                    
+                    // Remove from original socket and add to new socket
+                    originalSocket.Connections.Remove(connectionHandle);
+                    markerOutSocket.Data.Connections.Add(connectionHandle);
+                }
+            }
+        }
+
+        // Update connection states
+        markerInSocket.IsConnected = markerInSocket.Data.Connections.Count > 0;
+        markerOutSocket.IsConnected = markerOutSocket.Data.Connections.Count > 0;
+        markerCutDestSocket.IsConnected = markerCutDestSocket.Data.Connections.Count > 0;
+
+        // Rebuild UI connections
+        RebuildQuestConnections();
+    }
+
+    /// <summary>
+    /// Rebuilds the quest connections in the UI after socket changes
+    /// </summary>
+    private void RebuildQuestConnections()
+    {
+        Connections.Clear();
+        
+        // Create socket lookup table for quest input connectors
+        var socketNodeLookup = new Dictionary<graphGraphSocketDefinition, QuestInputConnectorViewModel>();
+        foreach (var nodeViewModel in Nodes.OfType<BaseQuestViewModel>())
+        {
+            foreach (var inputConnector in nodeViewModel.Input.OfType<QuestInputConnectorViewModel>())
+            {
+                socketNodeLookup[inputConnector.Data] = inputConnector;
+            }
+        }
+
+        // Rebuild connections by iterating through output connectors
+        foreach (var nodeViewModel in Nodes.OfType<BaseQuestViewModel>())
+        {
+            foreach (var outputConnector in nodeViewModel.Output.OfType<QuestOutputConnectorViewModel>())
+            {
+                foreach (var connectionHandle in outputConnector.Data.Connections)
+                {
+                    var connection = connectionHandle.Chunk;
+                    if (connection?.Destination?.Chunk != null && socketNodeLookup.TryGetValue(connection.Destination.Chunk, out var targetInput))
+                    {
+                        Connections.Add(new QuestConnectionViewModel(outputConnector, targetInput, connection));
+                    }
+                }
+            }
+        }
+    }
+
     private void RemoveQuestNode(BaseQuestViewModel node)
     {
         foreach (var inputConnectorViewModel in node.Input)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -188,6 +188,21 @@ public partial class RedGraph : IDisposable
         DocumentViewModel?.SetIsDirty(true);
     }
 
+    /// <summary>
+    /// Replace a quest node with a deletion marker (soft delete)
+    /// </summary>
+    /// <param name="node">The quest node to replace</param>
+    public void ReplaceNodeWithQuestDeletionMarker(BaseQuestViewModel node)
+    {
+        if (GraphType != RedGraphType.Quest)
+        {
+            throw new InvalidOperationException("Cannot replace with quest deletion marker on non-quest graph");
+        }
+
+        // Call the quest-specific implementation from the partial class
+        ReplaceNodeWithQuestDeletionMarkerInternal(node);
+    }
+
     public void DuplicateNode(NodeViewModel node)
     {
         if (!Nodes.Contains(node))

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -5140,11 +5140,11 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     }
     
     /// <summary>
-    /// Get the root node data (scene graph node) that this property belongs to
+    /// Get the root node data (scene or quest graph node) that this property belongs to
     /// </summary>
     private RedBaseClass? GetRootNodeData()
     {
-        // Walk up the tree to find a scene graph node
+        // Walk up the tree to find a scene or quest graph node
         var current = this;
         while (current != null)
         {
@@ -5152,6 +5152,13 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             {
                 return sceneNode;
             }
+            
+            // Also check for quest nodes
+            if (current.Data is questNodeDefinition questNode)
+            {
+                return questNode;
+            }
+            
             current = current.Parent;
         }
         

--- a/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
+++ b/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
@@ -81,6 +81,11 @@ namespace WolvenKit.Converters
                 {
                     chunkViewModel = factory.ChunkViewModel(redData, combinedScene.RDTViewModel, appViewModel);
                 }
+                // If we have a QuestPhaseGraphViewModel, use its RDTViewModel as the tab reference
+                else if (currentTab is QuestPhaseGraphViewModel combinedQuestPhase && combinedQuestPhase.RDTViewModel != null)
+                {
+                    chunkViewModel = factory.ChunkViewModel(redData, combinedQuestPhase.RDTViewModel, appViewModel);
+                }
                 // If we have an RDTDataViewModel directly, use it
                 else if (currentTab is RDTDataViewModel rdtTab)
                 {

--- a/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
+++ b/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
@@ -208,6 +208,36 @@ namespace WolvenKit.Converters
                         }
                     }
                 }
+                // For all quest node types in quest graphs, expand everything one level except sockets
+                else if (redData is questNodeDefinition)
+                {
+                    try
+                    {
+                        // Auto-expand all properties one level deep, but exclude sockets
+                        foreach (var property in rootChunk.TVProperties ?? Enumerable.Empty<ChunkViewModel>())
+                        {
+                            // Skip socket properties to keep them collapsed
+                            if (property.Name.Equals("sockets", StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+                            
+                            try
+                            {
+                                property.CalculateProperties();
+                                property.IsExpanded = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                LoggerService?.Error($"Failed to expand property '{property.Name}' for quest node: {ex.Message}");
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        LoggerService?.Error($"Failed to auto-expand quest node properties: {ex.Message}");
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
@@ -101,6 +101,16 @@
                            Foreground="White" 
                            FontSize="10" 
                            Margin="0,0,16,0"/>
+                <TextBlock Text="Phase Nodes:" 
+                           VerticalAlignment="Center" 
+                           Foreground="Gray" 
+                           FontSize="10" 
+                           Margin="0,0,4,0"/>
+                <TextBlock Text="{Binding TotalPhaseNodes}" 
+                           VerticalAlignment="Center" 
+                           Foreground="White" 
+                           FontSize="10" 
+                           Margin="0,0,16,0"/>
                 <TextBlock Text="Phase Prefabs:" 
                            VerticalAlignment="Center" 
                            Foreground="Gray" 

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
@@ -203,7 +203,21 @@
 
             <!-- Right Panel: Graph Editor -->
             <Grid Grid.Column="2">
-                <graphEditor:GraphEditorView Source="{Binding MainGraph}" x:Name="QuestPhaseGraphEditor" />
+                <graphEditor:GraphEditorView Source="{Binding MainGraph}" x:Name="QuestPhaseGraphEditor" NodeDoubleClick="Editor_OnNodeDoubleClick" />
+                
+                <!-- Breadcrumb Navigation (Floating) -->
+                <Border HorizontalAlignment="Left" 
+                        VerticalAlignment="Top" 
+                        Margin="12,12,0,0"
+                        Background="#DD2A2A2A" 
+                        BorderBrush="#FF404040" 
+                        BorderThickness="1" 
+                        CornerRadius="4"
+                        Padding="8,4">
+                    <StackPanel x:Name="Breadcrumb" Orientation="Horizontal" VerticalAlignment="Center">
+                        <!-- Breadcrumb elements will be dynamically added here -->
+                    </StackPanel>
+                </Border>
                 
                 <!-- Loading Overlay -->
                 <Border Background="#AA000000" 

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
@@ -1,0 +1,250 @@
+<UserControl x:Class="WolvenKit.Views.Documents.QuestPhaseGraphView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:documents="clr-namespace:WolvenKit.App.ViewModels.Documents;assembly=WolvenKit.App"
+             xmlns:local="clr-namespace:WolvenKit.Views.Documents"
+             xmlns:graphEditor="clr-namespace:WolvenKit.Views.GraphEditor"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:shell="clr-namespace:WolvenKit.App.ViewModels.Shell;assembly=WolvenKit.App"
+             xmlns:tools="clr-namespace:WolvenKit.Views.Tools"
+             xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
+             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+             xmlns:nodify="https://miroiu.github.io/nodify"
+             xmlns:questNodes="clr-namespace:WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;assembly=WolvenKit.App"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance documents:QuestPhaseGraphViewModel, IsDesignTimeCreatable=False}"
+             d:DesignHeight="800" d:DesignWidth="1200"
+             PreviewKeyDown="QuestPhaseGraphView_OnPreviewKeyDown">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <!-- Merge Scene Editor specific converters (reused for quest phase) -->
+                <ResourceDictionary Source="/WolvenKit;component/Resources/Converters/SceneEditorConverters.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            
+        <Style x:Key="SpacedWolvenKitTabControl" 
+               BasedOn="{StaticResource WolvenKitTabControl}"
+               TargetType="{x:Type syncfusion:TabControlExt}">
+            <Setter Property="TabItemSelectedBackground" Value="{StaticResource WolvenKitRedShadow}" />
+            <Setter Property="TabItemHoverBackground" Value="{StaticResource WolvenKitRed}" />
+            <Setter Property="TabItemSelectedBorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+            <Setter Property="TabItemHoverBorderBrush" Value="{StaticResource WolvenKitRed}" />
+        </Style>
+        
+        <Style x:Key="SpacedTabItemStyle" 
+               TargetType="{x:Type syncfusion:TabItemExt}"
+               BasedOn="{StaticResource SyncfusionTabItemExtStyle}">
+            <Setter Property="Padding" Value="12,8,12,8"/>
+            <Setter Property="Margin" Value="0,0,2,0"/>
+        </Style>
+        
+        <!-- Quest Connection Template with Variable Thickness -->
+        <DataTemplate x:Key="QuestConnectionTemplate" DataType="{x:Type questNodes:QuestConnectionViewModel}">
+            <nodify:Connection
+                Source="{Binding Source.Anchor}"
+                SourceOffset="7,0"
+                SourceOffsetMode="Static"
+                Target="{Binding Target.Anchor}"
+                TargetOffset="7,0"
+                TargetOffsetMode="Static"
+                IsSelectable="True"
+                IsSelected="{Binding IsSelected}"
+                MouseRightButtonDown="Connection_OnRightClick">
+                <nodify:Connection.Style>
+                    <Style TargetType="{x:Type nodify:BaseConnection}">
+                        <Setter Property="Cursor" Value="Hand" />
+                        <Setter Property="Stroke" Value="#FF7F7F7F" />
+                        <Setter Property="Opacity" Value="1.0" />
+                        <Setter Property="StrokeThickness" 
+                                Value="{Binding PathType, Converter={StaticResource PathTypeToThicknessConverter}}" />
+
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Stroke" Value="{StaticResource WolvenKitYellow}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Stroke" Value="{StaticResource WolvenKitGreen}" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </nodify:Connection.Style>
+            </nodify:Connection>
+        </DataTemplate>
+        
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        
+        <!-- Toolbar -->
+        <Border Grid.Row="0" Background="{StaticResource ContentBackground}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="8,4">
+            <StackPanel Orientation="Horizontal">
+                <iconPacks:PackIconMaterial Kind="InformationOutline" VerticalAlignment="Center" Margin="0,0,8,0" Width="12" Height="12"/>
+                <TextBlock Text="{Binding FileName}" 
+                           VerticalAlignment="Center" 
+                           Foreground="White" 
+                           FontSize="11" 
+                           FontWeight="Medium"
+                           Margin="0,0,16,0"/>
+                <TextBlock Text="Total Nodes:" 
+                           VerticalAlignment="Center" 
+                           Foreground="Gray" 
+                           FontSize="10" 
+                           Margin="0,0,4,0"/>
+                <TextBlock Text="{Binding TotalNodes}" 
+                           VerticalAlignment="Center" 
+                           Foreground="White" 
+                           FontSize="10" 
+                           Margin="0,0,16,0"/>
+                <TextBlock Text="Phase Prefabs:" 
+                           VerticalAlignment="Center" 
+                           Foreground="Gray" 
+                           FontSize="10" 
+                           Margin="0,0,4,0"/>
+                <TextBlock Text="{Binding TotalPhasePrefabs}" 
+                           VerticalAlignment="Center" 
+                           Foreground="White" 
+                           FontSize="10" 
+                           Margin="0,0,16,0"/>
+                <TextBlock Text="Inplace Phases:" 
+                           VerticalAlignment="Center" 
+                           Foreground="Gray" 
+                           FontSize="10" 
+                           Margin="0,0,4,0"/>
+                <TextBlock Text="{Binding TotalInplacePhases}" 
+                           VerticalAlignment="Center" 
+                           Foreground="White" 
+                           FontSize="10" />
+            </StackPanel>
+        </Border>
+
+        <!-- Main Content -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
+
+            <!-- Left Panel: Curated Tab Control -->
+            <syncfusion:TabControlExt Grid.Column="0" 
+                                      Style="{StaticResource SpacedWolvenKitTabControl}"
+                                      ItemContainerStyle="{StaticResource SpacedTabItemStyle}"
+                                      ItemsSource="{Binding Tabs}"
+                                      SelectedItem="{Binding SelectedTab, Mode=TwoWay}"
+                                      EnableLabelEdit="False">
+                <syncfusion:TabControlExt.ItemTemplate>
+                    <DataTemplate DataType="{x:Type documents:QuestPhaseTabDefinition}">
+                        <StackPanel Orientation="Horizontal">
+                            <iconPacks:PackIconMaterial Kind="{Binding Icon}" VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <TextBlock Text="{Binding Header}" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </DataTemplate>
+                </syncfusion:TabControlExt.ItemTemplate>
+                <syncfusion:TabControlExt.ContentTemplate>
+                    <DataTemplate DataType="{x:Type documents:QuestPhaseTabDefinition}">
+                        <Grid>
+                            <!-- Traditional tree view layout for all tabs except Node Properties -->
+                            <Grid>
+                                <Grid.Style>
+                                    <Style TargetType="Grid">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <!-- Hide traditional view for Node Properties tab -->
+                                            <DataTrigger Binding="{Binding Header}" Value="Node Properties">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Grid.Style>
+                                
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="2*" />
+                                </Grid.ColumnDefinitions>
+
+                                <!-- RedTreeView bound directly to the filtered ICollectionView -->
+                                <tools:RedTreeView Grid.Column="0" 
+                                                   ItemsSource="{Binding DataContext.SelectedTabContent, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}"
+                                                   SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}, Mode=TwoWay}"
+                                                   SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}, Mode=TwoWay}"/>
+                                
+                                <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
+                                
+                                <editors:RedTypeView Grid.Column="2" DataContext="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}"/>
+                            </Grid>
+                            
+                            <!-- Node Properties tab shows our custom selection-driven view -->
+                            <local:NodePropertiesView>
+                                <local:NodePropertiesView.Style>
+                                    <Style TargetType="local:NodePropertiesView">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Header}" Value="Node Properties">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </local:NodePropertiesView.Style>
+                            </local:NodePropertiesView>
+                        </Grid>
+                    </DataTemplate>
+                </syncfusion:TabControlExt.ContentTemplate>
+            </syncfusion:TabControlExt>
+
+            <!-- Grid Splitter -->
+            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
+
+            <!-- Right Panel: Graph Editor -->
+            <Grid Grid.Column="2">
+                <graphEditor:GraphEditorView Source="{Binding MainGraph}" x:Name="QuestPhaseGraphEditor" />
+                
+                <!-- Loading Overlay -->
+                <Border Background="#AA000000" 
+                        Visibility="{Binding IsGraphLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <iconPacks:PackIconMaterial Kind="GraphOutline" 
+                                                    Foreground="{StaticResource WolvenKitYellow}"
+                                                    Width="48" 
+                                                    Height="48" 
+                                                    HorizontalAlignment="Center"
+                                                    Margin="0,0,0,16">
+                            <iconPacks:PackIconMaterial.RenderTransform>
+                                <RotateTransform x:Name="LoadingRotation" />
+                            </iconPacks:PackIconMaterial.RenderTransform>
+                            <iconPacks:PackIconMaterial.Triggers>
+                                <EventTrigger RoutedEvent="FrameworkElement.Loaded">
+                                    <BeginStoryboard>
+                                        <Storyboard RepeatBehavior="Forever">
+                                            <DoubleAnimation 
+                                                Storyboard.TargetProperty="RenderTransform.Angle"
+                                                From="0" To="360" Duration="0:0:2" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </EventTrigger>
+                            </iconPacks:PackIconMaterial.Triggers>
+                        </iconPacks:PackIconMaterial>
+                        
+                        <TextBlock Text="Loading quest phase graph..." 
+                                   Foreground="White" 
+                                   FontSize="16" 
+                                   FontWeight="Medium"
+                                   HorizontalAlignment="Center"/>
+                        
+                        <TextBlock Text="Building nodes and connections" 
+                                   Foreground="Gray" 
+                                   FontSize="12" 
+                                   HorizontalAlignment="Center"
+                                   Margin="0,4,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl> 

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -1,0 +1,660 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+using WolvenKit.App.ViewModels.Documents;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.Models;
+using WolvenKit.App.Interaction;
+using Splat;
+using WolvenKit.Views.Dialogs;
+using AdonisUI.Controls;
+
+namespace WolvenKit.Views.Documents
+{
+    /// <summary>
+    /// Interaction logic for QuestPhaseGraphView.xaml
+    /// </summary>
+    public partial class QuestPhaseGraphView : UserControl
+    {
+        // Navigation memory: tracks which child was last visited from each node in each direction
+        private readonly Dictionary<(uint nodeId, Key direction), uint> _navigationMemory = new();
+        private readonly List<uint> _navigationHistory = new();
+
+        public QuestPhaseGraphView()
+        {
+            InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is not QuestPhaseGraphViewModel viewModel) return;
+
+            viewModel.MainGraph.Connections.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
+            viewModel.MainGraph.Nodes.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
+
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                SetupConnectionTemplate();
+                UpdateConnectionPathTypes(viewModel.MainGraph);
+                
+                // Add a small delay to ensure smooth loading experience
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    viewModel.SetGraphLoaded();
+                }), System.Windows.Threading.DispatcherPriority.Background);
+            }), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
+
+        private void SetupConnectionTemplate()
+        {
+            if (QuestPhaseGraphEditor?.Editor == null) return;
+
+            var questConnectionTemplate = Resources["QuestConnectionTemplate"] as DataTemplate;
+            if (questConnectionTemplate != null)
+            {
+                QuestPhaseGraphEditor.Editor.SetCurrentValue(Nodify.NodifyEditor.ConnectionTemplateProperty, questConnectionTemplate);
+            }
+        }
+
+        private void UpdateConnectionPathTypes(RedGraph graph)
+        {
+            if (graph?.Nodes == null || graph.Connections == null)
+                return;
+
+            var pathTypes = CalculateConnectionPathTypes(graph);
+
+            foreach (var connection in graph.Connections.OfType<QuestConnectionViewModel>())
+            {
+                connection.PathType = pathTypes.GetValueOrDefault(connection, 2); // Default to live path
+            }
+        }
+
+        private Dictionary<QuestConnectionViewModel, int> CalculateConnectionPathTypes(RedGraph graph)
+        {
+            var connectionTypeMap = new Dictionary<QuestConnectionViewModel, int>();
+            if (graph?.Connections == null) return connectionTypeMap;
+
+            const int deadEndNodeThreshold = 4;
+            const int deadEndPathType = 1;
+            const int livePathType = 2;
+
+            var adjacencyMap = BuildAdjacencyMap(graph);
+            var endNodeIds = graph.Nodes.OfType<questEndNodeDefinitionWrapper>().Select(n => n.UniqueId).ToList();
+
+            foreach (var connection in graph.Connections.OfType<QuestConnectionViewModel>())
+            {
+                var (containsEndNode, downstreamNodeCount) = CheckPath(
+                    connection.Target.OwnerId,
+                    adjacencyMap,
+                    endNodeIds,
+                    new HashSet<uint>()
+                );
+
+                if (downstreamNodeCount <= deadEndNodeThreshold && !containsEndNode)
+                {
+                    connectionTypeMap[connection] = deadEndPathType;
+                }
+                else
+                {
+                    connectionTypeMap[connection] = livePathType;
+                }
+            }
+
+            return connectionTypeMap;
+        }
+
+        private (bool containsEndNode, int downstreamNodeCount) CheckPath(
+            uint nodeId,
+            Dictionary<uint, List<uint>> adjacencyMap,
+            IReadOnlyCollection<uint> endNodeIds,
+            HashSet<uint> visited)
+        {
+            if (!visited.Add(nodeId))
+            {
+                return (false, 0); // Cycle detected
+            }
+
+            var pathContainsEndNode = endNodeIds.Contains(nodeId);
+            var count = 0;
+
+            if (adjacencyMap.TryGetValue(nodeId, out var neighbors))
+            {
+                foreach (var neighborId in neighbors)
+                {
+                    var result = CheckPath(neighborId, adjacencyMap, endNodeIds, visited);
+                    pathContainsEndNode |= result.containsEndNode;
+                    count += 1 + result.downstreamNodeCount;
+                }
+            }
+
+            return (pathContainsEndNode, count);
+        }
+
+        private Dictionary<uint, List<uint>> BuildAdjacencyMap(RedGraph graph)
+        {
+            var adjacencyMap = new Dictionary<uint, List<uint>>();
+
+            foreach (var connection in graph.Connections.OfType<QuestConnectionViewModel>())
+            {
+                var sourceId = connection.Source.OwnerId;
+                var targetId = connection.Target.OwnerId;
+
+                if (!adjacencyMap.ContainsKey(sourceId))
+                    adjacencyMap[sourceId] = new List<uint>();
+
+                adjacencyMap[sourceId].Add(targetId);
+            }
+
+            return adjacencyMap;
+        }
+
+        /// <summary>
+        /// Smart navigation with memory - cycles through multiple connections in the same direction
+        /// </summary>
+        private WolvenKit.App.ViewModels.GraphEditor.NodeViewModel FindNextNodeInDirection(
+            RedGraph graph, 
+            WolvenKit.App.ViewModels.GraphEditor.NodeViewModel currentNode, 
+            Key direction)
+        {
+            if (graph?.Nodes == null) return null;
+
+            // Get all connected nodes in the specified direction
+            var connectedCandidates = GetConnectedNodesInDirection(graph, currentNode, direction);
+            
+            if (connectedCandidates.Count > 0)
+            {
+                // If we have multiple connected options, use memory to cycle through them
+                if (connectedCandidates.Count > 1)
+                {
+                    return GetNextNodeWithMemory(currentNode.UniqueId, direction, connectedCandidates);
+                }
+                
+                // Single connected option
+                return connectedCandidates[0];
+            }
+
+            // No connected nodes, fallback to spatial navigation for any node in that direction
+            return GetNearestNodeInDirection(graph, currentNode, direction);
+        }
+
+        /// <summary>
+        /// Get connected nodes in the specified direction, sorted by spatial positioning
+        /// </summary>
+        private List<WolvenKit.App.ViewModels.GraphEditor.NodeViewModel> GetConnectedNodesInDirection(
+            RedGraph graph, 
+            WolvenKit.App.ViewModels.GraphEditor.NodeViewModel currentNode, 
+            Key direction)
+        {
+            var candidates = new List<(WolvenKit.App.ViewModels.GraphEditor.NodeViewModel node, double distance)>();
+            var currentX = currentNode.Location.X;
+            var currentY = currentNode.Location.Y;
+
+            // Get all connected nodes
+            var connectedNodeIds = graph.Connections
+                .OfType<WolvenKit.App.ViewModels.GraphEditor.ConnectionViewModel>()
+                .Where(c => c.Source.OwnerId == currentNode.UniqueId || c.Target.OwnerId == currentNode.UniqueId)
+                .Select(c => c.Source.OwnerId == currentNode.UniqueId ? c.Target.OwnerId : c.Source.OwnerId)
+                .ToHashSet();
+
+            foreach (var node in graph.Nodes.Where(n => connectedNodeIds.Contains(n.UniqueId)))
+            {
+                var deltaX = node.Location.X - currentX;
+                var deltaY = node.Location.Y - currentY;
+                var distance = Math.Sqrt(deltaX * deltaX + deltaY * deltaY);
+
+                if (distance < 10) continue;
+
+                bool isInDirection = direction switch
+                {
+                    Key.Right => deltaX > Math.Abs(deltaY) * 0.5,
+                    Key.Left => deltaX < -Math.Abs(deltaY) * 0.5,
+                    Key.Down => deltaY > Math.Abs(deltaX) * 0.5,
+                    Key.Up => deltaY < -Math.Abs(deltaX) * 0.5,
+                    _ => false
+                };
+
+                if (isInDirection)
+                {
+                    candidates.Add((node, distance));
+                }
+            }
+
+            return candidates.OrderBy(c => c.distance).Select(c => c.node).ToList();
+        }
+
+        /// <summary>
+        /// Use navigation memory to cycle through multiple connected options
+        /// </summary>
+        private WolvenKit.App.ViewModels.GraphEditor.NodeViewModel GetNextNodeWithMemory(
+            uint currentNodeId, 
+            Key direction, 
+            List<WolvenKit.App.ViewModels.GraphEditor.NodeViewModel> candidates)
+        {
+            var memoryKey = (currentNodeId, direction);
+            
+            // Check if we have memory for this node/direction combination
+            if (_navigationMemory.TryGetValue(memoryKey, out var lastVisitedId))
+            {
+                // Find the index of the last visited node
+                var lastIndex = candidates.FindIndex(n => n.UniqueId == lastVisitedId);
+                if (lastIndex >= 0)
+                {
+                    // Return the next node in the cycle
+                    var nextIndex = (lastIndex + 1) % candidates.Count;
+                    return candidates[nextIndex];
+                }
+            }
+
+            // No memory or last visited node not found, return first candidate
+            return candidates[0];
+        }
+
+        /// <summary>
+        /// Fallback spatial navigation for unconnected nodes
+        /// </summary>
+        private WolvenKit.App.ViewModels.GraphEditor.NodeViewModel GetNearestNodeInDirection(
+            RedGraph graph, 
+            WolvenKit.App.ViewModels.GraphEditor.NodeViewModel currentNode, 
+            Key direction)
+        {
+            var candidates = new List<(WolvenKit.App.ViewModels.GraphEditor.NodeViewModel node, double distance)>();
+            var currentX = currentNode.Location.X;
+            var currentY = currentNode.Location.Y;
+
+            foreach (var node in graph.Nodes)
+            {
+                if (node.UniqueId == currentNode.UniqueId) continue;
+
+                var deltaX = node.Location.X - currentX;
+                var deltaY = node.Location.Y - currentY;
+                var distance = Math.Sqrt(deltaX * deltaX + deltaY * deltaY);
+
+                if (distance < 10) continue;
+
+                bool isInDirection = direction switch
+                {
+                    Key.Right => deltaX > Math.Abs(deltaY) * 0.5,
+                    Key.Left => deltaX < -Math.Abs(deltaY) * 0.5,
+                    Key.Down => deltaY > Math.Abs(deltaX) * 0.5,
+                    Key.Up => deltaY < -Math.Abs(deltaX) * 0.5,
+                    _ => false
+                };
+
+                if (isInDirection)
+                {
+                    candidates.Add((node, distance));
+                }
+            }
+
+            return candidates.OrderBy(c => c.distance).FirstOrDefault().node;
+        }
+
+        /// <summary>
+        /// Update navigation memory when moving between nodes
+        /// </summary>
+        private void UpdateNavigationMemory(uint fromNodeId, Key direction, uint toNodeId)
+        {
+            var memoryKey = (fromNodeId, direction);
+            _navigationMemory[memoryKey] = toNodeId;
+            
+            // Also update navigation history for potential future features
+            _navigationHistory.Add(toNodeId);
+            
+            // Keep history manageable (last 50 moves)
+            if (_navigationHistory.Count > 50)
+            {
+                _navigationHistory.RemoveAt(0);
+            }
+        }
+
+        /// <summary>
+        /// Smoothly pan the graph view towards the selected node
+        /// </summary>
+        private void CenterViewOnSelectedNode(RedGraph graph, WolvenKit.App.ViewModels.GraphEditor.NodeViewModel targetNode)
+        {
+            if (QuestPhaseGraphEditor?.Editor == null || graph == null || targetNode == null)
+                return;
+
+            try 
+            {
+                var editor = QuestPhaseGraphEditor.Editor;
+                var nodeLocation = targetNode.Location;
+                var currentViewport = editor.ViewportLocation;
+                var viewportSize = editor.ViewportSize;
+                
+                // Calculate if node is already reasonably visible
+                var nodeViewportX = nodeLocation.X - currentViewport.X;
+                var nodeViewportY = nodeLocation.Y - currentViewport.Y;
+                
+                var margin = 150; // Larger margin to trigger panning earlier
+                var needsPanX = nodeViewportX < margin || nodeViewportX > viewportSize.Width - margin;
+                var needsPanY = nodeViewportY < margin || nodeViewportY > viewportSize.Height - margin;
+                
+                if (!needsPanX && !needsPanY)
+                    return; // Node is already well visible, no need to pan
+                
+                // Calculate target viewport location (center the node more nicely)
+                var targetX = currentViewport.X;
+                var targetY = currentViewport.Y;
+                
+                if (needsPanX)
+                {
+                    // Center horizontally with slight offset to avoid perfect centering (less jarring)
+                    targetX = nodeLocation.X - (viewportSize.Width * 0.4); // 40% from left edge
+                }
+                
+                if (needsPanY)
+                {
+                    // Center vertically with slight offset
+                    targetY = nodeLocation.Y - (viewportSize.Height * 0.4); // 40% from top edge
+                }
+                
+                // Smooth animated pan
+                AnimateViewportTo(new Point(targetX, targetY), TimeSpan.FromMilliseconds(300));
+            }
+            catch (Exception)
+            {
+                // Silently handle any viewport manipulation errors
+            }
+        }
+
+        /// <summary>
+        /// Animate viewport to target location with smooth easing
+        /// </summary>
+        private void AnimateViewportTo(Point targetLocation, TimeSpan duration)
+        {
+            if (QuestPhaseGraphEditor?.Editor == null) return;
+            
+            var editor = QuestPhaseGraphEditor.Editor;
+            var startLocation = editor.ViewportLocation;
+            var startTime = DateTime.Now;
+            
+            var timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(16)
+            };
+            
+            timer.Tick += (sender, e) =>
+            {
+                var elapsed = DateTime.Now - startTime;
+                var progress = Math.Min(elapsed.TotalMilliseconds / duration.TotalMilliseconds, 1.0);
+                
+                if (progress >= 1.0)
+                {
+                    editor.ViewportLocation = targetLocation;
+                    timer.Stop();
+                    return;
+                }
+                
+                // Smooth easing function (ease-out)
+                var easedProgress = 1 - Math.Pow(1 - progress, 3);
+                
+                var currentX = startLocation.X + (targetLocation.X - startLocation.X) * easedProgress;
+                var currentY = startLocation.Y + (targetLocation.Y - startLocation.Y) * easedProgress;
+                
+                editor.ViewportLocation = new Point(currentX, currentY);
+            };
+            
+            timer.Start();
+        }
+
+        /// <summary>
+        /// Search for a node by its ID and navigate to it
+        /// </summary>
+        public bool SearchAndNavigateToNode(uint nodeId)
+        {
+            var viewModel = DataContext as QuestPhaseGraphViewModel;
+            if (viewModel?.MainGraph?.Nodes == null)
+                return false;
+
+            // Find the node with the specified ID
+            var targetNode = viewModel.MainGraph.Nodes.FirstOrDefault(n => n.UniqueId == nodeId);
+            if (targetNode == null)
+                return false;
+
+            // Select the node
+            QuestPhaseGraphEditor?.Editor?.SelectedItems.Clear();
+            QuestPhaseGraphEditor?.Editor?.SelectedItems.Add(targetNode);
+            NodeSelectionService.Instance.SelectedNode = targetNode;
+
+            // Center view on the node
+            CenterViewOnSelectedNode(viewModel.MainGraph, targetNode);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Shows a dialog to go directly to a node by its ID
+        /// </summary>
+        public void ShowGoToNodeDialog()
+        {
+            var dialog = new InputDialogView("Go to Node", "");
+
+            if (dialog.ViewModel is not InputDialogViewModel vm ||
+                dialog.ShowDialog(Application.Current.MainWindow) != true)
+            {
+                return;
+            }
+
+            if (uint.TryParse(vm.Text?.Trim(), out var nodeId))
+            {
+                if (!SearchAndNavigateToNode(nodeId))
+                {
+                    MessageBoxModel messageBox = new()
+                    {
+                        Text = $"Node with ID {nodeId} not found.",
+                        Caption = "Go to Node",
+                        Icon = AdonisUI.Controls.MessageBoxImage.Information,
+                        Buttons = new[] { MessageBoxButtons.Ok() }
+                    };
+                    AdonisUI.Controls.MessageBox.Show(Application.Current.MainWindow, messageBox);
+                }
+            }
+            else
+            {
+                MessageBoxModel messageBox = new()
+                {
+                    Text = "Please enter a valid numeric Node ID.",
+                    Caption = "Invalid Input",
+                    Icon = AdonisUI.Controls.MessageBoxImage.Warning,
+                    Buttons = new[] { MessageBoxButtons.Ok() }
+                };
+                AdonisUI.Controls.MessageBox.Show(Application.Current.MainWindow, messageBox);
+            }
+        }
+
+        /// <summary>
+        /// Handles keyboard shortcuts for node deletion and navigation
+        /// </summary>
+        private void QuestPhaseGraphView_OnPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            var viewModel = DataContext as QuestPhaseGraphViewModel;
+            if (viewModel?.MainGraph == null)
+                return;
+
+            // Shortcut: Delete key to soft delete, Shift+Delete for hard delete
+            if (e.Key == Key.Delete)
+            {
+                // Use SelectedNodes from underlying GraphEditor
+                var selectedNodes = QuestPhaseGraphEditor?.Editor?.SelectedItems?
+                    .OfType<BaseQuestViewModel>()
+                    .Where(node => !(node is questStartNodeDefinitionWrapper || node is questEndNodeDefinitionWrapper)) // Can't delete start/end nodes
+                    .ToList();
+
+                if (selectedNodes != null && selectedNodes.Count > 0)
+                {
+                    if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+                    {
+                        // Shift+Del: Hard delete (permanent removal)
+                        var nodeViewModels = selectedNodes.Cast<object>().ToList();
+                        viewModel.MainGraph.RemoveNodes(nodeViewModels);
+                    }
+                    else
+                    {
+                        // Del: Hard delete for quest nodes (no soft delete/deletion markers)
+                        var nodeViewModels = selectedNodes.Cast<object>().ToList();
+                        viewModel.MainGraph.RemoveNodes(nodeViewModels);
+                    }
+                    e.Handled = true;
+                }
+            }
+
+            // Shortcut: Ctrl+D to duplicate currently selected node
+            if (e.Key == Key.D && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+            {
+                var selectedNode = NodeSelectionService.Instance.SelectedNode;
+                if (selectedNode != null)
+                {
+                    viewModel.MainGraph.DuplicateNode(selectedNode);
+                    e.Handled = true;
+                }
+            }
+
+            // Shortcut: Ctrl+N to open new node dialog
+            if (e.Key == Key.N && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+            {
+                OpenNewNodeDialog(viewModel.MainGraph);
+                e.Handled = true;
+            }
+
+            // Shortcut: Ctrl+G to open "go to node" dialog
+            if (e.Key == Key.G && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+            {
+                ShowGoToNodeDialog();
+                e.Handled = true;
+                return;
+            }
+
+            // Shortcut: Arrow keys for smart graph walk based on spatial positioning
+            if (e.Key is Key.Left or Key.Right or Key.Up or Key.Down)
+            {
+                var currentNode = NodeSelectionService.Instance.SelectedNode;
+                if (currentNode == null)
+                    return;
+
+                var next = FindNextNodeInDirection(viewModel.MainGraph, currentNode, e.Key);
+
+                if (next != null)
+                {
+                    // Update navigation memory
+                    UpdateNavigationMemory(currentNode.UniqueId, e.Key, next.UniqueId);
+                    
+                    // Update selection in editor
+                    QuestPhaseGraphEditor?.Editor?.SelectedItems.Clear();
+                    QuestPhaseGraphEditor?.Editor?.SelectedItems.Add(next);
+                    NodeSelectionService.Instance.SelectedNode = next;
+                    
+                    // Auto-scroll graph view to keep selected node visible
+                    CenterViewOnSelectedNode(viewModel.MainGraph, next);
+                    
+                    e.Handled = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Open the new node type selector dialog
+        /// </summary>
+        private async void OpenNewNodeDialog(RedGraph graph)
+        {
+            if (graph?.GraphType != RedGraphType.Quest) return;
+
+            try
+            {
+                var appViewModel = Locator.Current.GetService<AppViewModel>();
+                if (appViewModel == null) return;
+
+                // Get quest node types
+                var questNodeTypes = graph.GetQuestNodeTypes();
+                
+                var questTypes = questNodeTypes
+                    .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Quest", x))
+                    .OrderBy(x => x.Name)
+                    .ToList();
+
+                // Create and show the type selector dialog
+                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(questTypes)
+                {
+                    DialogHandler = model =>
+                    {
+                        appViewModel.CloseDialogCommand.Execute(null);
+                        if (model is TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType })
+                        {
+                            // Create new node at current viewport center
+                            var viewportCenter = GetViewportCenter();
+                            graph.CreateQuestNode(selectedType, viewportCenter);
+                        }
+                    }
+                });
+            }
+            catch (Exception)
+            {
+                // Silently handle any dialog creation errors
+            }
+        }
+
+        /// <summary>
+        /// Get the center point of the current viewport for placing new nodes
+        /// </summary>
+        private Point GetViewportCenter()
+        {
+            if (QuestPhaseGraphEditor?.Editor == null)
+                return new Point(0, 0);
+
+            var viewport = QuestPhaseGraphEditor.Editor.ViewportLocation;
+            var size = QuestPhaseGraphEditor.Editor.ViewportSize;
+            
+            return new Point(
+                viewport.X + size.Width / 2,
+                viewport.Y + size.Height / 2
+            );
+        }
+
+        /// <summary>
+        /// Forward connection right-click events to the underlying GraphEditorView
+        /// </summary>
+        private void Connection_OnRightClick(object sender, MouseButtonEventArgs e)
+        {
+            // Forward the event to the underlying GraphEditorView's Connection_OnRightClick method
+            QuestPhaseGraphEditor?.Connection_OnRightClick(sender, e);
+        }
+
+        /// <summary>
+        /// Selects a node by its ID
+        /// </summary>
+        private void SelectNodeById(uint nodeId)
+        {
+            var viewModel = DataContext as QuestPhaseGraphViewModel;
+            if (viewModel?.MainGraph?.Nodes == null || QuestPhaseGraphEditor?.Editor == null) return;
+
+            // Find the node with the specified ID
+            var targetNode = viewModel.MainGraph.Nodes.FirstOrDefault(n => n.UniqueId == nodeId);
+
+            if (targetNode != null)
+            {
+                // Clear current selection
+                QuestPhaseGraphEditor.Editor.SelectedItems.Clear();
+                
+                // Select the target node
+                QuestPhaseGraphEditor.Editor.SelectedItems.Add(targetNode);
+                
+                // Update the NodeSelectionService
+                NodeSelectionService.Instance.SelectedNode = targetNode;
+            }
+        }
+    }
+} 

--- a/WolvenKit/Views/Documents/RedDocumentView.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentView.xaml
@@ -53,6 +53,10 @@
                 <docV:SceneGraphView DataContext="{Binding}" />
             </DataTemplate>
 
+            <DataTemplate DataType="{x:Type docVM:QuestPhaseGraphViewModel}">
+                <docV:QuestPhaseGraphView DataContext="{Binding}" />
+            </DataTemplate>
+
         </Grid.Resources>
 
         <Grid.RowDefinitions>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -445,7 +445,7 @@ public partial class GraphEditorView : UserControl
             node.ContextMenu.Items.Add(new Separator());
         }
 
-                node.ContextMenu.Items.Add(CreateMenuItem("Destroy Node", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNode(nvm)));
+        node.ContextMenu.Items.Add(CreateMenuItem("Destroy Node", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNode(nvm)));
 
         // Add deletion markers info for scene graphs for now
         if (Source.GraphType == RedGraphType.Scene)


### PR DESCRIPTION
# Quest Editor
![image](https://github.com/user-attachments/assets/1bf8d988-4a72-4cf7-b3e5-b43f52bf89e2)

Follow on from #2444 - this PR adds a similar interface for editing .questphase files

I'm using most of the same converters, helpers, and overall architecture I used for the Scene Editor so the realtime sync, tabs, node styling work out of the box. The questphase resource is also a bit simpler so there are only two tabs: Node Properties and Phase Resources

One additional thing that had to be accounted is nested graphs via Phase node: I've rearranged the existing breadcrumb view but all existing functionality is mostly drop in (double click to open Phase node etc). But double clicking a Scene node will now show a popup redirecting you to the Scene Editor (and will no longer open the scene graph in the Quest Editor)

![image](https://github.com/user-attachments/assets/9dc7ad54-1985-45e2-9f0c-15a1a77e722f)

I've also worked on the node selection logic a bit to ensure we clear a selected node when navigating to a different questphase/scene and some selection restoration logic when you navigate back.

Right click context menu has a similar layout doing similar things:
![image](https://github.com/user-attachments/assets/cd444a47-6015-4e0c-a078-eeeafb435371)

Ctr + G also works (Goto node ID)

Some remaining things:
- [x] isPlayer label
- [ ] Add Node dialog improvements similar to [d271fad](https://github.com/WolvenKit/WolvenKit/pull/2444/commits/d271fad33b71b9efb356d46d365574bceebbb7ed) 
