### PR TITLE
feat: add scene editor button bar

### DIFF
--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -201,6 +201,12 @@ public static class Interactions
     public static Func<(string dialogueTitle, string defaultValue), string> AskForTextInput { get; set; } =
         _ => throw new NotImplementedException();
 
+    /// <summary>
+    /// Ask user for scene input (unified dialog for actors, props, dialogue, options)
+    /// </summary>
+    public static Func<(string title, string primaryLabel, string primaryDefault, bool showSecondary, string secondaryLabel, string checkboxText), (string? primaryInput, bool enableSecondary, string? secondaryInput)> AskForSceneInput { get; set; } =
+        _ => throw new NotImplementedException();
+
 
     /// <summary>
     /// Ask user for folder path. Will enforce validity for path-type arguments and check if directory exists.

--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -204,7 +204,7 @@ public static class Interactions
     /// <summary>
     /// Ask user for scene input (unified dialog for actors, props, dialogue, options)
     /// </summary>
-    public static Func<(string title, string primaryLabel, string primaryDefault, bool showSecondary, string secondaryLabel, string checkboxText), (string? primaryInput, bool enableSecondary, string? secondaryInput)> AskForSceneInput { get; set; } =
+    public static Func<(string title, string primaryLabel, string primaryDefault, bool showSecondary, string secondaryLabel, string checkboxText, bool showDropdown, string dropdownLabel, IEnumerable<string>? dropdownOptions, string? defaultDropdownValue), (string? primaryInput, bool enableSecondary, string? secondaryInput, string? dropdownValue)> AskForSceneInput { get; set; } =
         _ => throw new NotImplementedException();
 
 

--- a/WolvenKit.App/ViewModels/Dialogs/SceneInputDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SceneInputDialogViewModel.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
 
@@ -13,7 +15,11 @@ public partial class SceneInputDialogViewModel : DialogViewModel
         string primaryDefaultValue = "",
         bool showSecondaryInput = false,
         string secondaryLabel = "Secondary:",
-        string checkboxText = "Enable secondary input")
+        string checkboxText = "Enable secondary input",
+        bool showDropdown = false,
+        string dropdownLabel = "Type:",
+        IEnumerable<string>? dropdownOptions = null,
+        string? defaultDropdownValue = null)
     {
         Title = title;
         PrimaryLabel = primaryLabel;
@@ -21,6 +27,18 @@ public partial class SceneInputDialogViewModel : DialogViewModel
         ShowSecondaryInput = showSecondaryInput;
         SecondaryLabel = secondaryLabel;
         CheckboxText = checkboxText;
+        ShowDropdown = showDropdown;
+        DropdownLabel = dropdownLabel;
+        
+        if (dropdownOptions != null)
+        {
+            DropdownOptions = dropdownOptions.ToList();
+            SelectedDropdownValue = defaultDropdownValue ?? DropdownOptions.FirstOrDefault();
+        }
+        else
+        {
+            DropdownOptions = new List<string>();
+        }
     }
 
     /// <summary>
@@ -44,6 +62,21 @@ public partial class SceneInputDialogViewModel : DialogViewModel
     [ObservableProperty] private string? _secondaryInputValue = "";
 
     /// <summary>
+    /// Whether to show the dropdown section
+    /// </summary>
+    [ObservableProperty] private bool _showDropdown;
+
+    /// <summary>
+    /// The selected dropdown value
+    /// </summary>
+    [ObservableProperty] private string? _selectedDropdownValue;
+
+    /// <summary>
+    /// The available dropdown options
+    /// </summary>
+    public List<string> DropdownOptions { get; set; } = new();
+
+    /// <summary>
     /// The label text for the primary input field
     /// </summary>
     public string PrimaryLabel { get; set; }
@@ -52,6 +85,11 @@ public partial class SceneInputDialogViewModel : DialogViewModel
     /// The label text for the secondary input field
     /// </summary>
     public string SecondaryLabel { get; set; }
+
+    /// <summary>
+    /// The label text for the dropdown field
+    /// </summary>
+    public string DropdownLabel { get; set; }
 
     /// <summary>
     /// The checkbox text

--- a/WolvenKit.App/ViewModels/Dialogs/SceneInputDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/SceneInputDialogViewModel.cs
@@ -1,0 +1,65 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+/// <summary>
+/// ViewModel for unified scene input dialog that handles actors, props, dialogue lines, and choice options
+/// </summary>
+public partial class SceneInputDialogViewModel : DialogViewModel
+{
+    public SceneInputDialogViewModel(
+        string title = "Scene Input", 
+        string primaryLabel = "Value:", 
+        string primaryDefaultValue = "",
+        bool showSecondaryInput = false,
+        string secondaryLabel = "Secondary:",
+        string checkboxText = "Enable secondary input")
+    {
+        Title = title;
+        PrimaryLabel = primaryLabel;
+        PrimaryInputValue = primaryDefaultValue;
+        ShowSecondaryInput = showSecondaryInput;
+        SecondaryLabel = secondaryLabel;
+        CheckboxText = checkboxText;
+    }
+
+    /// <summary>
+    /// The primary input value (always visible)
+    /// </summary>
+    [ObservableProperty] private string? _primaryInputValue = "";
+
+    /// <summary>
+    /// Whether to show the secondary input section
+    /// </summary>
+    [ObservableProperty] private bool _showSecondaryInput;
+
+    /// <summary>
+    /// Whether the secondary input checkbox is checked
+    /// </summary>
+    [ObservableProperty] private bool _enableSecondaryInput;
+
+    /// <summary>
+    /// The secondary input value (conditionally visible)
+    /// </summary>
+    [ObservableProperty] private string? _secondaryInputValue = "";
+
+    /// <summary>
+    /// The label text for the primary input field
+    /// </summary>
+    public string PrimaryLabel { get; set; }
+
+    /// <summary>
+    /// The label text for the secondary input field
+    /// </summary>
+    public string SecondaryLabel { get; set; }
+
+    /// <summary>
+    /// The checkbox text
+    /// </summary>
+    public string CheckboxText { get; set; }
+
+    /// <summary>
+    /// The dialog title
+    /// </summary>
+    public string Title { get; set; }
+}

--- a/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
@@ -99,4 +99,55 @@ public partial class scnSceneResource
     {
         return 2 + propIndex * 256;
     }
+    
+    /// <summary>
+    /// Gets embedded text content for a given locstring ID from scene's LocStore
+    /// Based on logic from scnSectionNodeWrapper.cs
+    /// </summary>
+    /// <param name="locStringId">The locstring ID to look up</param>
+    /// <returns>The embedded text content, or empty string if not found</returns>
+    public string GetEmbeddedTextForLocString(CRUID locStringId)
+    {
+        if (LocStore?.VdEntries == null || LocStore?.VpEntries == null)
+        {
+            return string.Empty;
+        }
+
+        var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.en_us;
+        var vdEntryPreferred = LocStore.VdEntries.FirstOrDefault(vd => 
+            vd.LocstringId?.Ruid == locStringId && vd.LocaleId == preferredLocaleId);
+
+        if (vdEntryPreferred != null && vdEntryPreferred.VariantId != null)
+        {
+            var targetVariantRuid = vdEntryPreferred.VariantId.Ruid;
+            var vpEntry = LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == targetVariantRuid);
+            if (vpEntry != null)
+            {
+                var content = vpEntry.Content.ToString();
+                if (!string.IsNullOrEmpty(content))
+                {
+                    return content;
+                }
+            }
+        }
+
+        var vdEntryFallback = LocStore.VdEntries.FirstOrDefault(vd => 
+            vd.LocstringId?.Ruid == locStringId && vd.LocaleId != preferredLocaleId);
+        
+        if (vdEntryFallback != null && vdEntryFallback.VariantId != null)
+        {
+            var fallbackVariantRuid = vdEntryFallback.VariantId.Ruid;
+            var vpEntryFallback = LocStore.VpEntries.FirstOrDefault(vp => vp.VariantId?.Ruid == fallbackVariantRuid);
+            if (vpEntryFallback != null)
+            {
+                var content = vpEntryFallback.Content.ToString();
+                if (!string.IsNullOrEmpty(content))
+                {
+                    return content;
+                }
+            }
+        }
+
+        return string.Empty;
+    }
 } 

--- a/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
@@ -47,6 +47,40 @@ public partial class scnSceneResource
     }
     
     /// <summary>
+    /// Adds a prop to the scene with automatic ID calculation and performer debug symbol creation
+    /// </summary>
+    /// <param name="prop">The prop to add</param>
+    public void AddProp(scnPropDef prop)
+    {
+        if (prop == null) return;
+        
+        // Set prop ID
+        prop.PropId.Id = (uint)Props.Count;
+        
+        // Add to props collection
+        Props.Add(prop);
+        
+        // Create performer debug symbol for the prop
+        DebugSymbols ??= new scnDebugSymbols();
+        var performerSymbol = new scnPerformerSymbol
+        {
+            PerformerId = new scnPerformerId { Id = CalculatePropPerformerId(prop.PropId.Id) },
+            EntityRef = prop.FindEntityInWorldParams?.ActorRef ?? new gameEntityReference { Names = new CArray<CName>() },
+            EditorPerformerId = new CRUID()
+        };
+        DebugSymbols.PerformersDebugSymbols.Add(performerSymbol);
+    }
+    
+    /// <summary>
+    /// Gets the next available prop ID
+    /// </summary>
+    /// <returns>The next prop ID that should be used</returns>
+    public uint GetNextPropId()
+    {
+        return (uint)Props.Count;
+    }
+    
+    /// <summary>
     /// Calculates the performer ID for a given actor index
     /// </summary>
     /// <param name="actorIndex">The actor index (0, 1, 2, etc.)</param>
@@ -54,5 +88,15 @@ public partial class scnSceneResource
     public static uint CalculatePerformerId(uint actorIndex)
     {
         return 1 + actorIndex * 256;
+    }
+    
+    /// <summary>
+    /// Calculates the performer ID for a given prop index
+    /// </summary>
+    /// <param name="propIndex">The prop index (0, 1, 2, etc.)</param>
+    /// <returns>The corresponding performer ID (2, 258, 514, etc.)</returns>
+    public static uint CalculatePropPerformerId(uint propIndex)
+    {
+        return 2 + propIndex * 256;
     }
 } 

--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
@@ -6,7 +6,9 @@
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     Title="{Binding Title}"
     MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
-    SizeToContent="WidthAndHeight"
+    MaxWidth="800"
+    SizeToContent="Height"
+    Width="500"
     FocusManager.FocusedElement="{Binding ElementName=PrimaryInputTextBox}"
     WindowStartupLocation="CenterScreen">
     <Grid
@@ -33,11 +35,11 @@
                 HelpVisibility="Collapsed"
                 NextVisibility="Collapsed"
                 PageType="Exterior">
-                <StackPanel Margin="10" MinWidth="350">
+                <StackPanel Margin="10" MinWidth="450">
                     <!-- Primary Input Field (always visible) -->
                     <Grid Margin="0,0,0,10">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" MinWidth="140" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" 
@@ -52,7 +54,11 @@
                                  Padding="{DynamicResource WolvenKitMarginTiny}"
                                  VerticalContentAlignment="Center"
                                  FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                 Text="{Binding PrimaryInputValue, UpdateSourceTrigger=PropertyChanged}" />
+                                 Text="{Binding PrimaryInputValue, UpdateSourceTrigger=PropertyChanged}"
+                                 TextWrapping="Wrap"
+                                 AcceptsReturn="False"
+                                 VerticalScrollBarVisibility="Auto"
+                                 MaxHeight="80" />
                     </Grid>
 
                     <!-- Secondary Input Checkbox (conditionally visible) -->
@@ -67,7 +73,7 @@
                     <Grid Margin="0,0,0,0" 
                           Visibility="{Binding EnableSecondaryInput, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="Auto" MinWidth="140" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" 

--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
@@ -1,0 +1,95 @@
+<Window
+    x:Class="WolvenKit.Views.Dialogs.SceneInputDialogView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    Title="{Binding Title}"
+    MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
+    SizeToContent="WidthAndHeight"
+    FocusManager.FocusedElement="{Binding ElementName=PrimaryInputTextBox}"
+    WindowStartupLocation="CenterScreen">
+    <Grid
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Stretch"
+        hc:ThemeManager.RequestedAccentColor="{DynamicResource MahApps.Brushes.Accent3}">
+        <Grid.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <hc:ThemeResources />
+                    <hc:Theme />
+                </ResourceDictionary.MergedDictionaries>
+                <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            </ResourceDictionary>
+        </Grid.Resources>
+
+        <syncfusion:WizardControl
+            CancelButtonCancelsWindow="True"
+            FinishButtonClosesWindow="True">
+            <syncfusion:WizardPage
+                BackVisibility="Collapsed"
+                CancelVisibility="Visible"
+                FinishVisibility="Visible"
+                HelpVisibility="Collapsed"
+                NextVisibility="Collapsed"
+                PageType="Exterior">
+                <StackPanel Margin="10" MinWidth="350">
+                    <!-- Primary Input Field (always visible) -->
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" 
+                                   Text="{Binding PrimaryLabel}" 
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Right"
+                                   Margin="0,0,10,0"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
+                        <TextBox x:Name="PrimaryInputTextBox"
+                                 Grid.Column="1"
+                                 Padding="{DynamicResource WolvenKitMarginTiny}"
+                                 VerticalContentAlignment="Center"
+                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                 Text="{Binding PrimaryInputValue, UpdateSourceTrigger=PropertyChanged}" />
+                    </Grid>
+
+                    <!-- Secondary Input Checkbox (conditionally visible) -->
+                    <CheckBox Content="{Binding CheckboxText}"
+                              IsChecked="{Binding EnableSecondaryInput}"
+                              VerticalAlignment="Center"
+                              FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                              Margin="0,5,0,10"
+                              Visibility="{Binding ShowSecondaryInput, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+
+                    <!-- Secondary Input Field (conditionally visible) -->
+                    <Grid Margin="0,0,0,0" 
+                          Visibility="{Binding EnableSecondaryInput, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" 
+                                   Text="{Binding SecondaryLabel}" 
+                                   VerticalAlignment="Top"
+                                   HorizontalAlignment="Right"
+                                   Margin="0,8,10,0"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
+                        <TextBox Grid.Column="1"
+                                 Padding="{DynamicResource WolvenKitMarginTiny}"
+                                 VerticalContentAlignment="Top"
+                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                 Text="{Binding SecondaryInputValue, UpdateSourceTrigger=PropertyChanged}"
+                                 TextWrapping="Wrap"
+                                 AcceptsReturn="True"
+                                 MinHeight="60"
+                                 MaxHeight="120"
+                                 VerticalScrollBarVisibility="Auto" />
+                    </Grid>
+                </StackPanel>
+            </syncfusion:WizardPage>
+        </syncfusion:WizardControl>
+    </Grid>
+</Window>

--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
@@ -36,6 +36,28 @@
                 NextVisibility="Collapsed"
                 PageType="Exterior">
                 <StackPanel Margin="10" MinWidth="450">
+                    <!-- Dropdown Field (conditionally visible) -->
+                    <Grid Margin="0,0,0,10"
+                          Visibility="{Binding ShowDropdown, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="140" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" 
+                                   Text="{Binding DropdownLabel}" 
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Right"
+                                   Margin="0,0,10,0"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
+                        <ComboBox Grid.Column="1"
+                                  Padding="{DynamicResource WolvenKitMarginTiny}"
+                                  FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                  ItemsSource="{Binding DropdownOptions}"
+                                  SelectedItem="{Binding SelectedDropdownValue, UpdateSourceTrigger=PropertyChanged}"
+                                  IsReadOnly="True" />
+                    </Grid>
+
                     <!-- Primary Input Field (always visible) -->
                     <Grid Margin="0,0,0,10">
                         <Grid.ColumnDefinitions>

--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Generic;
 using System.Windows;
 using WolvenKit.App.ViewModels.Dialogs;
 
@@ -14,9 +15,14 @@ public partial class SceneInputDialogView : Window
         string primaryDefaultValue = "",
         bool showSecondaryInput = false,
         string secondaryLabel = "Secondary:",
-        string checkboxText = "Enable secondary input")
+        string checkboxText = "Enable secondary input",
+        bool showDropdown = false,
+        string dropdownLabel = "Type:",
+        IEnumerable<string>? dropdownOptions = null,
+        string? defaultDropdownValue = null)
     {
-        ViewModel = new SceneInputDialogViewModel(title, primaryLabel, primaryDefaultValue, showSecondaryInput, secondaryLabel, checkboxText);
+        ViewModel = new SceneInputDialogViewModel(title, primaryLabel, primaryDefaultValue, showSecondaryInput, 
+            secondaryLabel, checkboxText, showDropdown, dropdownLabel, dropdownOptions, defaultDropdownValue);
         DataContext = ViewModel;
         InitializeComponent();
     }
@@ -25,6 +31,7 @@ public partial class SceneInputDialogView : Window
     public string? PrimaryInput => ViewModel.PrimaryInputValue;
     public bool EnableSecondaryInput => ViewModel.EnableSecondaryInput;
     public string? SecondaryInput => ViewModel.SecondaryInputValue;
+    public string? DropdownValue => ViewModel.SelectedDropdownValue;
 
     public bool? ShowDialog(Window owner)
     {

--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System.Windows;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs;
+
+public partial class SceneInputDialogView : Window
+{
+    public SceneInputDialogViewModel ViewModel { get; set; }
+
+    public SceneInputDialogView(
+        string title, 
+        string primaryLabel, 
+        string primaryDefaultValue = "",
+        bool showSecondaryInput = false,
+        string secondaryLabel = "Secondary:",
+        string checkboxText = "Enable secondary input")
+    {
+        ViewModel = new SceneInputDialogViewModel(title, primaryLabel, primaryDefaultValue, showSecondaryInput, secondaryLabel, checkboxText);
+        DataContext = ViewModel;
+        InitializeComponent();
+    }
+
+    // Convenience properties for easy access
+    public string? PrimaryInput => ViewModel.PrimaryInputValue;
+    public bool EnableSecondaryInput => ViewModel.EnableSecondaryInput;
+    public string? SecondaryInput => ViewModel.SecondaryInputValue;
+
+    public bool? ShowDialog(Window owner)
+    {
+        Owner = owner;
+        return ShowDialog();
+    }
+}

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -73,6 +73,43 @@
             </nodify:Connection>
         </DataTemplate>
         
+        <!-- Button Style for Add Actor/Prop buttons -->
+        <Style x:Key="SceneEditorButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+            <Setter Property="Foreground" Value="{StaticResource WolvenKitRedShadow}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,4" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" 
+                                            VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRed}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRed}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRedShadow}" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+                                <Setter Property="Foreground" Value="White" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -183,21 +220,54 @@
                                     </Style>
                                 </Grid.Style>
                                 
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="3*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="2*" />
-                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                
+                                <!-- Button Bar -->
+                                <Border Grid.Row="0" Background="{StaticResource ContentBackgroundAlt}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="8,4"
+                                        Visibility="{Binding DataContext.IsButtonBarVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <StackPanel Orientation="Horizontal" Margin="5">
+                                        <Button Content="+ Add Actor" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewActorCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsActorCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Prop" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewPropCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsPropCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Dialogue" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewDialogueCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsDialogueCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Option" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewOptionCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsOptionCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                    </StackPanel>
+                                </Border>
+                                
+                                <Grid Grid.Row="1">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="3*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="2*" />
+                                    </Grid.ColumnDefinitions>
 
-                                <!-- RedTreeView bound directly to the filtered ICollectionView -->
-                                <tools:RedTreeView Grid.Column="0" 
-                                                   ItemsSource="{Binding DataContext.SelectedTabContent, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                   SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"
-                                                   SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"/>
-                                
+                                    <!-- RedTreeView bound directly to the filtered ICollectionView -->
+                                    <tools:RedTreeView Grid.Column="0" 
+                                                       ItemsSource="{Binding DataContext.SelectedTabContent, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                       SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"
+                                                       SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"/>
+                                    
                                 <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
-                                
+                                    
                                 <editors:RedTypeView Grid.Column="2" DataContext="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"/>
+                            </Grid>
                             </Grid>
                             
                             <!-- Node Properties tab shows our custom selection-driven view -->

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -247,7 +247,12 @@
                                         <Button Content="+ Add Option" 
                                                 Style="{StaticResource SceneEditorButtonStyle}"
                                                 Command="{Binding DataContext.CreateNewOptionCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsOptionCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                Visibility="{Binding DataContext.IsOptionCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Workspot" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewWorkspotCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsWorkspotCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                     </StackPanel>
                                 </Border>
                                 

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -226,7 +226,7 @@
                                 </Grid.RowDefinitions>
                                 
                                 <!-- Button Bar -->
-                                <Border Grid.Row="0" Background="{StaticResource ContentBackgroundAlt}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="8,4"
+                                <Border Grid.Row="0" Background="{StaticResource ContentBackgroundAlt}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,1,0,1" Padding="8,4"
                                         Visibility="{Binding DataContext.IsButtonBarVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                                     <StackPanel Orientation="Horizontal" Margin="5">
                                         <Button Content="+ Add Actor" 
@@ -249,6 +249,12 @@
                                                 Command="{Binding DataContext.CreateNewOptionCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
                                                 Visibility="{Binding DataContext.IsOptionCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
                                                 Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Animation" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewAnimationCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsAnimationCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"
+                                                />
                                         <Button Content="+ Add Workspot" 
                                                 Style="{StaticResource SceneEditorButtonStyle}"
                                                 Command="{Binding DataContext.CreateNewWorkspotCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
@@ -257,7 +263,8 @@
                                         <Button Content="+ Add Effect" 
                                                 Style="{StaticResource SceneEditorButtonStyle}"
                                                 Command="{Binding DataContext.CreateNewEffectCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsEffectCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                Visibility="{Binding DataContext.IsEffectCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                />
                                     </StackPanel>
                                 </Border>
                                 

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -252,7 +252,12 @@
                                         <Button Content="+ Add Workspot" 
                                                 Style="{StaticResource SceneEditorButtonStyle}"
                                                 Command="{Binding DataContext.CreateNewWorkspotCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsWorkspotCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                Visibility="{Binding DataContext.IsWorkspotCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                Margin="0,0,5,0"/>
+                                        <Button Content="+ Add Effect" 
+                                                Style="{StaticResource SceneEditorButtonStyle}"
+                                                Command="{Binding DataContext.CreateNewEffectCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                                Visibility="{Binding DataContext.IsEffectCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                     </StackPanel>
                                 </Border>
                                 

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -148,6 +148,14 @@ namespace WolvenKit.Views.Tools
                     return innerVm.Text;
                 };
 
+                Interactions.AskForSceneInput = (parameters) =>
+                {
+                    var (title, primaryLabel, primaryDefault, showSecondary, secondaryLabel, checkboxText) = parameters;
+                    var dialog = new SceneInputDialogView(title, primaryLabel, primaryDefault, showSecondary, secondaryLabel, checkboxText);
+                    var result = dialog.ShowDialog();
+                    return result == true ? (dialog.PrimaryInput, dialog.EnableSecondaryInput, dialog.SecondaryInput) : (null, false, null);
+                };
+
                 Interactions.AskForFolderPathInput = (args) =>
                 {
                     var dialog = new FolderPathInputDialogView(args.Item2, args.Item1);

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -150,10 +150,12 @@ namespace WolvenKit.Views.Tools
 
                 Interactions.AskForSceneInput = (parameters) =>
                 {
-                    var (title, primaryLabel, primaryDefault, showSecondary, secondaryLabel, checkboxText) = parameters;
-                    var dialog = new SceneInputDialogView(title, primaryLabel, primaryDefault, showSecondary, secondaryLabel, checkboxText);
+                    var (title, primaryLabel, primaryDefault, showSecondary, secondaryLabel, checkboxText, 
+                         showDropdown, dropdownLabel, dropdownOptions, defaultDropdownValue) = parameters;
+                    var dialog = new SceneInputDialogView(title, primaryLabel, primaryDefault, showSecondary, 
+                        secondaryLabel, checkboxText, showDropdown, dropdownLabel, dropdownOptions, defaultDropdownValue);
                     var result = dialog.ShowDialog();
-                    return result == true ? (dialog.PrimaryInput, dialog.EnableSecondaryInput, dialog.SecondaryInput) : (null, false, null);
+                    return result == true ? (dialog.PrimaryInput, dialog.EnableSecondaryInput, dialog.SecondaryInput, dialog.DropdownValue) : (null, false, null, null);
                 };
 
                 Interactions.AskForFolderPathInput = (args) =>


### PR DESCRIPTION
# Add a button bar in Scene Editor

**Implemented:**
PR adds a button bar to the Scene Editor that will allow users to create commonly used scene properties easily.

Currently adding new entries for scene properties like an actor or dialogue requires:
- Knowing how the ids for each type of property is calculated. For eg actors have performer ids that are 256 increments, but a prop's performer id is in 256+2 increments. This gets really annoying as a scene grows beyond the first couple of entries and having to note and remember the formulas without mistakes
- Tasks that are mentally atomic in nature like "create an actor" actually mean adding entries in multiple places (for actors, this means appending in `actors` and in `debugSymbols` for example) so again error prone

Note that - there are no workflow changes for editing and defining the properties after creating them. The buttons only help create new entries and automatically calculate ids + prefill defaults.

PR adds buttons that create the following:

In "Actors & Props" tab:
- Actor
- Prop
<img width="2108" height="464" alt="image" src="https://github.com/user-attachments/assets/c5fe4104-70c3-4d55-ab6f-167aa5e6366d" />


In "Dialogue" tab:
- Dialogue
- Option
<img width="2010" height="703" alt="image" src="https://github.com/user-attachments/assets/27a80d4d-acff-45a3-b341-3bfc5eeef107" />


In "Asset Library" tab:
- Workspot
- Animation
- Effect
<img width="2250" height="863" alt="image" src="https://github.com/user-attachments/assets/2fb8bcff-d3de-4b62-8e07-5b410b68d567" />

Note: Animation creation loads .anims files to extract and populate animation names automatically and effect creation loads .effect files to populate compiled effect event information.

The buttons go along with a new input dialog (`SceneInputDialogView`). The buttons execute commands via new [RelayCommand] handlers in SceneGraphViewModel. Also added some resource helpers in scnSceneResource to insert props and derive performer ids and debug symbols.

Mental note to myself for a future PR: we will also need a "Recalculate Actor ID" button. This is because of `playerActors` which is annoyingly appended to `actors` so typically when you're working on a scene and decide to add a new actor but you already have `playerActors` populated, you need to now recalculate new ids for the player actor and its usage across the entire scene (ie not just in all nodes but also in `screenplayStore`). This button would theoretically do that for you but its a lot more work and destructive in nature (and will likely be slow)
