### PR TITLE
fix: text contrast ratio of MenuItem.ToolTip

### DIFF
--- a/WolvenKit/App.xaml
+++ b/WolvenKit/App.xaml
@@ -164,6 +164,39 @@
                 <Setter Property="Foreground" Value="{StaticResource ForegroundColor}" />
             </Style>
 
+            <!-- Don't override TextBlock of ToolTip -->
+            <Style
+                x:Key="{x:Type ToolTip}"
+                BasedOn="{StaticResource WPFToolTipStyle}"
+                TargetType="{x:Type ToolTip}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ToolTip}">
+                            <Border
+                                Margin="0"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{StaticResource MaterialDark.ThemeCornerRadiusVariant1}"
+                                SnapsToDevicePixels="True"
+                                Effect="{StaticResource Default.ShadowDepth3}">
+                                <ContentPresenter
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                    <ContentPresenter.Resources>
+                                        <Style TargetType="{x:Type TextBlock}">
+                                            <Setter Property="Foreground" Value="Black" />
+                                        </Style>
+                                    </ContentPresenter.Resources>
+                                </ContentPresenter>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <!-- See https://help.syncfusion.com/wpf/autocomplete/textbox-customization -->
             <Style TargetType="{x:Type syncfusion:SfTextBoxExt}">
                 <Setter Property="BorderThickness" Value="0" />


### PR DESCRIPTION
# fix: text contrast ratio of MenuItem.ToolTip

**Fixed:**
- keep black text color (default) to provide an accessible contrast ratio.

**Additional notes:**
Regression introduced after upgrading Syncfusion to v30+ (see #2565).

Before:
<img width="541" height="212" alt="WolvenKit ToolTip issue" src="https://github.com/user-attachments/assets/8e69d32e-ee41-43c8-85d4-6db96e487d86" />

After:
<img width="576" height="211" alt="WolvenKit ToolTip fix" src="https://github.com/user-attachments/assets/4cd6ab29-54cb-421a-8153-fc9a1012c129" />