### PR TITLE
Fixed missing name if a CMaterialTemplate is used directly

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/Common/MaterialExtractor.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Common/MaterialExtractor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -357,7 +357,10 @@ public partial class MaterialExtractor
 
                 mergedMaterial = new RawMaterial
                 {
-                    BaseMaterial = fileName, MaterialTemplate = fileName, Data = new Dictionary<string, object?>()
+                    Name = materialName,
+                    BaseMaterial = fileName,
+                    MaterialTemplate = fileName,
+                    Data = new Dictionary<string, object?>()
                 };
 
                 template = new RawMaterial


### PR DESCRIPTION
# Fixed missing name if a CMaterialTemplate is used directly

**Fixed:**
- Fixed missing name if a CMaterialTemplate is used directly

