### PR TITLE
Added workflow to sync main into dev on commit / pr closed

### DIFF
--- a/.github/workflows/sync-main-into-dev.yml
+++ b/.github/workflows/sync-main-into-dev.yml
@@ -1,0 +1,40 @@
+name: Sync main into dev
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  merge:
+    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout target branch (dev)
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch source branch (main)
+        run: git fetch origin main:main
+
+      - name: Merge main into dev
+        run: |
+          git checkout dev
+          git merge main --no-edit
+
+      - name: Push changes
+        run: git push origin dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Added workflow to sync main into dev on commit / pr closed

**Implemented:**
- merges main into dev when main changes

merging tends to be overly cautious of changes in the same file so if a file has been changed in both main and dev the action will prob fail, but most files are the same in dev as they are in main so it'll still save time.

Workflow permissions will need to be set to read and write if it isn't already for it to work.