### PR TITLE
fix: color dropdown's value including display properties

### DIFF
--- a/WolvenKit.App/Helpers/CvmDropdownHelper.cs
+++ b/WolvenKit.App/Helpers/CvmDropdownHelper.cs
@@ -893,6 +893,14 @@ public abstract class CvmDropdownHelper
                     ret = documentTools.GetMultilayerProperties(materialPath, cvm.Name, forceCacheRefresh);
                 }
 
+                // Color scale dropdown menu has percentages in its display key,
+                // which must not be in the value
+                if (cvm.Name == "colorScale")
+                {
+                    return ret.Distinct().Where(x => !string.IsNullOrEmpty(x))
+                        .ToDictionary(x => x!, y => y?.Split(" ").FirstOrDefault() ?? "");
+                }
+
                 break;
             }
 
@@ -925,7 +933,8 @@ public abstract class CvmDropdownHelper
 
         #endregion
 
-        return (ret ?? []).Distinct().Where(x => !string.IsNullOrEmpty(x)).ToDictionary(x => x!, y => y!);
+        return (ret ?? []).Distinct().Where(x => !string.IsNullOrEmpty(x))
+            .ToDictionary(x => x!, y => y!);
 
 
     }


### PR DESCRIPTION
# fix: color dropdown's value including display properties

<img width="1529" height="380" alt="image" src="https://github.com/user-attachments/assets/5df7a6e4-90b7-4096-9480-0b19945c7b61" />
Percentage values should be display-only