### PR TITLE
feat(CLI): add build command

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -465,7 +465,10 @@ public class RED4Controller : ObservableObject, IGameController
     /// This method will move everything into ModDirectory/packed.
     /// </summary>
     private async Task<bool> PackProjectFilesAsync(LaunchProfile options, Cp77Project cp77Proj)
-    {        
+    {
+        // NOTE: this implementation is partially duplicated in "WolvenKit.Modkit\RED4\Build.cs".
+        //       Changing the code below should be mirrored there too.
+        
         // copy files to packed dir
         // pack archives
         var archives = Directory.EnumerateFiles(cp77Proj.ModDirectory, "*", SearchOption.AllDirectories).ToList();

--- a/WolvenKit.CLI/Commands/BuildCommand.cs
+++ b/WolvenKit.CLI/Commands/BuildCommand.cs
@@ -1,0 +1,37 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO;
+using CP77Tools.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using WolvenKit.Core.Interfaces;
+
+namespace CP77Tools.Commands;
+
+internal class BuildCommand : CommandBase
+{
+    private const string s_description = "Build project(s) like WolvenKit application.";
+    private const string s_name = "build";
+
+    public BuildCommand() : base(s_name, s_description)
+    {
+        AddArgument(new Argument<DirectoryInfo[]>("paths", "Input folder(s) containing WKit project(s)."));
+
+        SetInternalHandler(CommandHandler.Create<DirectoryInfo[], IHost>(Action));
+    }
+
+    private int Action(DirectoryInfo[] paths, IHost host)
+    {
+        var serviceProvider = host.Services;
+        var logger = serviceProvider.GetRequiredService<ILoggerService>();
+
+        if (paths == null || paths.Length < 1)
+        {
+            logger.Error("Please fill in at least one input path.");
+            return ConsoleFunctions.ERROR_BAD_ARGUMENTS;
+        }
+
+        var consoleFunctions = serviceProvider.GetRequiredService<ConsoleFunctions>();
+        return consoleFunctions.BuildTask(paths);
+    }
+}

--- a/WolvenKit.CLI/Commands/BuildCommand.cs
+++ b/WolvenKit.CLI/Commands/BuildCommand.cs
@@ -10,12 +10,12 @@ namespace CP77Tools.Commands;
 
 internal class BuildCommand : CommandBase
 {
-    private const string s_description = "Build project(s) like WolvenKit application.";
+    private const string s_description = "Builds all WolvenKit .cpmodproj project(s) found in <paths>.";
     private const string s_name = "build";
 
     public BuildCommand() : base(s_name, s_description)
     {
-        AddArgument(new Argument<DirectoryInfo[]>("paths", "Input folder(s) containing WKit project(s)."));
+        AddArgument(new Argument<DirectoryInfo[]>("paths", "Input folder(s) containing WolvenKit .cpmodproj project(s)."));
 
         SetInternalHandler(CommandHandler.Create<DirectoryInfo[], IHost>(Action));
     }
@@ -27,7 +27,7 @@ internal class BuildCommand : CommandBase
 
         if (paths == null || paths.Length < 1)
         {
-            logger.Error("Please fill in at least one input path.");
+            logger.Error("Input path(s) missing for build.");
             return ConsoleFunctions.ERROR_BAD_ARGUMENTS;
         }
 

--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -47,6 +47,7 @@ internal class Program
             new ImportCommand(),
             new ExportCommand(),
             new PackCommand(),
+            new BuildCommand(),
 
             new ConvertCommand(),
             new ConflictsCommand(),

--- a/WolvenKit.Common/Interfaces/IModTools.cs
+++ b/WolvenKit.Common/Interfaces/IModTools.cs
@@ -10,6 +10,7 @@ namespace WolvenKit.Common.Interfaces
 {
     public interface IModTools
     {
+        public bool Build(DirectoryInfo inPath);
         public bool Pack(DirectoryInfo infolder, DirectoryInfo outpath, string? modname = null);
         public bool InstallFiles(DirectoryInfo packedDirectory, DirectoryInfo gameDirectory, bool installToHot = false);
 

--- a/WolvenKit.Modkit/RED4/Build.cs
+++ b/WolvenKit.Modkit/RED4/Build.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using WolvenKit.Core.Extensions;
+
+namespace WolvenKit.Modkit.RED4
+{
+    public partial class ModTools
+    {
+        /// <summary>
+        /// Builds a project like WolvenKit application. It generates an archive file, and adds extra files (like .xl)
+        /// in packed/ directory.
+        /// </summary>
+        /// <param name="path">Path of the WolvenKit project to build.</param>
+        /// <returns>true when the task was executed successfully, false otherwise.</returns>
+        public bool Build(DirectoryInfo path)
+        {
+            if (!path.Exists)
+            {
+                _loggerService.Error($"Building failed. Could not find directory {path}.");
+                return false;
+            }
+
+            // ReSharper disable JoinDeclarationAndInitializer
+            Dictionary<string, string> errors = new();
+            IEnumerable<string> files;
+            DirectoryInfo packedDir;
+            DirectoryInfo archiveDir;
+            string modName;
+
+            #region Find project
+
+            try
+            {
+                var projectFile = path.GetFiles("*.cpmodproj", SearchOption.TopDirectoryOnly).Single();
+                modName = Path.GetFileNameWithoutExtension(projectFile.Name);
+            }
+            catch (Exception)
+            {
+                _loggerService.Error("Building failed. Could not find .cpmodproj file.");
+                return false;
+            }
+
+            #endregion
+
+            #region Clean
+
+            packedDir = new DirectoryInfo(Path.Combine(path.FullName, "packed"));
+            try
+            {
+                packedDir.Delete(true);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // TOCTOU
+            }
+            catch (Exception e)
+            {
+                _loggerService.Error("Building failed. Could not clean previous build:");
+                _loggerService.Error(e.Message);
+                return false;
+            }
+
+            #endregion
+
+            #region Create packed/ directories
+
+            packedDir = new DirectoryInfo(Path.Combine(path.FullName, "packed"));
+            archiveDir = new DirectoryInfo(Path.Combine(path.FullName, "packed", "archive", "pc", "mod"));
+            try
+            {
+                packedDir.Create();
+                archiveDir.Create();
+            }
+            catch (IOException e)
+            {
+                _loggerService.Error("Building failed. Could not create packed/ directories:");
+                _loggerService.Error(e.Message);
+                return false;
+            }
+
+            #endregion
+
+            if (!Pack(path, archiveDir, modName))
+            {
+                _loggerService.Error("Building failed. Could not create archive file.");
+                return false;
+            }
+
+            // NOTE: derived from "WolvenKit.App\Controllers\RED4Controller.PackProjectFilesAsync()"
+
+            #region ArchiveXL
+
+            files = GetArchiveXlFiles(path.FullName);
+            foreach (var file in files)
+            {
+                var filename = Path.GetFileName(file);
+                try
+                {
+                    var outputPath = Path.Combine(packedDir.FullName, filename);
+                    File.Copy(file, outputPath);
+                }
+                catch (Exception e)
+                {
+                    errors.Add(filename, e.Message);
+                }
+            }
+
+            if (LogErrors(errors, "ArchiveXL"))
+            {
+                return false;
+            }
+
+            #endregion
+
+            #region Resources
+
+            var resourcesPath = Path.Combine(path.FullName, "source", "resources");
+            files = GetResourceFiles(resourcesPath);
+            foreach (var file in files)
+            {
+                var relativeFile = Path.GetRelativePath(resourcesPath, file);
+                var relativeDir = Path.Combine(packedDir.FullName, Path.GetDirectoryName(relativeFile).NotNull());
+                if (!Directory.Exists(relativeDir))
+                {
+                    Directory.CreateDirectory(relativeDir);
+                }
+                
+                try
+                {
+                    var outputPath = Path.Combine(packedDir.FullName, relativeFile);
+                    File.Copy(file, outputPath);
+                }
+                catch (Exception e)
+                {
+                    errors.Add(relativeFile, e.Message);
+                }
+            }
+
+            if (LogErrors(errors, "resource"))
+            {
+                return false;
+            }
+
+            #endregion
+
+            return true;
+        }
+
+        private bool LogErrors(Dictionary<string, string> errors, string fileType)
+        {
+            if (errors.Count == 0)
+            {
+                return false;
+            }
+
+            _loggerService.Error($"Building failed. Could not copy {fileType} files:");
+            foreach (var error in errors)
+            {
+                _loggerService.Error($"\t{error.Value}\tin\t{error.Key}");
+            }
+
+            return true;
+        }
+
+        private static IEnumerable<string> GetArchiveXlFiles(string path) =>
+            Directory.EnumerateFiles(path, "*.xl", SearchOption.AllDirectories).ToList();
+
+        private static IEnumerable<string> GetResourceFiles(string path) => Directory
+            .EnumerateFiles(path, "*.*", SearchOption.AllDirectories)
+            .Where(name => !IsSpecialExtension(name))
+            .Where(x => Path.GetFileName(x) != "info.json")
+            .ToList();
+
+        private static bool IsSpecialExtension(string filename)
+        {
+            return Path.GetExtension(filename) switch
+            {
+                ".xl" or ".script" or ".ws" or ".tweak" => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/WolvenKit.Modkit/RED4/Build.cs
+++ b/WolvenKit.Modkit/RED4/Build.cs
@@ -18,7 +18,7 @@ namespace WolvenKit.Modkit.RED4
         {
             if (!path.Exists)
             {
-                _loggerService.Error($"Building failed. Could not find directory {path}.");
+                _loggerService.Error($"Build failed. Could not find directory: \"{path}\".");
                 return false;
             }
 
@@ -38,7 +38,7 @@ namespace WolvenKit.Modkit.RED4
             }
             catch (Exception)
             {
-                _loggerService.Error("Building failed. Could not find .cpmodproj file.");
+                _loggerService.Error("Build failed. Could not find .cpmodproj file.");
                 return false;
             }
 
@@ -57,7 +57,7 @@ namespace WolvenKit.Modkit.RED4
             }
             catch (Exception e)
             {
-                _loggerService.Error("Building failed. Could not clean previous build:");
+                _loggerService.Error("Build failed. Could not clean previous build:");
                 _loggerService.Error(e.Message);
                 return false;
             }
@@ -75,7 +75,7 @@ namespace WolvenKit.Modkit.RED4
             }
             catch (IOException e)
             {
-                _loggerService.Error("Building failed. Could not create packed/ directories:");
+                _loggerService.Error("Build failed. Could not create \"packed/\" directories:");
                 _loggerService.Error(e.Message);
                 return false;
             }
@@ -84,7 +84,7 @@ namespace WolvenKit.Modkit.RED4
 
             if (!Pack(path, archiveDir, modName))
             {
-                _loggerService.Error("Building failed. Could not create archive file.");
+                _loggerService.Error("Build failed. Could not create archive file.");
                 return false;
             }
 
@@ -155,7 +155,7 @@ namespace WolvenKit.Modkit.RED4
                 return false;
             }
 
-            _loggerService.Error($"Building failed. Could not copy {fileType} files:");
+            _loggerService.Error($"Build failed. Could not copy {fileType} files:");
             foreach (var error in errors)
             {
                 _loggerService.Error($"\t{error.Value}\tin\t{error.Key}");

--- a/WolvenKit.Modkit/RED4/Build.cs
+++ b/WolvenKit.Modkit/RED4/Build.cs
@@ -98,7 +98,7 @@ namespace WolvenKit.Modkit.RED4
                 var filename = Path.GetFileName(file);
                 try
                 {
-                    var outputPath = Path.Combine(packedDir.FullName, filename);
+                    var outputPath = Path.Combine(archiveDir.FullName, filename);
                     File.Copy(file, outputPath);
                 }
                 catch (Exception e)

--- a/WolvenKit.Modkit/RED4/ModTools.cs
+++ b/WolvenKit.Modkit/RED4/ModTools.cs
@@ -3,7 +3,6 @@ using WolvenKit.Common.Interfaces;
 using WolvenKit.Common.Services;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Core.Services;
-using WolvenKit.Modkit.Scripting;
 using WolvenKit.RED4.CR2W;
 
 namespace WolvenKit.Modkit.RED4

--- a/WolvenKit.Modkit/RED4/Tasks/BuildTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/BuildTask.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace CP77Tools.Tasks;
+
+public partial class ConsoleFunctions
+{
+    /// <summary>
+    /// Builds a list of projects like WolvenKit application.
+    /// </summary>
+    /// <param name="paths">List of path per WolvenKit project to build.</param>
+    public int BuildTask(DirectoryInfo[] paths)
+    {
+        if (paths.Length < 1)
+        {
+            _loggerService.Error("Please fill in at least one input path.");
+            return ERROR_BAD_ARGUMENTS;
+        }
+
+        var result = 0;
+        Parallel.ForEach(paths, file => result += BuildTaskInner(file));
+        return result > 0 ? ERROR_COMPLETED_WITH_ERRORS : 0;
+    }
+
+    private int BuildTaskInner(DirectoryInfo path, int cp = 0)
+    {
+        if (!_modTools.Build(path))
+        {
+            _loggerService.Error($"Building failed for input path: \"{path.FullName}\".");
+            return ERROR_GENERAL_ERROR;
+        }
+
+        return 0;
+    }
+}

--- a/WolvenKit.Modkit/RED4/Tasks/IConsoleFunctions.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/IConsoleFunctions.cs
@@ -8,8 +8,11 @@ namespace CP77Tools.Tasks
     {
         public int ArchiveTask(FileSystemInfo[] path, string pattern, string regex, bool diff, bool list);
         public int UnbundleTask(FileSystemInfo[] path, UnbundleTaskOptions options);
-        public Task<int> Cr2wTask(FileSystemInfo[] path, DirectoryInfo outpath, bool deserialize, bool serialize, string pattern,
+
+        public Task<int> Cr2wTask(FileSystemInfo[] path, DirectoryInfo outpath, bool deserialize, bool serialize,
+            string pattern,
             string regex, ETextConvertFormat format, bool print);
+
         public int ExportTask(FileSystemInfo[] path, ExportTaskOptions options);
         public Task<int> ImportTask(FileSystemInfo[] path, DirectoryInfo outDir, bool keep);
         public int ConflictsTask(DirectoryInfo path, bool structured);

--- a/WolvenKit.Modkit/RED4/Tasks/IConsoleFunctions.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/IConsoleFunctions.cs
@@ -18,6 +18,7 @@ namespace CP77Tools.Tasks
         public int ConflictsTask(DirectoryInfo path, bool structured);
         public int OodleTask(FileInfo path, FileInfo outpath, bool decompress, bool compress);
         public int PackTask(DirectoryInfo[] path, DirectoryInfo outpath);
+        public int BuildTask(DirectoryInfo[] paths);
         public int UncookTask(FileSystemInfo[] path, UncookTaskOptions options);
     }
 }


### PR DESCRIPTION
# feat(CLI): add build command

**Implemented:**
- `build <path1> <pathN>` command in `WolvenKit.CLI`. It builds a WKit project like the button "Build Project" of the application.

**Additional notes:**
- implementation is derived from [RED4Controller](https://github.com/WolvenKit/WolvenKit/blob/e81cbad020ddf085bd0b50a844aabd1a4ffcc2e8/WolvenKit.App/Controllers/RED4Controller.cs#L467).
- it doesn't support REDmod content: can be implemented later when requested by a user.
- it doesn't create a `.zip` file: can be implemented later with an option like `--zip`.