### PR TITLE
adjust log level to be inline with behavior

### DIFF
--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -503,10 +503,10 @@ public class RED4Controller : ObservableObject, IGameController
                 .Where(f => f.Any(char.IsUpper) || f.Any(char.IsWhiteSpace)).ToList();
             if (invalidFiles.Count != 0)
             {
-                _loggerService.Error("Capital letters and/or whitespaces found (this may cause issues):");
+                _loggerService.Warning("Capital letters and/or whitespaces found (this may cause issues):");
                 foreach (var filePath in invalidFiles)
                 {
-                    _loggerService.Error($"\t {filePath}");
+                    _loggerService.Warning($"\t {filePath}");
                 }
             }
 


### PR DESCRIPTION
# adjust log level to be inline with behavior

**Fixed:**
- logging capital letters and spaces as an error despite not failing the packing 

**Additional notes:**
closes #2652 

as mentioned in #2615 the intended behavior would be to fail it, but introducing breaking behavior in inconsistent stages would be frustrating for the end user. As such it should stay permitted as it was with the behavior being changed at once across the application as part of the above issue. 

