### PR TITLE
fix insensible sector default values

### DIFF
--- a/WolvenKit.RED4/Types/ClassesExt/Appendix/worldStreamingSector.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/Appendix/worldStreamingSector.cs
@@ -76,7 +76,8 @@ public partial class worldStreamingSector : IRedAppendix
         NodeData = new DataBuffer();
         Nodes = new CArray<CHandle<worldNode>>();
         NodeRefs = new CArray<NodeRef>();
-        VariantIndices = new CArray<CInt32>();
+        VariantIndices = new CArray<CInt32>() { 0 };
+        Version = 62;
     }
 
     public void Read(Red4Reader reader, uint size)


### PR DESCRIPTION
# fix insensible sector default values

**Fixed:**
- default version not being one accepted by the game
- missing variant indices entry without which no nodes would load ingame

**Additional notes:**
This makes the user experience of creating a new sector less frustrating and requiring less preexisting knowledge. 

closes #2016 
closes #2754 
