### PR TITLE
fix(NewFileViewModel): log exceptions with ILoggerService

### DIFF
--- a/WolvenKit.App/Factories/DialogViewModelFactory.cs
+++ b/WolvenKit.App/Factories/DialogViewModelFactory.cs
@@ -23,5 +23,5 @@ public class DialogViewModelFactory : IDialogViewModelFactory
 
     }
     public SoundModdingViewModel SoundModdingViewModel() => new(_notificationService, _loggerService, _projectManager);
-    public NewFileViewModel NewFileViewModel() => new(_projectManager);
+    public NewFileViewModel NewFileViewModel() => new(_projectManager, _loggerService);
 }

--- a/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
@@ -11,6 +11,7 @@ using WolvenKit.App.Services;
 using WolvenKit.Common;
 using WolvenKit.Common.Model;
 using WolvenKit.Core.Extensions;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive;
 using WolvenKit.RED4.CR2W;
 
@@ -22,10 +23,12 @@ public partial class NewFileViewModel : DialogViewModel
     public delegate Task ReturnHandler(NewFileViewModel? file);
     public ReturnHandler? FileHandler;
     private readonly IProjectManager _projectManager;
+    private readonly ILoggerService _loggerService;
 
-    public NewFileViewModel(IProjectManager projectManager)
+    public NewFileViewModel(IProjectManager projectManager, ILoggerService loggerService)
     {
         _projectManager = projectManager;
+        _loggerService = loggerService;
 
         Title = "Create new file";
 
@@ -58,7 +61,7 @@ public partial class NewFileViewModel : DialogViewModel
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
+            _loggerService.Error(e);
             throw;
         }
     }


### PR DESCRIPTION
# fix(NewFileViewModel): log exceptions with ILoggerService

**Fixed:**
- log exceptions with ILoggerService

**Additional notes:**
Based on this [feedback](https://discord.com/channels/717692382849663036/727800260486758410/1408168393328168970), user don't see any errors in the Log view. Which means it is not possible to reproduce the issue in the first place. Issue might not throw an exception, however `Console.WriteLine` is not the way to log anymore (implementation was done in 2021, d9dad40a7a61eaeaed8fd226f2044c2d1936c5f9).