### PR TITLE
removed pr closed trigger to avoid duplicate runs

### DIFF
--- a/.github/workflows/sync-main-into-dev.yml
+++ b/.github/workflows/sync-main-into-dev.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [closed]
-    branches:
-      - main
 
 jobs:
   merge:


### PR DESCRIPTION
# removed pr closed trigger to avoid duplicate runs

**Fixed:**
- sync action failing often due to duplicate runs when pr is merged into main 
