### PR TITLE
fix: initialize graph for questphase on creation

### DIFF
--- a/WolvenKit.RED4/Types/ClassesExt/questQuestPhaseResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/questQuestPhaseResource.cs
@@ -1,0 +1,9 @@
+namespace WolvenKit.RED4.Types;
+
+public partial class questQuestPhaseResource
+{
+    partial void PostConstruct()
+    {
+        Graph ??= new CHandle<graphGraphDefinition>() { Chunk = new questGraphDefinition() };
+    }
+}


### PR DESCRIPTION
**Fixed:**
Ensure graph is initialized on creation of a new questphase file (following the same pattern of scene files)