### PR TITLE
feat(WelcomePageView): improve layout and responsiveness

### DIFF
--- a/WolvenKit.App/ViewModels/HomePage/HomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/HomePageViewModel.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
-using WolvenKit.Core.Extensions;
 
 namespace WolvenKit.App.ViewModels.HomePage;
 
@@ -28,7 +26,7 @@ public partial class HomePageViewModel : ObservableObject
     {
         _appViewModel = appViewModel;
         _settingsManager = settingsManager;
-        
+
         CurrentWindowState = WindowState.Normal;
     }
 
@@ -38,6 +36,8 @@ public partial class HomePageViewModel : ObservableObject
     public WindowState CurrentWindowState { get; set; }
 
     public string VersionNumber => _settingsManager.GetVersionNumber();
+
+    public bool IsNightly => VersionNumber.Contains("nightly");
 
 
     [RelayCommand]
@@ -50,5 +50,5 @@ public partial class HomePageViewModel : ObservableObject
 
     [RelayCommand]
     private void CheckForUpdates() => _appViewModel.CheckForUpdatesCommand.Execute(false);
-    
+
 }

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -307,12 +307,12 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             ShowHomePageSync();
         }
 
-        #if !DEBUG
+#if !DEBUG
         if (SettingsManager.AutoUpdateOnStartup)
         {
             CheckForUpdatesCommand.SafeExecute(true);
         }
-        #endif
+#endif
 
         CheckForScriptUpdatesCommand.SafeExecute();
         CheckForLongPathSupport();
@@ -2473,7 +2473,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         // WelcomePageView
         resources["WolvenKitWelcomeLogoMaxHeight"] = Math.Round(150 * _uiScalePercentage);
         resources["WolvenKitWelcomeLeftMinWidth"] = Math.Round(315 * _uiScalePercentage);
-        resources["WolvenKitWelcomeRightLength"] = new GridLength(380).Mul(_uiScalePercentage).Round();
+        resources["WolvenKitWelcomeRightLength"] = Math.Round(380 * _uiScalePercentage);
         resources["WolvenKitWelcomeOrderWidth"] = Math.Round(140 * _uiScalePercentage);
         resources["WolvenKitWelcomeCardSammyWidth"] = new GridLength(70).Mul(_uiScalePercentage).Round();
         resources["WolvenKitWelcomeCardSammyHeight"] = Math.Round(70 * _uiScalePercentage);
@@ -2489,6 +2489,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         resources["WolvenKitWelcomeSocialButtonHeight"] = Math.Round(50 * _uiScalePercentage);
 
         resources["WolvenKitWelcomeBreakWidth"] = Math.Round(1250 * _uiScalePercentage);
+        resources["WolvenKitWelcomeActionsColumnBreakWidth"] = Math.Round(914 * _uiScalePercentage);
 
         // SettingsPageView
         resources["WolvenKitSettingsGridLabelWidth"] = new GridLength(200).Mul(_uiScalePercentage).Round();

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -2471,6 +2471,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         resources["WolvenKitHomeSharedPaddingLeft"] = new Thickness(10, 0, 0, 0).Mul(_uiScalePercentage).Round();
 
         // WelcomePageView
+        resources["WolvenKitWelcomeLogoMaxHeight"] = Math.Round(150 * _uiScalePercentage);
+        resources["WolvenKitWelcomeLeftMinWidth"] = Math.Round(315 * _uiScalePercentage);
         resources["WolvenKitWelcomeRightLength"] = new GridLength(380).Mul(_uiScalePercentage).Round();
         resources["WolvenKitWelcomeOrderWidth"] = Math.Round(140 * _uiScalePercentage);
         resources["WolvenKitWelcomeCardSammyWidth"] = new GridLength(70).Mul(_uiScalePercentage).Round();
@@ -2485,6 +2487,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         resources["WolvenKitWelcomeStackHeight"] = Math.Round(70 * _uiScalePercentage);
         resources["WolvenKitWelcomeStackMargin"] = new Thickness(0, 4, 50, 0).Mul(_uiScalePercentage).Round();
         resources["WolvenKitWelcomeSocialButtonHeight"] = Math.Round(50 * _uiScalePercentage);
+
+        resources["WolvenKitWelcomeBreakWidth"] = Math.Round(1250 * _uiScalePercentage);
 
         // SettingsPageView
         resources["WolvenKitSettingsGridLabelWidth"] = new GridLength(200).Mul(_uiScalePercentage).Round();

--- a/WolvenKit/Converters/LessThanConverter.cs
+++ b/WolvenKit/Converters/LessThanConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace WolvenKit.Converters
+{
+    /// <summary>
+    /// Runs condition `Value < Parameter` where `Parameter` can be:
+    /// - a number as a double
+    /// - a resource as a string (as found in App.Sizes.xaml)
+    /// </summary>
+    [ValueConversion(typeof(double), typeof(bool))]
+    public sealed class LessThanConverter : IValueConverter
+    {
+        public static readonly LessThanConverter Default = new();
+
+        public object Convert(object rawValue, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (rawValue is double value)
+            {
+                if (double.TryParse(parameter as string, out var threshold))
+                {
+                    return value < threshold;
+                }
+                else
+                {
+                    var resources = Application.Current.Resources;
+                    return value < (double)resources[parameter as string]!;
+                }
+            }
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WolvenKit/Themes/App.Sizes.xaml
+++ b/WolvenKit/Themes/App.Sizes.xaml
@@ -120,6 +120,8 @@
     <Thickness x:Key="WolvenKitHomeSharedPaddingLeft">10,0,0,0</Thickness>
 
     <!-- WelcomePageView -->
+    <system:Double x:Key="WolvenKitWelcomeLogoMaxHeight">150</system:Double>
+    <system:Double x:Key="WolvenKitWelcomeLeftMinWidth">315</system:Double>
     <GridLength x:Key="WolvenKitWelcomeRightLength">380</GridLength>
     <system:Double x:Key="WolvenKitWelcomeOrderWidth">140</system:Double>
     <GridLength x:Key="WolvenKitWelcomeCardSammyWidth">70</GridLength>
@@ -134,6 +136,8 @@
     <system:Double x:Key="WolvenKitWelcomeStackHeight">70</system:Double>
     <Thickness x:Key="WolvenKitWelcomeStackMargin">0,4,50,0</Thickness>
     <system:Double x:Key="WolvenKitWelcomeSocialButtonHeight">50</system:Double>
+
+    <system:Double x:Key="WolvenKitWelcomeBreakWidth">1250</system:Double>
 
     <!-- SettingsPageView -->
     <GridLength x:Key="WolvenKitSettingsGridLabelWidth">200</GridLength>

--- a/WolvenKit/Themes/App.Sizes.xaml
+++ b/WolvenKit/Themes/App.Sizes.xaml
@@ -122,7 +122,7 @@
     <!-- WelcomePageView -->
     <system:Double x:Key="WolvenKitWelcomeLogoMaxHeight">150</system:Double>
     <system:Double x:Key="WolvenKitWelcomeLeftMinWidth">315</system:Double>
-    <GridLength x:Key="WolvenKitWelcomeRightLength">380</GridLength>
+    <system:Double x:Key="WolvenKitWelcomeRightLength">380</system:Double>
     <system:Double x:Key="WolvenKitWelcomeOrderWidth">140</system:Double>
     <GridLength x:Key="WolvenKitWelcomeCardSammyWidth">70</GridLength>
     <system:Double x:Key="WolvenKitWelcomeCardSammyHeight">70</system:Double>
@@ -138,6 +138,7 @@
     <system:Double x:Key="WolvenKitWelcomeSocialButtonHeight">50</system:Double>
 
     <system:Double x:Key="WolvenKitWelcomeBreakWidth">1250</system:Double>
+    <system:Double x:Key="WolvenKitWelcomeActionsColumnBreakWidth">914</system:Double>
 
     <!-- SettingsPageView -->
     <GridLength x:Key="WolvenKitSettingsGridLabelWidth">200</GridLength>

--- a/WolvenKit/Views/HomePage/HomePageView.xaml
+++ b/WolvenKit/Views/HomePage/HomePageView.xaml
@@ -48,13 +48,13 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
 
-            <!-- Left Bottom Button -->
+            <!-- Continue to Editor Button -->
             <Button
                 x:Name="ToEditorButton"
                 Grid.Row="0"
                 Margin="4,4,4,30"
                 Padding="0"
-                HorizontalAlignment="Stretch"
+                HorizontalAlignment="Left"
                 Background="{StaticResource ContentBackgroundAlt}"
                 BorderThickness="0">
                 <Grid>
@@ -82,12 +82,42 @@
                 </Grid>
             </Button>
 
-            <!-- Left Bottom Version Number -->
-            <StackPanel
+            <!-- Version Number -->
+            <Grid
                 Grid.Row="1"
                 Margin="{DynamicResource WolvenKitHomeVersionMargin}"
-                HorizontalAlignment="Left"
-                Orientation="Horizontal">
+                HorizontalAlignment="Left">
+                <Grid.Resources>
+                    <Style
+                        x:Key="NightlyResponsiveStyle"
+                        TargetType="{x:Type StackPanel}">
+                        <Setter Property="Grid.Column" Value="1" />
+                        <Setter Property="Grid.Row" Value="0" />
+
+                        <Style.Triggers>
+                            <DataTrigger
+                                Binding="{Binding IsNightly}"
+                                Value="True">
+                                <Setter Property="Grid.Column" Value="0" />
+                                <Setter Property="Grid.ColumnSpan" Value="2" />
+                                <Setter Property="Grid.Row" Value="1" />
+                                <Setter Property="HorizontalAlignment" Value="Right" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Resources>
+
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <!-- 2nd row reserved for responsiveness -->
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+
                 <TextBlock
                     Margin="{DynamicResource WolvenKitHomeVersionMargin}"
                     VerticalAlignment="Center"
@@ -97,19 +127,21 @@
                     FlowDirection="LeftToRight"
                     Text="{Binding VersionNumber}" />
 
-                <templates:IconBox
-                    IconPack="Codicons"
-                    Kind="Versions"
-                    Size="{DynamicResource WolvenKitIcon}"
-                    Foreground="{StaticResource WolvenKitRed}" />
+                <StackPanel
+                    Style="{StaticResource NightlyResponsiveStyle}"
+                    Orientation="Horizontal">
+                    <templates:IconBox
+                        IconPack="Codicons"
+                        Kind="Versions"
+                        Size="{DynamicResource WolvenKitIcon}"
+                        Foreground="{StaticResource WolvenKitRed}" />
 
-                <Button
-                    x:Name="CheckForUpdateButton"
-                    Margin="{DynamicResource WolvenKitHomeVersionMargin}"
-                    Padding="0"
-                    Background="Transparent"
-                    BorderThickness="0">
-                    <Grid>
+                    <Button
+                        x:Name="CheckForUpdateButton"
+                        Margin="{DynamicResource WolvenKitHomeVersionMargin}"
+                        Padding="0"
+                        Background="Transparent"
+                        BorderThickness="0">
                         <templates:IconBox
                             IconPack="Material"
                             Kind="Update"
@@ -118,10 +150,9 @@
                             VerticalAlignment="Center"
                             Size="{DynamicResource WolvenKitIconMilli}"
                             Foreground="{StaticResource WolvenKitRed}" />
-                    </Grid>
-                </Button>
-
-            </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Grid>
         </Grid>
 
         <!-- Left Navigation -->

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -6,714 +6,798 @@
     xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
     xmlns:reactiveUi="http://reactiveui.net"
     xmlns:shared="clr-namespace:WolvenKit.App.ViewModels.HomePage.Pages;assembly=WolvenKit.App"
+    xmlns:converters="clr-namespace:WolvenKit.Converters"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf">
-    <Grid
-        x:Name="topGrid"
-        Margin="50,00,50,0">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="PercentageThing" Width="4*" />
-            <ColumnDefinition Width="200*" />
-            <ColumnDefinition Width="{DynamicResource WolvenKitWelcomeRightLength}" />
-            <ColumnDefinition x:Name="PercentageThingHalf" Width="1*" />
-            <ColumnDefinition Width="3*" />
-        </Grid.ColumnDefinitions>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid
+            x:Name="topGrid"
+            Margin="{DynamicResource WolvenKitMarginHorizontal}">
+            <Grid.Resources>
+                <ResourceDictionary>
+                    <converters:LessThanConverter x:Key="LessThanConverter" />
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="1*" />
-            <RowDefinition Height="3*" />
-        </Grid.RowDefinitions>
+                    <Style
+                        x:Key="WelcomeButton"
+                        BasedOn="{StaticResource ButtonDefault}"
+                        TargetType="{x:Type Button}">
+                        <Setter Property="Background" Value="{StaticResource ContentBackgroundAlt}" />
 
-        <Grid.Resources>
-            <ResourceDictionary>
-                <Style
-                    x:Key="WelcomeButton"
-                    BasedOn="{StaticResource ButtonDefault}"
-                    TargetType="{x:Type Button}">
-                    <Setter Property="Background" Value="{StaticResource ContentBackgroundAlt}" />
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{StaticResource ContentBackgroundAlt3}" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
 
-                    <Style.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="{StaticResource ContentBackgroundAlt3}" />
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
+                    <Style
+                        x:Key="CardViewItemStyle"
+                        TargetType="{x:Type syncfusion:CardViewItem}">
+                        <Setter Property="Margin" Value="0,0,0,10" />
 
-                <Style
-                    x:Key="CardViewItemStyle"
-                    TargetType="{x:Type syncfusion:CardViewItem}">
-                    <Setter Property="Margin" Value="0,0,0,10" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type syncfusion:CardViewItem}">
+                                    <Grid Margin="{Binding ActualWidth, ElementName=PercentageThingHalf}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="300" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
 
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="{x:Type syncfusion:CardViewItem}">
-                                <Grid Margin="{Binding ActualWidth, ElementName=PercentageThingHalf}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="300" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
+                                        <!-- Header Alignment -->
+                                        <Grid>
+                                            <Grid.Resources>
+                                                <Style
+                                                    x:Key="CardItemBorder"
+                                                    TargetType="Border">
+                                                    <Setter Property="Background" Value="Transparent" />
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Background" Value="#2D2D30" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Grid.Resources>
 
-                                    <!-- Header Alignment -->
-                                    <Grid>
-                                        <Grid.Resources>
-                                            <Style
-                                                x:Key="CardItemBorder"
-                                                TargetType="Border">
-                                                <Setter Property="Background" Value="Transparent" />
-                                                <Style.Triggers>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="Background" Value="#2D2D30" />
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Grid.Resources>
-
-                                        <Button
-                                            Height="Auto"
-                                            Padding="0"
-                                            HorizontalContentAlignment="Stretch"
-                                            VerticalContentAlignment="Stretch"
-                                            Background="Transparent"
-                                            BorderThickness="0"
-                                            Command="{Binding ElementName=topGrid,
-                                                              Path=DataContext.OpenProjectCommand}"
-                                            CommandParameter="{Binding ProjectPath}"
-                                            ToolTip="{Binding Path=ProjectPath}">
-                                            <!--Button.OpacityMask>
+                                            <Button
+                                                Height="Auto"
+                                                Padding="0"
+                                                HorizontalContentAlignment="Stretch"
+                                                VerticalContentAlignment="Stretch"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Command="{Binding ElementName=topGrid,
+                                                                  Path=DataContext.OpenProjectCommand}"
+                                                CommandParameter="{Binding ProjectPath}"
+                                                ToolTip="{Binding Path=ProjectPath}">
+                                                <!--Button.OpacityMask>
                                                 <VisualBrush Visual="{Binding ElementName=headerBackground}" />
                                             </Button.OpacityMask-->
 
-                                            <Border
-                                                x:Name="headerBackground"
-                                                CornerRadius="10"
-                                                Style="{StaticResource CardItemBorder}">
-                                                <Grid Width="300">
-                                                    <Grid.Resources>
-                                                        <Style
-                                                            x:Key="ProjectIconBackground"
-                                                            TargetType="Border">
-                                                            <Setter Property="Background" Value="{StaticResource WolvenKitYellow}" />
-                                                            <Style.Triggers>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="1">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitYellow}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="2">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitCyan}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="3">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="4">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="5">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitPurple}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger
-                                                                    Binding="{Binding ProjectColor}"
-                                                                    Value="6">
-                                                                    <Setter Property="Background" Value="{StaticResource WolvenKitTan}" />
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </Grid.Resources>
+                                                <Border
+                                                    x:Name="headerBackground"
+                                                    CornerRadius="10"
+                                                    Style="{StaticResource CardItemBorder}">
+                                                    <Grid Width="300">
+                                                        <Grid.Resources>
+                                                            <Style
+                                                                x:Key="ProjectIconBackground"
+                                                                TargetType="Border">
+                                                                <Setter Property="Background" Value="{StaticResource WolvenKitYellow}" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="1">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitYellow}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="2">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitCyan}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="3">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="4">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="5">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitPurple}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger
+                                                                        Binding="{Binding ProjectColor}"
+                                                                        Value="6">
+                                                                        <Setter Property="Background" Value="{StaticResource WolvenKitTan}" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Grid.Resources>
 
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="{DynamicResource WolvenKitWelcomeCardSammyWidth}" />
-                                                        <ColumnDefinition Width="*" />
-                                                    </Grid.ColumnDefinitions>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="{DynamicResource WolvenKitWelcomeCardSammyWidth}" />
+                                                            <ColumnDefinition Width="*" />
+                                                        </Grid.ColumnDefinitions>
 
-                                                    <Border
-                                                        Height="{DynamicResource WolvenKitWelcomeCardSammyHeight}"
-                                                        CornerRadius="3"
-                                                        Style="{StaticResource ProjectIconBackground}">
-                                                        <Image
-                                                            Width="{DynamicResource WolvenKitWelcomeCardSammyClipHeight}"
-                                                            HorizontalAlignment="Center"
-                                                            VerticalAlignment="Center"
-                                                            RenderOptions.BitmapScalingMode="HighQuality"
-                                                            Source="pack://application:,,,/Resources/Media/Images/Application/Sammy_Alpha_Mask.png" />
-                                                    </Border>
+                                                        <Border
+                                                            Height="{DynamicResource WolvenKitWelcomeCardSammyHeight}"
+                                                            CornerRadius="3"
+                                                            Style="{StaticResource ProjectIconBackground}">
+                                                            <Image
+                                                                Width="{DynamicResource WolvenKitWelcomeCardSammyClipHeight}"
+                                                                HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center"
+                                                                RenderOptions.BitmapScalingMode="HighQuality"
+                                                                Source="pack://application:,,,/Resources/Media/Images/Application/Sammy_Alpha_Mask.png" />
+                                                        </Border>
 
-                                                    <StackPanel
-                                                        Grid.Column="1"
-                                                        Margin="10,5,0,8"
-                                                        VerticalAlignment="Center">
-                                                        <TextBlock
-                                                            Foreground="White"
-                                                            FontSize="{DynamicResource WolvenKitFontMedium}"
-                                                            FontWeight="Bold"
-                                                            Text="{Binding Path=SafeName}"
-                                                            TextTrimming="CharacterEllipsis" />
+                                                        <StackPanel
+                                                            Grid.Column="1"
+                                                            Margin="10,5,0,8"
+                                                            VerticalAlignment="Center">
+                                                            <TextBlock
+                                                                Foreground="White"
+                                                                FontSize="{DynamicResource WolvenKitFontMedium}"
+                                                                FontWeight="Bold"
+                                                                Text="{Binding Path=SafeName}"
+                                                                TextTrimming="CharacterEllipsis" />
 
-                                                        <TextBlock
-                                                            Margin="0,1,0,2"
-                                                            HorizontalAlignment="Left"
-                                                            Foreground="#999999"
-                                                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                                            Text="{Binding Path=ProjectPath}"
-                                                            TextTrimming="CharacterEllipsis" />
+                                                            <TextBlock
+                                                                Margin="0,1,0,2"
+                                                                HorizontalAlignment="Left"
+                                                                Foreground="#999999"
+                                                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                                                Text="{Binding Path=ProjectPath}"
+                                                                TextTrimming="CharacterEllipsis" />
 
-                                                        <TextBlock
-                                                            FontSize="{DynamicResource WolvenKitFontAltTitle}"
-                                                            Text="{Binding CreationDate}" />
-                                                    </StackPanel>
-                                                </Grid>
-                                            </Border>
-                                        </Button>
+                                                            <TextBlock
+                                                                FontSize="{DynamicResource WolvenKitFontAltTitle}"
+                                                                Text="{Binding CreationDate}" />
+                                                        </StackPanel>
+                                                    </Grid>
+                                                </Border>
+                                            </Button>
+                                        </Grid>
+
+                                        <StackPanel
+                                            Grid.Column="1"
+                                            Margin="0,0,10,0"
+                                            VerticalAlignment="Center"
+                                            Orientation="Vertical">
+                                            <ToggleButton
+                                                Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
+                                                Style="{StaticResource ToggleButtonCustom}"
+                                                IsChecked="{Binding IsPinned,
+                                                                    Mode=TwoWay}"
+                                                ToolTip="Pin project">
+                                                <ToggleButton.Resources>
+                                                    <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
+                                                        <Setter Property="Kind" Value="StarEmpty" />
+
+                                                        <Style.Triggers>
+                                                            <DataTrigger
+                                                                Binding="{Binding IsChecked,
+                                                                                  RelativeSource={RelativeSource AncestorType=ToggleButton}}"
+                                                                Value="True">
+                                                                <Setter Property="Kind" Value="StarFull" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ToggleButton.Resources>
+
+                                                <iconPacks:PackIconCodicons Width="{DynamicResource WolvenKitIconTiny}" />
+                                            </ToggleButton>
+
+                                            <Button
+                                                Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
+                                                Style="{StaticResource ButtonCustom}"
+                                                Command="{Binding ElementName=topGrid,
+                                                                  Path=DataContext.OpenInExplorerCommand}"
+                                                CommandParameter="{Binding ProjectPath}"
+                                                ToolTip="Find in Explorer">
+                                                <Button.Resources>
+                                                    <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
+                                                        <Setter Property="Foreground" Value="White" />
+
+                                                        <Style.Triggers>
+                                                            <DataTrigger
+                                                                Binding="{Binding IsMouseOver,
+                                                                                  RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                Value="True">
+                                                                <Setter Property="Foreground" Value="#cccccc" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Resources>
+
+                                                <iconPacks:PackIconCodicons
+                                                    Kind="FolderOpened"
+                                                    Width="{DynamicResource WolvenKitIconTiny}" />
+                                            </Button>
+
+                                            <Button
+                                                x:Name="RUIDeleteProjectButton"
+                                                Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
+                                                Style="{StaticResource ButtonCustom}"
+                                                Command="{Binding ElementName=topGrid,
+                                                                  Path=DataContext.DeleteProjectCommand}"
+                                                CommandParameter="{Binding ProjectPath}"
+                                                ToolTip="Remove from Recents">
+                                                <Button.Resources>
+                                                    <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
+                                                        <Setter Property="Foreground" Value="{StaticResource WolvenKitRed}" />
+
+                                                        <Style.Triggers>
+                                                            <DataTrigger
+                                                                Binding="{Binding IsMouseOver,
+                                                                                  RelativeSource={RelativeSource AncestorType=Button}}"
+                                                                Value="True">
+                                                                <Setter Property="Foreground" Value="{StaticResource WolvenKitRedShadow}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Button.Resources>
+
+                                                <iconPacks:PackIconCodicons
+                                                    Kind="ChromeClose"
+                                                    Width="{DynamicResource WolvenKitIconTiny}" />
+                                            </Button>
+                                        </StackPanel>
                                     </Grid>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Setter Property="Width" Value="Auto" />
+                    </Style>
 
-                                    <StackPanel
-                                        Grid.Column="1"
-                                        Margin="0,0,10,0"
-                                        VerticalAlignment="Center"
-                                        Orientation="Vertical">
-                                        <ToggleButton
-                                            Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
-                                            Style="{StaticResource ToggleButtonCustom}"
-                                            IsChecked="{Binding IsPinned,
-                                                                Mode=TwoWay}"
-                                            ToolTip="Pin project">
-                                            <ToggleButton.Resources>
-                                                <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
-                                                    <Setter Property="Kind" Value="StarEmpty" />
+                    <Style
+                        x:Key="ActionResponsiveStyle"
+                        TargetType="{x:Type Grid}">
+                        <!-- Must be set here to allow override with Style.Triggers -->
+                        <Setter Property="Grid.Column" Value="2" />
+                        <Setter Property="Grid.Row" Value="0" />
+                        <Setter Property="HorizontalAlignment" Value="Right" />
 
-                                                    <Style.Triggers>
-                                                        <DataTrigger
-                                                            Binding="{Binding IsChecked,
-                                                                              RelativeSource={RelativeSource AncestorType=ToggleButton}}"
-                                                            Value="True">
-                                                            <Setter Property="Kind" Value="StarFull" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </ToggleButton.Resources>
+                        <Style.Triggers>
+                            <DataTrigger
+                                Binding="{Binding Path=ActualWidth,
+                                                  Converter={StaticResource LessThanConverter},
+                                                  ConverterParameter=WolvenKitWelcomeBreakWidth,
+                                                  RelativeSource={RelativeSource AncestorType=Window}}"
+                                Value="True">
+                                <Setter Property="Grid.Column" Value="0" />
+                                <Setter Property="Grid.ColumnSpan" Value="3" />
+                                <Setter Property="Grid.Row" Value="1" />
+                                <Setter Property="HorizontalAlignment" Value="Left" />
+                                <Setter Property="Margin" Value="0,8,0,0" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
+            </Grid.Resources>
 
-                                            <iconPacks:PackIconCodicons Width="{DynamicResource WolvenKitIconTiny}" />
-                                        </ToggleButton>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition MinWidth="{DynamicResource WolvenKitWelcomeLeftMinWidth}" />
+                <ColumnDefinition Width="{DynamicResource WolvenKitWelcomeRightLength}" />
+            </Grid.ColumnDefinitions>
 
-                                        <Button
-                                            Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
-                                            Style="{StaticResource ButtonCustom}"
-                                            Command="{Binding ElementName=topGrid,
-                                                              Path=DataContext.OpenInExplorerCommand}"
-                                            CommandParameter="{Binding ProjectPath}"
-                                            ToolTip="Find in Explorer">
-                                            <Button.Resources>
-                                                <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
-                                                    <Setter Property="Foreground" Value="White" />
-
-                                                    <Style.Triggers>
-                                                        <DataTrigger
-                                                            Binding="{Binding IsMouseOver,
-                                                                              RelativeSource={RelativeSource AncestorType=Button}}"
-                                                            Value="True">
-                                                            <Setter Property="Foreground" Value="#cccccc" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Button.Resources>
-
-                                            <iconPacks:PackIconCodicons
-                                                Kind="FolderOpened"
-                                                Width="{DynamicResource WolvenKitIconTiny}" />
-                                        </Button>
-
-                                        <Button
-                                            x:Name="RUIDeleteProjectButton"
-                                            Padding="{DynamicResource WolvenKitWelcomeTogglePadding}"
-                                            Style="{StaticResource ButtonCustom}"
-                                            Command="{Binding ElementName=topGrid,
-                                                              Path=DataContext.DeleteProjectCommand}"
-                                            CommandParameter="{Binding ProjectPath}"
-                                            ToolTip="Remove from Recents">
-                                            <Button.Resources>
-                                                <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
-                                                    <Setter Property="Foreground" Value="{StaticResource WolvenKitRed}" />
-
-                                                    <Style.Triggers>
-                                                        <DataTrigger
-                                                            Binding="{Binding IsMouseOver,
-                                                                              RelativeSource={RelativeSource AncestorType=Button}}"
-                                                            Value="True">
-                                                            <Setter Property="Foreground" Value="{StaticResource WolvenKitRedShadow}" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Button.Resources>
-
-                                            <iconPacks:PackIconCodicons
-                                                Kind="ChromeClose"
-                                                Width="{DynamicResource WolvenKitIconTiny}" />
-                                        </Button>
-                                    </StackPanel>
-                                </Grid>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                    <Setter Property="Width" Value="Auto" />
-                </Style>
-            </ResourceDictionary>
-        </Grid.Resources>
-
-        <!-- WK Text Logo -->
-        <Image
-            Grid.Row="0"
-            Grid.Column="1"
-            Grid.ColumnSpan="2"
-            Margin="66,30,66,20"
-            HorizontalAlignment="Center"
-            RenderOptions.BitmapScalingMode="HighQuality"
-            Source="pack://application:,,,/Resources/Media/Images/Application/wkit_logo_text_singlestack_white.png" />
-
-        <!-- Left Column \ Projects -->
-        <Grid
-            Grid.Row="1"
-            Grid.Column="1"
-            Background="Transparent">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="3*" />
             </Grid.RowDefinitions>
 
-            <!-- Pinned Projects -->
-            <Grid
+            <!-- WK Text Logo -->
+            <Image
                 Grid.Row="0"
-                Margin="{DynamicResource WolvenKitMarginBottom}"
-                Visibility="{Binding ShowPinned,
-                                     Converter={StaticResource BooleanToVisibilityConverter}}">
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                MaxHeight="{DynamicResource WolvenKitWelcomeLogoMaxHeight}"
+                Margin="{DynamicResource WolvenKitMarginVertical}"
+                HorizontalAlignment="Center"
+                RenderOptions.BitmapScalingMode="HighQuality"
+                Source="pack://application:,,,/Resources/Media/Images/Application/wkit_logo_text_singlestack_white.png" />
+
+            <!-- Left Column \ Projects -->
+            <Grid
+                Grid.Row="1"
+                Grid.Column="0"
+                Margin="0,0,6,24">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <!-- Header -->
-                <Grid Grid.Row="0">
-                    <StackPanel
-                        Margin="9,0,0,20"
-                        HorizontalAlignment="Left"
-                        Orientation="Horizontal">
-                        <Border Width="{Binding ActualWidth, ElementName=PercentageThingHalf}" />
+                <!-- Pinned Projects -->
+                <Grid
+                    Grid.Row="0"
+                    Margin="{DynamicResource WolvenKitMarginBottom}"
+                    Visibility="{Binding ShowPinned,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
 
-                        <iconPacks:PackIconCodicons
-                            Kind="StarFull"
-                            Width="{DynamicResource WolvenKitIconSmall}"
-                            Height="{DynamicResource WolvenKitIconSmall}"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                            Spin="False"
-                            SpinAutoReverse="False" />
+                    <!-- Header -->
+                    <Grid
+                        Grid.Row="0"
+                        Margin="0,0,0,12">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <!-- 2nd row reserved for responsiveness -->
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
 
-                        <TextBlock
-                            x:Name="PinnedProjectTour"
-                            Margin="{DynamicResource WolvenKitMarginSmallLeft}"
-                            FontSize="{DynamicResource WolvenKitFontTitle}"
-                            Text="Pinned Projects" />
-                    </StackPanel>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                    <StackPanel
-                        Margin="9,0,0,20"
-                        HorizontalAlignment="Right"
-                        Orientation="Horizontal">
-                        <TextBox
-                            x:Name="PinnedFilter"
-                            Width="{DynamicResource WolvenKitWelcomeOrderWidth}" />
-
-                        <ComboBox
-                            x:Name="PinnedOrder"
-                            Width="{DynamicResource WolvenKitWelcomeOrderWidth}"
-                            DisplayMemberPath="Key"
-                            ItemsSource="{Binding SortMode,
-                                                  Mode=OneWay}"
-                            SelectedValuePath="Value" />
-                    </StackPanel>
-                </Grid>
-
-                <!-- Cards -->
-                <syncfusion:CardView
-                    Name="PinnedCardView"
-                    Grid.Row="1"
-                    MaxHeight="190"
-                    Margin="10,0,0,0"
-                    HorizontalAlignment="Left"
-                    Background="Transparent"
-                    CanSort="False"
-                    ItemContainerStyle="{StaticResource CardViewItemStyle}"
-                    ItemsSource="{Binding FancyPinnedProjects}"
-                    Orientation="Horizontal"
-                    ShowHeader="False">
-                    <syncfusion:CardView.Resources>
-                        <!-- gets rid of margin around items -->
-                        <Style TargetType="{x:Type ItemsPresenter}">
-                            <Setter Property="Margin" Value="-10" />
-                        </Style>
-                    </syncfusion:CardView.Resources>
-                </syncfusion:CardView>
-            </Grid>
-
-            <!-- Recent Projects -->
-            <Grid Grid.Row="1">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <!-- Header -->
-                <Grid Grid.Row="0">
-                    <StackPanel
-                        Margin="9,0,0,20"
-                        HorizontalAlignment="Left"
-                        Orientation="Horizontal">
-                        <Border Width="{Binding ActualWidth, ElementName=PercentageThingHalf}" />
-
-                        <iconPacks:PackIconCodicons
-                            Kind="GoToFile"
-                            Width="{DynamicResource WolvenKitIconSmall}"
-                            Height="{DynamicResource WolvenKitIconSmall}"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                            Spin="False"
-                            SpinAutoReverse="False" />
-
-                        <TextBlock
-                            x:Name="RecentProjectTour"
-                            Margin="{DynamicResource WolvenKitMarginSmallLeft}"
-                            FontSize="{DynamicResource WolvenKitFontTitle}"
-                            Text="Recent Projects" />
-                    </StackPanel>
-
-                    <StackPanel
-                        Margin="9,0,0,20"
-                        HorizontalAlignment="Right"
-                        Orientation="Horizontal">
-                        <TextBox
-                            x:Name="RecentFilter"
-                            Width="{DynamicResource WolvenKitWelcomeOrderWidth}" />
-
-                        <ComboBox
-                            x:Name="RecentOrder"
-                            Width="{DynamicResource WolvenKitWelcomeOrderWidth}"
-                            DisplayMemberPath="Key"
-                            ItemsSource="{Binding SortMode,
-                                                  Mode=OneWay}"
-                            SelectedValuePath="Value" />
-                    </StackPanel>
-                </Grid>
-
-                <!-- Cards -->
-                <syncfusion:CardView
-                    Name="RecentCardView"
-                    Grid.Row="1"
-                    Margin="10,0,0,0"
-                    HorizontalAlignment="Left"
-                    Background="Transparent"
-                    CanSort="False"
-                    ItemContainerStyle="{StaticResource CardViewItemStyle}"
-                    ItemsSource="{Binding FancyProjects}"
-                    Orientation="Horizontal"
-                    ShowHeader="False">
-                    <syncfusion:CardView.Resources>
-                        <!-- gets rid of margin around items -->
-                        <Style TargetType="{x:Type ItemsPresenter}">
-                            <Setter Property="Margin" Value="-10" />
-                        </Style>
-                    </syncfusion:CardView.Resources>
-                </syncfusion:CardView>
-            </Grid>
-        </Grid>
-
-        <!-- Right Column -->
-        <Grid
-            Grid.Row="1"
-            Grid.Column="2">
-            <Grid>
-                <Border
-                    Margin="0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top">
-                    <StackPanel>
-                        <Button
-                            x:Name="NewProjectButton"
-                            Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
-                            Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
-                            Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
-                            HorizontalAlignment="Stretch"
-                            BorderThickness="0"
-                            Style="{StaticResource WelcomeButton}">
-                            <Grid>
-                                <StackPanel
-                                    Height="{DynamicResource WolvenKitWelcomeStackHeight}"
-                                    Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontHeader}"
-                                        Text="Create a new project" />
-
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        Foreground="Gray"
-                                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                        Text="Get started with WolvenKit by creating a new mod project"
-                                        TextWrapping="Wrap" />
-                                </StackPanel>
-                                <iconPacks:PackIconCodicons
-                                    Kind="Add"
-                                    Width="{DynamicResource WolvenKitIconHuge}"
-                                    Height="{DynamicResource WolvenKitIconHuge}"
-                                    Margin="0"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Center" />
-                            </Grid>
-                        </Button>
-
-                        <Button
-                            x:Name="OpenProjectButton"
-                            Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
-                            Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
-                            Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
-                            HorizontalAlignment="Stretch"
-                            BorderThickness="0"
-                            Style="{StaticResource WelcomeButton}">
-                            <Grid>
-                                <StackPanel
-                                    Height="{DynamicResource WolvenKitWelcomeStackHeight}"
-                                    Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontHeader}"
-                                        Text="Open a project" />
-
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        Foreground="Gray"
-                                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                        Text="Open an existing .modproj file"
-                                        TextWrapping="Wrap" />
-                                </StackPanel>
-                                <iconPacks:PackIconCodicons
-                                    Kind="GoToFile"
-                                    Width="{DynamicResource WolvenKitIconHuge}"
-                                    Height="{DynamicResource WolvenKitIconHuge}"
-                                    Margin="0"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Center" />
-                            </Grid>
-                        </Button>
-
-                        <Button
-                            x:Name="ContinueWithoutProjectButton"
-                            Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
-                            Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
-                            Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
-                            HorizontalAlignment="Stretch"
-                            BorderThickness="0"
-                            Style="{StaticResource WelcomeButton}">
-                            <Grid>
-                                <StackPanel
-                                    Height="{DynamicResource WolvenKitWelcomeStackHeight}"
-                                    Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontHeader}"
-                                        Text="Continue to editor" />
-
-                                    <TextBlock
-                                        Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
-                                        HorizontalAlignment="Center"
-                                        Foreground="Gray"
-                                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                        Text="Access the WolvenKit Editor"
-                                        TextWrapping="Wrap" />
-                                </StackPanel>
-                                <iconPacks:PackIconCodicons
-                                    Kind="ArrowRight"
-                                    Width="{DynamicResource WolvenKitIconHuge}"
-                                    Height="{DynamicResource WolvenKitIconHuge}"
-                                    Margin="0"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Center" />
-                            </Grid>
-                        </Button>
-
-                        <!-- Socials Header -->
-
-                        <StackPanel
-                            Margin="3,20,0,20"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Bottom"
-                            Orientation="Horizontal">
-                            <StackPanel Orientation="Horizontal">
-                                <iconPacks:PackIconBoxIcons
-                                    Kind="RegularNetworkChart"
-                                    Width="{DynamicResource WolvenKitIconSmall}"
-                                    Height="{DynamicResource WolvenKitIconSmall}"
-                                    VerticalAlignment="Center"
-                                    Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                                    Spin="False"
-                                    SpinAutoReverse="False" />
-
-                                <TextBlock
-                                    Margin="8,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    FontSize="{DynamicResource WolvenKitFontTitle}"
-                                    Text="Socials" />
-                            </StackPanel>
-                        </StackPanel>
-
-                        <Grid
-                            Margin="0,0,0,0"
-                            HorizontalAlignment="Stretch">
+                        <!-- Pinned Projects -->
+                        <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <!-- Socials -->
-
-                            <Button
-                                x:Name="DiscordLinkButton"
-                                Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
-                                Margin="0,0,4,0"
-                                HorizontalAlignment="Stretch"
-                                BorderThickness="0"
-                                Style="{StaticResource WelcomeButton}">
-                                <StackPanel Orientation="Horizontal">
-                                    <iconPacks:PackIconBoxIcons
-                                        Kind="LogosDiscord"
-                                        Width="{DynamicResource WolvenKitIconSmall}"
-                                        Height="{DynamicResource WolvenKitIconSmall}"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center" />
-
-                                    <TextBlock
-                                        Margin="7,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontMedium}"
-                                        Text="Discord" />
-                                </StackPanel>
-                            </Button>
-
-                            <Button
-                                x:Name="YoutubeLinkButton"
-                                Grid.Column="1"
-                                Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
-                                Margin="4,0,0,0"
-                                HorizontalAlignment="Stretch"
-                                BorderThickness="0"
-                                Style="{StaticResource WelcomeButton}">
-                                <StackPanel Orientation="Horizontal">
-                                    <iconPacks:PackIconBoxIcons
-                                        Kind="LogosYoutube"
-                                        Width="{DynamicResource WolvenKitIconSmall}"
-                                        Height="{DynamicResource WolvenKitIconSmall}"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center" />
-
-                                    <TextBlock
-                                        Margin="7,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontMedium}"
-                                        Text="YouTube" />
-                                </StackPanel>
-                            </Button>
-                        </Grid>
-
-                        <!-- Support Header -->
-                        <StackPanel
-                            Margin="3,20,0,20"
-                            FlowDirection="LeftToRight"
-                            Orientation="Horizontal">
-                            <iconPacks:PackIconBoxIcons
-                                Kind="RegularDonateHeart"
+                            <iconPacks:PackIconCodicons
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Kind="StarFull"
                                 Width="{DynamicResource WolvenKitIconSmall}"
                                 Height="{DynamicResource WolvenKitIconSmall}"
                                 VerticalAlignment="Center"
-                                Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+                                Foreground="{StaticResource ForegroundColor}"
+                                Spin="False"
+                                SpinAutoReverse="False" />
 
                             <TextBlock
-                                Margin="10,0,0,0"
+                                x:Name="PinnedProjectTour"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontSize="{DynamicResource WolvenKitFontTitle}"
-                                Text="Support Us" />
-                        </StackPanel>
+                                Text="Pinned Projects" />
+                        </Grid>
 
-                        <!-- Support -->
-                        <Grid>
+                        <!-- Filter and Dropdown -->
+                        <Grid Style="{StaticResource ActionResponsiveStyle}">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition />
+                                <ColumnDefinition />
                             </Grid.ColumnDefinitions>
 
-                            <Button
-                                x:Name="OpenCollectiveLinkButton"
-                                Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
-                                Margin="0,0,4,0"
-                                HorizontalAlignment="Stretch"
-                                BorderThickness="0"
-                                Style="{StaticResource WelcomeButton}">
-                                <StackPanel Orientation="Horizontal">
-                                    <iconPacks:PackIconBoxIcons
-                                        Kind="SolidDonateHeart"
-                                        Width="{DynamicResource WolvenKitIconSmall}"
-                                        Height="{DynamicResource WolvenKitIconSmall}"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center" />
+                            <TextBox
+                                x:Name="PinnedFilter"
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Width="{DynamicResource WolvenKitWelcomeOrderWidth}" />
 
-                                    <TextBlock
-                                        Margin="7,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontMedium}"
-                                        Text="Open Collective" />
-                                </StackPanel>
-                            </Button>
-
-                            <Button
-                                x:Name="PatreonLinkButton"
+                            <ComboBox
+                                x:Name="PinnedOrder"
+                                Grid.Row="0"
                                 Grid.Column="1"
-                                Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
-                                Margin="4,0,0,0"
+                                Width="{DynamicResource WolvenKitWelcomeOrderWidth}"
+                                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+                                DisplayMemberPath="Key"
+                                ItemsSource="{Binding SortMode,
+                                                      Mode=OneWay}"
+                                SelectedValuePath="Value" />
+                        </Grid>
+                    </Grid>
+
+                    <!-- Cards -->
+                    <syncfusion:CardView
+                        Name="PinnedCardView"
+                        Grid.Row="1"
+                        MaxHeight="190"
+                        HorizontalAlignment="Left"
+                        Background="Transparent"
+                        CanSort="False"
+                        ItemContainerStyle="{StaticResource CardViewItemStyle}"
+                        ItemsSource="{Binding FancyPinnedProjects}"
+                        Orientation="Horizontal"
+                        ShowHeader="False">
+                        <syncfusion:CardView.Resources>
+                            <!-- gets rid of margin around items -->
+                            <Style TargetType="{x:Type ItemsPresenter}">
+                                <Setter Property="Margin" Value="-10" />
+                            </Style>
+                        </syncfusion:CardView.Resources>
+                    </syncfusion:CardView>
+                </Grid>
+
+                <!-- Recent Projects -->
+                <Grid Grid.Row="1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Header -->
+                    <Grid
+                        Grid.Row="0"
+                        Margin="0,0,0,12">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <!-- 2nd row reserved for responsiveness -->
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Recent Projects -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <iconPacks:PackIconCodicons
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Kind="GoToFile"
+                                Width="{DynamicResource WolvenKitIconSmall}"
+                                Height="{DynamicResource WolvenKitIconSmall}"
+                                VerticalAlignment="Center"
+                                Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                Spin="False"
+                                SpinAutoReverse="False" />
+
+                            <TextBlock
+                                x:Name="RecentProjectTour"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                FontSize="{DynamicResource WolvenKitFontTitle}"
+                                Text="Recent Projects" />
+                        </Grid>
+
+                        <!-- Filter and Dropdown -->
+                        <Grid Style="{StaticResource ActionResponsiveStyle}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBox
+                                x:Name="RecentFilter"
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Width="{DynamicResource WolvenKitWelcomeOrderWidth}" />
+
+                            <ComboBox
+                                x:Name="RecentOrder"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Width="{DynamicResource WolvenKitWelcomeOrderWidth}"
+                                Margin="{DynamicResource WolvenKitMarginSmallLeft}"
+                                DisplayMemberPath="Key"
+                                ItemsSource="{Binding SortMode,
+                                                      Mode=OneWay}"
+                                SelectedValuePath="Value" />
+                        </Grid>
+                    </Grid>
+
+                    <!-- Cards -->
+                    <syncfusion:CardView
+                        Name="RecentCardView"
+                        Grid.Row="1"
+                        HorizontalAlignment="Left"
+                        Background="Transparent"
+                        CanSort="False"
+                        ItemContainerStyle="{StaticResource CardViewItemStyle}"
+                        ItemsSource="{Binding FancyProjects}"
+                        Orientation="Horizontal"
+                        ShowHeader="False">
+                        <syncfusion:CardView.Resources>
+                            <!-- gets rid of margin around items -->
+                            <Style TargetType="{x:Type ItemsPresenter}">
+                                <Setter Property="Margin" Value="-10" />
+                            </Style>
+                        </syncfusion:CardView.Resources>
+                    </syncfusion:CardView>
+                </Grid>
+            </Grid>
+
+            <!-- Right Column \ Main Actions -->
+            <Grid
+                Grid.Row="1"
+                Grid.Column="1"
+                Margin="6,0,0,24">
+                <Grid>
+                    <Border
+                        Margin="0"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Top">
+                        <StackPanel>
+                            <Button
+                                x:Name="NewProjectButton"
+                                Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
+                                Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
+                                Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
                                 HorizontalAlignment="Stretch"
                                 BorderThickness="0"
                                 Style="{StaticResource WelcomeButton}">
+                                <Grid>
+                                    <StackPanel
+                                        Height="{DynamicResource WolvenKitWelcomeStackHeight}"
+                                        Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontHeader}"
+                                            Text="Create a new project" />
+
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            Foreground="Gray"
+                                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                            Text="Get started with WolvenKit by creating a new mod project"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <iconPacks:PackIconCodicons
+                                        Kind="Add"
+                                        Width="{DynamicResource WolvenKitIconBig}"
+                                        Height="{DynamicResource WolvenKitIconBig}"
+                                        Margin="0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center" />
+                                </Grid>
+                            </Button>
+
+                            <Button
+                                x:Name="OpenProjectButton"
+                                Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
+                                Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
+                                Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
+                                HorizontalAlignment="Stretch"
+                                BorderThickness="0"
+                                Style="{StaticResource WelcomeButton}">
+                                <Grid>
+                                    <StackPanel
+                                        Height="{DynamicResource WolvenKitWelcomeStackHeight}"
+                                        Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontHeader}"
+                                            Text="Open a project" />
+
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            Foreground="Gray"
+                                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                            Text="Open an existing .modproj file"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <iconPacks:PackIconCodicons
+                                        Kind="GoToFile"
+                                        Width="{DynamicResource WolvenKitIconBig}"
+                                        Height="{DynamicResource WolvenKitIconBig}"
+                                        Margin="0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center" />
+                                </Grid>
+                            </Button>
+
+                            <Button
+                                x:Name="ContinueWithoutProjectButton"
+                                Height="{DynamicResource WolvenKitWelcomeButtonHeight}"
+                                Margin="{DynamicResource WolvenKitWelcomeButtonMargin}"
+                                Padding="{DynamicResource WolvenKitWelcomeButtonPadding}"
+                                HorizontalAlignment="Stretch"
+                                BorderThickness="0"
+                                Style="{StaticResource WelcomeButton}">
+                                <Grid>
+                                    <StackPanel
+                                        Height="{DynamicResource WolvenKitWelcomeStackHeight}"
+                                        Margin="{DynamicResource WolvenKitWelcomeStackMargin}">
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontHeader}"
+                                            Text="Continue to editor" />
+
+                                        <TextBlock
+                                            Width="{DynamicResource WolvenKitWelcomeButtonWidth}"
+                                            HorizontalAlignment="Center"
+                                            Foreground="Gray"
+                                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                            Text="Access the WolvenKit Editor"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+                                    <iconPacks:PackIconCodicons
+                                        Kind="ArrowRight"
+                                        Width="{DynamicResource WolvenKitIconBig}"
+                                        Height="{DynamicResource WolvenKitIconBig}"
+                                        Margin="0"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center" />
+                                </Grid>
+                            </Button>
+
+                            <!-- Socials Header -->
+
+                            <StackPanel
+                                Margin="3,20,0,20"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom"
+                                Orientation="Horizontal">
                                 <StackPanel Orientation="Horizontal">
                                     <iconPacks:PackIconBoxIcons
-                                        Kind="LogosPatreon"
+                                        Kind="RegularNetworkChart"
                                         Width="{DynamicResource WolvenKitIconSmall}"
                                         Height="{DynamicResource WolvenKitIconSmall}"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center" />
+                                        VerticalAlignment="Center"
+                                        Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                        Spin="False"
+                                        SpinAutoReverse="False" />
 
                                     <TextBlock
-                                        Margin="7,0,0,0"
+                                        Margin="8,0"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
-                                        FontSize="{DynamicResource WolvenKitFontMedium}"
-                                        Text="Patreon" />
+                                        FontSize="{DynamicResource WolvenKitFontTitle}"
+                                        Text="Socials" />
                                 </StackPanel>
-                            </Button>
-                        </Grid>
-                    </StackPanel>
-                </Border>
+                            </StackPanel>
+
+                            <Grid
+                                Margin="0,0,0,0"
+                                HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <!-- Socials -->
+
+                                <Button
+                                    x:Name="DiscordLinkButton"
+                                    Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
+                                    Margin="0,0,4,0"
+                                    HorizontalAlignment="Stretch"
+                                    BorderThickness="0"
+                                    Style="{StaticResource WelcomeButton}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <iconPacks:PackIconBoxIcons
+                                            Kind="LogosDiscord"
+                                            Width="{DynamicResource WolvenKitIconSmall}"
+                                            Height="{DynamicResource WolvenKitIconSmall}"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+
+                                        <TextBlock
+                                            Margin="7,0,0,0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontMedium}"
+                                            Text="Discord" />
+                                    </StackPanel>
+                                </Button>
+
+                                <Button
+                                    x:Name="YoutubeLinkButton"
+                                    Grid.Column="1"
+                                    Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
+                                    Margin="4,0,0,0"
+                                    HorizontalAlignment="Stretch"
+                                    BorderThickness="0"
+                                    Style="{StaticResource WelcomeButton}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <iconPacks:PackIconBoxIcons
+                                            Kind="LogosYoutube"
+                                            Width="{DynamicResource WolvenKitIconSmall}"
+                                            Height="{DynamicResource WolvenKitIconSmall}"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+
+                                        <TextBlock
+                                            Margin="7,0,0,0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontMedium}"
+                                            Text="YouTube" />
+                                    </StackPanel>
+                                </Button>
+                            </Grid>
+
+                            <!-- Support Header -->
+                            <StackPanel
+                                Margin="3,20,0,20"
+                                FlowDirection="LeftToRight"
+                                Orientation="Horizontal">
+                                <iconPacks:PackIconBoxIcons
+                                    Kind="RegularDonateHeart"
+                                    Width="{DynamicResource WolvenKitIconSmall}"
+                                    Height="{DynamicResource WolvenKitIconSmall}"
+                                    VerticalAlignment="Center"
+                                    Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+
+                                <TextBlock
+                                    Margin="10,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    FontSize="{DynamicResource WolvenKitFontTitle}"
+                                    Text="Support Us" />
+                            </StackPanel>
+
+                            <!-- Support -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <Button
+                                    x:Name="OpenCollectiveLinkButton"
+                                    Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
+                                    Margin="0,0,4,0"
+                                    HorizontalAlignment="Stretch"
+                                    BorderThickness="0"
+                                    Style="{StaticResource WelcomeButton}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <iconPacks:PackIconBoxIcons
+                                            Kind="SolidDonateHeart"
+                                            Width="{DynamicResource WolvenKitIconSmall}"
+                                            Height="{DynamicResource WolvenKitIconSmall}"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+
+                                        <TextBlock
+                                            Margin="7,0,0,0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontMedium}"
+                                            Text="Open Collective" />
+                                    </StackPanel>
+                                </Button>
+
+                                <Button
+                                    x:Name="PatreonLinkButton"
+                                    Grid.Column="1"
+                                    Height="{DynamicResource WolvenKitWelcomeSocialButtonHeight}"
+                                    Margin="4,0,0,0"
+                                    HorizontalAlignment="Stretch"
+                                    BorderThickness="0"
+                                    Style="{StaticResource WelcomeButton}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <iconPacks:PackIconBoxIcons
+                                            Kind="LogosPatreon"
+                                            Width="{DynamicResource WolvenKitIconSmall}"
+                                            Height="{DynamicResource WolvenKitIconSmall}"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+
+                                        <TextBlock
+                                            Margin="7,0,0,0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontMedium}"
+                                            Text="Patreon" />
+                                    </StackPanel>
+                                </Button>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+                </Grid>
             </Grid>
         </Grid>
-    </Grid>
+    </ScrollViewer>
 </reactiveUi:ReactiveUserControl>

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -367,6 +367,7 @@
             <!-- Left Column \ Projects -->
             <Grid
                 Margin="0,0,6,24"
+                VerticalAlignment="Top"
                 Style="{StaticResource ProjectsResponsiveStyle}">
                 <Grid.RowDefinitions>
                     <RowDefinition />

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -9,13 +9,34 @@
     xmlns:converters="clr-namespace:WolvenKit.Converters"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ScrollViewer.Resources>
+            <ResourceDictionary>
+                <converters:LessThanConverter x:Key="LessThanConverter" />
+
+                <Style
+                    x:Key="LayoutResponsiveStyle"
+                    TargetType="{x:Type Grid}">
+                    <Style.Triggers>
+                        <DataTrigger
+                            Binding="{Binding Path=ActualWidth,
+                                              Converter={StaticResource LessThanConverter},
+                                              ConverterParameter=WolvenKitWelcomeBreakWidth,
+                                              RelativeSource={RelativeSource AncestorType=Window}}"
+                            Value="True">
+
+                            <Setter Property="HorizontalAlignment" Value="Center" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ResourceDictionary>
+        </ScrollViewer.Resources>
+
         <Grid
             x:Name="topGrid"
-            Margin="{DynamicResource WolvenKitMarginHorizontal}">
+            Margin="{DynamicResource WolvenKitMarginHorizontal}"
+            Style="{StaticResource LayoutResponsiveStyle}">
             <Grid.Resources>
                 <ResourceDictionary>
-                    <converters:LessThanConverter x:Key="LessThanConverter" />
-
                     <Style
                         x:Key="WelcomeButton"
                         BasedOn="{StaticResource ButtonDefault}"
@@ -255,6 +276,27 @@
                     </Style>
 
                     <Style
+                        x:Key="ProjectsResponsiveStyle"
+                        TargetType="{x:Type Grid}">
+                        <Setter Property="Grid.Column" Value="0" />
+                        <Setter Property="Grid.Row" Value="1" />
+                        <Setter Property="Margin" Value="6,0,0,24" />
+
+                        <Style.Triggers>
+                            <DataTrigger
+                                Binding="{Binding Path=ActualWidth,
+                                                  Converter={StaticResource LessThanConverter},
+                                                  ConverterParameter=WolvenKitWelcomeActionsColumnBreakWidth,
+                                                  RelativeSource={RelativeSource AncestorType=Window}}"
+                                Value="True">
+                                <Setter Property="Grid.ColumnSpan" Value="2" />
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="Margin" Value="0,0,0,24" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+
+                    <Style
                         x:Key="ActionResponsiveStyle"
                         TargetType="{x:Type Grid}">
                         <!-- Must be set here to allow override with Style.Triggers -->
@@ -277,23 +319,44 @@
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
+
+                    <Style
+                        x:Key="MainActionsResponsiveStyle"
+                        TargetType="{x:Type Grid}">
+                        <Setter Property="Grid.Column" Value="1" />
+                        <Setter Property="Grid.Row" Value="1" />
+                        <Setter Property="Margin" Value="6,0,0,24" />
+
+                        <Style.Triggers>
+                            <DataTrigger
+                                Binding="{Binding Path=ActualWidth,
+                                                  Converter={StaticResource LessThanConverter},
+                                                  ConverterParameter=WolvenKitWelcomeActionsColumnBreakWidth,
+                                                  RelativeSource={RelativeSource AncestorType=Window}}"
+                                Value="True">
+                                <Setter Property="Grid.Column" Value="0" />
+                                <Setter Property="Grid.ColumnSpan" Value="2" />
+                                <Setter Property="Grid.Row" Value="2" />
+                                <Setter Property="Margin" Value="0,0,0,24" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
                 </ResourceDictionary>
             </Grid.Resources>
 
             <Grid.ColumnDefinitions>
                 <ColumnDefinition MinWidth="{DynamicResource WolvenKitWelcomeLeftMinWidth}" />
-                <ColumnDefinition Width="{DynamicResource WolvenKitWelcomeRightLength}" />
+                <ColumnDefinition MaxWidth="{DynamicResource WolvenKitWelcomeRightLength}" />
             </Grid.ColumnDefinitions>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="1*" />
-                <RowDefinition Height="3*" />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
 
             <!-- WK Text Logo -->
             <Image
-                Grid.Row="0"
-                Grid.Column="0"
                 Grid.ColumnSpan="2"
                 MaxHeight="{DynamicResource WolvenKitWelcomeLogoMaxHeight}"
                 Margin="{DynamicResource WolvenKitMarginVertical}"
@@ -303,12 +366,11 @@
 
             <!-- Left Column \ Projects -->
             <Grid
-                Grid.Row="1"
-                Grid.Column="0"
-                Margin="0,0,6,24">
+                Margin="0,0,6,24"
+                Style="{StaticResource ProjectsResponsiveStyle}">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
 
                 <!-- Pinned Projects -->
@@ -514,10 +576,7 @@
             </Grid>
 
             <!-- Right Column \ Main Actions -->
-            <Grid
-                Grid.Row="1"
-                Grid.Column="1"
-                Margin="6,0,0,24">
+            <Grid Style="{StaticResource MainActionsResponsiveStyle}">
                 <Grid>
                     <Border
                         Margin="0"


### PR DESCRIPTION
# feat(WelcomePageView): improve layout and responsiveness

**Implemented:**
- add `LessThanConverter` to be used as breakpoint
- move filter/dropdown in a 2nd row when left column (Projects) reach a threshold
- add minimum width on left column (Projects)
- add vertical scrollbar on the entire view
- uniformize view's margin, with static sizes

**Fixed:**
- fix layout to fit version number in the left panel (for nightly releases)

**Additional notes:**
Closes #2627

**Screenshot:**
![wkit_welcomepage_ui](https://github.com/user-attachments/assets/45e7ca89-ac31-47a5-8818-1e830248663e)
