### PR TITLE
fix: set default socketName for Input nodes

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -140,6 +140,11 @@ public partial class RedGraph
                 // Initialize the Type property with questSetVar_NodeType (the only implementation)
                 factsDBNode.Type = new CHandle<questIFactsDBManagerNodeType>(new questSetVar_NodeType());
             }
+
+            if (nodeDefinition is questInputNodeDefinition inputNode)
+            {
+                inputNode.SocketName = "In1";
+            }
         }
 
         return questNode;


### PR DESCRIPTION
# set default socketName for Input nodes

**Fixed:**
Reported on Discord: Assign a default socketName label for Input quest nodes on creation (as expected by AXL)
