### PR TITLE
RedCNameEditor: Allow file paths

### DIFF
--- a/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/RedCNameEditor.xaml.cs
@@ -66,7 +66,7 @@ namespace WolvenKit.Views.Editors
             s_validCharactersRegex(),
             s_placeholderRegex(),
             s_dynamicVariantRegex()
-        ]; 
+        ];
 
         private void RecalculateValidityAndTooltip()
         {
@@ -82,10 +82,12 @@ namespace WolvenKit.Views.Editors
                 hasError = true;
                 TextBoxToolTip = $"Invalid dynamic appearance condition! {invalidConditions}";
             }
-            else if (!s_regularExpressions.Any(r => r.IsMatch(Text)))
+            else if (!s_regularExpressions.Any(r => r.IsMatch(Text)) &&
+                     App.Helpers.ArchiveXlHelper.GetFirstExistingPath(Text) is null) // allow depot paths
             {
                 hasWarning = true;
-                TextBoxToolTip = $"'{Text}' contains invalid characters, or leading/trailing spaces! (Ignore this if everything works)";
+                TextBoxToolTip =
+                    $"'{Text}' contains invalid characters, leading/trailing spaces, or points at an invalid resource! (Ignore this if everything works)";
             }
             else
             {
@@ -111,7 +113,7 @@ namespace WolvenKit.Views.Editors
             }
             OnPropertyChanged(nameof(TextBoxToolTip));
         }
-       
+
         public CName RedString
         {
             get => (CName)GetValue(RedStringProperty);


### PR DESCRIPTION
# RedCNameEditor: Allow file paths

File paths will no longer show a warning about invalid character (for @context material)