### PR TITLE
perf: improve loading time at startup

### DIFF
--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -50,7 +50,9 @@ public partial class AppScriptService : ScriptService
         DefaultHostObject = new() { { "wkit", _wkit } };
 
         RegisterHooks();
-        RefreshUIScripts();
+
+        // Improve FCP (~500 ms)
+        _ = Task.Run(RefreshUIScripts);
     }
 
 

--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -23,7 +23,7 @@ namespace WolvenKit.App.Services;
 public partial class AppScriptService : ScriptService
 {
     private readonly AppScriptFunctions _wkit;
-    
+
     private readonly ISettingsManager _settingsManager;
     private readonly IHookService _hookService;
 
@@ -31,8 +31,8 @@ public partial class AppScriptService : ScriptService
 
     public AppScriptService(
         ISettingsManager settingsManager,
-        ILoggerService loggerService, 
-        IProjectManager projectManager, 
+        ILoggerService loggerService,
+        IProjectManager projectManager,
         IArchiveManager archiveManager,
         Red4ParserService red4ParserService,
         IModTools modTools,
@@ -46,7 +46,7 @@ public partial class AppScriptService : ScriptService
 
         _wkit = new AppScriptFunctions(_loggerService, projectManager, archiveManager, red4ParserService, modTools, importExportHelper, gameController, geometryCacheService, settingsManager);
         _ui = new UiScriptFunctions(this);
-        
+
         DefaultHostObject = new() { { "wkit", _wkit } };
 
         RegisterHooks();

--- a/WolvenKit.App/ViewModels/Tools/PropertiesViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/PropertiesViewModel.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using HelixToolkit.SharpDX.Core;
@@ -31,9 +33,6 @@ public partial class PropertiesViewModel : ToolViewModel
     private readonly ILoggerService _loggerService;
     private readonly ISettingsManager _settingsManager;
     private readonly IArchiveManager _archiveManager;
-    private readonly IProjectManager _projectManager;
-    private readonly MeshTools _meshTools;
-    private readonly IModTools _modTools;
     private readonly Red4ParserService _parser;
 
     public const string ToolContentId = "Properties_Tool";
@@ -46,7 +45,7 @@ public partial class PropertiesViewModel : ToolViewModel
 
     public EffectsManager EffectsManager { get; }
 
-    public SharpDX.BoundingBox ModelGroupBounds { get; set; } = new();
+    public SharpDX.BoundingBox ModelGroupBounds { get; set; }
 
     public Camera Camera { get; }
 
@@ -56,35 +55,22 @@ public partial class PropertiesViewModel : ToolViewModel
 
     #endregion
 
-    /// <summary>
-    /// Constructor PropertiesViewModel
-    /// </summary>
-    /// <param name="projectManager"></param>
-    /// <param name="loggerService"></param>
-    /// <param name="meshTools"></param>
     public PropertiesViewModel(
-        IProjectManager projectManager,
         IArchiveManager archiveManager,
         ILoggerService loggerService,
         ISettingsManager settingsManager,
-        MeshTools meshTools,
-        IModTools modTools,
         Red4ParserService parserService
     ) : base(ToolTitle)
     {
         _settingsManager = settingsManager;
-        _projectManager = projectManager;
         _loggerService = loggerService;
         _archiveManager = archiveManager;
-        _meshTools = meshTools;
-        _modTools = modTools;
         _parser = parserService;
 
         SetupToolDefaults();
         SideInDockedMode = DockSide.Left;
 
         SetToNullAndResetVisibility();
-
 
         EffectsManager = new DefaultEffectsManager();
         Camera = new PerspectiveCamera()
@@ -174,7 +160,7 @@ public partial class PropertiesViewModel : ToolViewModel
             return;
         }
 
-        CR2WFile? cr2W = null;
+        CR2WFile? cr2W;
         using (var stream = new MemoryStream())
         {
             var selectedGameFile = selectedItem.GetGameFile();
@@ -223,7 +209,7 @@ public partial class PropertiesViewModel : ToolViewModel
             return;
         }
 
-        CR2WFile? cr2WFile = null;
+        CR2WFile? cr2WFile;
         using (var stream = new FileStream(model.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096,
                    FileOptions.SequentialScan))
         {
@@ -314,8 +300,6 @@ public partial class PropertiesViewModel : ToolViewModel
                 crpdr.TextureData.RenderResourceBlobPC.GetValue() is rendRenderTextureBlobPC:
                 SetupImage(crpdr);
                 break;
-            default:
-                break;
         }
     }
 
@@ -373,9 +357,8 @@ public partial class PropertiesViewModel : ToolViewModel
         }
         catch
         {
-
+            // ignored
         }
-
     }
 
     public void LoadImage(BitmapSource p0) => LoadedBitmapFrame = p0;

--- a/WolvenKit.CLI/Program.cs
+++ b/WolvenKit.CLI/Program.cs
@@ -5,8 +5,10 @@ using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
 using CP77Tools.Commands;
 using CP77Tools.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using WolvenKit.Common;
 using WolvenKit.Common.Model.Arguments;
+using WolvenKit.Common.Services;
 using WolvenKit.Core.Compression;
 
 namespace WolvenKit.CLI;
@@ -34,7 +36,7 @@ internal class Program
                        "Please do so to ensure that WolvenKit works properly." + Environment.NewLine + Environment.NewLine +
                        "For more informations:" + Environment.NewLine +
                        "https://wiki.redmodding.org/wolvenkit/help/faq/long-file-path-support" + Environment.NewLine + Environment.NewLine;
-            
+
             Console.Error.Write(text);
         }
 
@@ -69,6 +71,17 @@ internal class Program
         var parser = new CommandLineBuilder(rootCommand)
             .UseDefaults()
             .UseHost(GenericHost.CreateHostBuilder)
+            .AddMiddleware(context =>
+            {
+                var host = context.GetHost();
+                var servicesProvider = host.Services;
+
+                var hashService = servicesProvider.GetRequiredService<IHashService>();
+                hashService.Load();
+
+                var cruidService = servicesProvider.GetRequiredService<CRUIDService>();
+                cruidService.Load();
+            })
             .Build();
 
         ImportExportArgs.IsCLI = true;

--- a/WolvenKit.Common/Services/CRUIDService.cs
+++ b/WolvenKit.Common/Services/CRUIDService.cs
@@ -18,10 +18,13 @@ public class CRUIDService
 
     private const string s_used = "WolvenKit.Common.Resources.basecruids.kark";
 
+    private volatile bool _isLoaded;
     private List<ulong> _baseCRUIDS = new();
     private List<ulong> _additionalCRUIDS = new();
     
     private readonly Random _random = new();
+
+    public bool IsLoaded => _isLoaded;
 
     #endregion
 
@@ -29,24 +32,12 @@ public class CRUIDService
 
     public CRUIDService()
     {
-        Load();
         s_Instance = this;
     }
 
     #endregion Constructors
 
     #region Private Methods
-
-    private void Load()
-    {
-        _baseCRUIDS = JsonSerializer.Deserialize<List<ulong>>(DecompressEmbeddedFile(s_used)).NotNull();
-
-        var userFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "REDModding", "WolvenKit", "user_cruids.json");
-        if (File.Exists(userFile))
-        {
-            _additionalCRUIDS = JsonSerializer.Deserialize<List<ulong>>(File.ReadAllText(userFile)).NotNull();
-        }
-    }
 
     private MemoryStream DecompressEmbeddedFile(string resourceName)
     {
@@ -76,7 +67,20 @@ public class CRUIDService
     #region Public Methods
 
     public static CRUID GenerateRandomCRUID() => s_Instance?.GenerateNewCRUID() ?? new CRUID();
-    
+
+    public void Load()
+    {
+        _baseCRUIDS = JsonSerializer.Deserialize<List<ulong>>(DecompressEmbeddedFile(s_used)).NotNull();
+
+        var userFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "REDModding", "WolvenKit", "user_cruids.json");
+        if (File.Exists(userFile))
+        {
+            _additionalCRUIDS = JsonSerializer.Deserialize<List<ulong>>(File.ReadAllText(userFile)).NotNull();
+        }
+
+        _isLoaded = true;
+    }
+
     public void SaveUserCRUIDS()
     {
         var dataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "REDModding", "WolvenKit");

--- a/WolvenKit.Common/Services/CRUIDService.cs
+++ b/WolvenKit.Common/Services/CRUIDService.cs
@@ -13,7 +13,7 @@ namespace WolvenKit.Common.Services;
 public class CRUIDService
 {
     private static CRUIDService? s_Instance;
-    
+
     #region Fields
 
     private const string s_used = "WolvenKit.Common.Resources.basecruids.kark";
@@ -21,7 +21,7 @@ public class CRUIDService
     private volatile bool _isLoaded;
     private List<ulong> _baseCRUIDS = new();
     private List<ulong> _additionalCRUIDS = new();
-    
+
     private readonly Random _random = new();
 
     public bool IsLoaded => _isLoaded;
@@ -94,7 +94,7 @@ public class CRUIDService
         while (true)
         {
             var value = _random.NextCRUID();
-            
+
             if (!_baseCRUIDS.Contains(value) && !_additionalCRUIDS.Contains(value))
             {
                 _additionalCRUIDS.Add(value);

--- a/WolvenKit.Common/Services/HashService.cs
+++ b/WolvenKit.Common/Services/HashService.cs
@@ -39,7 +39,27 @@ namespace WolvenKit.Common.Services
 
         #region Methods
 
-        public Task LoadAsync() => Task.Run(Load);
+        public void Load()
+        {
+            var hashesMemory = DecompressEmbeddedFile(s_used);
+            ReadHashes(hashesMemory.GetStream());
+
+            hashesMemory.Dispose();
+
+            var nodeRefsMemory = DecompressEmbeddedFile(s_nodeRefs);
+            ReadNodeRefs(nodeRefsMemory.GetStream());
+
+            nodeRefsMemory.Dispose();
+
+            var tweakNamesMemory = DecompressEmbeddedFile(s_tweakDbStr);
+            ReadTweakNames(tweakNamesMemory.GetStream());
+
+            tweakNamesMemory.Dispose();
+
+            LoadMissingHashes();
+
+            _isLoaded = true;
+        }
 
         public IEnumerable<ulong> GetAllHashes() => _hashes.Keys;
 
@@ -82,28 +102,6 @@ namespace WolvenKit.Common.Services
             }
 
             return null;
-        }
-
-        private void Load()
-        {
-            var hashesMemory = DecompressEmbeddedFile(s_used);
-            ReadHashes(hashesMemory.GetStream());
-
-            hashesMemory.Dispose();
-
-            var nodeRefsMemory = DecompressEmbeddedFile(s_nodeRefs);
-            ReadNodeRefs(nodeRefsMemory.GetStream());
-
-            nodeRefsMemory.Dispose();
-
-            var tweakNamesMemory = DecompressEmbeddedFile(s_tweakDbStr);
-            ReadTweakNames(tweakNamesMemory.GetStream());
-
-            tweakNamesMemory.Dispose();
-
-            LoadMissingHashes();
-
-            _isLoaded = true;
         }
 
         private static unsafe UnmanagedMemory DecompressEmbeddedFile(string resourceName)

--- a/WolvenKit.Common/Services/HashService.cs
+++ b/WolvenKit.Common/Services/HashService.cs
@@ -88,31 +88,31 @@ namespace WolvenKit.Common.Services
         {
             var hashesMemory = DecompressEmbeddedFile(s_used);
             ReadHashes(hashesMemory.GetStream());
-            
+
             hashesMemory.Dispose();
-            
+
             var nodeRefsMemory = DecompressEmbeddedFile(s_nodeRefs);
             ReadNodeRefs(nodeRefsMemory.GetStream());
-            
+
             nodeRefsMemory.Dispose();
-            
+
             var tweakNamesMemory = DecompressEmbeddedFile(s_tweakDbStr);
             ReadTweakNames(tweakNamesMemory.GetStream());
-            
+
             tweakNamesMemory.Dispose();
-            
+
             LoadMissingHashes();
 
             _isLoaded = true;
         }
-        
+
         private static unsafe UnmanagedMemory DecompressEmbeddedFile(string resourceName)
         {
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName).NotNull();
 
             // read KARK header
             var oodleCompression = stream.ReadStruct<uint>();
-            
+
             if (oodleCompression != Oodle.KARK)
             {
                 throw new DecompressionException("Incorrect hash file.");
@@ -123,7 +123,7 @@ namespace WolvenKit.Common.Services
             var compressedBufferLength = (int)(stream.Length - (sizeof(uint) * 2));
             using var compressedBuffer = UnmanagedMemory.Allocate(compressedBufferLength);
             var decompressedBuffer = UnmanagedMemory.Allocate((int) outputSize);
-            
+
             // read the rest of the stream
             var read = stream.Read(compressedBuffer.GetSpan());
 
@@ -135,7 +135,7 @@ namespace WolvenKit.Common.Services
             Oodle.Decompress(
                 compressedBuffer.Pointer, compressedBuffer.Size,
                 decompressedBuffer.Pointer, decompressedBuffer.Size);
-            
+
             return decompressedBuffer;
         }
 
@@ -146,7 +146,7 @@ namespace WolvenKit.Common.Services
             var readerTask = Task.Run(() =>
             {
                 using var sr = new StreamReader(memoryStream);
-                
+
                 while (true)
                 {
                     var nextLine = sr.ReadLine();
@@ -158,7 +158,7 @@ namespace WolvenKit.Common.Services
 
                     collection.Add(nextLine);
                 }
-                
+
                 collection.CompleteAdding();
             });
 

--- a/WolvenKit.Common/Services/HashService.cs
+++ b/WolvenKit.Common/Services/HashService.cs
@@ -31,15 +31,15 @@ namespace WolvenKit.Common.Services
 
         private Dictionary<ulong, string> _missing = new();
 
+        private volatile bool _isLoaded;
+
+        public bool IsLoaded => _isLoaded;
+
         #endregion Fields
 
-        #region Constructors
-
-        public HashService() => Load();
-
-        #endregion Constructors
-
         #region Methods
+
+        public Task LoadAsync() => Task.Run(Load);
 
         public IEnumerable<ulong> GetAllHashes() => _hashes.Keys;
 
@@ -102,6 +102,8 @@ namespace WolvenKit.Common.Services
             tweakNamesMemory.Dispose();
             
             LoadMissingHashes();
+
+            _isLoaded = true;
         }
         
         private static unsafe UnmanagedMemory DecompressEmbeddedFile(string resourceName)

--- a/WolvenKit.Core/Services/IHashService.cs
+++ b/WolvenKit.Core/Services/IHashService.cs
@@ -7,7 +7,7 @@ namespace WolvenKit.Common.Services
     {
         bool IsLoaded { get; }
 
-        Task LoadAsync();
+        void Load();
 
         bool Contains(ulong key, bool checkUserHashes = true);
 

--- a/WolvenKit.Core/Services/IHashService.cs
+++ b/WolvenKit.Core/Services/IHashService.cs
@@ -1,9 +1,14 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace WolvenKit.Common.Services
 {
     public interface IHashService
     {
+        bool IsLoaded { get; }
+
+        Task LoadAsync();
+
         bool Contains(ulong key, bool checkUserHashes = true);
 
         string? Get(ulong key);

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -16,6 +16,7 @@ using WolvenKit.App;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Services;
+using WolvenKit.Common.Services;
 using WolvenKit.Core.Compression;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Helpers;
@@ -92,6 +93,16 @@ namespace WolvenKit
                 .WhenPropertyChanged(settings => settings.UiScale)
                 .Skip(1)
                 .Subscribe(_ => OnUiScaleChanged());
+
+            // offload hashes to reduce blocking load time (~5 seconds)
+            _ = Task.Run(async () =>
+            {
+                var hashService = Locator.Current.GetService<IHashService>();
+                if (hashService != null)
+                {
+                    await hashService.LoadAsync();
+                }
+            });
 
             base.OnStartup(e);
         }

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -94,7 +94,7 @@ namespace WolvenKit
                 .Skip(1)
                 .Subscribe(_ => OnUiScaleChanged());
 
-            // offload hashes to reduce blocking load time (~5 seconds)
+            // Improve FCP (~5 000 ms)
             _ = Task.Run(async () =>
             {
                 var hashService = Locator.Current.GetService<IHashService>();
@@ -102,6 +102,13 @@ namespace WolvenKit
                 {
                     await hashService.LoadAsync();
                 }
+            });
+
+            // Improve FCP (~250 ms)
+            _ = Task.Run(() =>
+            {
+                var cruidService = Locator.Current.GetService<CRUIDService>();
+                cruidService?.Load();
             });
 
             base.OnStartup(e);

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -83,7 +83,6 @@ namespace WolvenKit
             _loggerService.Debug("Initializing Shell");
             Initializations.InitializeShell(_settingsManager);
 
-
             _loggerService.Debug("Initializing Discord RPC API");
             DiscordHelper.InitializeDiscordRPC();
 

--- a/WolvenKit/App.xaml.cs
+++ b/WolvenKit/App.xaml.cs
@@ -94,13 +94,10 @@ namespace WolvenKit
                 .Subscribe(_ => OnUiScaleChanged());
 
             // Improve FCP (~5 000 ms)
-            _ = Task.Run(async () =>
+            _ = Task.Run(() =>
             {
                 var hashService = Locator.Current.GetService<IHashService>();
-                if (hashService != null)
-                {
-                    await hashService.LoadAsync();
-                }
+                hashService?.Load();
             });
 
             // Improve FCP (~250 ms)


### PR DESCRIPTION
# perf: improve loading time at startup

**Implemented:**
- asynchronously load hashes (saves ~5 000 ms)
- asynchronously load CRUIDs (saves ~500 ms)
- asynchronously refresh UI scripts (saves ~500 ms)

**Additional notes:**
Tool: dotTrace with timeline profile (+ profile build).
Scenario: timing from the launch to [First Contentful Paint](https://web.dev/articles/fcp) (when Main View is rendered and user can interact).

Elapsed time before: ~20 000 ms
Elapsed time after: ~10 000 ms
Overall improvement: ~50 %

A major remaining bottle neck is during `WolvenKit.Views.Shell.DockingAdapter.PART_DockingManager_Loaded` which calls `LoadDockState` of Syncfusion's `DockingManager`. It takes ~5 000 ms to process and layout the dock. So far I couldn't find an easy fix, while still rendering the dock when no project is open.

FileIcon template takes ~1 000ms to load SVG file. SharpVector dependency allows asynchronous loading but I couldn't make it works smoothly for now. Moreover this loading time, is not THE major bottle neck...

CLI is updated with a middleware to synchronously load hashes and CRUIDs.

Added comments with format `// Improve FCP (~[time] [unit])` to be explicit about these changes and how they are important regarding UX.