### PR TITLE
fix: optimize graph connection and scnChoiceNode operations

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
@@ -512,18 +512,6 @@ public class scnChoiceNodeWrapper : BaseSceneViewModel<scnChoiceNode>, IRefresha
         // Notify UI and mark document dirty
         NotifySocketsChanged();
         
-        // Refresh the property panel to show the new screenplay/localization entries
-        if (DocumentViewModel != null)
-        {
-            var sceneGraphTab = DocumentViewModel.TabItemViewModels
-                .OfType<SceneGraphViewModel>()
-                .FirstOrDefault();
-                
-            if (sceneGraphTab?.MainGraph is RedGraph graph)
-            {
-                graph.RefreshSceneResourcePropertiesInTabs();
-            }
-        }
     }
 
     /// <summary>
@@ -566,17 +554,5 @@ public class scnChoiceNodeWrapper : BaseSceneViewModel<scnChoiceNode>, IRefresha
 
         NotifySocketsChanged();
         
-        // Refresh the property panel to show the removed screenplay/localization entries
-        if (DocumentViewModel != null)
-        {
-            var sceneGraphTab = DocumentViewModel.TabItemViewModels
-                .OfType<SceneGraphViewModel>()
-                .FirstOrDefault();
-                
-            if (sceneGraphTab?.MainGraph is RedGraph graph)
-            {
-                graph.RefreshSceneResourcePropertiesInTabs();
-            }
-        }
-    }
+   }
 }


### PR DESCRIPTION
# optimize graph connection and scnChoiceNode operations

Fixed:

Looks like I left a lot of unnecessary expensive recursive property updates (during some point in my first iteration of scene editor when I was first working on sync), and as a result:
- Large scenes took forever to add or delete a connection
- Choice node operations like add socket also triggered a unnecessary complete scene resource refresh

This is now fixed as I removed most of these calls and replaced them with updates that are done selectively and smartly, and with sync still intact