### PR TITLE
fix(TweakDB): wait for HashService to be loaded

### DIFF
--- a/Tests/WolvenKit.Utility/GameUnitTest.cs
+++ b/Tests/WolvenKit.Utility/GameUnitTest.cs
@@ -124,7 +124,8 @@ namespace WolvenKit.Utility
             //RuntimeTypeModel.Default[typeof(IGameArchive)].AddSubType(20, typeof(Archive));
 
 
-            Locator.CurrentMutable.RegisterConstant(new TweakDBService(), typeof(ITweakDBService));
+            Locator.CurrentMutable.RegisterConstant(
+                new TweakDBService(_host.Services.GetRequiredService<IHashService>()), typeof(ITweakDBService));
 
             s_tweakDbPath = Path.Combine(gameDirectory.FullName, "r6", "cache", "tweakdb_ep1.bin");
             //var tweakService = _host.Services.GetRequiredService<ITweakDBService>();

--- a/WolvenKit.Common/Services/TweakDBService.cs
+++ b/WolvenKit.Common/Services/TweakDBService.cs
@@ -14,11 +14,16 @@ namespace WolvenKit.Common.Services
     {
         private static TweakDB s_tweakDb = new();
 
+        private IHashService _hashService;
         private bool _isLoading;
 
         public bool IsLoaded { get; set; }
         public event EventHandler? Loaded;
 
+        public TweakDBService(IHashService hashService)
+        {
+            _hashService = hashService;
+        }
 
         private void OnLoadDB() => Loaded?.Invoke(this, EventArgs.Empty);
 
@@ -30,6 +35,8 @@ namespace WolvenKit.Common.Services
             }
 
             _isLoading = true;
+
+            await _hashService.Loaded;
 
             await Task.Run(() =>
             {

--- a/WolvenKit.Core/Services/IHashService.cs
+++ b/WolvenKit.Core/Services/IHashService.cs
@@ -5,7 +5,7 @@ namespace WolvenKit.Common.Services
 {
     public interface IHashService
     {
-        bool IsLoaded { get; }
+        Task Loaded { get; }
 
         void Load();
 


### PR DESCRIPTION
# fix(TweakDB): wait for HashService to be loaded

**Fixed:**
- prevent TweakDB to be in an inconsistent state due to HashService not yet fully loaded.

**Additional notes:**
`IsLoader` getter wasn't used at all. I replaced with a unique Task which will either complete when it is loaded, or fail by forwarding any exception.

Closes #2759