### PR TITLE
Debugging for WScripts

### DIFF
--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -64,10 +64,10 @@ public partial class AppScriptService : ScriptService
         return _projectExplorerViewModel;
     }
 
-    public async Task ExecuteAsync(string code)
+    public async Task ExecuteAsync(string code, bool enableDebugging = false)
     {
         GetProjectExplorerViewModel()?.SuspendFileWatcher();
-        await ExecuteAsync(code, DefaultHostObject);
+        await ExecuteAsync(code, DefaultHostObject, null, enableDebugging);
         GetProjectExplorerViewModel()?.ResumeFileWatcher();
     }
 
@@ -88,11 +88,11 @@ public partial class AppScriptService : ScriptService
         return result;
     }
 
-    protected override V8ScriptEngine GetScriptEngine(Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
+    protected override V8ScriptEngine GetScriptEngine(Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null, bool enableDebugging = false)
     {
         searchPaths ??= new List<string> { ISettingsManager.GetWScriptDir(), Path.GetFullPath(@"Resources\Scripts") };
 
-        var engine = base.GetScriptEngine(hostObjects, searchPaths);
+        var engine = base.GetScriptEngine(hostObjects, searchPaths, enableDebugging);
 
         engine.AddHostType(typeof(EUncookExtension));
         engine.AddHostType(typeof(MeshExporterType));

--- a/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/WScriptDocumentViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -36,6 +36,7 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
         if(e.PropertyName == nameof(ScriptService.IsRunning))
         {
             RunCommand.NotifyCanExecuteChanged();
+            DebugCommand.NotifyCanExecuteChanged();
             StopCommand.NotifyCanExecuteChanged();
         }
     }
@@ -68,6 +69,9 @@ public partial class WScriptDocumentViewModel : DocumentViewModel
     private bool CanRun() => !_scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanRun))]
     private async Task Run() => await _scriptService.ExecuteAsync(Text);
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task Debug() => await _scriptService.ExecuteAsync(Text, true);
 
     private bool CanStop() => _scriptService.IsRunning;
     [RelayCommand(CanExecute = nameof(CanStop))]

--- a/WolvenKit.Modkit/Scripting/ScriptService.cs
+++ b/WolvenKit.Modkit/Scripting/ScriptService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -29,7 +29,7 @@ public partial class ScriptService : ObservableObject
     
     public ScriptService(ILoggerService loggerService) => _loggerService = loggerService;
 
-    public async Task ExecuteAsync(string code, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
+    public async Task ExecuteAsync(string code, Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null, bool enableDebugging = false)
     {
         if (_mainEngine != null)
         {
@@ -41,7 +41,7 @@ public partial class ScriptService : ObservableObject
 
         var sw = Stopwatch.StartNew();
 
-        _mainEngine = GetScriptEngine(hostObjects, searchPaths);
+        _mainEngine = GetScriptEngine(hostObjects, searchPaths, enableDebugging);
 
         try
         {
@@ -91,9 +91,16 @@ public partial class ScriptService : ObservableObject
         IsRunning = false;
     }
 
-    protected virtual V8ScriptEngine GetScriptEngine(Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null)
+    protected virtual V8ScriptEngine GetScriptEngine(Dictionary<string, object>? hostObjects = null, List<string>? searchPaths = null, bool enableDebugging = false)
     {
-        var engine = new V8ScriptEngine();
+        var flags = V8ScriptEngineFlags.None;
+        if (enableDebugging)
+        {
+            flags |= V8ScriptEngineFlags.EnableDebugging;
+            flags |= V8ScriptEngineFlags.AwaitDebuggerAndPauseOnStart;
+        }
+
+        var engine = new V8ScriptEngine(flags);
 
         engine.AddHostType(typeof(OpenAs));
         engine.AddHostObject("logger", _loggerService);

--- a/WolvenKit/Views/Documents/WScriptDocumentView.xaml
+++ b/WolvenKit/Views/Documents/WScriptDocumentView.xaml
@@ -1,4 +1,4 @@
-﻿<reactiveUi:ReactiveUserControl
+<reactiveUi:ReactiveUserControl
     x:Class="WolvenKit.Views.Documents.WScriptDocumentView"
     x:TypeArguments="documents:WScriptDocumentViewModel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -65,6 +65,21 @@
                     <templates:IconBox
                         IconPack="Material"
                         Kind="Play"
+                        Foreground="{StaticResource WolvenKitGreen}" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem
+                Visibility="{Binding IsNormalScript,
+                                     Converter={StaticResource BooleanToVisibilityConverter}}"
+                Command="{Binding DebugCommand}"
+                CommandParameter="{Binding Document.Text}"
+                Header="Debug"
+                ToolTip="Waits for debugger on port 9222">
+                <MenuItem.Icon>
+                    <templates:IconBox
+                        IconPack="Material"
+                        Kind="BugPlay"
                         Foreground="{StaticResource WolvenKitGreen}" />
                 </MenuItem.Icon>
             </MenuItem>


### PR DESCRIPTION
# Debugging for WScripts

**Implemented:**
- Debugging for WScripts

**Additional notes:**
Running a wscript via the new `Debug` button in the script editor, will start the process and then wait until an external debugger is attached.
It's listening on port 9222 for incoming connections. I.e. for VSC you could use:
```json
"launch": {
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Attach to ClearScript V8 on port 9222",
            "type": "node",
            "request": "attach",
            "protocol": "inspector",
            "address": "localhost",
            "port": 9222
        }
    ]
}
```
