### PR TITLE
fix: add cache invalidation to prevent node selection from breaking

### DIFF
--- a/WolvenKit.App/Services/NodePropertiesSelectionService.cs
+++ b/WolvenKit.App/Services/NodePropertiesSelectionService.cs
@@ -45,7 +45,7 @@ namespace WolvenKit.App.Services
         public void ClearSelection()
         {
             SelectedProperty = null;
-            SelectedProperties.Clear();
+            SelectedProperties?.Clear();
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/WolvenKit.App/Services/NodeSelectionService.cs
+++ b/WolvenKit.App/Services/NodeSelectionService.cs
@@ -22,11 +22,11 @@ namespace WolvenKit.App.Services
                 if (_selectedNode != value)
                 {
                     _selectedNode = value;
-                    
+
                     // Clear the properties selection when node changes to prevent 
                     // properties from previous node persisting in the panel
-                    NodePropertiesSelectionService.Instance.ClearSelection();
-                    
+                    NodePropertiesSelectionService.Instance?.ClearSelection();
+
                     OnPropertyChanged();
                 }
             }
@@ -44,4 +44,4 @@ namespace WolvenKit.App.Services
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
-} 
+}

--- a/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
+++ b/WolvenKit/Converters/RedTypeToChunkViewModelCollectionConverter.cs
@@ -28,6 +28,14 @@ namespace WolvenKit.Converters
         /// </summary>
         private static readonly ConditionalWeakTable<RedBaseClass, List<ChunkViewModel>> s_globalCache = new();
         
+        /// <summary>
+        /// Invalidates the cache for a specific data object, forcing fresh conversion
+        /// </summary>
+        public static void InvalidateCache(RedBaseClass redData)
+        {
+            s_globalCache.Remove(redData);
+        }
+        
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value is not RedBaseClass redData)
@@ -250,4 +258,4 @@ namespace WolvenKit.Converters
             throw new NotSupportedException("RedTypeToChunkViewModelCollectionConverter is one-way only");
         }
     }
-} 
+}


### PR DESCRIPTION
**Fixed:**
Successive duplication of array items in a node in scene/quest editor breaks NodeSelectionService, causing property panel to get stuck displaying the selected node

This was because of stale CVM cache in RedTypeToChunkViewModelCollectionConverter. Fixed by adding cache invalidation in ChunkViewModel.DuplicateChunk() for graph editor contexts only

