### PR TITLE
fix: use correct id for first item in dialogue creation

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -358,7 +358,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 var createEmbedText = dialogResult.enableSecondary;
                 var embeddedText = dialogResult.secondaryInput;
 
-                var itemId = (uint)2; // First id is always 2
+                var itemId = (uint)1; // First id is always 1
                 if (_sceneData.ScreenplayStore.Lines.Count > 0)
                 {
                     itemId = _sceneData.ScreenplayStore.Lines[^1].ItemId.Id + 256;


### PR DESCRIPTION
**Fixed:**

First id for dialogue lines in a scene always start from 1, not 2 (2 is for options) (This is used by the "Create Dialogue" button)

I didn't notice this earlier because I didn't test in a fresh scene with no lines
