### PR TITLE
fix multi-selection sync issues in RedTreeView

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewToolbarModel.cs
@@ -133,10 +133,8 @@ public partial class RedDocumentViewToolbarModel : ObservableObject
 
         SelectedChunk = (ChunkViewModel?)dataViewModel.SelectedChunk;
         SelectedChunks.Clear();
-        if (dataViewModel.SelectedChunks is IList list)
-        {
-            SelectedChunks.AddRange(list.OfType<ChunkViewModel>());
-        }
+        var chunkViewModels = dataViewModel.SelectedChunks?.OfType<ChunkViewModel>().ToList() ?? [];
+        SelectedChunks.AddRange(chunkViewModels);
 
         RefreshContextMenuItems();
 

--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -2027,6 +2027,7 @@
         SelectedItems="{Binding ElementName=redTreeView,
                                 Path=SelectedItems,
                                 Mode=TwoWay}"
+        SelectionChanged="OnSelectionChanged"
         MouseDoubleClick="OnDoubleClick"
         MouseRightButtonDown="OnMouseRightButtonDown"
         SelectionMode="Extended"

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -1372,6 +1372,28 @@ namespace WolvenKit.Views.Tools
 
         }
 
+        private void OnSelectionChanged(object sender, ItemSelectionChangedEventArgs e)
+        {
+            if (sender is not SfTreeView treeView)
+                return;
+
+            var selectedChunks = treeView.SelectedItems?.OfType<ChunkViewModel>().ToList() ?? new List<ChunkViewModel>();
+            
+            // Update the dependency properties
+            SetCurrentValue(SelectedItemsProperty, new ObservableCollection<object>(selectedChunks));
+            SetCurrentValue(SelectedItemProperty, selectedChunks.LastOrDefault());
+
+            // Update the RDTDataViewModel
+            if (selectedChunks.Count > 0)
+            {
+                _rdtDataViewModel?.SetSelection(selectedChunks);
+            }
+            else
+            {
+                _rdtDataViewModel?.ClearSelection();
+            }
+        }
+
         private void OnDoubleClick(object sender, MouseButtonEventArgs e)
         {
             if (SelectedItem is null)


### PR DESCRIPTION
- change SelectedChunks to ObservableCollection and fix property change timing in batch operations with suppression
- add SelectionChanged event handler for reliable multi-select sync
