### PR TITLE
math.min-ing to prevent out of bounds error

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -772,9 +772,9 @@ namespace WolvenKit.Modkit.RED4
                 var x = qScale.X != 0 ? (mesh.positions[i].X - qTrans.X) / qScale.X : 0;
                 var y = qScale.Y != 0 ? (mesh.positions[i].Y - qTrans.Y) / qScale.Y : 0;
                 var z = qScale.Z != 0 ? (mesh.positions[i].Z - qTrans.Z) / qScale.Z : 0;
-                re4Mesh.ExpVerts[i, 0] = Convert.ToInt16(Math.Max(-1, Math.Min(x, 1) * short.MaxValue));
-                re4Mesh.ExpVerts[i, 1] = Convert.ToInt16(Math.Max(-1,Math.Min(y, 1) * short.MaxValue));
-                re4Mesh.ExpVerts[i, 2] = Convert.ToInt16(Math.Max(-1,Math.Min(z, 1) * short.MaxValue));
+                re4Mesh.ExpVerts[i, 0] = Convert.ToInt16(Math.Clamp(x, -1, 1) * short.MaxValue);
+                re4Mesh.ExpVerts[i, 1] = Convert.ToInt16(Math.Clamp(y, -1, 1) * short.MaxValue);
+                re4Mesh.ExpVerts[i, 2] = Convert.ToInt16(Math.Clamp(z, -1, 1) * short.MaxValue);
             }
 
             // converting normals struct


### PR DESCRIPTION
# mesh import: math.min-ing to prevent out of bounds error

Unsure what the risks of this are - it works for a static mesh