### PR TITLE
fixed inconsistent search for nested properties in RDTDataView

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -571,10 +571,7 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
         HasActiveSearch = !string.IsNullOrEmpty(searchBoxText);
         foreach (var chunkViewModel in Chunks)
         {
-            if (ModifierViewStateService.IsShiftBeingHeld)
-            {
-                chunkViewModel.CalculatePropertiesRecursive(0, 1024);
-            }
+            chunkViewModel.CalculatePropertiesRecursive(0, 1024);
             chunkViewModel.SetVisibilityStatusBySearchString(searchBoxText);
         }
 


### PR DESCRIPTION
# fixed inconsistent search for nested properties in RDTDataView

**Fixed:**
- RDTDataView properties not being initialized fully before searching unless shift was pressed

**Additional notes:**
closes #2539 
