### PR TITLE
fix: prefer en-us for dialogLine event detail

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnSectionNodeWrapper.cs
@@ -203,7 +203,7 @@ public class scnSectionNodeWrapper : BaseSceneViewModel<scnSectionNode>, IDynami
                                     string? dialogueText = null;
                                     bool foundText = false;
 
-                                    var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.db_db;
+                                    var preferredLocaleId = WolvenKit.RED4.Types.Enums.scnlocLocaleId.en_us;
                                     var vdEntryPreferred = _sceneResource.LocStore.VdEntries.FirstOrDefault(vd => 
                                         vd.LocstringId?.Ruid == locstringRuid && vd.LocaleId == preferredLocaleId);
 


### PR DESCRIPTION
**Fixed:**
prefer en-us locale for dialogLine event detail in scene graph

