### PR TITLE
fix: prevent quest/scene node tree collapse when editing properties

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/BaseQuestViewModel.cs
@@ -322,9 +322,6 @@ public abstract class BaseQuestViewModel : GraphEditor.NodeViewModel, IRefreshab
         UpdateTitle();
         OnPropertyChanged(nameof(Title));
         
-        // DON'T regenerate sockets for quest nodes
-        OnPropertyChanged(nameof(Data));
-        
         // Refresh details
         RefreshDetails();
     }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/Internal/BaseSceneViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/Internal/BaseSceneViewModel.cs
@@ -378,9 +378,8 @@ public abstract class BaseSceneViewModel : NodeViewModel, IRefreshableDetails
         OnPropertyChanged(nameof(Title));
 
         // DON'T regenerate sockets here – counts are unchanged
-        TriggerPropertyChanged(nameof(Output));
-        TriggerPropertyChanged(nameof(Input));
-        OnPropertyChanged(nameof(Data));
+        OnPropertyChanged(nameof(Output));
+        OnPropertyChanged(nameof(Input));
         
         // Refresh details if implemented by derived class (this is important for property sync)
         if (this is IRefreshableDetails refreshable)


### PR DESCRIPTION
# fix: prevent quest/scene node tree collapse when editing properties

**Fixed:**
Removed unnecessary Data property change notifications from both RefreshFromData() methods for scene and quest nodes which was causing the whole node property tree to lose its expansion states while editing a node property

This is unnecessary because individual ChunkViewModels already handle their own property changes through data binding so sync between the panel <> graph is unaffected

