### PR TITLE
fix: connections to Output node in "Convert to phase"

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -964,7 +964,7 @@ public partial class RedGraph
             var outputNodeDef = outputNodeDefs[i];
             var phaseOutSocket = (QuestOutputConnectorViewModel)wrappedPhaseNode.Output.First(s => s.Name == outputNodeDef.SocketName);
             var tempWrappedOutput = WrapQuestNode(outputNodeDef, true);
-            var internalInSocket = (QuestInputConnectorViewModel)tempWrappedOutput.Input.First();
+            var internalInSocket = (QuestInputConnectorViewModel)tempWrappedOutput.Input.First(s => ((QuestInputConnectorViewModel)s).Data.Type == Enums.questSocketType.Input);
 
             AddConnectionToData((QuestOutputConnectorViewModel)group.Key, internalInSocket);
             foreach (var conn in group)


### PR DESCRIPTION
**Fixed:**
- connections to Output node in "Convert to phase" - connection was made to CutDestination socket type instead of the Input socket type
