### PR TITLE
add Visibility binding for Mlsetup item

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -87,7 +87,11 @@
 
                 <MenuItem
                     Command="{Binding OpenInMlsbCommand}"
-                    Header="Open in MlSetupBuilder">
+                    Header="Open in MlSetupBuilder"
+                    Visibility="{Binding Path=IsEnabled,
+                                         RelativeSource={RelativeSource Self},
+                                         Mode=OneWay,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}">
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Empty"


### PR DESCRIPTION
**Implemented:**
Small QoL: show 'Open in MlSetupBuilder' option only for mlsetup files. It currently shows for all files on right click (but greyed out). PR just adds a Visibilty binding for the menu item so it shows up only for supported files