### PR TITLE
ignore !!+ in cybersearch

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -1108,7 +1108,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
 
         if (SearchBarText is not null)
         {
-            await PerformSearch(SearchBarText);
+            await PerformSearch(SearchBarText.Trim());
         }
     }
 


### PR DESCRIPTION
# ignore !!+ in cybersearch

just accidentally crashed the asset browser by throwing in a mod name