### PR TITLE
exclude .bin files from project wide validation

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -64,7 +64,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
 
     private static readonly string[] s_ignoredExtensions = [".xbm", ".mlmask", ".bin"];
 
-    private static readonly string[] s_packIgnoredExtensions = [".bin"];
+    private static readonly string[] s_packIgnoredExtensions = ["bin"];
 
     private static readonly string[] s_resourceFileExtensions = ["xl", "yaml", "yml"];
 
@@ -161,7 +161,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
 
         foreach (var file in filesToValidate)
         {
-            var fileExtension = file.Extension.ToLower();
+            var fileExtension = file.Extension.TrimStart('.').ToLower();
             if (!redExtensions.Contains(fileExtension) && !s_packIgnoredExtensions.Contains(fileExtension))
             {
                 _loggerService.Warning($"{file.FileName} has an unsupported extension and will not be packed!");


### PR DESCRIPTION
# exclude .bin files from project wide validation

These are temp files or something - and they're spamming the log