### PR TITLE
fix(ProjectExplorer): font scaling in hierarchical tree and flat tree

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -86,12 +86,12 @@
                 </MenuItem>
 
                 <MenuItem
-                    Command="{Binding OpenInMlsbCommand}"
-                    Header="Open in MlSetupBuilder"
                     Visibility="{Binding Path=IsEnabled,
                                          RelativeSource={RelativeSource Self},
                                          Mode=OneWay,
-                                         Converter={StaticResource BooleanToVisibilityConverter}}">
+                                         Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Command="{Binding OpenInMlsbCommand}"
+                    Header="Open in MlSetupBuilder">
                     <MenuItem.Icon>
                         <templates:IconBox
                             IconPack="Empty"
@@ -493,6 +493,7 @@
                         Grid.Column="1"
                         Margin="{DynamicResource WolvenKitMarginTinyLeft}"
                         VerticalAlignment="Center"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
                         Text="{Binding Path=Name}" />
 
                     <TextBlock
@@ -500,6 +501,7 @@
                         Grid.Column="1"
                         Margin="{DynamicResource WolvenKitMarginTinyLeft}"
                         VerticalAlignment="Center"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
                         Text="{Binding Path=Name}" />
 
                     <!-- Copy relative path - Open in Windows Explorer - Open file - Delete -->
@@ -625,6 +627,7 @@
                         Grid.Column="1"
                         Margin="{DynamicResource WolvenKitMarginTinyLeft}"
                         VerticalAlignment="Center"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
                         Text="{Binding Path=Name}"
                         TextTrimming="CharacterEllipsis" />
                 </Grid>
@@ -1072,6 +1075,7 @@
                 <Style TargetType="syncfusion:TreeGridCell">
                     <Setter Property="BorderBrush" Value="Transparent" />
                     <Setter Property="BorderThickness" Value="0" />
+                    <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
                 </Style>
 
                 <Style TargetType="syncfusion:TreeGridExpanderCell">


### PR DESCRIPTION
# fix(ProjectExplorer): support font scaling in hierarchical tree and flat tree

**Fixed:**
- font was not scaling in hierarchical tree and flat tree

**Additional notes:**
At 100%:
<img width="496" height="532" alt="Capture d'écran 2025-10-01 130056" src="https://github.com/user-attachments/assets/5fc03e60-be68-4dac-b73f-d142281727ff" />
<img width="496" height="532" alt="Capture d'écran 2025-10-01 130107" src="https://github.com/user-attachments/assets/253508e8-a747-4d30-adda-b5d6a6c02117" />

At 150%:
<img width="464" height="483" alt="Capture d'écran 2025-10-01 125623" src="https://github.com/user-attachments/assets/014c3339-e74d-440a-9e0e-9b3d63d4b80f" />
<img width="694" height="482" alt="Capture d'écran 2025-10-01 125939" src="https://github.com/user-attachments/assets/0f619644-8fc8-46de-b9c3-6b4c9a87bd47" />