### PR TITLE
Find broken references: ignore cdpr and axl files

### DIFF
--- a/WolvenKit.sln.DotSettings
+++ b/WolvenKit.sln.DotSettings
@@ -20,6 +20,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=basegame/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bigwk/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ccxl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cdpr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cdproj/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=choom/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=chunkmask/@EntryIndexedValue">True</s:Boolean>
@@ -40,6 +41,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=garmentsupportweight/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inkatlas/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inkcharactercustomization/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=kerenzikov/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kvp_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lhcs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lipsync/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
# Find broken references ignore cdpr and axl files

```c#
    private static readonly List<string> s_allowedDeadReferencePartials =
    [
        // in psiberx we trust
        @"archive_xl\characters\common",
        @"archive_xl\characters\head\player_base_heads",
        @"archive_xl\common\null.morphtarget",
        // xbae's photo mode anims - will do nothing if not present
        @"base\animations\xbaebsae\pm_facials",
        // CDPR originals - they have them in all of their NPCS, surely it'll be fine to just ignore them
        @"base\fx\characters\npc\kerenzikov",
        @"base\animations\anim_motion_database\cover_action.csv",
        @"ep1\animations\npc\gameplay\woman_average\gang\unarmed\wa_gang_unarmed_reaction_death.anims",
    ];
```