### PR TITLE
CVM material properties: follow mi chain

### DIFF
--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -804,6 +804,12 @@ public class DocumentTools
         {
             ret.AddRange(FilterByType(cvmResolvedData, cachedList));
         }
+        else if (materialPath.EndsWith(".mi") &&
+                 ReadCr2WFromRelativePath(materialPath) is { RootChunk: CMaterialInstance mi } &&
+                 mi.BaseMaterial.DepotPath.GetResolvedText() is string baseMaterial)
+        {
+            ret.AddRange(GetMaterialKeys(cvmResolvedData, baseMaterial, forceCacheRefresh));
+        }
         else if (ReadCr2WFromRelativePath(materialPath) is not { RootChunk: CMaterialTemplate template })
         {
             ret = [];


### PR DESCRIPTION
# CVM material properties: follow mi chain

CVM dropdown for material propertie names will now be correctly be populated, even if there are a bunch of .mi files in the way