### PR TITLE
updated dropdown for journal entries

### DIFF
--- a/WolvenKit.App/Helpers/CvmDropdownHelper.cs
+++ b/WolvenKit.App/Helpers/CvmDropdownHelper.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.App.ViewModels.Shell;
-using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.Core.Extensions;
 using WolvenKit.RED4.Types;
-using Splat;
 
 namespace WolvenKit.App.Helpers;
 
@@ -50,61 +48,9 @@ public abstract class CvmDropdownHelper
         "meshAppearance", "appearanceName"
     ];
 
-    /// <summary>
-    /// Finds the scene resource context, either from the root model or from the current document
-    /// </summary>
-    private static scnSceneResource? GetSceneContext(ChunkViewModel cvm)
-    {
-        // First try the normal root model approach
-        var rootModel = cvm.GetRootModel();
-        if (rootModel?.ResolvedData is scnSceneResource sceneFromRoot)
-        {
-            return sceneFromRoot;
-        }
-
-
-        // If that doesn't work, we might be in the graph editor context
-        // Try to get the scene from the current document
-        try
-        {
-            var appViewModel = Locator.Current.GetService<App.ViewModels.Shell.AppViewModel>();
-            
-            if (appViewModel?.ActiveDocument is RedDocumentViewModel redDoc)
-            {
-
-                // Check if we have a SceneGraphViewModel
-                if (redDoc.SelectedTabItemViewModel is SceneGraphViewModel combinedScene)
-                {
-                    var sceneRootChunk = combinedScene.RDTViewModel.GetRootChunk();
-                    
-                    if (sceneRootChunk?.ResolvedData is scnSceneResource sceneFromCombined)
-                    {
-                        return sceneFromCombined;
-                    }
-                }
-                
-                // Check if we have an RDTDataViewModel with scene data
-                if (redDoc.SelectedTabItemViewModel is RDTDataViewModel rdtTab)
-                {
-                    var rdtRootChunk = rdtTab.GetRootChunk();
-                    
-                    if (rdtRootChunk?.ResolvedData is scnSceneResource sceneFromRdt)
-                    {
-                        return sceneFromRdt;
-                    }
-                }
-            }
-        }
-        catch (System.Exception)
-        {
-            // Fallback gracefully if service lookup fails
-        }
-        return null;
-    }
-
 
     public static Dictionary<string, string> GetDropdownOptions(ChunkViewModel cvm, DocumentTools documentTools,
-        bool forceCacheRefresh = false)
+        bool forceCacheRefresh = false, string? filter = null)
     {
         if (cvm.Parent is not ChunkViewModel parent)
         {
@@ -114,11 +60,11 @@ public abstract class CvmDropdownHelper
         IEnumerable<string?> ret = [];
         switch (parent.ResolvedData)
         {
-            case gameJournalPath when cvm.Name is "className" && parent.Name is not null && s_questHandleParentNames.Contains(parent.Name):
+            case gameJournalPath when cvm.Name is "className" && s_questHandleParentNames.Contains(parent.Name):
                 ret = RedTypeHelper.GetExtendingClassNames(typeof(gameJournalEntry));
                 break;
             case gameJournalPath journalPath when cvm.Name is "realPath":
-                ret = documentTools.GetAllJournalPaths(forceCacheRefresh);
+                ret = documentTools.GetAllJournalPathsAsync(forceCacheRefresh, filter).Result.Select(path => (string?)path);
                 break;
             case entISkinTargetComponent when cvm.Name is "renderingPlaneAnimationParam":
                 ret = s_appFileRenderPlane;
@@ -223,383 +169,7 @@ public abstract class CvmDropdownHelper
                 break;
         }
 
-        // Special case for scnActorId.Id - check if we're editing the Id property of a scnActorId
-        if (cvm.Name == "id" && parent.ResolvedData is scnActorId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Generate dropdown options for actor IDs with actor names
-                // Key = display text, Value = actual ID value
-                var actorOptions = new Dictionary<string, string>();
-                
-                // Add regular actors
-                for (int i = 0; i < scene.Actors.Count; i++)
-                {
-                    var actor = scene.Actors[i];
-                    string actorName = actor.ActorName; // Implicit conversion from CString to string
-                    if (string.IsNullOrEmpty(actorName))
-                    {
-                        actorName = $"Actor {i}";
-                    }
-                    actorOptions.Add($"{i}: {actorName}", i.ToString());
-                }
-                
-                // Add player actors
-                for (int i = 0; i < scene.PlayerActors.Count; i++)
-                {
-                    var playerActor = scene.PlayerActors[i];
-                    var actorId = scene.Actors.Count + i;
-                    string actorName = playerActor.PlayerName; // Implicit conversion from CString to string
-                    if (string.IsNullOrEmpty(actorName))
-                    {
-                        actorName = $"Player Actor {i}";
-                    }
-                    actorOptions.Add($"{actorId}: {actorName}", actorId.ToString());
-                }
-                
-                return actorOptions;
-            }
-        }
-
-        // Special case for scnPerformerId.Id - check if we're editing the Id property of a scnPerformerId
-        if (cvm.Name == "id" && parent.ResolvedData is scnPerformerId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context (where IDs should be editable) vs usage context (where dropdown is helpful)
-                // Definition contexts: debugSymbols.performersDebugSymbols, actors, playerActors, props, etc.
-                // Usage contexts: scene events, quest nodes, etc.
-                
-                var parentPath = GetParentPath(cvm);
-                
-                // Skip dropdown if we're in definition contexts
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for performer IDs with performer names from debugSymbols
-                // Key = display text, Value = actual ID value
-                var performerOptions = new Dictionary<string, string>();
-                
-                if (scene.DebugSymbols?.PerformersDebugSymbols != null)
-                {
-                    foreach (var performerSymbol in scene.DebugSymbols.PerformersDebugSymbols)
-                    {
-                        var performerId = performerSymbol.PerformerId.Id;
-                        var performerIdValue = ((uint)performerId).ToString();
-                        
-                        // Try to get performer name from various sources
-                        string performerName = $"Performer {performerIdValue}";
-                        
-                        // Try first name in Names array first (most reliable)
-                        if (performerSymbol.EntityRef.Names.Count > 0)
-                        {
-                            if (performerSymbol.EntityRef.Names[0] != "None")
-                            {
-                                performerName = performerSymbol.EntityRef.Names[0]!;
-                            }
-                        }
-                        
-                        // If Names didn't work, try Reference (NodeRef)
-                        if (performerName == $"Performer {performerIdValue}")
-                        {
-                            var referenceString = performerSymbol.EntityRef.Reference.GetResolvedText() ?? "";
-                            if (!string.IsNullOrEmpty(referenceString) && referenceString != "0")
-                            {
-                                // Remove the # prefix if present
-                                performerName = referenceString.StartsWith("#") ? referenceString.Substring(1) : referenceString;
-                            }
-                        }
-                        
-                        // Try SceneActorContextName
-                        if (performerName == $"Performer {performerIdValue}")
-                        {
-                            if (performerSymbol.EntityRef.SceneActorContextName != "None")
-                            {
-                                performerName = performerSymbol.EntityRef.SceneActorContextName!;
-                            }
-                        }
-                        
-                        // Try DynamicEntityUniqueName
-                        if (performerName == $"Performer {performerIdValue}")
-                        {
-                            if (performerSymbol.EntityRef.DynamicEntityUniqueName != "None")
-                            {
-                                performerName = performerSymbol.EntityRef.DynamicEntityUniqueName!;
-                            }
-                        }
-                        
-                        performerOptions.Add($"{performerIdValue}: {performerName}", performerIdValue);
-                    }
-                }
-                
-                return performerOptions;
-            }
-        }
-
-        // Special case for scnSceneWorkspotInstanceId.Id - check if we're editing the Id property of a scnSceneWorkspotInstanceId
-        if (cvm.Name == "id" && parent.ResolvedData is scnSceneWorkspotInstanceId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for workspot instance IDs with workspot resource names
-                // Key = display text, Value = actual ID value
-                var workspotOptions = new Dictionary<string, string>();
-                
-                foreach (var workspotInstance in scene.WorkspotInstances)
-                {
-                    var instanceId = workspotInstance.WorkspotInstanceId.Id;
-                    var instanceDataId = workspotInstance.DataId.Id;
-                    
-                    // Find the workspot resource by DataId
-                    var workspotResource = scene.Workspots.FirstOrDefault(w => w.Chunk is scnWorkspotData workspotData && workspotData.DataId.Id == instanceDataId);
-                    var workspotPath = "Unknown";
-                    
-                    if (workspotResource?.Chunk is scnWorkspotData_ExternalWorkspotResource externalWorkspot)
-                    {
-                        workspotPath = externalWorkspot.WorkspotResource.DepotPath.GetResolvedText() ?? "Unknown";
-                    }
-                    
-                    // Extract filename without extension and get origin marker
-                    var filename = System.IO.Path.GetFileNameWithoutExtension(workspotPath);
-                    var originMarkerText = workspotInstance.OriginMarker.NodeRef.GetResolvedText();
-                    var originMarker = string.IsNullOrEmpty(originMarkerText) ? "Unknown" : originMarkerText;
-                    
-                    var displayText = $"{instanceId}: {filename} ({originMarker})";
-                    workspotOptions[displayText] = instanceId.ToString();
-                }
-                
-                return workspotOptions;
-            }
-        }
-
-        // Special case for scnEffectInstanceId.Id - check if we're editing the Id property of a scnEffectInstanceId
-        if (cvm.Name == "id" && parent.ResolvedData is scnEffectInstanceId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for effect instance IDs with effect resource names and first RUID
-                // Key = display text, Value = actual ID value
-                var effectOptions = new Dictionary<string, string>();
-                
-                foreach (var effectInstance in scene.EffectInstances)
-                {
-                    var instanceId = effectInstance.EffectInstanceId.Id;
-                    var effectId = effectInstance.EffectInstanceId.EffectId.Id;
-                    var effectDef = scene.EffectDefinitions
-                        .FirstOrDefault(e => e.Id.Id == effectId);
-                    
-                    if (effectDef != null)
-                    {
-                        var effectPath = effectDef.Effect.DepotPath.GetResolvedText();
-                        if (!string.IsNullOrEmpty(effectPath))
-                        {
-                            var filename = System.IO.Path.GetFileNameWithoutExtension(effectPath);
-                            
-                            // Get first RUID from compiled effect if available
-                            string ruidInfo = "";
-                            if (effectInstance.CompiledEffect?.EventsSortedByRUID != null && effectInstance.CompiledEffect.EventsSortedByRUID.Count > 0)
-                            {
-                                ruidInfo = $": {effectInstance.CompiledEffect.EventsSortedByRUID[0].EventRUID}";
-                            }
-                            
-                            effectOptions[$"{instanceId}: {filename}{ruidInfo}"] = instanceId.ToString();
-                        }
-                        else
-                        {
-                            effectOptions[$"{instanceId}: [No Effect Path]"] = instanceId.ToString();
-                        }
-                    }
-                    else
-                    {
-                        effectOptions[$"{instanceId}: [Unknown Effect]"] = instanceId.ToString();
-                    }
-                }
-                
-                return effectOptions;
-            }
-        }
-
-        // Special case for scnPropId.Id - check if we're editing the Id property of a scnPropId
-        if (cvm.Name == "id" && parent.ResolvedData is scnPropId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for prop IDs with prop names
-                // Key = display text, Value = actual ID value
-                var propOptions = new Dictionary<string, string>();
-                
-                foreach (var propDefinition in scene.Props)
-                {
-                    var propId = propDefinition.PropId.Id;
-                    var propName = propDefinition.PropName.ToString();
-                    
-                    if (!string.IsNullOrEmpty(propName))
-                    {
-                        propOptions[$"{propId}: {propName}"] = propId.ToString();
-                    }
-                    else
-                    {
-                        propOptions[$"{propId}: [Unnamed Prop]"] = propId.ToString();
-                    }
-                }
-                
-                return propOptions;
-            }
-        }
-
-        // Special case for scnCinematicAnimSetSRRefId.Id - check if we're editing the Id property of a scnCinematicAnimSetSRRefId
-        if (cvm.Name == "id" && parent.ResolvedData is scnCinematicAnimSetSRRefId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for cinematic animation set IDs with animation file paths
-                // Key = display text, Value = actual ID value (index)
-                var animSetOptions = new Dictionary<string, string>();
-                
-                if (scene.ResouresReferences?.CinematicAnimSets != null)
-                {
-                    for (int i = 0; i < scene.ResouresReferences.CinematicAnimSets.Count; i++)
-                    {
-                        var animSet = scene.ResouresReferences.CinematicAnimSets[i];
-                        var animSetPath = animSet.AsyncAnimSet.DepotPath.GetResolvedText();
-                        
-                        if (!string.IsNullOrEmpty(animSetPath))
-                        {
-                            var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
-                            var displayText = $"{i}: {filename}.anims";
-                            
-                            animSetOptions[displayText] = i.ToString();
-                        }
-                        else
-                        {
-                            animSetOptions[$"{i}: [No Animation Set Path]"] = i.ToString();
-                        }
-                    }
-                }
-                
-                return animSetOptions;
-            }
-        }
-
-        // Special case for scnLipsyncAnimSetSRRefId.Id - check if we're editing the Id property of a scnLipsyncAnimSetSRRefId
-        if (cvm.Name == "id" && parent.ResolvedData is scnLipsyncAnimSetSRRefId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for lipsync animation set IDs with animation file paths
-                // Key = display text, Value = actual ID value (index)
-                var animSetOptions = new Dictionary<string, string>();
-                
-                if (scene.ResouresReferences?.LipsyncAnimSets != null)
-                {
-                    for (int i = 0; i < scene.ResouresReferences.LipsyncAnimSets.Count; i++)
-                    {
-                        var animSet = scene.ResouresReferences.LipsyncAnimSets[i];
-                        var animSetPath = animSet.AsyncRefLipsyncAnimSet.DepotPath.GetResolvedText();
-                        
-                        if (!string.IsNullOrEmpty(animSetPath))
-                        {
-                            var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
-                            var displayText = $"{i}: {filename}.anims";
-                            animSetOptions[displayText] = i.ToString();
-                        }
-                        else
-                        {
-                            animSetOptions[$"{i}: [No Animation Set Path]"] = i.ToString();
-                        }
-                    }
-                }
-                
-                return animSetOptions;
-            }
-        }
-
-        // Special case for scnDynamicAnimSetSRRefId.Id - check if we're editing the Id property of a scnDynamicAnimSetSRRefId
-        if (cvm.Name == "id" && parent.ResolvedData is scnDynamicAnimSetSRRefId)
-        {
-            var scene = GetSceneContext(cvm);
-            if (scene != null)
-            {
-                // Check if we're in a definition context vs usage context
-                var parentPath = GetParentPath(cvm);
-                if (IsInDefinitionContext(parentPath))
-                {
-                    return new Dictionary<string, string>(); // Return empty to use regular integer editor
-                }
-                
-                // Generate dropdown options for dynamic animation set IDs with animation file paths
-                // Key = display text, Value = actual ID value (index)
-                var animSetOptions = new Dictionary<string, string>();
-                
-                if (scene.ResouresReferences?.DynamicAnimSets != null)
-                {
-                    for (int i = 0; i < scene.ResouresReferences.DynamicAnimSets.Count; i++)
-                    {
-                        var animSet = scene.ResouresReferences.DynamicAnimSets[i];
-                        var animSetPath = animSet.AsyncAnimSet.DepotPath.GetResolvedText();
-                        
-                        if (!string.IsNullOrEmpty(animSetPath))
-                        {
-                            var filename = System.IO.Path.GetFileNameWithoutExtension(animSetPath);
-                            var displayText = $"{i}: {filename}.anims";
-                            animSetOptions[displayText] = i.ToString();
-                        }
-                        else
-                        {
-                            animSetOptions[$"{i}: [No Animation Set Path]"] = i.ToString();
-                        }
-                    }
-                }
-                
-                return animSetOptions;
-            }
-        }
-
-        return (ret ?? []).Where(x => !string.IsNullOrEmpty(x)).ToDictionary(x => x!, y => y!);
+        return ret.Where(x => !string.IsNullOrEmpty(x)).ToDictionary(x => x!, y => y!);
     }
 
     /// <summary>
@@ -607,20 +177,9 @@ public abstract class CvmDropdownHelper
     /// </summary>
     public static bool HasDropdownOptions(ChunkViewModel cvm)
     {
-        var parent = cvm.Parent;
-        if (parent == null)
+        if (cvm.Parent is not ChunkViewModel parent)
         {
             return false;
-        }
-
-        // Check if we're in a definition context first - if so, always use regular editor
-        if (cvm.Name == "id")
-        {
-            var parentPath = GetParentPath(cvm);
-            if (IsInDefinitionContext(parentPath))
-            {
-                return false; // Use regular integer editor for definition contexts
-            }
         }
 
         return parent.ResolvedData switch
@@ -640,44 +199,19 @@ public abstract class CvmDropdownHelper
 
             #region ent 
             appearanceAppearancePart when cvm.Name is ("appearanceResource" or "resource") => true,
-            entSkinnedMeshComponent when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
+            entSkinnedMeshComponent when s_appearanceNames.Contains(cvm.Name) => true,
             entSkinnedMeshComponent when parent.Name == "mesh" => true,
-            entEntityTemplate when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
+            entEntityTemplate when s_appearanceNames.Contains(cvm.Name) => true,
             entTemplateAppearance when cvm.Name is ("appearanceName" or "appearanceResource") => true,
             #endregion
 
             #region app
-            appearanceAppearanceResource when cvm.Name is not null && s_appearanceNames.Contains(cvm.Name) => true,
-            IRedRef when cvm.Name is "resource" && cvm.Parent?.ResolvedData is appearanceAppearancePart => true,
+            appearanceAppearanceResource when s_appearanceNames.Contains(cvm.Name) => true,
+            IRedRef when cvm.Name is "resource" && cvm.Parent.ResolvedData is appearanceAppearancePart => true,
             #endregion
     
             // tags: ent and app
             IRedArray<CName> when parent is { Name: "tags", Parent.ResolvedData: redTagList } => true,
-
-            // scnActorId.Id dropdown - check if this is an id property in a scnActorId and we have scene context
-            scnActorId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnPerformerId.Id dropdown
-            scnPerformerId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnSceneWorkspotInstanceId.Id dropdown
-            scnSceneWorkspotInstanceId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnEffectInstanceId.Id dropdown
-            scnEffectInstanceId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnPropId.Id dropdown
-            scnPropId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnCinematicAnimSetSRRefId.Id dropdown
-            scnCinematicAnimSetSRRefId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnLipsyncAnimSetSRRefId.Id dropdown
-            scnLipsyncAnimSetSRRefId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
-            // scnDynamicAnimSetSRRefId.Id dropdown
-            scnDynamicAnimSetSRRefId when cvm.Name == "id" && GetSceneContext(cvm) != null => true,
-
             
             #region questPhase
             graphGraphNodeDefinition when cvm.Name is ("phaseResource" or "sceneFile") => true,
@@ -711,63 +245,5 @@ public abstract class CvmDropdownHelper
                        !string.IsNullOrEmpty(matInstance.BaseMaterial.DepotPath.GetResolvedText()) => true,
             _ => false
         };
-    }
-
-    /// <summary>
-    /// Gets the parent path of a ChunkViewModel to determine context
-    /// </summary>
-    private static string GetParentPath(ChunkViewModel cvm)
-    {
-        var pathParts = new List<string>();
-        var current = cvm.Parent;
-        
-        while (current != null)
-        {
-            if (!string.IsNullOrEmpty(current.PropertyName))
-            {
-                pathParts.Add(current.PropertyName);
-            }
-            else if (!string.IsNullOrEmpty(current.Name))
-            {
-                pathParts.Add(current.Name);
-            }
-            current = current.Parent;
-        }
-        
-        pathParts.Reverse();
-        return string.Join(".", pathParts);
-    }
-    
-    /// <summary>
-    /// Determines if we're in a definition context where IDs should be editable
-    /// vs usage context where dropdowns are helpful
-    /// </summary>
-    private static bool IsInDefinitionContext(string parentPath)
-    {
-        // Usage contexts that can be inside definition paths
-        var usagePaths = new[]
-        {
-            "bodyCinematicAnimSets",
-            "lipsyncAnimSet",
-            "dynamicAnimSets"
-        };
-        if (usagePaths.Any(parentPath.Contains))
-        {
-            return false;
-        }
-
-        // Definition contexts where IDs should be directly editable
-        var definitionPaths = new[]
-        {
-            "debugSymbols.performersDebugSymbols",  // Performer definitions
-            "actors",                               // Actor definitions  
-            "playerActors",                         // Player actor definitions
-            "props",                                // Prop definitions
-            "workspotInstances",                    // Workspot instance definitions
-            "effectInstances",                      // Effect instance definitions
-            "effectDefinitions"                     // Effect definitions
-        };
-        
-        return definitionPaths.Any(parentPath.Contains);
     }
 }

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -8,6 +8,10 @@ using WolvenKit.Common;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Types;
+using System.Threading.Tasks;
+using System;
+using System.Collections.Concurrent;
+
 
 namespace WolvenKit.App.Helpers;
 
@@ -20,6 +24,116 @@ public class DocumentTools
 
     public static Regex PlaceholderRegex { get; } = new Regex(@"^[-=_]+$");
 
+    // Class-level CR2WFile cache
+    private readonly Dictionary<string, CR2WFile?> _cr2wFileCache = new();
+
+    // LFU + TTL cache for filtered results (file path + filter)
+    private readonly Dictionary<(string filePath, string filter), FilteredCacheEntry> _filteredResultsCache = new();
+    private readonly SortedDictionary<int, HashSet<(string filePath, string filter)>> _frequencyMap = new();
+    private readonly Dictionary<(string filePath, string filter), int> _keyFrequency = new();
+    private const int FilteredCacheLimit = 100;
+    private const int FilteredCacheTTLMinutes = 30;
+    private DateTime _lastCleanupTime = DateTime.UtcNow;
+    private const int CleanupIntervalMinutes = 5; // Only cleanup every 5 minutes
+
+    // Cache entry with metadata for LFU + TTL
+    private class FilteredCacheEntry
+    {
+        public List<string> Results { get; set; }
+        public DateTime CachedAt { get; set; }
+
+        public FilteredCacheEntry(List<string> results)
+        {
+            Results = results;
+            CachedAt = DateTime.UtcNow;
+        }
+
+        public bool IsExpired => DateTime.UtcNow.Subtract(CachedAt).TotalMinutes > FilteredCacheTTLMinutes;
+    }
+
+
+
+    // Helper methods for LFU cache operations
+    private void IncrementFrequency((string filePath, string filter) key)
+    {
+        if (!_keyFrequency.ContainsKey(key)) return;
+
+        var oldFreq = _keyFrequency[key];
+        var newFreq = oldFreq + 1;
+
+        // Remove from old frequency bucket
+        if (_frequencyMap.ContainsKey(oldFreq))
+        {
+            _frequencyMap[oldFreq].Remove(key);
+            if (_frequencyMap[oldFreq].Count == 0)
+            {
+                _frequencyMap.Remove(oldFreq);
+            }
+        }
+
+        // Add to new frequency bucket
+        if (!_frequencyMap.ContainsKey(newFreq))
+        {
+            _frequencyMap[newFreq] = new HashSet<(string filePath, string filter)>();
+        }
+        _frequencyMap[newFreq].Add(key);
+        _keyFrequency[key] = newFreq;
+    }
+
+    private void RemoveFromCache((string filePath, string filter) key)
+    {
+        if (_filteredResultsCache.Remove(key))
+        {
+            if (_keyFrequency.TryGetValue(key, out var freq))
+            {
+                if (_frequencyMap.ContainsKey(freq))
+                {
+                    _frequencyMap[freq].Remove(key);
+                    if (_frequencyMap[freq].Count == 0)
+                    {
+                        _frequencyMap.Remove(freq);
+                    }
+                }
+                _keyFrequency.Remove(key);
+            }
+        }
+    }
+
+    private void EvictLeastFrequentlyUsed()
+    {
+        if (_frequencyMap.Count == 0) return;
+
+        var leastFreq = _frequencyMap.First().Key;
+        var leastFreqSet = _frequencyMap[leastFreq];
+        
+        if (leastFreqSet.Count > 0)
+        {
+            var keyToEvict = leastFreqSet.First();
+            RemoveFromCache(keyToEvict);
+        }
+    }
+
+    private void CleanupExpiredEntries()
+    {
+        // Lazy cleanup - only run every 5 minutes
+        var now = DateTime.UtcNow;
+        if (now.Subtract(_lastCleanupTime).TotalMinutes < CleanupIntervalMinutes)
+        {
+            return;
+        }
+        _lastCleanupTime = now;
+
+        var expiredKeys = _filteredResultsCache
+            .Where(kvp => kvp.Value.IsExpired)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in expiredKeys)
+        {
+            RemoveFromCache(key);
+        }
+    }
+
     public DocumentTools(ILoggerService loggerService, Cr2WTools cr2WTools, IArchiveManager archiveManager,
         IProjectManager projectManager)
     {
@@ -30,82 +144,211 @@ public class DocumentTools
     }
 
     #region journalFile
-    
-    private static readonly List<string> s_journalJournalsByPath = [];
-    
-    public IEnumerable<string?> GetAllJournalPaths(bool forceCacheRefresh)
+
+    public async Task<List<string>> GetAllJournalPathsAsync(bool forceCacheRefresh, string? filter = null, bool sortAndDistinct = true)
     {
         if (_projectManager.ActiveProject is not { } activeProject)
-        {
             return [];
-        }
-        
+
+        var journalPaths = CollectProjectFiles(".journal");
+
         if (forceCacheRefresh)
         {
-            s_journalJournalsByPath.Clear();
-        }
-        
-        if (s_journalJournalsByPath.Count > 0)
-        {
-            s_journalJournalsByPath.Order();
-        }
-        
-        s_journalJournalsByPath.AddRange(CollectProjectFiles(".journal"));
-    
-        List<string> journalIDs = [];
-        
-        foreach (var journal in s_journalJournalsByPath)
-        {
-            if (activeProject.GetAbsolutePath(journal) is string absolutePath && File.Exists(absolutePath))
+            foreach (var journal in journalPaths)
             {
-                if (_cr2WTools.ReadCr2W(absolutePath) is CR2WFile cr2W)
+                if (activeProject.GetAbsolutePath(journal) is string absolutePath)
                 {
-                    journalIDs.AddRange(GetJournalIDs(cr2W).Where(id => !journalIDs.Contains(id)));
+                    _cr2wFileCache.Remove(absolutePath);
+                    // Remove all filtered cache entries for this file
+                    foreach (var key in _filteredResultsCache.Keys.Where(k => k.filePath == absolutePath).ToList())
+                    {
+                        RemoveFromCache(key);
+                    }
+                }
+            }
+            // Remove all filtered cache entries for the current filter value
+            if (!string.IsNullOrEmpty(filter))
+            {
+                foreach (var key in _filteredResultsCache.Keys.Where(k => k.filter == filter).ToList())
+                {
+                    RemoveFromCache(key);
                 }
             }
         }
-    
-        return journalIDs;
+
+        var validJournalPaths = journalPaths
+            .Select(journal => new { journal, absolutePath = activeProject.GetAbsolutePath(journal) })
+            .Where(x => x.absolutePath is not null && File.Exists(x.absolutePath))
+            .ToList();
+
+        var tasks = validJournalPaths.Select(async x =>
+        {
+            if (!_cr2wFileCache.TryGetValue(x.absolutePath!, out var cr2w))
+            {
+                cr2w = _cr2WTools.ReadCr2W(x.absolutePath!);
+                _cr2wFileCache[x.absolutePath!] = cr2w;
+            }
+            return await GetJournalIDsAsync(cr2w, x.absolutePath!, filter);
+        });
+
+        var results = await Task.WhenAll(tasks);
+        IEnumerable<string> allIds = results.SelectMany(ids => ids);
+        if (sortAndDistinct && (string.IsNullOrEmpty(filter) || sortAndDistinct))
+        {
+            allIds = allIds.Distinct().OrderBy(x => x);
+        }
+        return allIds.ToList();
     }
 
-    private List<string> GetJournalIDs(CR2WFile? cr2W)
+    private async Task<List<string>> GetJournalIDsAsync(CR2WFile? cr2W, string absoluteFilePath, string? filter = null)
     {
-        if (cr2W?.RootChunk is not gameJournalResource journalResource)
+        if (cr2W == null || string.IsNullOrEmpty(filter)) return [];
+
+        var filterKey = (absoluteFilePath, filter);
+
+        CleanupExpiredEntries();
+
+        if (_filteredResultsCache.TryGetValue(filterKey, out var cachedFiltered) && !cachedFiltered.IsExpired)
         {
-            return [];
+            IncrementFrequency(filterKey);
+            return cachedFiltered.Results;
         }
 
-        if (journalResource.Entry.Chunk == null)
+        var entriesIDs = await ProcessJournalEntries(cr2W, filter);
+
+        _filteredResultsCache[filterKey] = new FilteredCacheEntry(entriesIDs);
+        _keyFrequency[filterKey] = 1;
+
+        if (!_frequencyMap.ContainsKey(1))
         {
-            return [];
+            _frequencyMap[1] = new HashSet<(string filePath, string filter)>();
+        }
+        _frequencyMap[1].Add(filterKey);
+
+        if (_filteredResultsCache.Count > FilteredCacheLimit)
+        {
+            EvictLeastFrequentlyUsed();
         }
 
-        List<string> entriesIDs = [];
-        if (journalResource.Entry.Chunk is gameJournalContainerEntry journalEntry)
-        {
-            ProcessJournalEntries(journalEntry.Entries, entriesIDs, "");
-        }    
         return entriesIDs;
     }
 
-    private void ProcessJournalEntries(IList<CHandle<gameJournalEntry>> entries, List<string> entriesIDs, string currentPath)
+    private async Task<List<string>> ProcessJournalEntries(CR2WFile? cr2W, string filter)
     {
-        foreach (var entry in entries)
+        if (cr2W?.RootChunk is not gameJournalResource journalResource || 
+            journalResource.Entry.Chunk is not gameJournalContainerEntry journalEntry)
         {
-            if (entry.Chunk != null)
+            return [];
+        }
+
+        var rootPath = journalResource.Entry.Chunk?.Id.ToString() ?? "";
+        var entriesIDs = new List<string>(50);
+
+        await ProcessEntries(journalEntry.Entries, entriesIDs, rootPath, filter);
+
+        return entriesIDs;
+    }
+
+    private Task ProcessEntries(IList<CHandle<gameJournalEntry>> entries, List<string> results, string currentPath, string filterStr)
+    {
+        if (entries.Count == 0) return Task.CompletedTask;
+
+        // Use parallel processing for larger entry sets
+        if (entries.Count > 5)
+        {
+            var bag = new System.Collections.Concurrent.ConcurrentBag<string>();
+            System.Threading.Tasks.Parallel.ForEach(entries, entry =>
             {
-                string entryId = entry.Chunk.Id.ToString();
-                string entryPath = string.IsNullOrEmpty(currentPath) ? entryId : $"{currentPath}/{entryId}";
-            
-                entriesIDs.Add(entryPath);
-            
+                if (entry.Chunk != null)
+                {
+                    ProcessEntry(entry, currentPath, filterStr, bag);
+                }
+            });
+            results.AddRange(bag);
+        }
+        else
+        {
+            // Sequential processing for small entry sets
+            foreach (var entry in entries)
+            {
+                if (entry.Chunk != null)
+                {
+                    ProcessEntry(entry, currentPath, filterStr, results);
+                }
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    private void ProcessEntry(CHandle<gameJournalEntry> entry, string currentPath, string filterStr, object results)
+    {
+        var entryId = entry.Chunk!.Id.ToString();
+        var entryPath = string.IsNullOrEmpty(currentPath) ? entryId : $"{currentPath}/{entryId}";
+
+        // Check if this entry matches the filter
+        if (ContainsFilter(entryPath, filterStr))
+        {
+            // Handle both ICollection<string> and ConcurrentBag<string>
+            if (results is ICollection<string> collection)
+            {
+                collection.Add(entryPath);
+            }
+            else if (results is System.Collections.Concurrent.ConcurrentBag<string> bag)
+            {
+                bag.Add(entryPath);
+            }
+        }
+
+        // Always process children if it's a container entry
+        if (entry.Chunk is gameJournalContainerEntry containerEntry)
+        {
+            ProcessContainerChildren(containerEntry.Entries, entryPath, filterStr, results);
+        }
+    }
+
+    private void ProcessContainerChildren(IList<CHandle<gameJournalEntry>> entries, string parentPath, string filterStr, object results)
+    {
+        var stack = new Stack<(IList<CHandle<gameJournalEntry>>, string)>();
+        stack.Push((entries, parentPath));
+
+        while (stack.Count > 0)
+        {
+            var (currentEntries, currentPath) = stack.Pop();
+            foreach (var entry in currentEntries)
+            {
+                if (entry.Chunk == null) continue;
+
+                var entryId = entry.Chunk.Id.ToString();
+                var entryPath = $"{currentPath}/{entryId}";
+
+                // Check if this entry matches the filter
+                if (ContainsFilter(entryPath, filterStr))
+                {
+                    if (results is ICollection<string> collection)
+                    {
+                        collection.Add(entryPath);
+                    }
+                    else if (results is System.Collections.Concurrent.ConcurrentBag<string> bag)
+                    {
+                        bag.Add(entryPath);
+                    }
+                }
+
+                // Always add children to stack if it's a container
                 if (entry.Chunk is gameJournalContainerEntry containerEntry)
                 {
-                    ProcessJournalEntries(containerEntry.Entries, entriesIDs, entryPath);
+                    stack.Push((containerEntry.Entries, entryPath));
                 }
             }
         }
     }
+
+    // Optimized filter checking with case-insensitive comparison
+    private static bool ContainsFilter(string text, string filter)
+    {
+        return text.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
     #endregion
     
     # region appfile

--- a/WolvenKit/Views/Templates/FilterableDropdownRedstringMenu.xaml
+++ b/WolvenKit/Views/Templates/FilterableDropdownRedstringMenu.xaml
@@ -54,6 +54,7 @@
             Style="{StaticResource WolvenkitTextBoxStyle}"
             helpers:TextBoxBehavior.TripleClickSelectAll="True"
             KeyboardNavigation.TabIndex="1"
+            KeyDown="FilterTextBox_KeyDown"
             Text="{Binding FilterText,
                            RelativeSource={RelativeSource AncestorType={x:Type editors:FilterableDropdownRedstringMenu}},
                            Mode=TwoWay}" />

--- a/WolvenKit/Views/Templates/FilterableDropdownRedstringMenu.xaml.cs
+++ b/WolvenKit/Views/Templates/FilterableDropdownRedstringMenu.xaml.cs
@@ -41,18 +41,89 @@ namespace WolvenKit.Views.Editors
                         x => x.RedStringEditor.RedString)
                     .DisposeWith(disposables);
 
-                SetCurrentValue(OptionsProperty, CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, false));
+                SetCurrentValue(OptionsProperty, CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, false, FilterText));
                 SetCurrentValue(ShowRefreshButtonProperty, CvmDropdownHelper.ShouldShowRefreshButton(vm));
+
+                // Also update options when FilterText changes
+                this.WhenAnyValue(x => x.FilterText)
+                    .Subscribe(filterText => 
+                    {
+                        // Refresh cache whenever filter text changes (including when it becomes empty)
+                        SetCurrentValue(OptionsProperty, CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, true, filterText));
+                    })
+                    .DisposeWith(disposables);
+
+                // Show/hide dropdown based on filter and results
+                this.WhenAnyValue(x => x.FilterText, x => x.FilteredOptions)
+                    .Subscribe(tuple =>
+                    {
+                        var (filter, filteredOptions) = tuple;
+                        
+                        if (IsJournalEntryField(vm))
+                        {
+                            // For journal entries, always show and enable the dropdown
+                            Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                            Dropdown.SetCurrentValue(IsEnabledProperty, true);
+                            
+                            if (string.IsNullOrWhiteSpace(filter))
+                            {
+                                Dropdown.SetCurrentValue(ComboBox.TextProperty, "Type to search journal entries...");
+                            }
+                            else if (filteredOptions != null && filteredOptions.Count > 0)
+                            {
+                                // Clear the text to show the dropdown items
+                                Dropdown.SetCurrentValue(ComboBox.TextProperty, "");
+                            }
+                            else
+                            {
+                                Dropdown.SetCurrentValue(ComboBox.TextProperty, "No matching entries found");
+                            }
+                        }
+                        else
+                        {
+                            // For non-journal entries, use the original logic
+                            if (string.IsNullOrWhiteSpace(filter))
+                            {
+                                // No filter provided - show dropdown but disable it with helpful message
+                                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                                Dropdown.SetCurrentValue(IsEnabledProperty, false);
+                                Dropdown.SetCurrentValue(ComboBox.TextProperty, "Type to search...");
+                            }
+                            else if (filteredOptions != null && filteredOptions.Count > 0)
+                            {
+                                // Filter provided and results found - show and enable dropdown
+                                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+                            }
+                            else
+                            {
+                                // Filter provided but no results - show dropdown and enable it so user can see the message
+                                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+                                Dropdown.SetCurrentValue(ComboBox.TextProperty, "No matching entries found");
+                            }
+                        }
+                    })
+                    .DisposeWith(disposables);
 
                 if (!ShowRefreshButton)
                 {
                     Col3.SetCurrentValue(ColumnDefinition.WidthProperty, new GridLength(0));
                 }
 
-                // If we don't have any options, no reason to show the dropdown - disable these UI elements
-                // and show only the default RedString editor
-                if (Options.Count == 0 && !ShowRefreshButton)
+                // For journal entries, always show the filter UI even if no options are loaded initially
+                if (IsJournalEntryField(vm))
                 {
+                    // Always show filter UI for journal entries
+                    Row1.SetCurrentValue(RowDefinition.HeightProperty, GridLength.Auto);
+                    Row2.SetCurrentValue(RowDefinition.HeightProperty, new GridLength(5));
+                    Placeholder.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                    Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                    FilterTextBox.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                }
+                else if (Options.Count == 0 && !ShowRefreshButton)
+                {
+                    // For non-journal entries, hide UI if no options
                     Row1.SetCurrentValue(RowDefinition.HeightProperty, new GridLength(0));
                     Row2.SetCurrentValue(RowDefinition.HeightProperty, new GridLength(0));
                     Placeholder.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
@@ -255,8 +326,111 @@ namespace WolvenKit.Views.Editors
             }
 
             SetCurrentValue(OptionsProperty,
-                CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, true));
+                CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, true, FilterText));
             RecalculateFilteredOptions();
+        }
+
+        private static bool IsJournalEntryField(ChunkViewModel vm)
+        {
+            return vm.Parent?.ResolvedData is gameJournalPath && vm.Name == "realPath";
+        }
+
+        private void UpdateDropdownState()
+        {
+            var filter = FilterText;
+            var filteredOptions = FilteredOptions;
+            
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                // No filter provided - show dropdown but disable it with helpful message
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, false);
+                Dropdown.SetCurrentValue(ComboBox.TextProperty, "Type to search journal entries...");
+            }
+            else if (filteredOptions != null && filteredOptions.Count > 0)
+            {
+                // Filter provided and results found - show and enable dropdown
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+            }
+            else
+            {
+                // Filter provided but no results - show dropdown and enable it so user can see the message
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+                Dropdown.SetCurrentValue(ComboBox.TextProperty, "No matching entries found");
+            }
+        }
+
+        private void UpdateDropdownStateFromFilter(string filterText)
+        {
+            // Recalculate filtered options first
+            RecalculateFilteredOptions();
+            
+            var filteredOptions = FilteredOptions;
+            
+            if (string.IsNullOrWhiteSpace(filterText))
+            {
+                // No filter provided - show dropdown but disable it with helpful message
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, false);
+                Dropdown.SetCurrentValue(ComboBox.TextProperty, "Type to search journal entries...");
+            }
+            else if (filteredOptions != null && filteredOptions.Count > 0)
+            {
+                // Filter provided and results found - show and enable dropdown
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+            }
+            else
+            {
+                // Filter provided but no results - show dropdown and enable it so user can see the message
+                Dropdown.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+                Dropdown.SetCurrentValue(IsEnabledProperty, true);
+                Dropdown.SetCurrentValue(ComboBox.TextProperty, "No matching entries found");
+            }
+        }
+
+
+
+        private void FilterTextBox_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter && !string.IsNullOrWhiteSpace(FilterText))
+            {
+                e.Handled = true;
+                
+                // Force refresh to load filtered results
+                if (DataContext is ChunkViewModel vm)
+                {
+                    SetCurrentValue(OptionsProperty, CvmDropdownHelper.GetDropdownOptions(vm, _documentTools, true, FilterText));
+                    RecalculateFilteredOptions();
+                }
+                
+                // Always move focus to dropdown and open it
+                Dropdown.SetCurrentValue(ComboBox.IsDropDownOpenProperty, true);
+                Dropdown.Focus();
+            }
+            else if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                e.Handled = true;
+                
+                // Clear the filter text
+                SetCurrentValue(FilterTextProperty, "");
+                
+                // Close dropdown if open
+                Dropdown.SetCurrentValue(ComboBox.IsDropDownOpenProperty, false);
+                
+                // Move focus back to filter textbox
+                FilterTextBox.Focus();
+            }
+            else if (e.Key == System.Windows.Input.Key.Down && FilteredOptions?.Count > 0)
+            {
+                e.Handled = true;
+                
+                // Open dropdown and move focus to it
+                Dropdown.SetCurrentValue(ComboBox.IsDropDownOpenProperty, true);
+                Dropdown.Focus();
+            }
         }
     }
 }


### PR DESCRIPTION
- Refactored DocumentTools to only process and cache journal entries IDs when a filter is provided, removing unnecessary logic for unfiltered cases.
- Improved FilterableDropdownRedstringMenu to provide more responsive filtering for journal entries.
- Updated CvmDropdownHelper to support the new filtering behavior.