### PR TITLE
add creation of new scnSceneGraph if null 

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -1449,6 +1449,7 @@ public partial class RedGraph
 
     public static RedGraph GenerateSceneGraph(string title, scnSceneResource sceneResource, RedDocumentViewModel doc)
     {
+        sceneResource.SceneGraph ??= new CHandle<scnSceneGraph>() { Chunk = new scnSceneGraph() };
         var graph = new RedGraph(title, sceneResource, doc);
 
         var nodeCache = new Dictionary<uint, BaseSceneViewModel>();


### PR DESCRIPTION
# add creation of new scnSceneGraph if null 

**Fixed:**
- empty `scnSceneResource` that was generated failing to be opened with null reference exception

**Additional notes:**
closes #2851 
