### PR TITLE
Feature: find broken files

### DIFF
--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -491,51 +491,6 @@
                 <!-- end Materials: mesh files -->
             </MenuItem>
 
-            <!-- ArchiveXL: mesh files -->
-            <MenuItem
-                Style="{StaticResource ShowInMeshFileMenuStyle}"
-                Header="ArchiveXL"
-                SubmenuOpened="OnMenuOpened"
-                SubmenuClosed="OnMenuClosed">
-
-                <!-- Un-dynamify materials -->
-                <MenuItem
-                    Style="{StaticResource MenuItemStyle}"
-                    Visibility="{Binding Path=IsEnabled,
-                                         RelativeSource={RelativeSource Self},
-                                         Mode=OneWay,
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Header="Un-dynamify materials"
-                    Click="OnUnDynamifyMaterialsClick">
-                    <MenuItem.Icon>
-                        <templates:IconBox
-                            IconPack="Material"
-                            Kind="ArrowUpBox"
-                            Foreground="White" />
-                    </MenuItem.Icon>
-                </MenuItem>
-
-                <!-- Generate CCXL Materials for hairs -->
-                <MenuItem
-                    Style="{StaticResource ShowMeshMenuItemStyle}"
-                    Visibility="{Binding Path=IsEnabled,
-                                         RelativeSource={RelativeSource Self},
-                                         Mode=OneWay,
-                                         Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Header="Convert hair to CCXL material"
-                    ToolTip="This will run adjust submesh counts first"
-                    Command="{Binding Path=ConvertHairToCCXLCommand}"
-                    Click="OnConvertHairToCCXLMaterials">
-                    <MenuItem.Icon>
-                        <templates:IconBox
-                            IconPack="MaterialDesign"
-                            Kind="SwitchAccessShortcut"
-                            Foreground="White" />
-                    </MenuItem.Icon>
-                </MenuItem>
-
-            </MenuItem>
-
             <!-- Clean up: .mesh / .json / .app -->
             <MenuItem
                 Style="{StaticResource ShowCleanUpMenuItemStyle}"
@@ -714,6 +669,51 @@
                             Foreground="{StaticResource WolvenKitRed}" />
                     </MenuItem.Icon>
                 </MenuItem>
+            </MenuItem>
+
+            <!-- ArchiveXL: mesh files -->
+            <MenuItem
+                Style="{StaticResource ShowInMeshFileMenuStyle}"
+                Header="ArchiveXL"
+                SubmenuOpened="OnMenuOpened"
+                SubmenuClosed="OnMenuClosed">
+
+                <!-- Un-dynamify materials -->
+                <MenuItem
+                    Style="{StaticResource MenuItemStyle}"
+                    Visibility="{Binding Path=IsEnabled,
+                                         RelativeSource={RelativeSource Self},
+                                         Mode=OneWay,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Header="Un-dynamify materials"
+                    Click="OnUnDynamifyMaterialsClick">
+                    <MenuItem.Icon>
+                        <templates:IconBox
+                            IconPack="Material"
+                            Kind="ArrowUpBox"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <!-- Generate CCXL Materials for hairs -->
+                <MenuItem
+                    Style="{StaticResource ShowMeshMenuItemStyle}"
+                    Visibility="{Binding Path=IsEnabled,
+                                         RelativeSource={RelativeSource Self},
+                                         Mode=OneWay,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Header="Convert hair to CCXL material"
+                    ToolTip="This will run adjust submesh counts first"
+                    Command="{Binding Path=ConvertHairToCCXLCommand}"
+                    Click="OnConvertHairToCCXLMaterials">
+                    <MenuItem.Icon>
+                        <templates:IconBox
+                            IconPack="MaterialDesign"
+                            Kind="SwitchAccessShortcut"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
             </MenuItem>
 
             <!-- Appearances (.app) / Components (.ent) -->

--- a/WolvenKit/Views/Shell/MenuBarView.xaml
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml
@@ -262,19 +262,7 @@
 
                 <Separator />
 
-                <MenuItem
-                    x:Name="ToolbarProjectScanFilePathsButton"
-                    Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
-                    Header="Scan project for broken file references">
-                    <MenuItem.Icon>
-                        <local:IconBox
-                            IconPack="Material"
-                            Kind="FileSearchOutline"
-                            Size="{DynamicResource WolvenKitIconTiny}"
-                            Foreground="White" />
-                    </MenuItem.Icon>
-                </MenuItem>
-
+                <!-- Project: Clean up -->
                 <MenuItem
                     x:Name="ToolbarCleanupButton"
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
@@ -282,6 +270,21 @@
                     <MenuItem.Icon>
                         <local:IconBox IconPack="Empty" />
                     </MenuItem.Icon>
+
+                    <MenuItem
+                        x:Name="ToolbarProjectFindUnusedFilesButton"
+                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                        Header="Scan for unused files">
+                        <MenuItem.Icon>
+                            <local:IconBox
+                                IconPack="Material"
+                                Kind="TextSearchVariant"
+                                Size="{DynamicResource WolvenKitIconTiny}"
+                                Foreground="White" />
+                        </MenuItem.Icon>
+                    </MenuItem>
+
+                    <Separator />
 
                     <MenuItem
                         x:Name="ToolbarProjectDeleteEmptyFoldersButton"
@@ -309,21 +312,38 @@
                         </MenuItem.Icon>
                     </MenuItem>
 
-                    <MenuItem
-                        x:Name="ToolbarProjectFindUnusedFilesButton"
-                        Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
-                        Header="Scan for unused project files">
-                        <MenuItem.Icon>
-                            <local:IconBox
-                                IconPack="Material"
-                                Kind="TextSearchVariant"
-                                Size="{DynamicResource WolvenKitIconTiny}"
-                                Foreground="White" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-
                 </MenuItem>
 
+                <Separator />
+
+                <MenuItem
+                    x:Name="ToolbarProjectScanFilePathsButton"
+                    Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                    Header="Scan for broken file references">
+                    <MenuItem.Icon>
+                        <local:IconBox
+                            IconPack="Material"
+                            Kind="FileSearchOutline"
+                            Size="{DynamicResource WolvenKitIconTiny}"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <MenuItem
+                    x:Name="ToolbarProjectScanForBrokenFilesButton"
+                    Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"
+                    ToolTip="Find broken CR2W files (such as corrupt textures) that will not be caught by other checks"
+                    Header="Scan for broken files">
+                    <MenuItem.Icon>
+                        <local:IconBox
+                            IconPack="Material"
+                            Kind="FileSearchOutline"
+                            Size="{DynamicResource WolvenKitIconTiny}"
+                            Foreground="White" />
+                    </MenuItem.Icon>
+                </MenuItem>
+
+                <Separator />
                 <MenuItem
                     x:Name="ToolbarProjectRunFileValidationButton"
                     Margin="{DynamicResource WolvenKitMenuBarItemMarginHorizontal}"

--- a/WolvenKit/Views/Shell/MenuBarView.xaml.cs
+++ b/WolvenKit/Views/Shell/MenuBarView.xaml.cs
@@ -100,6 +100,10 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                     view => view.ToolbarProjectScanFilePathsButton)
                 .DisposeWith(disposables);
             this.BindCommand(ViewModel,
+                    viewModel => viewModel.MainViewModel.ScanForBrokenFilesCommand,
+                    view => view.ToolbarProjectScanForBrokenFilesButton)
+                .DisposeWith(disposables);
+            this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.FindUnusedFilesCommand,
                     view => view.ToolbarProjectFindUnusedFilesButton)
                 .DisposeWith(disposables);
@@ -223,7 +227,7 @@ public partial class MenuBarView : ReactiveUserControl<MenuBarViewModel>
                    viewModel => viewModel.MainViewModel.ShowModsViewCommand,
                    view => view.MenuItemShowModsView)
                .DisposeWith(disposables);
-            
+
             this.BindCommand(ViewModel,
                     viewModel => viewModel.MainViewModel.OpenExternalLinkCommand,
                     view => view.MenuItemCyberpunkBlenderAddonLink,


### PR DESCRIPTION
# Feature: find broken files

Scans the project for CR2W files that can't be opened, or for texture without valid header data.

Use case: When creating NPVs, I had it happen at least four times that an item would show up black despite all dependencies being present. Turned out that the textures had become corrupted (preview not working). This is supposed to find those files.