### PR TITLE
fix(RedCurvePointEditor): show alpha slider of RedColorPicker

### DIFF
--- a/WolvenKit/Views/Templates/RedCurvePointEditor.xaml
+++ b/WolvenKit/Views/Templates/RedCurvePointEditor.xaml
@@ -61,7 +61,7 @@
                         RedHDRColor="{Binding ElementName=uc,
                                               Path=Value,
                                               Mode=TwoWay}"
-                        ShowAlpha="False" />
+                        ShowAlpha="True" />
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type types:Vector2}">

--- a/WolvenKit/Views/Tools/RedColorPicker.xaml.cs
+++ b/WolvenKit/Views/Tools/RedColorPicker.xaml.cs
@@ -82,12 +82,12 @@ namespace WolvenKit.Views.Tools
 
             SetCurrentValue(RedHDRColorProperty, new HDRColor
             {
-                Alpha = (CFloat)Color.A,
+                Alpha = (CFloat)Color.A / 255F,
                 Red = (CFloat)Color.RGB_R / 255F,
                 Green = (CFloat)Color.RGB_G / 255F,
                 Blue = (CFloat)Color.RGB_B / 255F
             });
-            
+
 
             UpdateBrush();
 
@@ -97,7 +97,7 @@ namespace WolvenKit.Views.Tools
                 cvm.NotifyChain(nameof(ChunkViewModel.Data));
                 cvm.RecalculateProperties();
             }
-            
+
             _updateFromColor = false;
         }
 
@@ -124,7 +124,7 @@ namespace WolvenKit.Views.Tools
             {
                 picker._updateFromColor = true;
 
-                picker.Color.A = color.Alpha;
+                picker.Color.A = color.Alpha * 255F;
                 picker.Color.RGB_R = color.Red * 255F;
                 picker.Color.RGB_G = color.Green * 255F;
                 picker.Color.RGB_B = color.Blue * 255F;


### PR DESCRIPTION
# fix(RedCurvePointEditor): show alpha slider of RedColorPicker

**Implemented:**
- show alpha slider when editing HDRColor of a curve

**Fixed:**
- convert Alpha channel between range [0; 255] and [0.0; 1.0]

**Additional notes:**
Closes #2546

Enabling Alpha channel slider also enable rendering of Alpha channel, which makes sense. Though it can look like this:
<img width="1548" height="580" alt="image" src="https://github.com/user-attachments/assets/bb3d85f5-91d6-4af9-b65e-7a194c909e74" />

I'm not sure what is the right approach to have.