### PR TITLE
feat: more quest/scene node details

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -149,21 +149,8 @@ internal class NodeProperties
         }
         else if (node is questUseWorkspotNodeDefinition useWorkspotNodeCasted)
         {
-            details["Entity Reference"] = ParseGameEntityReference(useWorkspotNodeCasted?.EntityReference);
-
-            if (useWorkspotNodeCasted?.ParamsV1?.Chunk is scnUseSceneWorkspotParamsV1 useSceneWorkspotCasted)
-            {
-                details["Entry Id"] = useSceneWorkspotCasted?.EntryId?.Id.ToString()!;
-                details["Exit Entry Id"] = useSceneWorkspotCasted?.ExitEntryId?.Id.ToString()!;
-                details["Workspot Instance Id"] = useSceneWorkspotCasted?.WorkspotInstanceId?.Id.ToString()!;
-                details["Workspot Name"] = GetWorkspotPath(useSceneWorkspotCasted?.WorkspotInstanceId?.Id, scnSceneResource);
-            }
-            else if (useWorkspotNodeCasted?.ParamsV1?.Chunk is questUseWorkspotParamsV1 useWorkspotCasted)
-            {
-                details["Entry Id"] = useWorkspotCasted?.EntryId?.Id.ToString()!;
-                details["Exit Entry Id"] = useWorkspotCasted?.ExitEntryId?.Id.ToString()!;
-                details["Workspot Node"] = useWorkspotCasted?.WorkspotNode.GetResolvedText()!;
-            }
+            Quest.questUseWorkspotNodeDefinitionWrapper
+                .PopulateWorkspotDetailsWithSceneContext(useWorkspotNodeCasted, details, scnSceneResource);
         }
         else if (node is questSceneManagerNodeDefinition sceneManagerNodeCasted)
         {
@@ -1292,8 +1279,7 @@ internal class NodeProperties
             prioritized["Type"] = properties["Type"];
         }
 
-        // Add high-priority properties
-        var highPriority = new[] { "Name", "Path", "Duration", "Action", "Value", "Count", "Mode", "State" };
+        var highPriority = new[] { "Entity", "Action", "Workspot", "Name", "Path", "Duration", "Value", "Count", "Mode", "State" };
         foreach (var priority in highPriority)
         {
             var key = properties.Keys.FirstOrDefault(k => k.Contains(priority));
@@ -1514,7 +1500,7 @@ internal class NodeProperties
         return "";
     }
 
-    private static string ParseGameEntityReference(gameEntityReference? entRef)
+    public static string ParseGameEntityReference(gameEntityReference? entRef)
     {
         string str = "-";
 
@@ -1616,7 +1602,7 @@ internal class NodeProperties
         return str;
     }
 
-    private static string GetWorkspotPath(CUInt32? workspotID, scnSceneResource? scnSceneResource)
+    public static string GetWorkspotPath(CUInt32? workspotID, scnSceneResource? scnSceneResource)
     {
         string retVal = "";
 

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -152,6 +152,10 @@ internal class NodeProperties
             Quest.questUseWorkspotNodeDefinitionWrapper
                 .PopulateWorkspotDetailsWithSceneContext(useWorkspotNodeCasted, details, scnSceneResource);
         }
+        else if (node is questTeleportPuppetNodeDefinition teleportNodeCasted)
+        {
+            Quest.questTeleportPuppetNodeDefinitionWrapper.PopulateTeleportDetailsInto(teleportNodeCasted, details);
+        }
         else if (node is questSceneManagerNodeDefinition sceneManagerNodeCasted)
         {
             details["Manager"] = GetNameFromClass(sceneManagerNodeCasted?.Type?.Chunk);
@@ -400,19 +404,6 @@ internal class NodeProperties
                     details["Visible"] = showOverlayNodeCasted?.Visible == true ? "True" : "False";
                 }
             }
-        }
-        else if (node is questTeleportPuppetNodeDefinition teleportNodeCasted)
-        {
-            details["Entity Reference"] = GetNameFromUniversalRef(teleportNodeCasted?.EntityReference?.Chunk);
-            details["Local Player"] = teleportNodeCasted?.EntityReference?.Chunk?.RefLocalPlayer == true ? "True" : "False";
-            details["Look At Action"] = teleportNodeCasted?.LookAtAction.ToEnumString()!;
-
-            details["Destination Offset"] = teleportNodeCasted?.Params?.Chunk?.DestinationOffset.ToString()!;
-            details["Destination Entity Reference"] = GetNameFromUniversalRef(teleportNodeCasted?.Params?.Chunk?.DestinationRef?.Chunk);
-            details["Heal At Teleport"] = teleportNodeCasted?.Params?.Chunk?.HealAtTeleport == true ? "True" : "False";
-
-            details["Player Look At Offset"] = teleportNodeCasted?.PlayerLookAt?.Chunk?.Offset.ToString()!;
-            details["Player Look At Target"] = ParseGameEntityReference(teleportNodeCasted?.PlayerLookAt?.Chunk?.LookAtTarget);
         }
         else if (node is questWorldDataManagerNodeDefinition worldDataManagerCasted)
         {
@@ -1279,7 +1270,7 @@ internal class NodeProperties
             prioritized["Type"] = properties["Type"];
         }
 
-        var highPriority = new[] { "Entity", "Action", "Workspot", "Name", "Path", "Duration", "Value", "Count", "Mode", "State" };
+        var highPriority = new[] { "Command", "Entity", "Action", "Workspot", "Name", "Path", "Duration", "Value", "Count", "Mode", "State" };
         foreach (var priority in highPriority)
         {
             var key = properties.Keys.FirstOrDefault(k => k.Contains(priority));

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questTeleportPuppetNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questTeleportPuppetNodeDefinitionWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WolvenKit.App.Extensions;
+using System.Collections.Generic;
+using WolvenKit.App.Extensions;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
@@ -7,7 +8,142 @@ public class questTeleportPuppetNodeDefinitionWrapper : questAICommandNodeBaseWr
 {
     public questTeleportPuppetNodeDefinitionWrapper(questTeleportPuppetNodeDefinition questAICommandNodeBase) : base(questAICommandNodeBase)
     {
-        Details.AddRange(NodeProperties.GetPropertiesFor(questAICommandNodeBase));
+        PopulateTeleportDetails();
+    }
+
+    public override void RefreshDetails()
+    {
+        PopulateTeleportDetails();
+        UpdateTitle();
+        OnPropertyChanged(nameof(Title));
+        OnPropertyChanged(nameof(IsPlayerNode));
+    }
+
+    private void PopulateTeleportDetails()
+    {
+        var tempDetails = new Dictionary<string, string>();
+        PopulateTeleportDetailsInto(_castedData, tempDetails);
+        Details = tempDetails;
+    }
+
+    public static void PopulateTeleportDetailsInto(questTeleportPuppetNodeDefinition teleportNode, Dictionary<string, string> details)
+    {
+        string entity = "Entity";
+        bool isPlayer = false;
+        
+        if (teleportNode?.EntityReference?.Chunk != null)
+        {
+            var entityRef = teleportNode.EntityReference.Chunk;
+            if (entityRef.RefLocalPlayer == true)
+            {
+                entity = "Player";
+                isPlayer = true;
+            }
+            else if (entityRef.EntityReference != null)
+            {
+                string parsedEntity = NodeProperties.ParseGameEntityReference(entityRef.EntityReference);
+                if (parsedEntity != "-")
+                {
+                    entity = parsedEntity;
+                }
+            }
+            else if (entityRef.MainPlayerObject == true)
+            {
+                entity = "Main Player Object";
+                isPlayer = true;
+            }
+        }
+
+        string destination = "Unknown";
+        string offsetInfo = "";
+        
+        if (teleportNode?.Params?.Chunk != null)
+        {
+            var teleportParams = teleportNode.Params.Chunk;
+            
+            if (teleportParams.DestinationRef?.Chunk != null)
+            {
+                var destUniRef = teleportParams.DestinationRef.Chunk;
+                string destRef = "";
+                
+                if (destUniRef.EntityReference != null)
+                {
+                    destRef = NodeProperties.ParseGameEntityReference(destUniRef.EntityReference);
+                }
+                
+                if (destRef == "-" || string.IsNullOrEmpty(destRef))
+                {
+                    if (destUniRef.RefLocalPlayer == true)
+                    {
+                        destRef = "Player";
+                    }
+                    else if (destUniRef.MainPlayerObject == true)
+                    {
+                        destRef = "Main Player Object";
+                    }
+                }
+                
+                if (!string.IsNullOrEmpty(destRef) && destRef != "-")
+                {
+                    destination = destRef;
+                }
+            }
+            
+            if (teleportParams.DestinationOffset != null)
+            {
+                var offset = teleportParams.DestinationOffset;
+                if (offset.X != 0 || offset.Y != 0 || offset.Z != 0)
+                {
+                    offsetInfo = $"Offset ({offset.X:F1}, {offset.Y:F1}, {offset.Z:F1})";
+                    
+                    if (destination == "Unknown")
+                    {
+                        destination = offsetInfo;
+                        offsetInfo = "";
+                    }
+                }
+            }
+        }
+
+        details["Command"] = $"Teleport {entity} to {destination}";
+        details["Entity"] = entity;
+        details["Destination"] = destination;
+        
+        if (!string.IsNullOrEmpty(offsetInfo))
+        {
+            details["Destination Offset"] = offsetInfo;
+        }
+
+        if (teleportNode?.Params?.Chunk != null)
+        {
+            var teleportParams = teleportNode.Params.Chunk;
+            
+            details["Heal At Teleport"] = teleportParams.HealAtTeleport ? "Yes" : "No";
+            details["Fast Travel"] = teleportParams.UseFastTravelMechanism ? "Yes" : "No";
+            details["Navigation Test"] = teleportParams.DoNavTest ? "Yes" : "No";
+        }
+        else
+        {
+            details["Heal At Teleport"] = "No";
+            details["Fast Travel"] = "No";  
+            details["Navigation Test"] = "No";
+        }
+
+        details["Look At Action"] = teleportNode?.LookAtAction.ToEnumString() ?? "Reset";
+
+        if (isPlayer && teleportNode?.PlayerLookAt?.Chunk != null && details.Count < 8)
+        {
+            var playerLookAt = teleportNode.PlayerLookAt.Chunk;
+            
+            if (playerLookAt.LookAtTarget != null)
+            {
+                string lookAtTarget = NodeProperties.ParseGameEntityReference(playerLookAt.LookAtTarget);
+                if (lookAtTarget != "-")
+                {
+                    details["Player Look At"] = lookAtTarget;
+                }
+            }
+        }
     }
 
     internal override void CreateDefaultSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questUseWorkspotNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questUseWorkspotNodeDefinitionWrapper.cs
@@ -1,5 +1,6 @@
-﻿using WolvenKit.App.Extensions;
 using WolvenKit.RED4.Types;
+using System.Collections.Generic;
+using System.IO;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 
@@ -7,8 +8,156 @@ public class questUseWorkspotNodeDefinitionWrapper : questAICommandNodeBaseWrapp
 {
     public questUseWorkspotNodeDefinitionWrapper(questUseWorkspotNodeDefinition questAICommandNodeBase) : base(questAICommandNodeBase)
     {
-        Details.AddRange(NodeProperties.GetPropertiesFor(questAICommandNodeBase));
+        PopulateWorkspotDetails();
     }
+    public override void RefreshDetails()
+    {
+        PopulateWorkspotDetails();
+        UpdateTitle();
+        OnPropertyChanged(nameof(Title));
+    }
+
+    private void PopulateWorkspotDetails()
+    {
+        var tempDetails = new Dictionary<string, string>();
+        PopulateWorkspotDetailsInto(_castedData, tempDetails);
+        Details = tempDetails;
+    }
+    private static void PopulateWorkspotDetailsInto(questUseWorkspotNodeDefinition workspotNode, Dictionary<string, string> details, string? resolvedWorkspotInfo = null)
+    {
+        var paramsV1 = workspotNode.ParamsV1?.GetValue() as questUseWorkspotParamsV1;
+        if (paramsV1 != null)
+        {
+            var function = (Enums.questUseWorkspotNodeFunctions)paramsV1.Function;
+            
+            if (workspotNode.EntityReference != null)
+            {
+                string entityStr = NodeProperties.ParseGameEntityReference(workspotNode.EntityReference);
+                if (entityStr != "-")
+                {
+                    details["Entity"] = entityStr;
+                }
+            }
+            
+            if (function == Enums.questUseWorkspotNodeFunctions.StopWorkspot)
+            {
+                details["Action"] = "Stop Workspot";
+            }
+            else if (function == Enums.questUseWorkspotNodeFunctions.UseWorkspot)
+            {
+                details["Action"] = "Use Workspot";
+            }
+            else
+            {
+                details["Action"] = function.ToString();
+            }
+            
+            if (function == Enums.questUseWorkspotNodeFunctions.UseWorkspot)
+            {
+                string workspotInfo = "";
+                
+                if (!string.IsNullOrEmpty(resolvedWorkspotInfo))
+                {
+                    workspotInfo = resolvedWorkspotInfo;
+                }
+                else
+                {
+                    // Fallback to local resolution
+                    if (paramsV1.GetType() == typeof(scnUseSceneWorkspotParamsV1))
+                    {
+                        var sceneParams = (scnUseSceneWorkspotParamsV1)paramsV1;
+                        if (sceneParams.WorkspotInstanceId != null && 
+                            sceneParams.WorkspotInstanceId.Id != uint.MaxValue &&
+                            sceneParams.WorkspotInstanceId.Id != 0)
+                        {
+                            // Show instance ID for scene workspots
+                            workspotInfo = $"Instance [{sceneParams.WorkspotInstanceId.Id}]";
+                        }
+                    }
+                    else if (paramsV1.WorkspotNode != NodeRef.Empty && paramsV1.WorkspotNode != 0)
+                    {
+                        string nodeRefText = paramsV1.WorkspotNode.GetResolvedText() ?? "[Unresolved]";
+                        // Extract just the filename if it's a path
+                        if (nodeRefText.Contains("\\") || nodeRefText.Contains("/"))
+                        {
+                            workspotInfo = Path.GetFileName(nodeRefText);
+                        }
+                        else
+                        {
+                            workspotInfo = nodeRefText;
+                        }
+                    }
+                }
+                
+                if (!string.IsNullOrEmpty(workspotInfo))
+                {
+                    details["Workspot"] = workspotInfo;
+                }
+            }
+            
+            if (paramsV1.EnableIdleMode)
+            {
+                details["Idle Mode"] = "Enabled";
+            }
+                
+            if (function == Enums.questUseWorkspotNodeFunctions.UseWorkspot)
+            {
+                if (paramsV1.GetType() == typeof(scnUseSceneWorkspotParamsV1))
+                {
+                    var sceneWorkspotParams = (scnUseSceneWorkspotParamsV1)paramsV1;
+                    
+                    if (sceneWorkspotParams.PlayAtActorLocation)
+                    {
+                        details["Play At Actor Location"] = "Yes";
+                    }
+                }
+
+                if (paramsV1.EntryId != null && paramsV1.EntryId.Id != uint.MaxValue)
+                {
+                    details["Entry ID"] = paramsV1.EntryId.Id.ToString();
+                }
+                
+                if (paramsV1.ExitEntryId != null && paramsV1.ExitEntryId.Id != uint.MaxValue)
+                {
+                    details["Exit Entry ID"] = paramsV1.ExitEntryId.Id.ToString();
+                }
+            }
+            
+            details["Teleport"] = paramsV1.Teleport ? "Yes" : "No";
+            details["Player"] = paramsV1.IsPlayer ? "Yes" : "No";
+            details["Infinite"] = paramsV1.IsWorkspotInfinite ? "Yes" : "No";
+            details["Movement Type"] = paramsV1.MovementType.ToString(); 
+            
+        }
+    }
+    public static void PopulateWorkspotDetailsWithSceneContext(questUseWorkspotNodeDefinition workspotNode, Dictionary<string, string> details, scnSceneResource? sceneResource = null)
+    {
+        string? resolvedWorkspotInfo = null;
+        
+        // Try to resolve scene workspot info if we have scene context
+        if (sceneResource != null)
+        {
+            var paramsV1 = workspotNode.ParamsV1?.GetValue() as questUseWorkspotParamsV1;
+            if (paramsV1?.GetType() == typeof(scnUseSceneWorkspotParamsV1))
+            {
+                var sceneParams = (scnUseSceneWorkspotParamsV1)paramsV1;
+                if (sceneParams.WorkspotInstanceId != null && 
+                    sceneParams.WorkspotInstanceId.Id != uint.MaxValue &&
+                    sceneParams.WorkspotInstanceId.Id != 0)
+                {
+                    // Try to resolve instance ID to actual workspot file path
+                    string workspotPath = NodeProperties.GetWorkspotPath(sceneParams.WorkspotInstanceId.Id, sceneResource);
+                    if (!string.IsNullOrEmpty(workspotPath))
+                    {
+                        resolvedWorkspotInfo = $"[Instance: {sceneParams.WorkspotInstanceId.Id}] {workspotPath}";
+                    }
+                }
+            }
+        }
+        
+        PopulateWorkspotDetailsInto(workspotNode, details, resolvedWorkspotInfo);
+    }
+
 
     internal override void CreateDefaultSockets()
     {

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnInterruptManagerNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnInterruptManagerNodeWrapper.cs
@@ -1,4 +1,5 @@
-﻿using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
+using System.Collections.Generic;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
@@ -10,5 +11,102 @@ public class scnInterruptManagerNodeWrapper : BaseSceneViewModel<scnInterruptMan
         InputSocketNames.Add(0, "In");
 
         OutputSocketNames.Add(0, "Out");
+
+        RefreshDetails();
+    }
+
+    public override void RefreshDetails()
+    {
+        var newDetails = new Dictionary<string, string>();
+
+        var operationsCount = _castedData.InterruptionOperations?.Count ?? 0;
+        newDetails["Operations Count"] = operationsCount.ToString();
+
+        if (_castedData.InterruptionOperations != null && _castedData.InterruptionOperations.Count > 0)
+        {
+            var counter = 1;
+            foreach (var operation in _castedData.InterruptionOperations)
+            {
+                if (counter > 3) break;
+                
+                var operationChunk = operation?.Chunk;
+                if (operationChunk != null)
+                {
+                    var operationType = GetOperationTypeName(operationChunk);
+                    
+                    if (operationsCount == 1)
+                    {
+                        newDetails["Operation Type"] = operationType;
+                        
+                        switch (operationChunk)
+                        {
+                            case scnToggleInterruption_InterruptionOperation toggleOp:
+                                newDetails["Enable"] = toggleOp.Enable ? "True" : "False";
+                                break;
+                                
+                            case scnOverrideInterruptionScenario_InterruptionOperation overrideOp:
+                                newDetails["Scenario ID"] = overrideOp.ScenarioId?.Id.ToString() ?? "0";
+                                var scenarioOpsCount = overrideOp.ScenarioOperations?.Count ?? 0;
+                                if (scenarioOpsCount > 0)
+                                {
+                                    newDetails["Sub-Operations"] = scenarioOpsCount.ToString();
+                                }
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        newDetails[$"Operation #{counter}"] = operationType;
+                        
+                        switch (operationChunk)
+                        {
+                            case scnToggleInterruption_InterruptionOperation toggleOp:
+                                newDetails[$"Op #{counter} Enable"] = toggleOp.Enable ? "True" : "False";
+                                break;
+                                
+                            case scnOverrideInterruptionScenario_InterruptionOperation overrideOp:
+                                newDetails[$"Op #{counter} Scenario ID"] = overrideOp.ScenarioId?.Id.ToString() ?? "0";
+                                var scenarioOpsCount = overrideOp.ScenarioOperations?.Count ?? 0;
+                                if (scenarioOpsCount > 0)
+                                {
+                                    newDetails[$"Op #{counter} Sub-Operations"] = scenarioOpsCount.ToString();
+                                }
+                                break;
+                        }
+                    }
+                }
+                else
+                {
+                    if (operationsCount == 1)
+                    {
+                        newDetails["Operation Type"] = "Empty";
+                    }
+                    else
+                    {
+                        newDetails[$"Operation #{counter}"] = "Empty";
+                    }
+                }
+                
+                counter++;
+            }
+        }
+        else
+        {
+            newDetails["Status"] = "No Operations";
+        }
+
+        Details = newDetails;
+        UpdateTitle();
+        OnPropertyChanged(nameof(Title));
+    }
+
+    private static string GetOperationTypeName(scnIInterruptionOperation operation)
+    {
+        return operation.GetType().Name switch
+        {
+            "scnToggleInterruption_InterruptionOperation" => "Toggle Interruption",
+            "scnOverrideInterruptionScenario_InterruptionOperation" => "Override Scenario",
+            _ => operation.GetType().Name.Replace("scn", "").Replace("_InterruptionOperation", "")
+        };
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Media;
 using Splat;
@@ -15,8 +15,11 @@ namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
 
 public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
 {
+    private readonly scnSceneResource _sceneResource;
+    
     public scnQuestNodeWrapper(scnQuestNode scnSceneGraphNode, scnSceneResource scnSceneResource) : base(scnSceneGraphNode)
     {
+        _sceneResource = scnSceneResource;
         if (_castedData.QuestNode != null)
         {
             //_castedData.QuestNode.PropertyChanged += QuestNodeOnPropertyChanged;
@@ -155,12 +158,7 @@ public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
             // Create a new Details dictionary to trigger UI updates
             var tempDetails = new Dictionary<string, string>();
             
-            // Get the scene resource from our parent document if possible
-            scnSceneResource? sceneResource = null;
-            if (DocumentViewModel?.SelectedTabItemViewModel is SceneGraphViewModel combinedScene)
-            {
-                sceneResource = combinedScene.RDTViewModel.GetData() as scnSceneResource;
-            }
+            scnSceneResource? sceneResource = _sceneResource;
 
             // Get details from the nested quest node
             if (_castedData.QuestNode?.Chunk != null)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -492,6 +492,35 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>, IDynami
                         detailSuffix = $" ({actionName}: {effectName})";
                     }
                     break;
+                case scneventsVFXDurationEvent vfxDurationEvent:
+                    {
+                        string startActionName = vfxDurationEvent.StartAction.ToString();
+                        string endActionName = vfxDurationEvent.EndAction.ToString();
+                        string effectName = "[No Effect]";
+                        if (vfxDurationEvent.EffectEntry != null && vfxDurationEvent.EffectEntry.EffectName != CName.Empty)
+                        {
+                            effectName = vfxDurationEvent.EffectEntry.EffectName.GetResolvedText() ?? "[unresolved]";
+                        }
+                        
+                        string performerName = "[No Performer]";
+                        if (vfxDurationEvent.PerformerId != null && _sceneResource != null)
+                        {
+                            performerName = ResolvePerformerName(vfxDurationEvent.PerformerId.Id, _sceneResource);
+                        }
+                        
+                        string nodeRefInfo = "";
+                        if (vfxDurationEvent.NodeRef != NodeRef.Empty)
+                        {
+                            string nodeRefName = vfxDurationEvent.NodeRef.GetResolvedText() ?? "[Unresolved Ref]";
+                            nodeRefInfo = $" - Node: {nodeRefName}";
+                        }
+                        
+                        string muteInfo = vfxDurationEvent.MuteSound ? " - Muted" : "";
+                        string sequenceInfo = vfxDurationEvent.SequenceShift > 0 ? $" - Shift: {vfxDurationEvent.SequenceShift}" : "";
+                        
+                        detailSuffix = $" ({performerName} - {startActionName}→{endActionName}: {effectName}{nodeRefInfo}{muteInfo}{sequenceInfo})";
+                    }
+                    break;
                 case scnChangeIdleAnimEvent idleAnimEvent:
                     {
                             string performerName = ResolvePerformerName(idleAnimEvent.Performer.Id, _sceneResource);

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Descriptor.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Descriptor.cs
@@ -448,13 +448,12 @@ public partial class ChunkViewModel
 
             case scnscreenplayDialogLine scnscreenplayDialogLine:
             {
-                Descriptor = scnscreenplayDialogLine.FemaleLipsyncAnimationName.GetResolvedText() ?? "";
-                if (StringHelper.StringifyOrNull(scnscreenplayDialogLine.MaleLipsyncAnimationName) is string s1)
-                {
-                    var separator = Value == "" ? "" : " | ";
-                    Descriptor = $"{Descriptor}{separator}${s1}";
-                }
-
+                Descriptor = scnscreenplayDialogLine.ItemId?.Id.ToString() ?? "";
+                break;
+            }
+            case scnscreenplayChoiceOption scnscreenplayChoiceOption:
+            {
+                Descriptor = scnscreenplayChoiceOption.ItemId?.Id.ToString() ?? "";
                 break;
             }
             case CMeshMaterialEntry materialEntry:

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.Value.cs
@@ -1085,8 +1085,8 @@ public partial class ChunkViewModel
                 IsValueExtrapolated = !IsDefault;
                 return;
             case scnscreenplayChoiceOption screenplayOption:
-                Value = $"{screenplayOption.ItemId.Id} => {screenplayOption.LocstringId.Ruid}";
-                IsValueExtrapolated = screenplayOption.ItemId.Id != 0 || screenplayOption.LocstringId.Ruid != 0;
+                Value = screenplayOption.LocstringId.Ruid.ToString();
+                IsValueExtrapolated = screenplayOption.LocstringId.Ruid != 0;
                 return;
             case scnSpawnDespawnEntityParams spawnDespawnParams
                 when spawnDespawnParams.SpecRecordId.GetResolvedText() is string specRecordId && specRecordId != "":

--- a/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace WolvenKit.RED4.Types;
 
 public partial class scnSceneResource
@@ -101,6 +103,38 @@ public partial class scnSceneResource
     }
     
     /// <summary>
+    /// Resolves an actor ID to actor name using direct index lookup
+    /// </summary>
+    /// <param name="actorId">The actor ID to resolve</param>
+    /// <returns>The actor name with ID, or a fallback string if not found</returns>
+    public string ResolveActorName(uint actorId)
+    {
+        if (actorId == uint.MaxValue) return "None";
+        
+        // Check player actors first
+        var playerActor = PlayerActors?.FirstOrDefault(p => p.ActorId?.Id == actorId);
+        if (playerActor != null)
+        {
+            string? playerName = playerActor.PlayerName;
+            if (string.IsNullOrEmpty(playerName)) playerName = "Player";
+            return $"{playerName} [{actorId}]";
+        }
+        
+        // Check regular actors by index
+        if (Actors != null && actorId < Actors.Count)
+        {
+            var actorDef = Actors[(int)actorId];
+            if (actorDef != null)
+            {
+                string? actorName = actorDef.ActorName;
+                return $"{actorName ?? "Unnamed"} [{actorId}]";
+            }
+        }
+        
+        return $"Unknown Actor [{actorId}]";
+    }
+
+    /// <summary>
     /// Gets embedded text content for a given locstring ID from scene's LocStore
     /// Based on logic from scnSectionNodeWrapper.cs
     /// </summary>
@@ -150,4 +184,4 @@ public partial class scnSceneResource
 
         return string.Empty;
     }
-} 
+}


### PR DESCRIPTION
Add better node details for Section events and Workspot nodes

**Implemented:**
- Add details for more Section event details (VFX duration, look at advanced, camera param, pose correction)
- Add proper details for workspot nodes
- Modify details shown in the "Dialogue" tab for .scene > screeplayStore -> lines/options to show itemId instead of animation names
- Add details for interrupt manager node

<img width="1124" height="897" alt="image" src="https://github.com/user-attachments/assets/45e3db0d-6497-4ded-bc8a-48c960ac6472" />
<img width="1203" height="742" alt="image" src="https://github.com/user-attachments/assets/9e1a289f-18c6-4481-bedb-bb6d6328aaeb" />

