### PR TITLE
feat: improve UI of Scene Graph and its dialog

### DIFF
--- a/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/SceneInputDialogView.xaml
@@ -5,10 +5,11 @@
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     Title="{Binding Title}"
+    Width="500"
     MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
     MaxWidth="800"
     SizeToContent="Height"
-    Width="500"
+    ResizeMode="NoResize"
     FocusManager.FocusedElement="{Binding ElementName=PrimaryInputTextBox}"
     WindowStartupLocation="CenterScreen">
     <Grid
@@ -35,88 +36,132 @@
                 HelpVisibility="Collapsed"
                 NextVisibility="Collapsed"
                 PageType="Exterior">
-                <StackPanel Margin="10" MinWidth="450">
+                <Grid Margin="{DynamicResource WolvenKitMarginSmallHeader}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+
                     <!-- Dropdown Field (conditionally visible) -->
-                    <Grid Margin="0,0,0,10"
-                          Visibility="{Binding ShowDropdown, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="{DynamicResource WolvenKitMarginSmallBottom}"
+                        Visibility="{Binding ShowDropdown,
+                                             Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="140" />
+                            <ColumnDefinition Width="Auto" MinWidth="{DynamicResource WolvenKitLabelWidthMedium}" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" 
-                                   Text="{Binding DropdownLabel}" 
-                                   VerticalAlignment="Center"
-                                   HorizontalAlignment="Right"
-                                   Margin="0,0,10,0"
-                                   Foreground="{DynamicResource PrimaryTextBrush}"
-                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
-                        <ComboBox Grid.Column="1"
-                                  Padding="{DynamicResource WolvenKitMarginTiny}"
-                                  FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                  ItemsSource="{Binding DropdownOptions}"
-                                  SelectedItem="{Binding SelectedDropdownValue, UpdateSourceTrigger=PropertyChanged}"
-                                  IsReadOnly="True" />
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="{DynamicResource WolvenKitMarginSmallRight}"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Text="{Binding DropdownLabel}" />
+
+                        <ComboBox
+                            Grid.Column="1"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            ItemsSource="{Binding DropdownOptions}"
+                            SelectedItem="{Binding SelectedDropdownValue,
+                                                   UpdateSourceTrigger=PropertyChanged}"
+                            IsReadOnly="True" />
                     </Grid>
 
                     <!-- Primary Input Field (always visible) -->
-                    <Grid Margin="0,0,0,10">
+                    <Grid
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{DynamicResource WolvenKitMarginSmallBottom}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="140" />
+                            <ColumnDefinition Width="Auto" MinWidth="{DynamicResource WolvenKitLabelWidthMedium}" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" 
-                                   Text="{Binding PrimaryLabel}" 
-                                   VerticalAlignment="Center"
-                                   HorizontalAlignment="Right"
-                                   Margin="0,0,10,0"
-                                   Foreground="{DynamicResource PrimaryTextBrush}"
-                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
-                        <TextBox x:Name="PrimaryInputTextBox"
-                                 Grid.Column="1"
-                                 Padding="{DynamicResource WolvenKitMarginTiny}"
-                                 VerticalContentAlignment="Center"
-                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                 Text="{Binding PrimaryInputValue, UpdateSourceTrigger=PropertyChanged}"
-                                 TextWrapping="Wrap"
-                                 AcceptsReturn="False"
-                                 VerticalScrollBarVisibility="Auto"
-                                 MaxHeight="80" />
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="{DynamicResource WolvenKitMarginTinyRightSide}"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Text="{Binding PrimaryLabel}" />
+
+                        <TextBox
+                            x:Name="PrimaryInputTextBox"
+                            Grid.Column="1"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Text="{Binding PrimaryInputValue,
+                                           UpdateSourceTrigger=PropertyChanged}"
+                            TextWrapping="Wrap"
+                            AcceptsReturn="False"
+                            VerticalScrollBarVisibility="Auto" />
                     </Grid>
 
                     <!-- Secondary Input Checkbox (conditionally visible) -->
-                    <CheckBox Content="{Binding CheckboxText}"
-                              IsChecked="{Binding EnableSecondaryInput}"
-                              VerticalAlignment="Center"
-                              FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                              Margin="0,5,0,10"
-                              Visibility="{Binding ShowSecondaryInput, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-
-                    <!-- Secondary Input Field (conditionally visible) -->
-                    <Grid Margin="0,0,0,0" 
-                          Visibility="{Binding EnableSecondaryInput, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Margin="{DynamicResource WolvenKitMarginSmallBottom}"
+                        VerticalAlignment="Top"
+                        Visibility="{Binding ShowSecondaryInput,
+                                             Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="140" />
+                            <ColumnDefinition Width="Auto" MinWidth="{DynamicResource WolvenKitLabelWidthMedium}" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" 
-                                   Text="{Binding SecondaryLabel}" 
-                                   VerticalAlignment="Top"
-                                   HorizontalAlignment="Right"
-                                   Margin="0,8,10,0"
-                                   Foreground="{DynamicResource PrimaryTextBrush}"
-                                   FontSize="{DynamicResource WolvenKitFontSubTitle}"/>
-                        <TextBox Grid.Column="1"
-                                 Padding="{DynamicResource WolvenKitMarginTiny}"
-                                 VerticalContentAlignment="Top"
-                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                 Text="{Binding SecondaryInputValue, UpdateSourceTrigger=PropertyChanged}"
-                                 TextWrapping="Wrap"
-                                 AcceptsReturn="True"
-                                 MinHeight="60"
-                                 MaxHeight="120"
-                                 VerticalScrollBarVisibility="Auto" />
+
+                        <CheckBox
+                            Grid.Column="1"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Content="{Binding CheckboxText}"
+                            IsChecked="{Binding EnableSecondaryInput}" />
                     </Grid>
-                </StackPanel>
+
+                    <!-- Secondary Input Field (conditionally visible) -->
+                    <Grid
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Margin="{DynamicResource WolvenKitMarginSmallBottom}"
+                        Visibility="{Binding EnableSecondaryInput,
+                                             Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="{DynamicResource WolvenKitLabelWidthMedium}" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="{DynamicResource WolvenKitMarginTinyRightSide}"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Foreground="{DynamicResource PrimaryTextBrush}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Text="{Binding SecondaryLabel}" />
+
+                        <TextBox
+                            Grid.Column="1"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Text="{Binding SecondaryInputValue,
+                                           UpdateSourceTrigger=PropertyChanged}"
+                            TextWrapping="Wrap"
+                            AcceptsReturn="True"
+                            VerticalScrollBarVisibility="Auto" />
+                    </Grid>
+                </Grid>
             </syncfusion:WizardPage>
         </syncfusion:WizardControl>
     </Grid>

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -1,115 +1,126 @@
-<UserControl x:Class="WolvenKit.Views.Documents.SceneGraphView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:documents="clr-namespace:WolvenKit.App.ViewModels.Documents;assembly=WolvenKit.App"
-             xmlns:local="clr-namespace:WolvenKit.Views.Documents"
-             xmlns:graphEditor="clr-namespace:WolvenKit.Views.GraphEditor"
-             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
-             xmlns:shell="clr-namespace:WolvenKit.App.ViewModels.Shell;assembly=WolvenKit.App"
-             xmlns:tools="clr-namespace:WolvenKit.Views.Tools"
-             xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
-             xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
-             xmlns:nodify="https://miroiu.github.io/nodify"
-             xmlns:sceneNodes="clr-namespace:WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;assembly=WolvenKit.App"
-             mc:Ignorable="d" 
-             d:DataContext="{d:DesignInstance documents:SceneGraphViewModel, IsDesignTimeCreatable=False}"
-             d:DesignHeight="800" d:DesignWidth="1200"
-             PreviewKeyDown="SceneGraphView_OnPreviewKeyDown">
+<UserControl
+    x:Class="WolvenKit.Views.Documents.SceneGraphView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:documents="clr-namespace:WolvenKit.App.ViewModels.Documents;assembly=WolvenKit.App"
+    xmlns:local="clr-namespace:WolvenKit.Views.Documents"
+    xmlns:graphEditor="clr-namespace:WolvenKit.Views.GraphEditor"
+    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    xmlns:shell="clr-namespace:WolvenKit.App.ViewModels.Shell;assembly=WolvenKit.App"
+    xmlns:tools="clr-namespace:WolvenKit.Views.Tools"
+    xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    xmlns:nodify="https://miroiu.github.io/nodify"
+    xmlns:sceneNodes="clr-namespace:WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;assembly=WolvenKit.App"
+    xmlns:templates="clr-namespace:WolvenKit.Views.Templates"
+    mc:Ignorable="d"
+    d:DataContext="{d:DesignInstance documents:SceneGraphViewModel,
+                                     IsDesignTimeCreatable=False}"
+    d:DesignHeight="800"
+    d:DesignWidth="1200"
+    PreviewKeyDown="SceneGraphView_OnPreviewKeyDown">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- Merge Scene Editor specific converters -->
                 <ResourceDictionary Source="/WolvenKit;component/Resources/Converters/SceneEditorConverters.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            
-        <Style x:Key="SpacedWolvenKitTabControl" 
-               BasedOn="{StaticResource WolvenKitTabControl}"
-               TargetType="{x:Type syncfusion:TabControlExt}">
-            <Setter Property="TabItemSelectedBackground" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="TabItemHoverBackground" Value="{StaticResource WolvenKitRed}" />
-            <Setter Property="TabItemSelectedBorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="TabItemHoverBorderBrush" Value="{StaticResource WolvenKitRed}" />
-        </Style>
-        
-        <Style x:Key="SpacedTabItemStyle" 
-               TargetType="{x:Type syncfusion:TabItemExt}"
-               BasedOn="{StaticResource SyncfusionTabItemExtStyle}">
-            <Setter Property="Padding" Value="12,8,12,8"/>
-            <Setter Property="Margin" Value="0,0,2,0"/>
-        </Style>
-        
-        <!-- Scene Connection Template with Variable Thickness -->
-        <DataTemplate x:Key="SceneConnectionTemplate" DataType="{x:Type sceneNodes:SceneConnectionViewModel}">
-            <nodify:Connection
-                Source="{Binding Source.Anchor}"
-                SourceOffset="7,0"
-                SourceOffsetMode="Static"
-                Target="{Binding Target.Anchor}"
-                TargetOffset="7,0"
-                TargetOffsetMode="Static"
-                IsSelectable="True"
-                IsSelected="{Binding IsSelected}"
-                MouseRightButtonDown="Connection_OnRightClick">
-                <nodify:Connection.Style>
-                    <Style TargetType="{x:Type nodify:BaseConnection}">
-                        <Setter Property="Cursor" Value="Hand" />
-                        <Setter Property="Stroke" Value="#FF7F7F7F" />
-                        <Setter Property="Opacity" Value="1.0" />
-                        <Setter Property="StrokeThickness" 
-                                Value="{Binding PathType, Converter={StaticResource PathTypeToThicknessConverter}}" />
 
-                        <Style.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="Stroke" Value="{StaticResource WolvenKitYellow}" />
-                            </Trigger>
-                            <Trigger Property="IsSelected" Value="True">
-                                <Setter Property="Stroke" Value="{StaticResource WolvenKitGreen}" />
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
-                </nodify:Connection.Style>
-            </nodify:Connection>
-        </DataTemplate>
-        
-        <!-- Button Style for Add Actor/Prop buttons -->
-        <Style x:Key="SceneEditorButtonStyle" TargetType="Button">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="Foreground" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Padding" Value="8,4" />
-            <Setter Property="FontWeight" Value="Medium" />
-            <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type Button}">
-                        <Border x:Name="border"
+            <Style
+                x:Key="SpacedWolvenKitTabControl"
+                BasedOn="{StaticResource WolvenKitTabControl}"
+                TargetType="{x:Type syncfusion:TabControlExt}">
+                <Setter Property="TabItemHoverBackground" Value="{StaticResource WolvenKitRed}" />
+                <Setter Property="TabItemHoverBorderBrush" Value="{StaticResource WolvenKitRed}" />
+                <Setter Property="TabItemSelectedBackground" Value="{StaticResource WolvenKitRedShadow}" />
+                <Setter Property="TabItemSelectedBorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+            </Style>
+
+            <Style
+                x:Key="SpacedTabItemStyle"
+                BasedOn="{StaticResource SyncfusionTabItemExtStyle}"
+                TargetType="{x:Type syncfusion:TabItemExt}">
+                <Setter Property="Margin" Value="0,0,2,0" />
+                <Setter Property="Padding" Value="12,8,12,8" />
+            </Style>
+
+            <!-- Scene Connection Template with Variable Thickness -->
+            <DataTemplate
+                x:Key="SceneConnectionTemplate"
+                DataType="{x:Type sceneNodes:SceneConnectionViewModel}">
+                <nodify:Connection
+                    Source="{Binding Source.Anchor}"
+                    SourceOffset="7,0"
+                    SourceOffsetMode="Static"
+                    Target="{Binding Target.Anchor}"
+                    TargetOffset="7,0"
+                    TargetOffsetMode="Static"
+                    IsSelectable="True"
+                    IsSelected="{Binding IsSelected}"
+                    MouseRightButtonDown="Connection_OnRightClick">
+                    <nodify:Connection.Style>
+                        <Style TargetType="{x:Type nodify:BaseConnection}">
+                            <Setter Property="Cursor" Value="Hand" />
+                            <Setter Property="Opacity" Value="1.0" />
+                            <Setter Property="Stroke" Value="#FF7F7F7F" />
+                            <Setter Property="StrokeThickness" Value="{Binding PathType, Converter={StaticResource PathTypeToThicknessConverter}}" />
+
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Stroke" Value="{StaticResource WolvenKitYellow}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Stroke" Value="{StaticResource WolvenKitGreen}" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </nodify:Connection.Style>
+                </nodify:Connection>
+            </DataTemplate>
+
+            <!-- Button Style for Add Actor/Prop buttons -->
+            <Style
+                x:Key="SceneEditorButtonStyle"
+                TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="FontWeight" Value="Medium" />
+                <Setter Property="Foreground" Value="{StaticResource WolvenKitRedShadow}" />
+                <Setter Property="Padding" Value="8,4" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type Button}">
+                            <Border
+                                x:Name="border"
+                                Padding="{TemplateBinding Padding}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Padding="{TemplateBinding Padding}">
-                            <ContentPresenter HorizontalAlignment="Center" 
-                                            VerticalAlignment="Center"/>
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRed}" />
-                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRed}" />
-                                <Setter Property="Foreground" Value="White" />
-                            </Trigger>
-                            <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRedShadow}" />
-                                <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
-                                <Setter Property="Foreground" Value="White" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                                <ContentPresenter
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="White" />
+                                    <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRed}" />
+                                    <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRed}" />
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter Property="Foreground" Value="White" />
+                                    <Setter TargetName="border" Property="Background" Value="{StaticResource WolvenKitRedShadow}" />
+                                    <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -117,66 +128,88 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        
+
         <!-- Toolbar -->
-        <Border Grid.Row="0" Background="{StaticResource ContentBackground}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="8,4">
+        <Border
+            Grid.Row="0"
+            Padding="{DynamicResource WolvenKitMarginSmall}"
+            Background="{StaticResource ContentBackground}"
+            BorderBrush="{StaticResource BorderAlt}"
+            BorderThickness="0,0,0,1">
             <StackPanel Orientation="Horizontal">
-                <iconPacks:PackIconMaterial Kind="InformationOutline" VerticalAlignment="Center" Margin="0,0,8,0" Width="12" Height="12"/>
-                <TextBlock Text="{Binding SceneTitleWithCategory}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="11" 
-                           FontWeight="Medium"
-                           Margin="0,0,16,0"/>
-                <TextBlock Text="Total Nodes:" 
-                           VerticalAlignment="Center" 
-                           Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
-                <TextBlock Text="{Binding TotalNodes}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
-                <TextBlock Text="Actors:" 
-                           VerticalAlignment="Center" 
-                           Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
-                <TextBlock Text="{Binding TotalActors}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
-                <TextBlock Text="Props:" 
-                           VerticalAlignment="Center" 
-                           Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
-                <TextBlock Text="{Binding TotalProps}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
-                <TextBlock Text="Choices:" 
-                           VerticalAlignment="Center" 
-                           Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
-                <TextBlock Text="{Binding TotalChoices}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
-                <TextBlock Text="Dialogues:" 
-                           VerticalAlignment="Center" 
-                           Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
-                <TextBlock Text="{Binding TotalDialogues}" 
-                           VerticalAlignment="Center" 
-                           Foreground="White" 
-                           FontSize="10" />
+                <StackPanel.Resources>
+                    <Style
+                        x:Key="Label"
+                        TargetType="{x:Type TextBlock}">
+                        <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontAltTitle}" />
+                        <Setter Property="Foreground" Value="Gray" />
+                        <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                    </Style>
+
+                    <Style
+                        x:Key="Value"
+                        TargetType="{x:Type TextBlock}">
+                        <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+                        <Setter Property="Foreground" Value="White" />
+                        <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginRight}" />
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                    </Style>
+                </StackPanel.Resources>
+
+                <templates:IconBox
+                    IconPack="Material"
+                    Kind="InformationOutline"
+                    Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                    Size="{DynamicResource WolvenKitIconMicro}" />
+
+                <TextBlock
+                    Margin="0,0,16,0"
+                    VerticalAlignment="Center"
+                    Foreground="White"
+                    FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                    FontWeight="Medium"
+                    Text="{Binding SceneTitleWithCategory}" />
+
+                <TextBlock
+                    Style="{StaticResource Label}"
+                    Text="Total Nodes:" />
+
+                <TextBlock
+                    Style="{StaticResource Value}"
+                    Text="{Binding TotalNodes}" />
+
+                <TextBlock
+                    Style="{StaticResource Label}"
+                    Text="Actors:" />
+
+                <TextBlock
+                    Style="{StaticResource Value}"
+                    Text="{Binding TotalActors}" />
+
+                <TextBlock
+                    Style="{StaticResource Label}"
+                    Text="Props:" />
+
+                <TextBlock
+                    Style="{StaticResource Value}"
+                    Text="{Binding TotalProps}" />
+
+                <TextBlock
+                    Style="{StaticResource Label}"
+                    Text="Choices:" />
+
+                <TextBlock
+                    Style="{StaticResource Value}"
+                    Text="{Binding TotalChoices}" />
+
+                <TextBlock
+                    Style="{StaticResource Label}"
+                    Text="Dialogues:" />
+
+                <TextBlock
+                    Style="{StaticResource Value}"
+                    Text="{Binding TotalDialogues}" />
             </StackPanel>
         </Border>
 
@@ -189,17 +222,24 @@
             </Grid.ColumnDefinitions>
 
             <!-- Left Panel: Curated Tab Control -->
-            <syncfusion:TabControlExt Grid.Column="0" 
-                                      Style="{StaticResource SpacedWolvenKitTabControl}"
-                                      ItemContainerStyle="{StaticResource SpacedTabItemStyle}"
-                                      ItemsSource="{Binding Tabs}"
-                                      SelectedItem="{Binding SelectedTab, Mode=TwoWay}"
-                                      EnableLabelEdit="False">
+            <syncfusion:TabControlExt
+                Grid.Column="0"
+                Style="{StaticResource SpacedWolvenKitTabControl}"
+                ItemContainerStyle="{StaticResource SpacedTabItemStyle}"
+                ItemsSource="{Binding Tabs}"
+                SelectedItem="{Binding SelectedTab,
+                                       Mode=TwoWay}"
+                EnableLabelEdit="False">
                 <syncfusion:TabControlExt.ItemTemplate>
                     <DataTemplate DataType="{x:Type documents:SceneTabDefinition}">
                         <StackPanel Orientation="Horizontal">
-                            <iconPacks:PackIconMaterial Kind="{Binding Icon}" VerticalAlignment="Center" Margin="0,0,8,0" />
-                            <TextBlock Text="{Binding Header}" VerticalAlignment="Center" />
+                            <iconPacks:PackIconMaterial
+                                Kind="{Binding Icon}"
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Text="{Binding Header}" />
                         </StackPanel>
                     </DataTemplate>
                 </syncfusion:TabControlExt.ItemTemplate>
@@ -210,64 +250,101 @@
                             <Grid>
                                 <Grid.Style>
                                     <Style TargetType="Grid">
-                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Setter Property="Visibility" Value="Visible" />
                                         <Style.Triggers>
                                             <!-- Hide traditional view for Node Properties tab -->
-                                            <DataTrigger Binding="{Binding Header}" Value="Node Properties">
-                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            <DataTrigger
+                                                Binding="{Binding Header}"
+                                                Value="Node Properties">
+                                                <Setter Property="Visibility" Value="Collapsed" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
                                 </Grid.Style>
-                                
+
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
-                                
+
                                 <!-- Button Bar -->
-                                <Border Grid.Row="0" Background="{StaticResource ContentBackgroundAlt}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,1,0,1" Padding="8,4"
-                                        Visibility="{Binding DataContext.IsButtonBarVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <StackPanel Orientation="Horizontal" Margin="5">
-                                        <Button Content="+ Add Actor" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewActorCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsActorCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"/>
-                                        <Button Content="+ Add Prop" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewPropCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsPropCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"/>
-                                        <Button Content="+ Add Dialogue" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewDialogueCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsDialogueCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"/>
-                                        <Button Content="+ Add Option" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewOptionCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsOptionCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"/>
-                                        <Button Content="+ Add Animation" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewAnimationCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsAnimationCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"
-                                                />
-                                        <Button Content="+ Add Workspot" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewWorkspotCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsWorkspotCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                Margin="0,0,5,0"/>
-                                        <Button Content="+ Add Effect" 
-                                                Style="{StaticResource SceneEditorButtonStyle}"
-                                                Command="{Binding DataContext.CreateNewEffectCommand, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                Visibility="{Binding DataContext.IsEffectCreationVisible, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                                />
+                                <Border
+                                    Grid.Row="0"
+                                    Padding="8,4"
+                                    Background="{StaticResource ContentBackgroundAlt}"
+                                    BorderBrush="{StaticResource BorderAlt}"
+                                    BorderThickness="0,1,0,1"
+                                    Visibility="{Binding DataContext.IsButtonBarVisible,
+                                                         RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                         Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <StackPanel
+                                        Margin="5"
+                                        Orientation="Horizontal">
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsActorCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Actor"
+                                            Command="{Binding DataContext.CreateNewActorCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsPropCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Prop"
+                                            Command="{Binding DataContext.CreateNewPropCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsDialogueCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Dialogue"
+                                            Command="{Binding DataContext.CreateNewDialogueCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsOptionCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Option"
+                                            Command="{Binding DataContext.CreateNewOptionCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsAnimationCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Animation"
+                                            Command="{Binding DataContext.CreateNewAnimationCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Margin="0,0,5,0"
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsWorkspotCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Workspot"
+                                            Command="{Binding DataContext.CreateNewWorkspotCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsEffectCreationVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="+ Add Effect"
+                                            Command="{Binding DataContext.CreateNewEffectCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
                                     </StackPanel>
                                 </Border>
-                                
+
                                 <Grid Grid.Row="1">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="3*" />
@@ -276,25 +353,40 @@
                                     </Grid.ColumnDefinitions>
 
                                     <!-- RedTreeView bound directly to the filtered ICollectionView -->
-                                    <tools:RedTreeView Grid.Column="0" 
-                                                       ItemsSource="{Binding DataContext.SelectedTabContent, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
-                                                       SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"
-                                                       SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}, Mode=TwoWay}"/>
-                                    
-                                <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
-                                    
-                                <editors:RedTypeView Grid.Column="2" DataContext="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"/>
+                                    <tools:RedTreeView
+                                        Grid.Column="0"
+                                        ItemsSource="{Binding DataContext.SelectedTabContent,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
+                                        SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk,
+                                                               RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                               Mode=TwoWay}"
+                                        SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks,
+                                                                RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                Mode=TwoWay}" />
+
+                                    <GridSplitter
+                                        Grid.Column="1"
+                                        Width="4"
+                                        HorizontalAlignment="Stretch"
+                                        Background="#FF404040" />
+
+                                    <editors:RedTypeView
+                                        Grid.Column="2"
+                                        DataContext="{Binding DataContext.RDTViewModel.SelectedChunk,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                </Grid>
                             </Grid>
-                            </Grid>
-                            
+
                             <!-- Node Properties tab shows our custom selection-driven view -->
                             <local:NodePropertiesView>
                                 <local:NodePropertiesView.Style>
                                     <Style TargetType="local:NodePropertiesView">
-                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Setter Property="Visibility" Value="Collapsed" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Header}" Value="Node Properties">
-                                                <Setter Property="Visibility" Value="Visible"/>
+                                            <DataTrigger
+                                                Binding="{Binding Header}"
+                                                Value="Node Properties">
+                                                <Setter Property="Visibility" Value="Visible" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -306,22 +398,33 @@
             </syncfusion:TabControlExt>
 
             <!-- Grid Splitter -->
-            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
+            <GridSplitter
+                Grid.Column="1"
+                Width="4"
+                HorizontalAlignment="Stretch"
+                Background="#FF404040" />
 
             <!-- Right Panel: Graph Editor -->
             <Grid Grid.Column="2">
-                <graphEditor:GraphEditorView Source="{Binding MainGraph}" x:Name="SceneGraphEditor" />
-                
+                <graphEditor:GraphEditorView
+                    x:Name="SceneGraphEditor"
+                    Source="{Binding MainGraph}" />
+
                 <!-- Loading Overlay -->
-                <Border Background="#AA000000" 
-                        Visibility="{Binding IsGraphLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                        <iconPacks:PackIconMaterial Kind="GraphOutline" 
-                                                    Foreground="{StaticResource WolvenKitYellow}"
-                                                    Width="48" 
-                                                    Height="48" 
-                                                    HorizontalAlignment="Center"
-                                                    Margin="0,0,0,16">
+                <Border
+                    Background="#AA000000"
+                    Visibility="{Binding IsGraphLoading,
+                                         Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                        <iconPacks:PackIconMaterial
+                            Kind="GraphOutline"
+                            Width="48"
+                            Height="48"
+                            Margin="0,0,0,16"
+                            HorizontalAlignment="Center"
+                            Foreground="{StaticResource WolvenKitYellow}">
                             <iconPacks:PackIconMaterial.RenderTransform>
                                 <RotateTransform x:Name="LoadingRotation" />
                             </iconPacks:PackIconMaterial.RenderTransform>
@@ -329,29 +432,33 @@
                                 <EventTrigger RoutedEvent="FrameworkElement.Loaded">
                                     <BeginStoryboard>
                                         <Storyboard RepeatBehavior="Forever">
-                                            <DoubleAnimation 
+                                            <DoubleAnimation
                                                 Storyboard.TargetProperty="RenderTransform.Angle"
-                                                From="0" To="360" Duration="0:0:2" />
+                                                From="0"
+                                                To="360"
+                                                Duration="0:0:2" />
                                         </Storyboard>
                                     </BeginStoryboard>
                                 </EventTrigger>
                             </iconPacks:PackIconMaterial.Triggers>
                         </iconPacks:PackIconMaterial>
-                        
-                        <TextBlock Text="Loading scene graph..." 
-                                   Foreground="White" 
-                                   FontSize="16" 
-                                   FontWeight="Medium"
-                                   HorizontalAlignment="Center"/>
-                        
-                        <TextBlock Text="Building nodes and connections" 
-                                   Foreground="Gray" 
-                                   FontSize="12" 
-                                   HorizontalAlignment="Center"
-                                   Margin="0,4,0,0"/>
+
+                        <TextBlock
+                            HorizontalAlignment="Center"
+                            Foreground="White"
+                            FontSize="16"
+                            FontWeight="Medium"
+                            Text="Loading scene graph..." />
+
+                        <TextBlock
+                            Margin="0,4,0,0"
+                            HorizontalAlignment="Center"
+                            Foreground="Gray"
+                            FontSize="12"
+                            Text="Building nodes and connections" />
                     </StackPanel>
                 </Border>
             </Grid>
         </Grid>
     </Grid>
-</UserControl> 
+</UserControl>


### PR DESCRIPTION
# feat: improve UI of Scene Graph and its dialog

**Implemented:**
- add UI scaling for the toolbar of the SceneGraph view
- improve layout of SceneInputDialog and UI scaling

**Additional notes:**
Follow up to #2667

**Screenshots:**
At 100%:
<img width="890" height="664" alt="Capture d'écran 2025-10-01 123050" src="https://github.com/user-attachments/assets/7678c2f0-6ef9-40bd-9719-0d15a86fb91b" />

At 150%:
<img width="895" height="641" alt="Capture d'écran 2025-10-01 122712" src="https://github.com/user-attachments/assets/cceef659-bc4a-4928-8082-6fed68c9f81d" />