### PR TITLE
scene and questphase QoL fixes

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -96,9 +96,13 @@ internal class NodeProperties
         }
         else if (node is questSwitchNodeDefinition switchCasted)
         {
-            foreach (var cond in switchCasted.Conditions)
+            // Show total conditions count right after the type
+            details["Total Cases"] = switchCasted.Conditions.Count.ToString();
+            
+            var conditionsToShow = switchCasted.Conditions.Take(8).ToList();
+            foreach (var cond in conditionsToShow)
             {
-                var socketPrefix = $"Socket {cond?.SocketId}";
+                var socketPrefix = $"Case {cond?.SocketId}";
                 var semanticDetails = QuestConditionHelper.GetSemanticConditionDisplay(cond?.Condition?.Chunk);
                 foreach (var kvp in semanticDetails)
                 {

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConditionHelper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConditionHelper.cs
@@ -201,6 +201,10 @@ public class QuestConditionHelper
         {
             return $"Wait {tick.TickCount} ticks";
         }
+        else if (time.Type?.Chunk is questTimePeriod_ConditionType timePeriod)
+        {
+            return FormatTimePeriodCondition(timePeriod);
+        }
         return "Time condition";
     }
 
@@ -1336,5 +1340,28 @@ public class QuestConditionHelper
             
             _ => $"Content {content.Type?.Chunk?.GetType().Name.Replace("questContent", "").Replace("_ConditionType", "")} condition"
         };
+    }
+
+    private static string FormatTimePeriodCondition(questTimePeriod_ConditionType timePeriod)
+    {
+        var beginTime = FormatGameTime(timePeriod.Begin);
+        var endTime = FormatGameTime(timePeriod.End);
+        
+        return $"Time between {beginTime} and {endTime}";
+    }
+
+    private static string FormatGameTime(GameTime? gameTime)
+    {
+        if (gameTime == null)
+        {
+            return "00:00";
+        }
+
+        // GameTime is represented in seconds since midnight
+        var totalSeconds = gameTime.Seconds;
+        var hours = (totalSeconds / 3600) % 24;
+        var minutes = (totalSeconds % 3600) / 60;
+        
+        return $"{hours:D2}:{minutes:D2}";
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questCheckpointNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questCheckpointNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WolvenKit.App.Extensions;
+﻿using System.Collections.Generic;
+using WolvenKit.App.Extensions;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
@@ -7,8 +8,13 @@ public class questCheckpointNodeDefinitionWrapper : questSignalStoppingNodeDefin
 {
     public questCheckpointNodeDefinitionWrapper(questCheckpointNodeDefinition questSignalStoppingNodeDefinition) : base(questSignalStoppingNodeDefinition)
     {
-        Details.Add("Debug String", questSignalStoppingNodeDefinition.DebugString);
-        Details.AddRange(NodeProperties.GetPropertiesFor(questSignalStoppingNodeDefinition));
+        RefreshDetails();
+    }
+
+    protected override void PopulateDetailsInto(Dictionary<string, string> details)
+    {
+        details.Add("Debug String", _castedData.DebugString);
+        base.PopulateDetailsInto(details);
     }
 
     internal override void CreateDefaultSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questOutputNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questOutputNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+﻿using System.Collections.Generic;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
@@ -7,7 +8,13 @@ public class questOutputNodeDefinitionWrapper : questIONodeDefinitionWrapper<que
 {
     public questOutputNodeDefinitionWrapper(questOutputNodeDefinition questOutputNodeDefinition) : base(questOutputNodeDefinition)
     {
-        Details.Add("Type", questOutputNodeDefinition.Type.ToEnumString());
+        RefreshDetails();
+    }
+
+    protected override void PopulateDetailsInto(Dictionary<string, string> details)
+    {
+        details.Add("Type", _castedData.Type.ToEnumString());
+        base.PopulateDetailsInto(details);
     }
 
     internal override void GenerateSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPauseConditionNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPauseConditionNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WolvenKit.App.Extensions;
+﻿using System.Collections.Generic;
+using WolvenKit.App.Extensions;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.RED4.Types;
 
@@ -27,5 +28,41 @@ public class questPauseConditionNodeDefinitionWrapper : questSignalStoppingNodeD
         CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
         CreateSocket("In", Enums.questSocketType.Input);
         CreateSocket("Out", Enums.questSocketType.Output);
+    }
+
+    /// <summary>
+    /// Override RefreshDetails to preserve semantic condition details
+    /// </summary>
+    public override void RefreshDetails()
+    {
+        // Create a new Details dictionary to trigger UI updates (like base class)
+        var tempDetails = new Dictionary<string, string>();
+        
+        // Use the same logic as constructor to preserve semantic details
+        if (_castedData.Condition?.Chunk != null)
+        {
+            // Get semantic condition details
+            var semanticDetails = QuestConditionHelper.GetSemanticConditionDisplay(_castedData.Condition.Chunk);
+            foreach (var kvp in semanticDetails)
+            {
+                tempDetails.Add(kvp.Key, kvp.Value);
+            }
+        }
+        else
+        {
+            // Fallback to general properties if no condition
+            var genericDetails = NodeProperties.GetPropertiesFor(_castedData);
+            foreach (var kvp in genericDetails)
+            {
+                tempDetails.Add(kvp.Key, kvp.Value);
+            }
+        }
+        
+        // Replace the Details dictionary to trigger WPF binding updates
+        Details = tempDetails;
+        
+        // Also refresh the title in case it depends on the data (from base class)
+        UpdateTitle();
+        OnPropertyChanged(nameof(Title));
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using WolvenKit.App.Factories;
 using WolvenKit.Common;
@@ -34,16 +35,23 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
         _nodeWrapperFactory = nodeWrapperFactory;
         _archiveManager = archiveManager;
 
+        RefreshDetails();
+    }
+
+    protected override void PopulateDetailsInto(Dictionary<string, string> details)
+    {
+        details.Add("Type", "Phase");
+        
         if (_castedData.PhaseResource.DepotPath != ResourcePath.Empty && _castedData.PhaseResource.DepotPath.IsResolvable)
         {
-            Details.Add("Filename", Path.GetFileName(_castedData.PhaseResource.DepotPath.GetResolvedText())!);
+            details.Add("Phase Resource", Path.GetFileName(_castedData.PhaseResource.DepotPath.GetResolvedText())!);
         }
         
         // Add node count for the phase
         var nodeCount = GetPhaseNodeCount();
         if (nodeCount > 0)
         {
-            Details.Add("Total Nodes", nodeCount.ToString());
+            details.Add("Total Nodes", nodeCount.ToString());
         }
     }
 

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSceneNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSceneNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using WolvenKit.App.Controllers;
 using WolvenKit.Common;
@@ -33,10 +34,17 @@ public class questSceneNodeDefinitionWrapper : questSignalStoppingNodeDefinition
         _archiveManager = archiveManager;
         _gameController = gameController;
 
+        RefreshDetails();
+    }
+
+    protected override void PopulateDetailsInto(Dictionary<string, string> details)
+    {
+        details.Add("Type", "Scene");
+        
         if (_castedData.SceneFile.DepotPath != ResourcePath.Empty && _castedData.SceneFile.DepotPath.IsResolvable)
         {
-            Details.Add("Filename", Path.GetFileName(_castedData.SceneFile.DepotPath.GetResolvedText())!);
-            Details.Add("Scene location", _castedData.SceneLocation.NodeRef.GetResolvedText()!);
+            details.Add("Scene File", Path.GetFileName(_castedData.SceneFile.DepotPath.GetResolvedText())!);
+            details.Add("Scene location", _castedData.SceneLocation.NodeRef.GetResolvedText()!);
         }
     }
 

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSwitchNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSwitchNodeDefinitionWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using WolvenKit.App.Extensions;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.RED4.Types;
+using System.Linq;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 
@@ -16,5 +17,53 @@ public class questSwitchNodeDefinitionWrapper : questDisableableNodeDefinitionWr
         CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
         CreateSocket("In", Enums.questSocketType.Input);
         CreateSocket("Otherwise", Enums.questSocketType.Output);
+
+        // Create output sockets for existing conditions with Case + socketId naming
+        foreach (var conditionItem in _castedData.Conditions)
+        {
+            var socketName = $"Case{conditionItem.SocketId}";
+            CreateSocket(socketName, Enums.questSocketType.Output);
+        }
+    }
+
+    /// <summary>
+    /// Adds a new condition to the switch node and creates a corresponding output socket
+    /// </summary>
+    public void AddCondition()
+    {
+        // Find the next available socket ID (starting from 2, since "Otherwise" would be 1)
+        var existingSocketIds = _castedData.Conditions.Select(c => c.SocketId).ToList();
+        uint nextSocketId = 2;
+        while (existingSocketIds.Contains(nextSocketId))
+        {
+            nextSocketId++;
+        }
+
+        // Create a new condition item with a default condition
+        var newConditionItem = new questConditionItem
+        {
+            SocketId = nextSocketId,
+            Condition = new CHandle<questIBaseCondition>() // Empty condition that can be configured later
+        };
+
+        // Add the condition to the switch node
+        _castedData.Conditions.Add(newConditionItem);
+
+        // Clear all existing sockets and recreate them to include the new condition socket
+        _castedData.Sockets.Clear();
+        CreateDefaultSockets();
+
+        // Regenerate sockets to reflect the changes in the UI
+        GenerateSockets();
+
+        // Refresh details to show the new condition
+        RefreshDetails();
+
+        //  Update property panel and graph editor without regenerating connectors
+        TriggerPropertyChanged(nameof(Output));
+        OnPropertyChanged(nameof(Data));
+
+        // Mark document as dirty
+        DocumentViewModel?.SetIsDirty(true);
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnEndNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnEndNodeWrapper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 using WolvenKit.RED4.Types;
 
@@ -13,7 +15,39 @@ public class scnEndNodeWrapper : BaseSceneViewModel<scnEndNode>
     public string Name
     {
         get => _scnExitPoint.Name.GetResolvedText()!;
-        set => _scnExitPoint.Name = value;
+        set 
+        {
+            if (_scnExitPoint.Name.GetResolvedText() != value)
+            {
+                _scnExitPoint.Name = value;
+                OnPropertyChanged(nameof(Name));
+                
+                // Mark document as dirty when name changes
+                if (!IsInitialLoad)
+                {
+                    DocumentViewModel?.SetIsDirty(true);
+                }
+                
+                // Trigger property panel refresh for exit points since the name changed
+                TriggerExitPointRefresh();
+            }
+        }
+    }
+    
+    private void TriggerExitPointRefresh()
+    {
+        // Find the main graph and trigger a selective refresh
+        if (DocumentViewModel != null)
+        {
+            var sceneGraphTab = DocumentViewModel.TabItemViewModels
+                .OfType<SceneGraphViewModel>()
+                .FirstOrDefault();
+                
+            if (sceneGraphTab?.MainGraph is RedGraph mainGraph)
+            {
+                mainGraph.RefreshSpecificProperties("exitPoints");
+            }
+        }
     }
 
     public Enums.scnEndNodeNsType Type

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
@@ -205,6 +205,19 @@ public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
                         }
                     }
                 }
+                else if (_castedData.QuestNode.Chunk is questCheckpointNodeDefinition checkpointNode)
+                {
+                    tempDetails["Debug String"] = checkpointNode.DebugString;
+                    
+                    var questNodeDetails = NodeProperties.GetPropertiesFor(_castedData.QuestNode.Chunk, sceneResource);
+                    foreach (var kvp in questNodeDetails)
+                    {
+                        if (kvp.Key != "Type")
+                        {
+                            tempDetails[kvp.Key] = kvp.Value;
+                        }
+                    }
+                }
                 else
                 {
                     var questNodeDetails = NodeProperties.GetPropertiesFor(_castedData.QuestNode.Chunk, sceneResource);

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnRandomizerNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnRandomizerNodeWrapper.cs
@@ -131,7 +131,7 @@ public class scnRandomizerNodeWrapper : BaseSceneViewModel<scnRandomizerNode>, I
             var nameAndTitle = $"({socket.Stamp.Name},{socket.Stamp.Ordinal})";
             var output = new SceneOutputConnectorViewModel(nameAndTitle, nameAndTitle, UniqueId, socket.Stamp.Name, socket.Stamp.Ordinal, socket);
             
-            // Calculate percentage for this socket
+            // Calculate percentage and set subtitle with proper format: (name,ordinal) [percentage%] OutX
             if (i < _castedData.Weights.Count && total > 0)
             {
                 var chance = (float)_castedData.Weights[i] / total * 100;
@@ -151,34 +151,17 @@ public class scnRandomizerNodeWrapper : BaseSceneViewModel<scnRandomizerNode>, I
         var outputSocket = new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = (ushort)Output.Count } };
         _castedData.OutputSockets.Add(outputSocket);
 
-        var index = (ushort)Output.Count;
-        var nameAndTitle = $"({outputSocket.Stamp.Name},{outputSocket.Stamp.Ordinal})";
-        var output = new SceneOutputConnectorViewModel(nameAndTitle, $"Out{index}", UniqueId, outputSocket.Stamp.Name, outputSocket.Stamp.Ordinal, outputSocket);
-        
+        var newSocketIndex = _castedData.OutputSockets.Count - 1;
         _castedData.NumOutSockets = (uint)(_castedData.OutputSockets.Count);
 
-        // Add a default weight for the new output if needed
-        if (_castedData.Weights.Count < _castedData.NumOutSockets)
+        // Set weight to 1 for the new output in the fixed-size array
+        if (newSocketIndex < _castedData.Weights.Count)
         {
-            _castedData.Weights.Add(1); // Default weight of 1
+            _castedData.Weights[newSocketIndex] = 1;
         }
 
-        // Calculate and set the percentage subtitle
-        var total = 0;
-        for (var i = 0; i < Math.Min(_castedData.NumOutSockets, _castedData.Weights.Count); i++)
-        {
-            total += _castedData.Weights[i];
-        }
-        
-        if (index < _castedData.Weights.Count && total > 0)
-        {
-            var chance = (float)_castedData.Weights[index] / total * 100;
-            output.Subtitle = $"[{chance:0.00}%] Out{index}";
-        }
-        else
-        {
-            output.Subtitle = $"[0.00%] Out{index}";
-        }
+        var nameAndTitle = $"({outputSocket.Stamp.Name},{outputSocket.Stamp.Ordinal})";
+        var output = new SceneOutputConnectorViewModel(nameAndTitle, nameAndTitle, UniqueId, outputSocket.Stamp.Name, outputSocket.Stamp.Ordinal, outputSocket);
         
         Output.Add(output);
 
@@ -204,16 +187,18 @@ public class scnRandomizerNodeWrapper : BaseSceneViewModel<scnRandomizerNode>, I
             // Only remove if it has no connections
             if (lastSocket.Destinations.Count == 0)
             {
+                var removedIndex = _castedData.OutputSockets.Count - 1;
+                
                 _castedData.OutputSockets.RemoveAt(_castedData.OutputSockets.Count - 1);
                 Output.RemoveAt(Output.Count - 1);
                 
                 // Update the counter
                 _castedData.NumOutSockets = (uint)Output.Count;
                 
-                // Update weights array if needed
-                if (_castedData.Weights.Count > _castedData.NumOutSockets)
+                // Reset the weight to 0 for the removed socket in the fixed-size array
+                if (removedIndex < _castedData.Weights.Count)
                 {
-                    _castedData.Weights.RemoveAt(_castedData.Weights.Count - 1);
+                    _castedData.Weights[removedIndex] = 0;
                 }
                 
                 // Update all socket percentages since totals changed

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -15,7 +15,7 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>, IDynami
     private readonly scnSceneResource _sceneResource;
     private readonly ILoggerService? _logger = Locator.Current.GetService<ILoggerService>();
     
-    public scnSectionNodeWrapper(scnSectionNode scnSectionNode, scnSceneResource scnSceneResource) : base(scnSectionNode)
+    public scnSectionNodeWrapper(scnSectionNode scnSectionNode, scnSceneResource scnSceneResource) : base(scnSectionNode, scnSceneResource)
     {
         _sceneResource = scnSceneResource;
         EnsureStandardSockets();

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -87,14 +87,15 @@ public partial class RedGraph : IDisposable
 
     public void Connect()
     {
+        // When dragging TO a node (Target), only create dynamic INPUT if the node supports it
         if (PendingConnection.Target is IDynamicInputNode dynIn)
         {
             PendingConnection.Target = dynIn.AddInput();
         }
-
-        if (PendingConnection.Target is IDynamicOutputNode dynOut)
+        // If target is a node that doesn't support dynamic inputs, don't proceed with connection
+        else if (PendingConnection.Target is IGraphProvider targetNode && PendingConnection.Source is BaseConnectorViewModel)
         {
-            PendingConnection.Target = dynOut.AddOutput();
+            return;
         }
 
         if (PendingConnection is { Source: OutputConnectorViewModel output1, Target: InputConnectorViewModel input1 })

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -2535,6 +2535,10 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         // RDTInkAtlasView
         resources["WolvenKitInkAtlasComboWidth"] = Math.Round(100 * _uiScalePercentage);
         resources["WolvenKitInkAtlasPropertyWidth"] = new GridLength(100).Mul(_uiScalePercentage).Round();
+
+        // Graph Editor Grid Scale
+        var gridScale = Math.Clamp(SystemParameters.PrimaryScreenHeight / 2160.0, 0.5, 4.0) * 1.5;
+        resources["WolvenKitGridScale"] = gridScale;
     }
 
     #endregion methods

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -44,6 +44,10 @@
                       Viewport="0,0,20,20"
                       ViewportUnits="Absolute"
                       Stretch="None">
+            <DrawingBrush.Transform>
+                <ScaleTransform ScaleX="{DynamicResource WolvenKitGridScale}"
+                               ScaleY="{DynamicResource WolvenKitGridScale}" />
+            </DrawingBrush.Transform>
             <DrawingBrush.Drawing>
                 <GeometryDrawing Brush="Transparent">
                     <GeometryDrawing.Pen>
@@ -67,6 +71,10 @@
                       Viewport="0,0,160,160"
                       ViewportUnits="Absolute"
                       Stretch="None">
+            <DrawingBrush.Transform>
+                <ScaleTransform ScaleX="{DynamicResource WolvenKitGridScale}"
+                               ScaleY="{DynamicResource WolvenKitGridScale}" />
+            </DrawingBrush.Transform>
             <DrawingBrush.Drawing>
                 <GeometryDrawing Brush="Transparent">
                     <GeometryDrawing.Pen>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -400,6 +400,12 @@ public partial class GraphEditorView : UserControl
             node.ContextMenu.Items.Add(new Separator());
         }
 
+        if (node.DataContext is questSwitchNodeDefinitionWrapper switchNode)
+        {
+            node.ContextMenu.Items.Add(CreateMenuItem("Add Case", "PlusCircle", () => switchNode.AddCondition()));
+            node.ContextMenu.Items.Add(new Separator());
+        }
+
         if (node.DataContext is IGraphProvider graphProvider)
         {
             node.ContextMenu.Items.Add(CreateMenuItem("Recalculate sockets", "Play", "WolvenKitGreen", () => Source.RecalculateSockets(graphProvider)));


### PR DESCRIPTION
# scene and questphase QoL fixes

- Fixed randomizer node sync (for both questphase and scene) - adding sockets and changing weights should now sync up properly in the graph in realtime
- Adding new start and end nodes in a scene should now properly sync up in the 'Logic & Flow' tab including editing the names from the graph
- Fixed an issue where adding new choice node in larger scenes took a lot of time
- Fixed a bug where dragging a connection to a scnSectionNode with an unspecified socket would create an empty events output socket
- Fixed a bug where semantic details for condition node types in questphase were getting polluted after editing
- Fixed a bug that prevented scnSectionNode from getting the notable point label in graph view
- Added TimePeriod to semantic details for condition 
- Added a "Add Case" right-click option for questSwitchNode to auto create named socket and condition pair 
- The graph background grid will now take screen resolution into account and scale properly 
- Fixed a bug where Phase, Scene, and Checkpoint quest node details would disappear after editing a property