### PR TITLE
Asset Browser: copy path/file name for multiple items

### DIFF
--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -533,6 +533,21 @@
                                                 Size="{DynamicResource WolvenKitIconMilli}" />
                                         </MenuItem.Icon>
                                     </MenuItem>
+                                    <MenuItem
+                                        x:Name="RightContextMenuCopyFileNameNoExtensionMenuItem"
+                                        Visibility="{Binding Path=IsEnabled,
+                                                             RelativeSource={RelativeSource Self},
+                                                             Mode=OneWay,
+                                                             Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Header="Copy File Name (no extension)">
+                                        <MenuItem.Icon>
+                                            <templates:IconBox
+                                                IconPack="Vaadin"
+                                                Kind="CopyOutline"
+                                                Margin="{DynamicResource WolvenKitMarginTiny}"
+                                                Size="{DynamicResource WolvenKitIconMilli}" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
                                 </ContextMenu>
                             </syncfusion:SfDataGrid.RecordContextMenu>
 

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml.cs
@@ -26,7 +26,7 @@ namespace WolvenKit.Views.Tools
 
 
         private readonly IModifierViewStateService _modifierViewSvc;
-        
+
 
         // ReSharper disable once MemberCanBePrivate.Global - used in view model
         public bool IsModBrowserEnabled { get; set; } = false;
@@ -39,7 +39,7 @@ namespace WolvenKit.Views.Tools
             _modifierViewSvc = Locator.Current.GetService<IModifierViewStateService>();
             _modifierViewSvc.ModifierStateChanged += OnModifierStateChanged;
 
-            
+
             this.WhenActivated(disposables =>
             {
                 if (DataContext is AssetBrowserViewModel vm)
@@ -99,6 +99,10 @@ namespace WolvenKit.Views.Tools
                 this.BindCommand(ViewModel,
                         viewModel => viewModel.CopyRelPathFileNameCommand,
                         view => view.RightContextMenuCopyNameMenuItem)
+                    .DisposeWith(disposables);
+                this.BindCommand(ViewModel,
+                        viewModel => viewModel.CopyRelPathFileNameNoExtensionCommand,
+                        view => view.RightContextMenuCopyFileNameNoExtensionMenuItem)
                     .DisposeWith(disposables);
                 this.BindCommand(ViewModel,
                       viewModel => viewModel.OpenFileOnlyCommand,


### PR DESCRIPTION
# Asset Browser: copy path/file name for multiple items

Unlike "copy relative path", "copy file name" used to ignore multiple selected items. This commit fixes that and adds the option to copy file names without the extension.