### PR TITLE
fix: info bar text scaling and padding in scene/questPhase editors

### DIFF
--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
@@ -23,26 +23,26 @@
                 <!-- Merge Scene Editor specific converters (reused for quest phase) -->
                 <ResourceDictionary Source="/WolvenKit;component/Resources/Converters/SceneEditorConverters.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            
-        <Style x:Key="SpacedWolvenKitTabControl" 
+
+            <Style x:Key="SpacedWolvenKitTabControl" 
                BasedOn="{StaticResource WolvenKitTabControl}"
                TargetType="{x:Type syncfusion:TabControlExt}">
-            <Setter Property="TabItemSelectedBackground" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="TabItemHoverBackground" Value="{StaticResource WolvenKitRed}" />
-            <Setter Property="TabItemSelectedBorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
-            <Setter Property="TabItemHoverBorderBrush" Value="{StaticResource WolvenKitRed}" />
-        </Style>
-        
-        <Style x:Key="SpacedTabItemStyle" 
+                <Setter Property="TabItemSelectedBackground" Value="{StaticResource WolvenKitRedShadow}" />
+                <Setter Property="TabItemHoverBackground" Value="{StaticResource WolvenKitRed}" />
+                <Setter Property="TabItemSelectedBorderBrush" Value="{StaticResource WolvenKitRedShadow}" />
+                <Setter Property="TabItemHoverBorderBrush" Value="{StaticResource WolvenKitRed}" />
+            </Style>
+
+            <Style x:Key="SpacedTabItemStyle" 
                TargetType="{x:Type syncfusion:TabItemExt}"
                BasedOn="{StaticResource SyncfusionTabItemExtStyle}">
-            <Setter Property="Padding" Value="12,8,12,8"/>
-            <Setter Property="Margin" Value="0,0,2,0"/>
-        </Style>
-        
-        <!-- Quest Connection Template with Variable Thickness -->
-        <DataTemplate x:Key="QuestConnectionTemplate" DataType="{x:Type questNodes:QuestConnectionViewModel}">
-            <nodify:Connection
+                <Setter Property="Padding" Value="12,8,12,8"/>
+                <Setter Property="Margin" Value="0,0,2,0"/>
+            </Style>
+
+            <!-- Quest Connection Template with Variable Thickness -->
+            <DataTemplate x:Key="QuestConnectionTemplate" DataType="{x:Type questNodes:QuestConnectionViewModel}">
+                <nodify:Connection
                 Source="{Binding Source.Anchor}"
                 SourceOffset="7,0"
                 SourceOffsetMode="Static"
@@ -52,27 +52,27 @@
                 IsSelectable="True"
                 IsSelected="{Binding IsSelected}"
                 MouseRightButtonDown="Connection_OnRightClick">
-                <nodify:Connection.Style>
-                    <Style TargetType="{x:Type nodify:BaseConnection}">
-                        <Setter Property="Cursor" Value="Hand" />
-                        <Setter Property="Stroke" Value="#FF7F7F7F" />
-                        <Setter Property="Opacity" Value="1.0" />
-                        <Setter Property="StrokeThickness" 
+                    <nodify:Connection.Style>
+                        <Style TargetType="{x:Type nodify:BaseConnection}">
+                            <Setter Property="Cursor" Value="Hand" />
+                            <Setter Property="Stroke" Value="#FF7F7F7F" />
+                            <Setter Property="Opacity" Value="1.0" />
+                            <Setter Property="StrokeThickness" 
                                 Value="{Binding PathType, Converter={StaticResource PathTypeToThicknessConverter}}" />
 
-                        <Style.Triggers>
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter Property="Stroke" Value="{StaticResource WolvenKitYellow}" />
-                            </Trigger>
-                            <Trigger Property="IsSelected" Value="True">
-                                <Setter Property="Stroke" Value="{StaticResource WolvenKitGreen}" />
-                            </Trigger>
-                        </Style.Triggers>
-                    </Style>
-                </nodify:Connection.Style>
-            </nodify:Connection>
-        </DataTemplate>
-        
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Stroke" Value="{StaticResource WolvenKitYellow}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Stroke" Value="{StaticResource WolvenKitGreen}" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </nodify:Connection.Style>
+                </nodify:Connection>
+            </DataTemplate>
+
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
@@ -80,56 +80,56 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        
         <!-- Toolbar -->
-        <Border Grid.Row="0" Background="{StaticResource ContentBackground}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="8,4">
+        <Border Grid.Row="0" Background="{StaticResource ContentBackground}" BorderBrush="{StaticResource BorderAlt}" BorderThickness="0,0,0,1" Padding="{DynamicResource WolvenKitMarginTiny}">
             <StackPanel Orientation="Horizontal">
-                <iconPacks:PackIconMaterial Kind="InformationOutline" VerticalAlignment="Center" Margin="0,0,8,0" Width="12" Height="12"/>
+                <iconPacks:PackIconMaterial Kind="InformationOutline" VerticalAlignment="Center" Margin="{DynamicResource WolvenKitMarginSmallRight}" Width="12" Height="12"/>
                 <TextBlock Text="{Binding FileName}" 
                            VerticalAlignment="Center" 
                            Foreground="White" 
-                           FontSize="11" 
+                           FontSize="{DynamicResource WolvenKitFontSubTitle}" 
                            FontWeight="Medium"
-                           Margin="0,0,16,0"/>
+                           Margin="{DynamicResource WolvenKitMarginRight}"/>
                 <TextBlock Text="Total Nodes:" 
                            VerticalAlignment="Center" 
                            Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginTinyRight}"/>
                 <TextBlock Text="{Binding TotalNodes}" 
                            VerticalAlignment="Center" 
                            Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginRight}"/>
                 <TextBlock Text="Phase Nodes:" 
                            VerticalAlignment="Center" 
                            Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginTinyRight}"/>
                 <TextBlock Text="{Binding TotalPhaseNodes}" 
                            VerticalAlignment="Center" 
                            Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginRight}"/>
                 <TextBlock Text="Phase Prefabs:" 
                            VerticalAlignment="Center" 
                            Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginTinyRight}"/>
                 <TextBlock Text="{Binding TotalPhasePrefabs}" 
                            VerticalAlignment="Center" 
                            Foreground="White" 
-                           FontSize="10" 
-                           Margin="0,0,16,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginRight}"/>
                 <TextBlock Text="Inplace Phases:" 
                            VerticalAlignment="Center" 
                            Foreground="Gray" 
-                           FontSize="10" 
-                           Margin="0,0,4,0"/>
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginTinyRight}"/>
                 <TextBlock Text="{Binding TotalInplacePhases}" 
                            VerticalAlignment="Center" 
                            Foreground="White" 
-                           FontSize="10" />
+                           FontSize="{DynamicResource WolvenKitFontAltTitle}" 
+                           Margin="{DynamicResource WolvenKitMarginRight}"/>
             </StackPanel>
         </Border>
 
@@ -172,7 +172,7 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Grid.Style>
-                                
+
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="3*" />
                                     <ColumnDefinition Width="Auto" />
@@ -184,12 +184,12 @@
                                                    ItemsSource="{Binding DataContext.SelectedTabContent, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}"
                                                    SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}, Mode=TwoWay}"
                                                    SelectedItems="{Binding DataContext.RDTViewModel.SelectedChunks, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}, Mode=TwoWay}"/>
-                                
+
                                 <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
-                                
+
                                 <editors:RedTypeView Grid.Column="2" DataContext="{Binding DataContext.RDTViewModel.SelectedChunk, RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}"/>
                             </Grid>
-                            
+
                             <!-- Node Properties tab shows our custom selection-driven view -->
                             <local:NodePropertiesView>
                                 <local:NodePropertiesView.Style>
@@ -214,7 +214,7 @@
             <!-- Right Panel: Graph Editor -->
             <Grid Grid.Column="2">
                 <graphEditor:GraphEditorView Source="{Binding MainGraph}" x:Name="QuestPhaseGraphEditor" NodeDoubleClick="Editor_OnNodeDoubleClick" />
-                
+
                 <!-- Breadcrumb Navigation (Floating) -->
                 <Border HorizontalAlignment="Left" 
                         VerticalAlignment="Top" 
@@ -228,7 +228,7 @@
                         <!-- Breadcrumb elements will be dynamically added here -->
                     </StackPanel>
                 </Border>
-                
+
                 <!-- Loading Overlay -->
                 <Border Background="#AA000000" 
                         Visibility="{Binding IsGraphLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -254,13 +254,13 @@
                                 </EventTrigger>
                             </iconPacks:PackIconMaterial.Triggers>
                         </iconPacks:PackIconMaterial>
-                        
+
                         <TextBlock Text="Loading quest phase graph..." 
                                    Foreground="White" 
                                    FontSize="16" 
                                    FontWeight="Medium"
                                    HorizontalAlignment="Center"/>
-                        
+
                         <TextBlock Text="Building nodes and connections" 
                                    Foreground="Gray" 
                                    FontSize="12" 

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -81,6 +81,25 @@
             </DataTemplate>
 
             <!-- Button Style for Add Actor/Prop buttons -->
+            <!-- Info bar text styles -->
+            <Style
+                x:Key="Label"
+                TargetType="TextBlock">
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Foreground" Value="Gray" />
+                <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontAltTitle}" />
+                <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+            </Style>
+
+            <Style
+                x:Key="Value"
+                TargetType="TextBlock">
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontAltTitle}" />
+                <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginRight}" />
+            </Style>
+
             <Style
                 x:Key="SceneEditorButtonStyle"
                 TargetType="Button">
@@ -132,39 +151,20 @@
         <!-- Toolbar -->
         <Border
             Grid.Row="0"
-            Padding="{DynamicResource WolvenKitMarginSmall}"
+            Padding="{DynamicResource WolvenKitMarginTiny}"
             Background="{StaticResource ContentBackground}"
             BorderBrush="{StaticResource BorderAlt}"
             BorderThickness="0,0,0,1">
             <StackPanel Orientation="Horizontal">
-                <StackPanel.Resources>
-                    <Style
-                        x:Key="Label"
-                        TargetType="{x:Type TextBlock}">
-                        <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontAltTitle}" />
-                        <Setter Property="Foreground" Value="Gray" />
-                        <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
-                        <Setter Property="VerticalAlignment" Value="Center" />
-                    </Style>
-
-                    <Style
-                        x:Key="Value"
-                        TargetType="{x:Type TextBlock}">
-                        <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
-                        <Setter Property="Foreground" Value="White" />
-                        <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginRight}" />
-                        <Setter Property="VerticalAlignment" Value="Center" />
-                    </Style>
-                </StackPanel.Resources>
-
-                <templates:IconBox
-                    IconPack="Material"
+                <iconPacks:PackIconMaterial
                     Kind="InformationOutline"
-                    Margin="{DynamicResource WolvenKitMarginTinyRight}"
-                    Size="{DynamicResource WolvenKitIconMicro}" />
+                    VerticalAlignment="Center"
+                    Margin="{DynamicResource WolvenKitMarginSmallRight}"
+                    Width="12"
+                    Height="12" />
 
                 <TextBlock
-                    Margin="0,0,16,0"
+                    Margin="{DynamicResource WolvenKitMarginRight}"
                     VerticalAlignment="Center"
                     Foreground="White"
                     FontSize="{DynamicResource WolvenKitFontSubTitle}"


### PR DESCRIPTION
Fixes info bar text scaling and padding issues in scene and quest editor (@poirierlouis I somehow missed seeing this in #2688 and noticed that the info bar was inappropriately scaled after this change)

This PR completes the fix by replacing hardcoded font sizes, margins with dynamic resources and also doing the same for the questphase edtitor which has a similar info bar

Before:
<img width="1124" height="121" alt="image 2 (4)" src="https://github.com/user-attachments/assets/7fb37d2d-bd1e-4412-98ab-f87b1070e607" />

After:
<img width="1124" height="105" alt="image 1 (6)" src="https://github.com/user-attachments/assets/6941cc8e-983f-4508-9881-ce44393a5f77" />
