### PR TITLE
feat: Add placeholder text for DisplayAsBitfield

### DIFF
--- a/WolvenKit.RED4/Types/Classes/rendChunk.cs
+++ b/WolvenKit.RED4/Types/Classes/rendChunk.cs
@@ -54,7 +54,8 @@ namespace WolvenKit.RED4.Types
 		}
 
 		[Ordinal(6)] 
-		[RED("baseRenderMask")] 
+		[RED("baseRenderMask")]
+		[DisplayAsEnum<EMeshChunkRenderMaskFlags>]
 		public CUInt16 BaseRenderMask
 		{
 			get => GetPropertyValue<CUInt16>();
@@ -62,7 +63,8 @@ namespace WolvenKit.RED4.Types
 		}
 
 		[Ordinal(7)] 
-		[RED("mergedRenderMask")] 
+		[RED("mergedRenderMask")]
+		[DisplayAsEnum<EMeshChunkRenderMaskFlags>]
 		public CUInt16 MergedRenderMask
 		{
 			get => GetPropertyValue<CUInt16>();

--- a/WolvenKit.RED4/Types/EnumsExt/CustomEnums.cs
+++ b/WolvenKit.RED4/Types/EnumsExt/CustomEnums.cs
@@ -181,4 +181,22 @@ public static partial class Enums
         Extended         = 8,
         Custom0          = 16
     }
+
+    // Cleaned up version of EMeshChunkRenderMask
+    [Flags]
+    public enum EMeshChunkRenderMaskFlags : UInt16
+    {
+        None                = 0,
+        Scene               = 1 << 0,
+        Cascade1            = 1 << 1,
+        Cascade2            = 1 << 2,
+        Cascade3            = 1 << 3,
+        Cascade4            = 1 << 4,
+        LocalShadows        = 1 << 5,
+        IsTwoSided          = 1 << 6,
+        DistantShadows      = 1 << 7,
+        IsRayTracedEmissive = 1 << 8,
+        PrefabProxy         = 1 << 11,
+        Cascades            = 1 << 12
+    }
 }

--- a/WolvenKit.RED4/Types/Helper/EnumHelper.cs
+++ b/WolvenKit.RED4/Types/Helper/EnumHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Numerics;
 using System.Reflection;
 
@@ -62,6 +62,6 @@ public class EnumHelper
                 values.Add(Enum.GetName(enumType, e) ?? "");
             }
         }
-        return values.Count > 0 ? string.Join(", ", values) : none;
+        return values.Count > 0 ? string.Join(", ", values) : $"{none} ({value:X})";
     }
 }

--- a/WolvenKit/Views/Templates/DisplayAsBitfieldEditor.xaml
+++ b/WolvenKit/Views/Templates/DisplayAsBitfieldEditor.xaml
@@ -24,6 +24,7 @@
                                   Mode=TwoWay,
                                   UpdateSourceTrigger=PropertyChanged}"
             SelectedItems="{Binding SelectedItems}"
-            SelectedValueDelimiter=", " />
+            SelectedValueDelimiter=", "
+            DefaultText="{Binding NoneString}" />
     </Grid>
 </UserControl>

--- a/WolvenKit/Views/Templates/DisplayAsBitfieldEditor.xaml.cs
+++ b/WolvenKit/Views/Templates/DisplayAsBitfieldEditor.xaml.cs
@@ -18,6 +18,8 @@ namespace WolvenKit.Views.Templates
         public ObservableCollection<string> SelectedItems { get; set; } = new();
         public ObservableCollection<string> BindingCollection { get; set; } = new();
 
+        public string NoneString { get; set; } = "None";
+
         public Type EnumType
         {
             get => (Type)GetValue(EnumTypeProperty);
@@ -64,6 +66,7 @@ namespace WolvenKit.Views.Templates
             {
                 view.BindingCollection.Clear();
                 view.SelectedItems.Clear();
+                view.NoneString = System.Activator.CreateInstance(enumType)?.ToString() ?? "None";
                 var val = EnumHelper.RedIntToULong(ri);
                 foreach (var ev in Enum.GetValues(enumType))
                 {


### PR DESCRIPTION
Extension of PR #2504

**Implemented:**
- Adds placeholder text for DisplayAsBitfieldEditor when no flag is set
  - Defaults to `"None"` but uses enum value for zero if one is defined
  - Includes the actual value after None (just as a sanity check in case my enum mappings are wrong)
- Added bitfield flag to `rendChunk.BaseRenderMask` and `rendChunk.MergedRenderMask`

<img width="1031" height="368" src="https://github.com/user-attachments/assets/24bac682-7a2d-4363-a6a0-b687053f3394" />
