### PR TITLE
filter exported inkatlas pngs from import tool

### DIFF
--- a/WolvenKit.App/ViewModels/Importers/ImportViewModel.cs
+++ b/WolvenKit.App/ViewModels/Importers/ImportViewModel.cs
@@ -339,7 +339,7 @@ public partial class ImportViewModel : AbstractImportExportViewModel
             // masklist items
             case "png":
                 var masklistPath = (Path.GetDirectoryName(filePath) ?? "").Replace("_layers", ".masklist");
-                return !File.Exists(masklistPath);
+                return !File.Exists(masklistPath) && !filePath.Contains($".inkatlas{Path.DirectorySeparatorChar}");
             // morphtarget texturesF
             case "dds":
                 var parentDirName = new DirectoryInfo(Path.GetDirectoryName(filePath) ?? string.Empty).Name;


### PR DESCRIPTION
# filter exported inkatlas pngs from import tool

You never want to import those individual icons - you'd use the inkatlas generator
<img width="1586" height="1217" alt="image" src="https://github.com/user-attachments/assets/2c12cce3-06b5-4c23-bc8e-a16964d35a5d" />
