### PR TITLE
fix(RedTreeView): force style of a selected item

### DIFF
--- a/WolvenKit/Views/Tools/RedTreeView.xaml
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml
@@ -2014,6 +2014,10 @@
                                 Path=SelectedItems,
                                 Mode=TwoWay}"
         SelectionChanged="OnSelectionChanged"
+        SelectionBackgroundColor="{StaticResource BackgroundColor_Control}"
+        SelectionForegroundColor="White"
+        FocusBorderColor="{StaticResource WolvenKitRedShadow}"
+        FocusBorderThickness="1"
         MouseDoubleClick="OnDoubleClick"
         MouseRightButtonDown="OnMouseRightButtonDown"
         SelectionMode="Extended"


### PR DESCRIPTION
# fix(RedTreeView): force style of a selected item

**Fixed:**
- directly force color styles on `SfTreeView`. I could not find where we are changing styles of this UI element.

**Additional notes:**
Arrows to expand items are outlined instead of filled (e.g. in `RDTDataView`). This is not the intent of this PR, which is to use our custom style instead of the default style from Syncfusion. Moreover, styling would require a lot of refactoring through the entire codebase. So ignoring these arrows for now.

Closes #2661

<img width="663" height="322" alt="image" src="https://github.com/user-attachments/assets/8868e403-2779-4d5d-a768-4da48e0b1311" />
