### PR TITLE
cr2reader: ignore warning for known suspects

### DIFF
--- a/WolvenKit.RED4/Archive/IO/CR2WReader.cs
+++ b/WolvenKit.RED4/Archive/IO/CR2WReader.cs
@@ -75,6 +75,11 @@ public partial class CR2WReader : Red4Reader
         }
     }
 
+    public static readonly List<string> s_ignoreWarningTypes =
+    [
+        "array:rendGradientEntry",
+    ];
+
     public bool ReadVariable(RedBaseClass cls, ExtendedTypeInfo typeInfo)
     {
         var varCName = ReadCName();
@@ -136,18 +141,23 @@ public partial class CR2WReader : Red4Reader
 
             if (propRedType == redTypeName)
             {
-                LoggerService?.Warning($"Can't read data for \"{fullName}\" (\"{propRedType}\"). Skipping");
+                if (!s_ignoreWarningTypes.Contains(propRedType))
+                {
+                    LoggerService?.Warning(
+                        $"Cr2WReader: Can't read data for \"{fullName}\" (\"{propRedType}\"). Skipping");
+                }
                 return true;
             }
 
-            LoggerService?.Warning($"Invalid RedType detected for \"{fullName}\". \"{redTypeName}\" instead of \"{propRedType}\". Skipping");
+            LoggerService?.Warning(
+                $"Cr2WReader: Invalid RedType detected for \"{fullName}\". \"{redTypeName}\" instead of \"{propRedType}\". Skipping");
             return true;
         }
 
         // dynamic stuff
         var redTypeInfos = RedReflection.GetRedTypeInfos(redTypeName!);
         var (hasError, errorRedName) = CheckRedTypeInfos(ref redTypeInfos);
-        
+
         if (hasError)
         {
             LoggerService?.Warning($"Type \"{errorRedName}\" is not known! Non-RTTI property \"{fullName}\" will be ignored");
@@ -157,7 +167,7 @@ public partial class CR2WReader : Red4Reader
         }
 
         var (type, _) = RedReflection.GetCSTypeFromRedType(redTypeName!);
-        
+
         cls.AddDynamicProperty(varName, type);
         value = Read(redTypeInfos, size);
         SetProperty(cls, varName, value);

--- a/WolvenKit.RED4/Archive/IO/RedPackageReader.cs
+++ b/WolvenKit.RED4/Archive/IO/RedPackageReader.cs
@@ -79,11 +79,14 @@ public partial class RedPackageReader : Red4Reader
 
                 if (propRedType == redTypeName)
                 {
-                    LoggerService?.Warning($"Can't read data for \"{fullName}\" (\"{propRedType}\"). Skipping");
+                    LoggerService?.Warning(
+                        $"RedPackageReader: Can't read data for \"{fullName}\" (\"{propRedType}\"). Skipping");
+
                     continue;
                 }
 
-                LoggerService?.Warning($"Invalid RedType detected for \"{fullName}\". \"{redTypeName}\" instead of \"{propRedType}\". Skipping");
+                LoggerService?.Warning(
+                    $"RedPackageReader: Invalid RedType detected for \"{fullName}\". \"{redTypeName}\" instead of \"{propRedType}\". Skipping");
                 continue;
             }
 


### PR DESCRIPTION
# cr2reader: ignore warning for known suspects

Is this OK? It'll irritate users, and we don't need to resolve those... do we?