### PR TITLE
Axl generator: add toggles, fix component names

### DIFF
--- a/WolvenKit.App/Helpers/YamlHelper.cs
+++ b/WolvenKit.App/Helpers/YamlHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using DynamicData;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 
@@ -115,7 +116,9 @@ public static class YamlHelper
             }
         }
 
-        var serializer = new SerializerBuilder().WithIndentedSequences().Build();
+
+        var serializer = new SerializerBuilder().WithDefaultScalarStyle(ScalarStyle.Folded).WithIndentedSequences()
+            .Build();
         var yaml = serializer.Serialize(rootNode).Replace("'", "");
 
         existingFileContents.AddRange(yaml.Split(Environment.NewLine), 0);

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -518,12 +518,13 @@ public partial class ArchiveXlItemService
             return;
         }
 
-        var displayName = $"{clothingItemData.ItemFileName}_i18n_$(base_color)";
+        var nameSuffix = "$(base_color)";
         if (clothingItemData.SecondaryVariants.Count > 0)
         {
-            displayName = $"{displayName}_$(secondary)";
+            nameSuffix = $"{nameSuffix}_$(secondary)";
         }
 
+        var displayName = $"{clothingItemData.ItemFileName}_i18n_{nameSuffix}";
         var description = $"{clothingItemData.ItemFileName}_i18n_desc";
 
         var entryList = locEntries.Entries.ToList();

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -1112,14 +1112,18 @@ public partial class ArchiveXlItemService
             }
         }
 
-        var appearanceName = clothingItemData.GetAppearanceName().Split("!").First();
+        var nameSuffix = "$(base_color)";
+        if (clothingItemData.SecondaryVariants.Count > 0)
+        {
+            nameSuffix = $"{nameSuffix}_$(secondary)";
+        }
 
         yamlData.Children.TryAdd("$base", itemBase);
         yamlData.Children.TryAdd("$instances", instances);
         yamlData.Children.TryAdd("appearanceName", clothingItemData.GetAppearanceName());
         yamlData.Children.TryAdd("entityName", $"{clothingItemData.ItemFileName}_factory_name");
         yamlData.Children.TryAdd("localizedDescription", $"LocKey#{clothingItemData.ItemFileName}_i18n_desc");
-        yamlData.Children.TryAdd("displayName", $"LocKey#{appearanceName.Replace("!", "")}");
+        yamlData.Children.TryAdd("displayName", $"LocKey#{clothingItemData.ItemFileName}_i18n_{nameSuffix}");
         yamlData.Children.TryAdd("quality", "Quality.Legendary");
         yamlData.Children.TryAdd("icon", icon);
         yamlData.Children.TryAdd("statModifiers", ArchiveXlClothingItem.StatModifiers);

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -35,6 +35,8 @@ public class ArchiveXlClothingItem
 
     public List<ArchiveXlHidingTags> HidingTags { get; init; } = [];
 
+    public string ItemFileName => $"{ItemName.ToFileName().ToLower().Replace(" ", "_")}";
+
     /// <summary>
     /// modderName/equipment/slot/projectName
     /// </summary>
@@ -66,11 +68,16 @@ public class ArchiveXlClothingItem
     /// </summary>
     public List<string> Variants { get; init; } = [];
 
+
     /// <summary>
     /// Secondary variants for dynamic appearances, e.g. [samurai, witcher, galaxy]
     /// </summary>
     public List<string> SecondaryVariants { get; init; } = [];
 
+    /// <summary>
+    /// Toggles for dynamic appearances (to generate entries in .app and .ent)
+    /// </summary>
+    public List<string> Toggles { get; init; } = [];
     public List<string> MeshesFromProject { get; set; } = [];
 
     public string? PrimaryAppearanceMesh { get; set; } = string.Empty;
@@ -99,6 +106,77 @@ public class ArchiveXlClothingItem
             .. Variants.SelectMany(variant =>
                 SecondaryVariants.Select(secondary => $"{variant}_{secondary}"))
         ];
+    }
+
+    private string _appearanceName = "";
+
+    public string GetAppearanceName()
+    {
+        if (!string.IsNullOrEmpty(_appearanceName))
+        {
+            return _appearanceName;
+        }
+
+        var itemNameBase = Toggles.Aggregate($"{ItemFileName}",
+            (current, toggle) => $"{current}_{toggle}_$({toggle})") ?? "FAILED_GENERATING_ITEM_NAME";
+
+        var itemNameAppearance = "$(base_color)";
+        if (SecondaryVariants.Count > 0)
+        {
+            itemNameAppearance = "$(base_color)+$(secondary)";
+        }
+
+        _appearanceName = $"{itemNameBase}!{itemNameAppearance}";
+        return _appearanceName;
+    }
+
+    private static IEnumerable<string> GenerateAppearanceNames(
+        string template,
+        IEnumerable<string> toggleNames)
+    {
+        var toggleList = toggleNames?.Where(name => !string.IsNullOrEmpty(name)).ToList() ?? new List<string>();
+
+        // If no toggles, just return the template as-is.
+        if (!toggleList.Any())
+        {
+            yield return template;
+            yield break;
+        }
+
+        // Start with one empty combination (a dictionary of chosen values)
+        IEnumerable<Dictionary<string, string>> combinations = new[] { new Dictionary<string, string>() };
+
+        // For each toggle, cross‑join with the two possible values ("on", "off")
+        combinations = toggleList.Aggregate(combinations, (current, toggle) => current.SelectMany(existing =>
+            new[] { "on", "off" }.Select(value =>
+            {
+                var newCombo = new Dictionary<string, string>(existing) { [toggle] = value };
+                return newCombo;
+            })));
+
+        // For each combination, replace placeholders in the template
+        foreach (var combo in combinations)
+        {
+            var result = combo.Aggregate(template, (current, kvp) => current.Replace($"$({kvp.Key})", kvp.Value));
+
+            yield return result;
+        }
+    }
+
+
+    private List<CName> _appearanceNames = [];
+
+    public List<CName> GetAppearanceNames()
+    {
+        if (_appearanceNames.Count > 0)
+        {
+            return _appearanceNames;
+        }
+
+        _appearanceNames = GenerateAppearanceNames(GetAppearanceName().Split("!").First(), Toggles)
+            .Select(s => (CName)s).ToList();
+
+        return _appearanceNames;
     }
 }
 
@@ -133,10 +211,10 @@ public partial class ArchiveXlItemService
     {
         if (!string.IsNullOrEmpty(_projectManager.ActiveProject?.Author))
         {
-            return _projectManager.ActiveProject.Author;
+            return _projectManager.ActiveProject.Author.ToFileName().Replace(" ", "_");
         }
 
-        return _settingsManager.ModderName ?? "wolvenkit_user";
+        return (_settingsManager.ModderName ?? "wolvenkit_user").ToFileName().Replace(" ", "_");
     }
 
     public void CreateEquipmentItem(ArchiveXlClothingItem clothingItemData)
@@ -171,7 +249,7 @@ public partial class ArchiveXlItemService
         var newFiles = activeProject.ModFiles.Where(f => !projectFiles.Contains(f)).ToList();
         if (newFiles.Count == 0)
         {
-            _logger.Success($"Your ArchiveXL item {clothingItemData.ItemName.ToFileName()} has been updated.");
+            _logger.Success($"Your ArchiveXL item {clothingItemData.ItemFileName} has been updated.");
             return;
         }
 
@@ -192,35 +270,39 @@ public partial class ArchiveXlItemService
             GetModderName(),
             "equipment",
             clothingItemData.Slot.ToString().Replace("outer_", "").Replace("inner_", ""),
-            clothingItemData.ItemName.ToFileName()
+            clothingItemData.ItemFileName
         ).ToFilePath();
 
         // Control files go into the folder of any existing csv file in the project, or the default path
         clothingItemData.ControlFilesRelPath =
             activeProject.ModFiles.Where(f => f.HasFileExtension("csv")).Select(Path.GetDirectoryName).FirstOrDefault()
-            ?? Path.Join(GetModderName(), activeProject.ModName, clothingItemData.ItemName).ToFilePath();
+            ?? Path.Join(
+                GetModderName(),
+                activeProject.ModName,
+                clothingItemData.ItemFileName
+            ).ToFilePath();
 
 
         // Now write paths into the item data
         clothingItemData.RootEntityPath = Path.Combine(clothingItemData.ControlFilesRelPath,
-            $"_root_entity.ent".ToFileName());
+            $"_root_entity.ent").ToFilePath();
         if (activeProject.ModFiles.FirstOrDefault(f => f.EndsWith("_root_entity.ent")) is string existingRoot)
         {
             clothingItemData.RootEntityPath = existingRoot;
         }
 
         clothingItemData.AppFilePath = Path.Combine(clothingItemData.ControlFilesRelPath,
-            $"_application.app".ToFileName());
+            $"_application.app").ToFilePath();
         if (activeProject.ModFiles.FirstOrDefault(f => f.EndsWith("_application.app")) is string existingApp)
         {
             clothingItemData.AppFilePath = existingApp;
         }
 
         clothingItemData.MeshEntityPath = Path.Combine(clothingItemData.ControlFilesRelPath,
-            $"_{clothingItemData.ItemName.ToFileName()}_mesh_entity.ent".ToFileName());
+            $"_{clothingItemData.ItemFileName}_mesh_entity.ent").ToFilePath();
 
         clothingItemData.InkatlasPath = Path.Combine(clothingItemData.ControlFilesRelPath,
-            $"{clothingItemData.ItemName.ToFileName()}_icons.inkatlas");
+            $"{clothingItemData.ItemFileName}_icons.inkatlas").ToFilePath();
 
         // If we have more than one .yaml file under resources, create a new one, otherwise append
         var yamlFiles = activeProject.ResourceFiles.Where(f => f.HasFileExtension("yaml")).ToList();
@@ -232,6 +314,7 @@ public partial class ArchiveXlItemService
         {
             clothingItemData.YamlFilePath = Path.Join(
                 activeProject.GetRelativeResourceTweakDirectory(),
+                GetModderName(),
                 $"{activeProject.ModName}.yaml"
             ).ToFilePath();
         }
@@ -333,7 +416,7 @@ public partial class ArchiveXlItemService
                        }
                    };
 
-        var itemName = $"{clothingItemData.ItemName.ToFileName()}_factory_name";
+        var itemName = $"{clothingItemData.ItemFileName}_factory_name";
 
         if (cr2W.RootChunk is not C2dArray factory)
         {
@@ -435,12 +518,13 @@ public partial class ArchiveXlItemService
             return;
         }
 
-        var displayName = $"{clothingItemData.ItemName.ToFileName()}_i18n_$(base_color)";
+        var displayName = $"{clothingItemData.ItemFileName}_i18n_$(base_color)";
         if (clothingItemData.SecondaryVariants.Count > 0)
         {
             displayName = $"{displayName}_$(secondary)";
         }
-        var description = $"{clothingItemData.ItemName.ToFileName()}_i18n_desc";
+
+        var description = $"{clothingItemData.ItemFileName}_i18n_desc";
 
         var entryList = locEntries.Entries.ToList();
 
@@ -509,9 +593,9 @@ public partial class ArchiveXlItemService
             _logger.Info($"Delete it or run Files -> Add Files -> Generate Inkatlas");
         }
 
-        var tempFolder = Path.Combine(Path.GetTempPath(), $"iconImages_{clothingItemData.ItemName.ToFileName()}");
+        var tempFolder = Path.Combine(Path.GetTempPath(), $"iconImages_{clothingItemData.ItemFileName}");
 
-        InkatlasImageGenerator.GenerateDummyIcons(tempFolder, $"{clothingItemData.ItemName.ToFileName()}_",
+        InkatlasImageGenerator.GenerateDummyIcons(tempFolder, $"{clothingItemData.ItemFileName}_",
             clothingItemData.GetAllVariants());
 
         InkatlasImageGenerator.GenerateAtlas(
@@ -704,11 +788,11 @@ public partial class ArchiveXlItemService
 
             if (isSecondaryComponent || fileName.Contains("shadow") || fileName.Contains("proxy"))
             {
-                fileName = MeshFileName_SecondaryRegex().Replace(fileName, clothingItemData.ItemName.ToFileName());
+                fileName = MeshFileName_SecondaryRegex().Replace(fileName, clothingItemData.ItemFileName);
             }
             else
             {
-                fileName = MeshFileNameRegex().Replace(fileName, clothingItemData.ItemName.ToFileName());
+                fileName = MeshFileNameRegex().Replace(fileName, clothingItemData.ItemFileName);
             }
 
 
@@ -806,30 +890,32 @@ public partial class ArchiveXlItemService
             return;
         }
 
-        var itemName = $"{clothingItemData.ItemName.ToFileName()}_";
 
-        var entTemplateAppearance = new entTemplateAppearance();
-        var isAdding = true;
-
-        if (rootEntity.Appearances.FirstOrDefault(e => e.Name == itemName) is { } existingAppearance)
+        var appearanceNames = clothingItemData.GetAppearanceNames();
+        foreach (var itemName in appearanceNames)
         {
-            entTemplateAppearance = existingAppearance;
-            isAdding = false;
+            var entTemplateAppearance = new entTemplateAppearance();
+            var isAdding = true;
+
+            if (rootEntity.Appearances.FirstOrDefault(e => e.Name == itemName) is { } existingAppearance)
+            {
+                entTemplateAppearance = existingAppearance;
+                isAdding = false;
+            }
+
+            entTemplateAppearance.Name = itemName;
+            entTemplateAppearance.AppearanceName = itemName;
+            entTemplateAppearance.AppearanceResource =
+                new CResourceAsyncReference<appearanceAppearanceResource>(clothingItemData.AppFilePath);
+
+            if (isAdding)
+            {
+                rootEntity.Appearances.Add(entTemplateAppearance);
+            }
         }
-
-        entTemplateAppearance.Name = itemName;
-        entTemplateAppearance.AppearanceName = itemName;
-        entTemplateAppearance.AppearanceResource =
-            new CResourceAsyncReference<appearanceAppearanceResource>(clothingItemData.AppFilePath);
-
-        if (isAdding)
-        {
-            rootEntity.Appearances.Add(entTemplateAppearance);
-        }
-
         // Take care of the tags
         rootEntity.VisualTagsSchema ??= new CHandle<entVisualTagsSchema>() { Chunk = new entVisualTagsSchema() };
-        rootEntity.DefaultAppearance = itemName;
+        rootEntity.DefaultAppearance = appearanceNames.First();
 
         var tags = rootEntity.VisualTagsSchema.Chunk ?? new entVisualTagsSchema();
         tags.VisualTags ??= new redTagList();
@@ -854,6 +940,7 @@ public partial class ArchiveXlItemService
         _cr2WTools.WriteCr2W(cr2W, rootEntityAbsPath);
     }
 
+
     private void AddAppFile(ArchiveXlClothingItem clothingItemData, Cp77Project activeProject)
     {
         var appFileAbsPath = Path.Combine(activeProject.ModDirectory, clothingItemData.AppFilePath);
@@ -876,38 +963,78 @@ public partial class ArchiveXlItemService
             return;
         }
 
-        var appearanceName = $"{clothingItemData.ItemName.ToFileName()}_";
-        var appAppearance = new appearanceAppearanceDefinition();
-        var appHandle = new CHandle<appearanceAppearanceDefinition>(appAppearance);
-        var isAdding = true;
+        var appearanceName = GetAppearanceName(clothingItemData).Split("!").FirstOrDefault() ??
+                             $"{clothingItemData.ItemFileName}_";
+        var appearanceNames = clothingItemData.GetAppearanceNames();
 
-        if (app.Appearances.FirstOrDefault(a =>
-                a.Chunk?.Name == appearanceName) is CHandle<appearanceAppearanceDefinition> existingHandle)
+
+        foreach (var name in appearanceNames)
         {
-            existingHandle.Chunk ??= appAppearance;
-            appHandle = existingHandle;
-            appAppearance = existingHandle.Chunk ?? appAppearance;
-            isAdding = false;
-        }
+            var appAppearance = new appearanceAppearanceDefinition();
+            var appHandle = new CHandle<appearanceAppearanceDefinition>(appAppearance);
+            var isAdding = true;
 
-        CArray<CName> tags = [.. clothingItemData.HidingTags.Select(t => (CName)t.ToString()).ToArray()];
-
-        appAppearance.Name = $"{clothingItemData.ItemName.ToFileName()}_";
-        appAppearance.PartsValues = new CArray<appearanceAppearancePart>([
-            new appearanceAppearancePart()
+            if (app.Appearances.FirstOrDefault(a =>
+                    a.Chunk?.Name.GetResolvedText() is string s && appearanceNames.Contains(s)) is
+                CHandle<appearanceAppearanceDefinition> existingHandle)
             {
-                Resource = new CResourceAsyncReference<entEntityTemplate>(
-                    (ResourcePath)clothingItemData.MeshEntityPath, InternalEnums.EImportFlags.Soft),
+                existingHandle.Chunk ??= appAppearance;
+                appHandle = existingHandle;
+                appAppearance = existingHandle.Chunk ?? appAppearance;
+                isAdding = false;
             }
-        ]);
-        appAppearance.VisualTags = new redTagList() { Tags = tags };
 
-        if (isAdding)
-        {
-            app.Appearances.Add(appHandle);
+            CArray<CName> tags = [.. clothingItemData.HidingTags.Select(t => (CName)t.ToString()).ToArray()];
+
+            appAppearance.Name = name;
+            appAppearance.PartsValues = new CArray<appearanceAppearancePart>([
+                new appearanceAppearancePart()
+                {
+                    Resource = new CResourceAsyncReference<entEntityTemplate>(
+                        (ResourcePath)clothingItemData.MeshEntityPath, InternalEnums.EImportFlags.Soft),
+                }
+            ]);
+            appAppearance.VisualTags = new redTagList() { Tags = tags };
+
+            if (isAdding)
+            {
+                app.Appearances.Add(appHandle);
+            }
         }
 
         _cr2WTools.WriteCr2W(cr2W, appFileAbsPath);
+    }
+
+
+    private static IEnumerable<Dictionary<string, string>> GetCombinations(
+        Dictionary<string, List<string>> attributeValues)
+    {
+        // Start with a single empty combination
+        IEnumerable<Dictionary<string, string>> combinations =
+            new[] { new Dictionary<string, string>() };
+
+        // For each attribute, cross‑join with its possible values
+        foreach (var kvp in attributeValues)
+        {
+            var key = kvp.Key;
+            var values = kvp.Value;
+
+            if (values.Count == 0)
+            {
+                continue;
+            }
+
+            combinations = combinations.SelectMany(
+                existingCombination => values.Select(value =>
+                {
+                    // Create a new dictionary based on the existing one
+                    var newCombination = new Dictionary<string, string>(existingCombination);
+                    newCombination[key] = value;
+                    return newCombination;
+                }));
+        }
+
+        return combinations;
     }
 
     /// <summary>
@@ -929,35 +1056,46 @@ public partial class ArchiveXlItemService
 
         var yamlAbsPath = Path.Combine(activeProject.ResourcesDirectory, clothingItemData.YamlFilePath);
 
-        var itemName = $"Items.{_settingsManager.ModderName}_{clothingItemData.ItemName.ToFileName()}_$(base_color)";
-        var atlasPathName = $"{clothingItemData.ItemName.ToFileName()}_$(base_color)";
-        var instances = new YamlSequenceNode(
-            clothingItemData.Variants.Select(color =>
-            {
-                var node = new YamlMappingNode { { "base_color", color } };
-                node.Style = YamlDotNet.Core.Events.MappingStyle.Flow;
+        var itemName = $"Items.{GetModderName()}_{clothingItemData.ItemFileName}_$(base_color)";
+        var atlasPathName = $"{clothingItemData.ItemFileName}_$(base_color)";
 
-                return node;
-            }));
-
-        var useSecondary = clothingItemData.SecondaryVariants.Count > 0;
         // Consider secondary variants
+        var useSecondary = clothingItemData.SecondaryVariants.Count > 0;
+
         if (useSecondary)
         {
             itemName = $"{itemName}_$(secondary)";
             atlasPathName = $"{atlasPathName}_$(secondary)";
-            instances = new YamlSequenceNode(
-                clothingItemData.Variants.SelectMany(color =>
-                {
-                    return clothingItemData.SecondaryVariants.Select(variant =>
-                    {
-                        var node = new YamlMappingNode { { "base_color", color }, { "secondary", variant } };
-                        node.Style = YamlDotNet.Core.Events.MappingStyle.Flow;
-
-                        return node;
-                    });
-                }));
         }
+
+        var instanceParts = new Dictionary<string, List<string>>();
+        instanceParts.Add("base_color", clothingItemData.Variants);
+        if (useSecondary)
+        {
+            instanceParts.Add("secondary", clothingItemData.SecondaryVariants);
+        }
+
+        foreach (var toggle in clothingItemData.Toggles)
+        {
+            instanceParts.Add(toggle, ["on", "off"]);
+        }
+
+        // Generate all combinations
+        var combinations = GetCombinations(instanceParts);
+
+        // Create YAML sequence nodes from the combinations
+        var instances = new YamlSequenceNode(
+            combinations.Select(combo =>
+            {
+                var node = new YamlMappingNode();
+                foreach (var kvp in combo)
+                {
+                    node.Add(kvp.Key, kvp.Value);
+                }
+
+                node.Style = YamlDotNet.Core.Events.MappingStyle.Flow;
+                return node;
+            }));
 
         var icon = new YamlMappingNode
         {
@@ -967,7 +1105,7 @@ public partial class ArchiveXlItemService
         var placementSlots = new YamlSequenceNode() { $"!append-once OutfitSlots.{clothingItemData.EqExSlot}" };
 
         var yamlData = new YamlMappingNode();
-        var yaml = new YamlMappingNode() { { itemName, yamlData } };
+
 
         if (YamlHelper.ReadYamlAsNodes(yamlAbsPath) is { } yamlFromFile)
         {
@@ -979,14 +1117,14 @@ public partial class ArchiveXlItemService
             }
         }
 
+        var appearanceName = clothingItemData.GetAppearanceName().Split("!").First();
+
         yamlData.Children.TryAdd("$base", itemBase);
         yamlData.Children.TryAdd("$instances", instances);
-        yamlData.Children.TryAdd("appearanceName",
-            $"{clothingItemData.ItemName.ToFileName()}_!$(base_color){(useSecondary ? "+$(secondary)" : string.Empty)}");
-        yamlData.Children.TryAdd("entityName", $"{clothingItemData.ItemName.ToFileName()}_factory_name");
-        yamlData.Children.TryAdd("localizedDescription", $"LocKey#{clothingItemData.ItemName.ToFileName()}_i18n_desc");
-        yamlData.Children.TryAdd("displayName",
-            $"LocKey#{clothingItemData.ItemName.ToFileName()}_i18n_$(base_color){(useSecondary ? "_$(secondary)" : string.Empty)}");
+        yamlData.Children.TryAdd("appearanceName", clothingItemData.GetAppearanceName());
+        yamlData.Children.TryAdd("entityName", $"{clothingItemData.ItemFileName}_factory_name");
+        yamlData.Children.TryAdd("localizedDescription", $"LocKey#{clothingItemData.ItemFileName}_i18n_desc");
+        yamlData.Children.TryAdd("displayName", $"LocKey#{appearanceName.Replace("!", "")}");
         yamlData.Children.TryAdd("quality", "Quality.Legendary");
         yamlData.Children.TryAdd("icon", icon);
         yamlData.Children.TryAdd("statModifiers", ArchiveXlClothingItem.StatModifiers);
@@ -998,13 +1136,31 @@ public partial class ArchiveXlItemService
             yamlData.Children.TryAdd("placementSlots", placementSlots);
         }
 
-        var comment = clothingItemData.Variants.SelectMany(color =>
+        var comment =
+            clothingItemData.Variants.SelectMany(color =>
             (clothingItemData.SecondaryVariants.Count > 0 ? clothingItemData.SecondaryVariants : [""])
             .Select(var => itemName.Replace("$(base_color)", color).Replace("$(secondary)", var))
             ).Select(s => $"Game.AddToInventory(\"{s}\")")
             .ToArray();
 
+        var yaml = new YamlMappingNode() { { itemName, yamlData } };
         YamlHelper.RemoveInExistingFileAndAppend(yamlAbsPath, itemName, yaml, comment);
+    }
+
+    private static string GetAppearanceName(ArchiveXlClothingItem clothingItemData)
+    {
+        var itemNameBase = $"{clothingItemData.ItemFileName}";
+
+        itemNameBase = clothingItemData.Toggles.Aggregate(itemNameBase,
+            (current, toggle) => $"{current}_${toggle}_$(${toggle})");
+
+        var itemNameAppearance = "$(base_color)";
+        if (clothingItemData.SecondaryVariants.Count > 0)
+        {
+            itemNameAppearance = "$(base_color)+$(secondary)";
+        }
+
+        return $"{itemNameBase}!{itemNameAppearance}";
     }
 
     [GeneratedRegex(@"\d(_[a-z0-9_]+)(?=_\w{1,19}.)")]

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -658,7 +658,6 @@ public partial class ArchiveXlItemService
         else
         {
             CreateMeshComponents();
-
         }
 
         // Garment support tags (size)
@@ -685,9 +684,6 @@ public partial class ArchiveXlItemService
             {
                 entTemplate.Components.Add(comp);
             }
-
-            List<string> componentNames = [];
-            var slotPrefix = EquipmentItemData.GetComponentPrefix(clothingItemData.Slot);
 
             var componentIndex = 0;
             foreach (var relativePath in clothingItemData.MeshesFromProject)
@@ -750,7 +746,8 @@ public partial class ArchiveXlItemService
                 // components will be named like h0_my_new_hat1
                 entComponent.Name = componentName;
 
-                var fileDestPath = GetDestMeshPath(slotPrefix, componentIndex, isSecondaryComponent);
+                var fileDestPath = GetDestMeshPath(entComponent.Mesh.DepotPath.GetResolvedText() ?? "", slotPrefix,
+                    componentIndex, isSecondaryComponent);
 
                 AddMeshFilesToProject(fileSourcePath, fileDestPath, isSecondaryComponent);
 
@@ -784,14 +781,16 @@ public partial class ArchiveXlItemService
             componentName.Contains("_secondary", StringComparison.OrdinalIgnoreCase) ||
             componentName.Contains("_patch", StringComparison.OrdinalIgnoreCase);
 
-        string GetDestMeshPath(string componentPrefix, int idx, bool isSecondaryComponent = false)
+        string GetDestMeshPath(string originalPath, string componentPrefix, int idx, bool isSecondaryComponent = false)
         {
-            var fileName = $"{componentPrefix}_{clothingItemData.ItemFileName}_{idx}.mesh";
+            var bodyGender = originalPath.Contains("_wa_") || originalPath.Contains("_pwa_") ? "pwa" : "pma";
+            var fileName = $"{componentPrefix}_{clothingItemData.ItemFileName}_{bodyGender}_base_body_{idx}.mesh";
 
             // if it's a secondary mesh, change file name (append that)
             if (isSecondaryComponent)
             {
-                fileName = $"{componentPrefix}_{clothingItemData.ItemFileName}_secondary_{idx}.mesh";
+                fileName =
+                    $"{componentPrefix}_{clothingItemData.ItemFileName}_{bodyGender}_base_body_secondary_{idx}.mesh";
             }
 
             var newPath = Path.Combine(relativeMeshFolder, fileName);

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -126,7 +126,7 @@ public class ArchiveXlClothingItem
             itemNameAppearance = "$(base_color)+$(secondary)";
         }
 
-        _appearanceName = $"{itemNameBase}!{itemNameAppearance}";
+        _appearanceName = $"{itemNameBase}_!{itemNameAppearance}";
         return _appearanceName;
     }
 
@@ -173,7 +173,7 @@ public class ArchiveXlClothingItem
             return _appearanceNames;
         }
 
-        _appearanceNames = GenerateAppearanceNames(GetAppearanceName().Split("!").First(), Toggles)
+        _appearanceNames = GenerateAppearanceNames(GetAppearanceName().Split("_!").First(), Toggles)
             .Select(s => (CName)s).ToList();
 
         return _appearanceNames;
@@ -691,10 +691,15 @@ public partial class ArchiveXlItemService
                 var meshPath = relativePath;
                 var isSecondaryComponent = meshPath == clothingItemData.SecondaryAppearanceMesh;
 
-                // these will be "wa" meshes, so we need to check for "ma" equivalents
-                if (activeProject.Files.Contains(meshPath.Replace("wa", "ma")))
+                // these will be "pwa" meshes, so we need to check for "pma" equivalents
+                if (activeProject.Files.Contains(meshPath.Replace("_pwa", "_pma")))
                 {
-                    meshPath = $"*{meshPath.Replace("wa", "{gender}")}";
+                    meshPath = $"*{meshPath.Replace("_pwa", "{gender}")}";
+                }
+
+                if (activeProject.Files.Contains(meshPath.Replace("_wa_", "_ma_")))
+                {
+                    meshPath = $"*{meshPath.Replace("_wa_", "_{gender}_")}";
                 }
 
                 var isSoft = ArchiveXlHelper.HasSubstitution(meshPath);
@@ -958,10 +963,7 @@ public partial class ArchiveXlItemService
             return;
         }
 
-        var appearanceName = GetAppearanceName(clothingItemData).Split("!").FirstOrDefault() ??
-                             $"{clothingItemData.ItemFileName}_";
         var appearanceNames = clothingItemData.GetAppearanceNames();
-
 
         foreach (var name in appearanceNames)
         {
@@ -1145,23 +1147,6 @@ public partial class ArchiveXlItemService
         var yaml = new YamlMappingNode() { { itemName, yamlData } };
         YamlHelper.RemoveInExistingFileAndAppend(yamlAbsPath, itemName, yaml, comment);
     }
-
-    private static string GetAppearanceName(ArchiveXlClothingItem clothingItemData)
-    {
-        var itemNameBase = $"{clothingItemData.ItemFileName}";
-
-        itemNameBase = clothingItemData.Toggles.Aggregate(itemNameBase,
-            (current, toggle) => $"{current}_${toggle}_$(${toggle})");
-
-        var itemNameAppearance = "$(base_color)";
-        if (clothingItemData.SecondaryVariants.Count > 0)
-        {
-            itemNameAppearance = "$(base_color)+$(secondary)";
-        }
-
-        return $"{itemNameBase}!{itemNameAppearance}";
-    }
-
 
     /// <summary>
     /// Regex for matching stuff like "an0_123" or "hh_" to strip prefixes from file names

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -647,6 +647,9 @@ public partial class ArchiveXlItemService
         var relativeMeshFolder = Path.Combine(clothingItemData.FilesRelPath, "meshes");
         Directory.CreateDirectory(Path.Combine(activeProject.ModDirectory, relativeMeshFolder));
 
+
+        var slotPrefix = EquipmentItemData.GetComponentPrefix(clothingItemData.Slot);
+
         if (clothingItemData.MeshesFromProject.Count == 0)
         {
             // we are not using meshes from project
@@ -686,6 +689,7 @@ public partial class ArchiveXlItemService
             List<string> componentNames = [];
             var slotPrefix = EquipmentItemData.GetComponentPrefix(clothingItemData.Slot);
 
+            var componentIndex = 0;
             foreach (var relativePath in clothingItemData.MeshesFromProject)
             {
                 var meshPath = relativePath;
@@ -712,8 +716,7 @@ public partial class ArchiveXlItemService
 
                 IRedMeshComponent component = new entGarmentSkinnedMeshComponent()
                 {
-                    Name =
-                        $"{slotPrefix}_{Path.GetFileName(meshPath).Replace("{gender}", "").Replace("__", "_").ToFileName()}",
+                    Name = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}",
                     Mesh = new CResourceAsyncReference<CMesh>(path, flag),
                     MeshAppearance = appearance
                 };
@@ -724,10 +727,11 @@ public partial class ArchiveXlItemService
         void AdjustExistingComponents()
         {
             var useSecondary = clothingItemData.SecondaryVariants.Count > 0;
+            var componentIndex = 0;
             foreach (var entComponent in entTemplate.Components.OfType<IRedMeshComponent>())
             {
-                // remove "pwa" from component name, it confuses people
-                entComponent.Name = (entComponent.Name.GetResolvedText() ?? "").Replace("pwa", "");
+                // components will be named like h0_my_new_hat1
+                entComponent.Name = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}";
 
                 var fileSourcePath = entComponent.Mesh.DepotPath.GetResolvedText();
                 if (string.IsNullOrEmpty(fileSourcePath))
@@ -915,7 +919,7 @@ public partial class ArchiveXlItemService
         }
         // Take care of the tags
         rootEntity.VisualTagsSchema ??= new CHandle<entVisualTagsSchema>() { Chunk = new entVisualTagsSchema() };
-        rootEntity.DefaultAppearance = appearanceNames.First();
+        rootEntity.DefaultAppearance = "default"; // checked with psiberx
 
         var tags = rootEntity.VisualTagsSchema.Chunk ?? new entVisualTagsSchema();
         tags.VisualTags ??= new redTagList();

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -750,8 +750,7 @@ public partial class ArchiveXlItemService
                 // components will be named like h0_my_new_hat1
                 entComponent.Name = componentName;
 
-
-                var fileDestPath = GetDestFilePath(fileSourcePath, slotPrefix, isSecondaryComponent);
+                var fileDestPath = GetDestMeshPath(slotPrefix, componentIndex, isSecondaryComponent);
 
                 AddMeshFilesToProject(fileSourcePath, fileDestPath, isSecondaryComponent);
 
@@ -785,71 +784,56 @@ public partial class ArchiveXlItemService
             componentName.Contains("_secondary", StringComparison.OrdinalIgnoreCase) ||
             componentName.Contains("_patch", StringComparison.OrdinalIgnoreCase);
 
-        string GetDestFilePath(string filePath, string componentPrefix, bool isSecondaryComponent = false)
+        string GetDestMeshPath(string componentPrefix, int idx, bool isSecondaryComponent = false)
         {
-            var fileName = Path.GetFileName(filePath);
-            if (!fileName.StartsWith($"{componentPrefix}_"))
+            var fileName = $"{componentPrefix}_{clothingItemData.ItemFileName}_{idx}.mesh";
+
+            // if it's a secondary mesh, change file name (append that)
+            if (isSecondaryComponent)
             {
-                fileName = $"{componentPrefix}_{fileName}";
+                fileName = $"{componentPrefix}_{clothingItemData.ItemFileName}_secondary_{idx}.mesh";
             }
+
             var newPath = Path.Combine(relativeMeshFolder, fileName);
-            if (activeProject.ModFiles.Contains(newPath))
-            {
-                return newPath;
-            }
-
-            if (isSecondaryComponent || fileName.Contains("shadow") || fileName.Contains("proxy"))
-            {
-                fileName = MeshFileName_SecondaryRegex().Replace(fileName, clothingItemData.ItemFileName);
-            }
-            else
-            {
-                fileName = MeshFileNameRegex().Replace(fileName, clothingItemData.ItemFileName);
-            }
-
-
-            return Path.Combine(relativeMeshFolder, fileName);
+            return newPath;
         }
 
         /*
          * Adds mesh files from .ent components to project. Will try to find pma/_ma mesh (entity is pwa/_wa).
          * Will not overwrite existing files.
          */
-        void AddMeshFilesToProject(string filePath, string pathInMod, bool isSecondaryComponent = false)
+        void AddMeshFilesToProject(string originalRelPath, string pathInMod, bool isSecondaryComponent = false)
         {
-            var textureDirPath = Path.Combine(clothingItemData.FilesRelPath, "textures");
-            if (_archiveManager.GetCR2WFile(filePath) is { RootChunk: CMesh mesh } componentMesh)
-            {
-                var destPath = Path.Combine(activeProject.ModDirectory, pathInMod);
-                if (File.Exists(destPath))
-                {
-                    _logger.Info($"Mesh {pathInMod} exists, not overwriting.");
-                    return;
-                }
+            var destPath = Path.Combine(activeProject.ModDirectory, pathInMod);
 
+            if (File.Exists(destPath))
+            {
+                _logger.Info($"Mesh {pathInMod} exists, not overwriting.");
+            }
+            else if (_archiveManager.GetCR2WFile(originalRelPath) is { RootChunk: CMesh mesh } componentMesh)
+
+            {
                 AdjustMeshAppearances(mesh, isSecondaryComponent);
 
                 _cr2WTools.WriteCr2W(componentMesh, destPath);
             }
 
-            var otherGenderSourcePath = filePath.Replace("pwa", "pma").Replace("_wa_", "_ma_");
-            var otherGenderDestPath = pathInMod.Replace("pwa", "pma").Replace("_wa_", "_ma_");
-
-            if (_archiveManager.GetCR2WFile(otherGenderSourcePath) is not { RootChunk: CMesh mesh2 } otherGenderMesh)
-            {
-                return;
-            }
-
-            var destPath2 = Path.Combine(activeProject.ModDirectory, otherGenderDestPath);
-            if (File.Exists(destPath2))
+            var otherGenderDestPath = destPath.Replace("pwa", "pma").Replace("_wa_", "_ma_");
+            if (File.Exists(otherGenderDestPath))
             {
                 _logger.Info($"Mesh {otherGenderDestPath} exists, not overwriting.");
                 return;
             }
 
+            var otherGenderSourcePath = originalRelPath.Replace("pwa", "pma").Replace("_wa_", "_ma_");
+            if (_archiveManager.GetCR2WFile(otherGenderSourcePath) is not { RootChunk: CMesh mesh2 } otherGenderMesh)
+            {
+                _logger.Warning($"Failed to add {otherGenderSourcePath} for masc variant. Please create it by hand!");
+                return;
+            }
             AdjustMeshAppearances(mesh2, isSecondaryComponent);
 
-            _cr2WTools.WriteCr2W(otherGenderMesh, destPath2);
+            _cr2WTools.WriteCr2W(otherGenderMesh, otherGenderDestPath);
         }
 
         /*
@@ -1175,9 +1159,10 @@ public partial class ArchiveXlItemService
         return $"{itemNameBase}!{itemNameAppearance}";
     }
 
-    [GeneratedRegex(@"\d(_[a-z0-9_]+)(?=_\w{1,19}.)")]
-    private static partial Regex MeshFileName_SecondaryRegex();
 
-    [GeneratedRegex("\\d(_[^.]+)")]
-    private static partial Regex MeshFileNameRegex();
+    /// <summary>
+    /// Regex for matching stuff like "an0_123" or "hh_" to strip prefixes from file names
+    /// </summary>
+    [GeneratedRegex(@"^([a-z]{1,2}[0-9]*_?[0-9]*_?)")]
+    private static partial Regex PrefixAndNumberRegex();
 }

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -751,7 +751,7 @@ public partial class ArchiveXlItemService
                 entComponent.Name = componentName;
 
 
-                var fileDestPath = GetDestFilePath(fileSourcePath, isSecondaryComponent);
+                var fileDestPath = GetDestFilePath(fileSourcePath, slotPrefix, isSecondaryComponent);
 
                 AddMeshFilesToProject(fileSourcePath, fileDestPath, isSecondaryComponent);
 
@@ -785,9 +785,13 @@ public partial class ArchiveXlItemService
             componentName.Contains("_secondary", StringComparison.OrdinalIgnoreCase) ||
             componentName.Contains("_patch", StringComparison.OrdinalIgnoreCase);
 
-        string GetDestFilePath(string filePath, bool isSecondaryComponent = false)
+        string GetDestFilePath(string filePath, string componentPrefix, bool isSecondaryComponent = false)
         {
             var fileName = Path.GetFileName(filePath);
+            if (!fileName.StartsWith($"{componentPrefix}_"))
+            {
+                fileName = $"{componentPrefix}_{fileName}";
+            }
             var newPath = Path.Combine(relativeMeshFolder, fileName);
             if (activeProject.ModFiles.Contains(newPath))
             {

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -992,6 +992,21 @@ public partial class ArchiveXlItemService
                         (ResourcePath)clothingItemData.MeshEntityPath, InternalEnums.EImportFlags.Soft),
                 }
             ]);
+
+            appAppearance.PartsOverrides ??= [];
+
+            if (clothingItemData.Toggles.Count > 0 && appAppearance.PartsOverrides.Count == 0)
+            {
+                CArray<appearancePartComponentOverrides> componentOverrides = [];
+                foreach (var toggle in clothingItemData.Toggles)
+                {
+                    componentOverrides.Add(new appearancePartComponentOverrides());
+                }
+
+                appAppearance.PartsOverrides.Add(
+                    new appearanceAppearancePartOverrides() { ComponentsOverrides = componentOverrides }
+                );
+            }
             appAppearance.VisualTags = new redTagList() { Tags = tags };
 
             if (isAdding)

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -705,8 +705,10 @@ public partial class ArchiveXlItemService
                 var path = isSoft && !meshPath.StartsWith("*") ? $"*{meshPath}" : meshPath;
                 var flag = isSoft ? InternalEnums.EImportFlags.Soft : InternalEnums.EImportFlags.Default;
                 var appearance = "*{variant}";
+                var componentName = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}";
                 if (isSecondaryComponent)
                 {
+                    componentName = $"{componentName}_secondary";
                     appearance = "*{variant.2}";
                 }
                 else if (clothingItemData.SecondaryVariants.Count > 0)
@@ -716,7 +718,7 @@ public partial class ArchiveXlItemService
 
                 IRedMeshComponent component = new entGarmentSkinnedMeshComponent()
                 {
-                    Name = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}",
+                    Name = componentName,
                     Mesh = new CResourceAsyncReference<CMesh>(path, flag),
                     MeshAppearance = appearance
                 };
@@ -730,8 +732,6 @@ public partial class ArchiveXlItemService
             var componentIndex = 0;
             foreach (var entComponent in entTemplate.Components.OfType<IRedMeshComponent>())
             {
-                // components will be named like h0_my_new_hat1
-                entComponent.Name = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}";
 
                 var fileSourcePath = entComponent.Mesh.DepotPath.GetResolvedText();
                 if (string.IsNullOrEmpty(fileSourcePath))
@@ -740,19 +740,22 @@ public partial class ArchiveXlItemService
                     continue;
                 }
 
-                if (fileSourcePath.StartsWith('*'))
+                var isSecondaryComponent = IsSecondaryComponent(entComponent.Name!);
+                var componentName = $"{slotPrefix}_{clothingItemData.ItemFileName}{componentIndex++:D2}";
+                if (isSecondaryComponent)
                 {
-                    _logger.Info($"Depot path for {entComponent.Name} is already dynamic. Skipping...");
-                    continue;
+                    componentName = $"{componentName}_secondary";
                 }
 
-                var isSecondaryComponent = IsSecondaryComponent(entComponent.Name!);
+                // components will be named like h0_my_new_hat1
+                entComponent.Name = componentName;
+
 
                 var fileDestPath = GetDestFilePath(fileSourcePath, isSecondaryComponent);
 
                 AddMeshFilesToProject(fileSourcePath, fileDestPath, isSecondaryComponent);
 
-                var dynamicPath = WolvenKit.Modkit.Resources.ArchiveXlHelper.MakeDynamic(fileDestPath);
+                var dynamicPath = ArchiveXlHelper.MakeDynamic(fileDestPath);
                 var hasSubstitution = ArchiveXlHelper.HasSubstitution(dynamicPath);
 
                 entComponent.Mesh =
@@ -779,6 +782,7 @@ public partial class ArchiveXlItemService
         bool IsSecondaryComponent(string componentName) =>
             componentName.Contains("_dec", StringComparison.OrdinalIgnoreCase) ||
             componentName.Contains("_cuff", StringComparison.OrdinalIgnoreCase) ||
+            componentName.Contains("_secondary", StringComparison.OrdinalIgnoreCase) ||
             componentName.Contains("_patch", StringComparison.OrdinalIgnoreCase);
 
         string GetDestFilePath(string filePath, bool isSecondaryComponent = false)

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -173,7 +173,7 @@ public class ArchiveXlClothingItem
             return _appearanceNames;
         }
 
-        _appearanceNames = GenerateAppearanceNames(GetAppearanceName().Split("_!").First(), Toggles)
+        _appearanceNames = GenerateAppearanceNames(GetAppearanceName().Split("!").First(), Toggles)
             .Select(s => (CName)s).ToList();
 
         return _appearanceNames;

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -209,18 +209,21 @@ public partial class ArchiveXlItemService
     /// gets modder name from project or settings
     private string GetModderName()
     {
-        if (!string.IsNullOrEmpty(_projectManager.ActiveProject?.Author))
+        if (!string.IsNullOrEmpty(_projectManager.ActiveProject?.Author?.ToArchiveFileName()))
         {
             return _projectManager.ActiveProject.Author.ToArchiveFileName();
         }
 
-        if (string.IsNullOrEmpty(_settingsManager.ModderName))
+        var modderName = _settingsManager.ModderName?.ToArchiveFileName();
+
+
+        if (string.IsNullOrEmpty(modderName))
         {
             return "wolvenkit_user";
         }
 
 
-        return _settingsManager.ModderName.ToArchiveFileName();
+        return modderName;
     }
 
     public void CreateEquipmentItem(ArchiveXlClothingItem clothingItemData)

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -459,7 +459,7 @@ public partial class ArchiveXlItemService
             if (appearanceNames.Count > 0)
             {
                 clothingItemData.Variants.Clear();
-                clothingItemData.Variants.AddRange(appearanceNames);
+                clothingItemData.Variants.AddRange(appearanceNames.Select(s => s.ToFileName()));
             }
         }
 
@@ -481,7 +481,7 @@ public partial class ArchiveXlItemService
         if (secondaryAppearances.Count > 0)
         {
             clothingItemData.SecondaryVariants.Clear();
-            clothingItemData.SecondaryVariants.AddRange(secondaryAppearances);
+            clothingItemData.SecondaryVariants.AddRange(secondaryAppearances.Select(s => s.ToFileName()));
         }
 
         if (clothingItemData.SecondaryVariants.Count == 0)

--- a/WolvenKit.App/Services/ArchiveXlItemService.cs
+++ b/WolvenKit.App/Services/ArchiveXlItemService.cs
@@ -211,10 +211,16 @@ public partial class ArchiveXlItemService
     {
         if (!string.IsNullOrEmpty(_projectManager.ActiveProject?.Author))
         {
-            return _projectManager.ActiveProject.Author.ToArchiveFileName().Replace(" ", "_");
+            return _projectManager.ActiveProject.Author.ToArchiveFileName();
         }
 
-        return (_settingsManager.ModderName ?? "wolvenkit_user").ToArchiveFileName().Replace(" ", "_");
+        if (string.IsNullOrEmpty(_settingsManager.ModderName))
+        {
+            return "wolvenkit_user";
+        }
+
+
+        return _settingsManager.ModderName.ToArchiveFileName();
     }
 
     public void CreateEquipmentItem(ArchiveXlClothingItem clothingItemData)
@@ -1156,10 +1162,4 @@ public partial class ArchiveXlItemService
         var yaml = new YamlMappingNode() { { itemName, yamlData } };
         YamlHelper.RemoveInExistingFileAndAppend(yamlAbsPath, itemName, yaml, comment);
     }
-
-    /// <summary>
-    /// Regex for matching stuff like "an0_123" or "hh_" to strip prefixes from file names
-    /// </summary>
-    [GeneratedRegex(@"^([a-z]{1,2}[0-9]*_?[0-9]*_?)")]
-    private static partial Regex PrefixAndNumberRegex();
 }

--- a/WolvenKit.App/ViewModels/Dialogs/AddArchiveXlFilesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/AddArchiveXlFilesDialogViewModel.cs
@@ -40,6 +40,8 @@ public partial class AddArchiveXlFilesDialogViewModel : DialogViewModel
     [ObservableProperty] private List<string>? _variants;
     [ObservableProperty] private bool _enableSecondaryVariants = false;
     [ObservableProperty] private List<string>? _secondaryVariants;
+    [ObservableProperty] private bool _enableToggles = false;
+    [ObservableProperty] private List<string>? _toggles;
 
     // select mesh files from project
     [ObservableProperty] private bool _isUseExistingMeshes = false;
@@ -75,6 +77,7 @@ public partial class AddArchiveXlFilesDialogViewModel : DialogViewModel
         EqExSlot = EquipmentExSlot.None;
 
         Variants = [];
+        Toggles = [];
 
         HidingTags = [];
         GarmentSupportTag = GarmentSupportTags.None;
@@ -110,6 +113,7 @@ public partial class AddArchiveXlFilesDialogViewModel : DialogViewModel
             HidingTags = HidingTags ?? [],
             GarmentSupportTag = GarmentSupportTag,
             Variants = Variants ?? [],
+            Toggles = Toggles ?? [],
             SecondaryVariants = EnableSecondaryVariants ? SecondaryVariants ?? [] : [],
             TagsHideInFpp = IsHideInFpp ?? false,
             TagsForceHair = IsForceHair ?? false,

--- a/WolvenKit.App/ViewModels/Dialogs/AddArchiveXlFilesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/AddArchiveXlFilesDialogViewModel.cs
@@ -83,9 +83,6 @@ public partial class AddArchiveXlFilesDialogViewModel : DialogViewModel
         GarmentSupportTag = GarmentSupportTags.None;
 
         ExistingFilesSource = currentProject.ModFiles.Where(f => f.HasFileExtension("mesh"))
-            .Select(f => f.Replace("wa", "{gender}").Replace("ma", "{gender}"))
-            .Distinct()
-            .Select(f => f.Replace("{gender}", "wa"))
             .ToList();
 
         IsHeadItem = false;

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
@@ -438,9 +438,6 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="5" />
                         </Grid.RowDefinitions>
 
                         <!-- Variants -->
@@ -471,38 +468,21 @@
                             Style="{StaticResource ExplanationStyle}"
                             Text="Use two variant fields" />
 
-                        <TextBlock
-                            Grid.Row="5"
-                            Grid.Column="0"
-                            VerticalAlignment="Top"
-                            Style="{StaticResource LabelStyle}"
-                            Text="Generate toggles" />
-                        <CheckBox
-                            Grid.Row="5"
-                            Grid.Column="1"
-                            KeyboardNavigation.TabIndex="-1"
-                            IsChecked="{Binding EnableToggles,
-                                                Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="6"
-                            Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
-                            Text="Toggle parts, e.g. 'stickers'. Generated values will be 'on' and 'off'." />
 
                         <TextBlock
-                            Grid.Row="8"
+                            Grid.Row="5"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Style="{StaticResource LabelStyle}"
                             Text="Read from files" />
                         <CheckBox
-                            Grid.Row="8"
+                            Grid.Row="5"
                             Grid.Column="1"
                             KeyboardNavigation.TabIndex="-1"
                             IsChecked="{Binding IsCollectMeshAppearances,
                                                 Mode=TwoWay}" />
                         <TextBlock
-                            Grid.Row="9"
+                            Grid.Row="6"
                             Grid.Column="1"
                             Style="{StaticResource ExplanationStyle}"
                             Text="Read appearances from existing files?" />
@@ -517,6 +497,9 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="5" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
                             <RowDefinition Height="Auto" />
@@ -550,28 +533,6 @@
                             Grid.Row="0"
                             Grid.Column="1">
 
-                            <!-- Variants 1 - show dropdown (read from mesh) -->
-                            <hc:ComboBox
-                                x:Name="PrimaryMeshPathDropdown"
-                                Grid.Row="1"
-                            Grid.Column="1"
-                            MaxWidth="{DynamicResource WolvenKitDialogWidthSmall}"
-                            Style="{StaticResource ComboboxStyle}"
-                            Visibility="{Binding IsCollectMeshAppearances,
-                                                 Converter={StaticResource BooleanVisibilityConverter}}"
-                            IsEnabled="True"
-                            SelectedValuePath="Content"
-                            SelectedValue="{Binding RelativeSource={RelativeSource Mode=Self},
-                                                    Path=Text}"
-                            IsEditable="True"
-                            KeyUp="ComboBox_KeyUp"
-                            IsTextSearchEnabled="False"
-                            GotFocus="Combobox_FocusGained"
-                            MouseDown="Combobox_OnClick"
-                            ItemsSource="{Binding ExistingFilesSource}"
-                            SelectionChanged="PrimaryMeshPathDropdown_OnChanged"
-                            KeyboardNavigation.TabIndex="-1" />
-
                             <!-- Variants 1 - user input (do not read from mesh) -->
                             <syncfusion:SfTextBoxExt
                                 x:Name="ItemVariantsTextBox"
@@ -583,18 +544,37 @@
                                 BorderBrush="{StaticResource ForegroundColor_Grey_Dark}"
                                 BorderThickness="1"
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                Visibility="{Binding IsCollectMeshAppearances,
-                                                     Converter={StaticResource InvertBooleanVisibilityConverter}}"
                                 helpers:TextBoxBehavior.TripleClickSelectAll="True"
                                 TextWrapping="Wrap"
                                 KeyboardNavigation.TabIndex="-1"
                                 Watermark="black, white, red"
                                 WatermarkTemplate="{StaticResource PlaceholderTemplate}"
-                                LostFocus="ItemVariants_FocusLost" />
+                                LostFocus="ItemVariants_FocusLost"
+                                KeyUp="ItemVariants_OnKeyUp" />
+
+                            <!-- Variants 1 - show dropdown (read from mesh) -->
+                            <hc:ComboBox
+                                x:Name="PrimaryMeshPathDropdown"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                MaxWidth="{DynamicResource WolvenKitDialogWidthSmall}"
+                                Style="{StaticResource ComboboxStyle}"
+                                Visibility="{Binding IsCollectMeshAppearances,
+                                                     Converter={StaticResource BooleanVisibilityConverter}}"
+                                SelectedValuePath="Content"
+                                SelectedValue="{Binding RelativeSource={RelativeSource Mode=Self},
+                                                        Path=Text}"
+                                IsEditable="True"
+                                KeyUp="ComboBox_KeyUp"
+                                IsTextSearchEnabled="False"
+                                GotFocus="Combobox_FocusGained"
+                                MouseDown="Combobox_OnClick"
+                                ItemsSource="{Binding ExistingFilesSource}"
+                                SelectionChanged="PrimaryMeshPathDropdown_OnChanged"
+                                KeyboardNavigation.TabIndex="-1" />
 
                             <!-- Variants 1: explanation -->
-                            <TextBlock
-                                Text="Item variants (separate with comma)">
+                            <TextBlock Text="Item variants (separate with comma)">
                                 <TextBlock.Style>
                                     <Style
                                         BasedOn="{StaticResource ExplanationStyle}"
@@ -603,8 +583,7 @@
                                             <DataTrigger
                                                 Binding="{Binding IsCollectMeshAppearances}"
                                                 Value="True">
-                                                <Setter Property="Text"
-                                                        Value="Use this file's appearances as primary variant (path must contain 'wa')" />
+                                                <Setter Property="Text" Value="Use this file's appearances as primary variants" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -636,13 +615,12 @@
                                 BorderBrush="{StaticResource ForegroundColor_Grey_Dark}"
                                 BorderThickness="1"
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                Visibility="{Binding IsCollectMeshAppearances,
-                                                     Converter={StaticResource InvertBooleanVisibilityConverter}}"
                                 helpers:TextBoxBehavior.TripleClickSelectAll="True"
                                 TextWrapping="Wrap"
                                 KeyboardNavigation.TabIndex="-1"
                                 Watermark="samurai, witcher, galaxy"
                                 WatermarkTemplate="{StaticResource PlaceholderTemplate}"
+                                KeyUp="SecondaryItemVariants_OnKeyUp"
                                 LostFocus="SecondaryItemVariants_FocusLost" />
 
                             <!-- read from mesh: show dropdown with meshes -->
@@ -651,7 +629,6 @@
                                 MaxWidth="{DynamicResource WolvenKitDialogWidthSmall}"
                                 Visibility="{Binding IsCollectMeshAppearances,
                                                      Converter={StaticResource BooleanToVisibilityConverter}}"
-                                IsEnabled="True"
                                 SelectedValuePath="Content"
                                 SelectedValue="{Binding RelativeSource={RelativeSource Mode=Self},
                                                         Path=Text}"
@@ -667,30 +644,55 @@
                             <TextBlock
                                 Visibility="{Binding IsCollectMeshAppearances,
                                                      Converter={StaticResource InvertBooleanVisibilityConverter}}"
-                                Style="{StaticResource ExplanationStyle}"
-                                Text="Secondary item variants (separate by comma)" />
-                            <TextBlock
-                                Visibility="{Binding IsCollectMeshAppearances,
-                                                     Converter={StaticResource BooleanToVisibilityConverter}}"
-                                Style="{StaticResource ExplanationStyle}"
-                                Text="Source mesh for secondary item variants" />
+                                Text="Secondary item variants (separate by comma)">
+                                <TextBlock.Style>
+                                    <Style
+                                        BasedOn="{StaticResource ExplanationStyle}"
+                                        TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger
+                                                Binding="{Binding IsCollectMeshAppearances}"
+                                                Value="True">
+                                                <Setter Property="Text" Value="Use this file's appearances as secondary variants" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
 
                         </StackPanel>
 
-                        <!-- Toggles -->
                         <TextBlock
                             Grid.Row="4"
                             Grid.Column="0"
                             VerticalAlignment="Top"
-                            Text="Part toggles"
+                            Style="{StaticResource LabelStyle}"
+                            Text="Generate toggles" />
+                        <CheckBox
+                            Grid.Row="4"
+                            Grid.Column="1"
+                            KeyboardNavigation.TabIndex="-1"
+                            IsChecked="{Binding EnableToggles,
+                                                Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="5"
+                            Grid.Column="1"
+                            Style="{StaticResource ExplanationStyle}"
+                            Text="Toggle parts, e.g. 'stickers'. Generated values will be 'on' and 'off'." />
+
+                        <!-- Toggles -->
+                        <TextBlock
+                            Grid.Row="7"
+                            Grid.Column="0"
+                            VerticalAlignment="Top"
                             Visibility="{Binding EnableToggles,
-                                                 Converter={StaticResource BooleanToVisibilityConverter}}">
-                        </TextBlock>
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Text="Part toggles" />
 
                         <!-- Toggles -->
                         <syncfusion:SfTextBoxExt
                             x:Name="PartTogglesTextBox"
-                            Grid.Row="4"
+                            Grid.Row="7"
                             Grid.Column="1"
                             Padding="{DynamicResource WolvenKitMarginTinyVertical}"
                             VerticalContentAlignment="Top"
@@ -709,12 +711,11 @@
 
                         <!-- Toggles: explanation -->
                         <TextBlock
+                            Grid.Row="8"
+                            Grid.Column="1"
                             Visibility="{Binding EnableToggles,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}"
-                            Grid.Row="5"
-                            Grid.Column="1"
-                            Text="Item part toggles (generate extra appearances in root_entity and .app)">
-                        </TextBlock>
+                            Text="Item part toggles (generate extra appearances in root_entity and .app)" />
 
 
                     </Grid>

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
@@ -24,7 +24,6 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>
-
     <Grid
         Height="Auto"
         Margin="{DynamicResource WolvenKitMarginHeader}"
@@ -439,6 +438,9 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="5" />
                         </Grid.RowDefinitions>
 
                         <!-- Variants -->
@@ -463,7 +465,6 @@
                             KeyboardNavigation.TabIndex="-1"
                             IsChecked="{Binding EnableSecondaryVariants,
                                                 Mode=TwoWay}" />
-
                         <TextBlock
                             Grid.Row="3"
                             Grid.Column="1"
@@ -475,16 +476,33 @@
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Style="{StaticResource LabelStyle}"
-                            Text="Read from files" />
+                            Text="Generate toggles" />
                         <CheckBox
                             Grid.Row="5"
                             Grid.Column="1"
                             KeyboardNavigation.TabIndex="-1"
-                            IsChecked="{Binding IsCollectMeshAppearances,
+                            IsChecked="{Binding EnableToggles,
                                                 Mode=TwoWay}" />
-
                         <TextBlock
                             Grid.Row="6"
+                            Grid.Column="1"
+                            Style="{StaticResource ExplanationStyle}"
+                            Text="Toggle parts, e.g. 'stickers'. Generated values will be 'on' and 'off'." />
+
+                        <TextBlock
+                            Grid.Row="8"
+                            Grid.Column="0"
+                            VerticalAlignment="Top"
+                            Style="{StaticResource LabelStyle}"
+                            Text="Read from files" />
+                        <CheckBox
+                            Grid.Row="8"
+                            Grid.Column="1"
+                            KeyboardNavigation.TabIndex="-1"
+                            IsChecked="{Binding IsCollectMeshAppearances,
+                                                Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="9"
                             Grid.Column="1"
                             Style="{StaticResource ExplanationStyle}"
                             Text="Read appearances from existing files?" />
@@ -498,12 +516,14 @@
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="5" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="5" />
                         </Grid.RowDefinitions>
+
 
                         <!-- Variants 1 -->
                         <TextBlock
@@ -526,11 +546,14 @@
                             </TextBlock.Style>
                         </TextBlock>
 
-
-                        <!-- Variants 1 - show dropdown (read from mesh) -->
-                        <hc:ComboBox
-                            x:Name="PrimaryMeshPathDropdown"
+                        <StackPanel
                             Grid.Row="0"
+                            Grid.Column="1">
+
+                            <!-- Variants 1 - show dropdown (read from mesh) -->
+                            <hc:ComboBox
+                                x:Name="PrimaryMeshPathDropdown"
+                                Grid.Row="1"
                             Grid.Column="1"
                             MaxWidth="{DynamicResource WolvenKitDialogWidthSmall}"
                             Style="{StaticResource ComboboxStyle}"
@@ -549,48 +572,49 @@
                             SelectionChanged="PrimaryMeshPathDropdown_OnChanged"
                             KeyboardNavigation.TabIndex="-1" />
 
-                        <!-- Variants 1 - user input (do not read from mesh) -->
-                        <syncfusion:SfTextBoxExt
-                            x:Name="ItemVariantsTextBox"
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Padding="{DynamicResource WolvenKitMarginTinyVertical}"
-                            VerticalContentAlignment="Top"
-                            Background="{StaticResource ContentBackgroundAlt2}"
-                            BorderBrush="{StaticResource ForegroundColor_Grey_Dark}"
-                            BorderThickness="1"
-                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                            Visibility="{Binding IsCollectMeshAppearances,
-                                                 Converter={StaticResource InvertBooleanVisibilityConverter}}"
-                            helpers:TextBoxBehavior.TripleClickSelectAll="True"
-                            TextWrapping="Wrap"
-                            KeyboardNavigation.TabIndex="-1"
-                            Watermark="black, white, red"
-                            WatermarkTemplate="{StaticResource PlaceholderTemplate}"
-                            LostFocus="ItemVariants_FocusLost" />
+                            <!-- Variants 1 - user input (do not read from mesh) -->
+                            <syncfusion:SfTextBoxExt
+                                x:Name="ItemVariantsTextBox"
+                                Grid.Row="0"
+                                Grid.Column="1"
+                                Padding="{DynamicResource WolvenKitMarginTinyVertical}"
+                                VerticalContentAlignment="Top"
+                                Background="{StaticResource ContentBackgroundAlt2}"
+                                BorderBrush="{StaticResource ForegroundColor_Grey_Dark}"
+                                BorderThickness="1"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Visibility="{Binding IsCollectMeshAppearances,
+                                                     Converter={StaticResource InvertBooleanVisibilityConverter}}"
+                                helpers:TextBoxBehavior.TripleClickSelectAll="True"
+                                TextWrapping="Wrap"
+                                KeyboardNavigation.TabIndex="-1"
+                                Watermark="black, white, red"
+                                WatermarkTemplate="{StaticResource PlaceholderTemplate}"
+                                LostFocus="ItemVariants_FocusLost" />
 
-                        <!-- Variants 1: explanation -->
-                        <TextBlock
-                            Grid.Row="1"
-                            Grid.Column="1"
-                            Text="Item variants (separate with comma)">
-                            <TextBlock.Style>
-                                <Style
-                                    BasedOn="{StaticResource ExplanationStyle}"
-                                    TargetType="TextBlock">
-                                    <Style.Triggers>
-                                        <DataTrigger
-                                            Binding="{Binding IsCollectMeshAppearances}"
-                                            Value="True">
-                                            <Setter Property="Text" Value="Use this file's appearances as primary variant (path must contain 'wa')" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
+                            <!-- Variants 1: explanation -->
+                            <TextBlock
+                                Text="Item variants (separate with comma)">
+                                <TextBlock.Style>
+                                    <Style
+                                        BasedOn="{StaticResource ExplanationStyle}"
+                                        TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger
+                                                Binding="{Binding IsCollectMeshAppearances}"
+                                                Value="True">
+                                                <Setter Property="Text"
+                                                        Value="Use this file's appearances as primary variant (path must contain 'wa')" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                        </StackPanel>
 
                         <TextBlock
-                            Grid.Row="3"
+                            Grid.Row="2"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Visibility="{Binding EnableSecondaryVariants,
@@ -598,7 +622,7 @@
                             Text="Secondary" />
 
                         <StackPanel
-                            Grid.Row="3"
+                            Grid.Row="2"
                             Grid.Column="1"
                             Visibility="{Binding EnableSecondaryVariants,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -642,14 +666,55 @@
 
                             <TextBlock
                                 Visibility="{Binding IsCollectMeshAppearances,
-                                                     Converter={StaticResource BooleanToVisibilityConverter}}"
+                                                     Converter={StaticResource InvertBooleanVisibilityConverter}}"
+                                Style="{StaticResource ExplanationStyle}"
                                 Text="Secondary item variants (separate by comma)" />
                             <TextBlock
                                 Visibility="{Binding IsCollectMeshAppearances,
-                                                     Converter={StaticResource InvertBooleanVisibilityConverter}}"
+                                                     Converter={StaticResource BooleanToVisibilityConverter}}"
+                                Style="{StaticResource ExplanationStyle}"
                                 Text="Source mesh for secondary item variants" />
 
                         </StackPanel>
+
+                        <!-- Toggles -->
+                        <TextBlock
+                            Grid.Row="4"
+                            Grid.Column="0"
+                            VerticalAlignment="Top"
+                            Text="Part toggles"
+                            Visibility="{Binding EnableToggles,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}">
+                        </TextBlock>
+
+                        <!-- Toggles -->
+                        <syncfusion:SfTextBoxExt
+                            x:Name="PartTogglesTextBox"
+                            Grid.Row="4"
+                            Grid.Column="1"
+                            Padding="{DynamicResource WolvenKitMarginTinyVertical}"
+                            VerticalContentAlignment="Top"
+                            Background="{StaticResource ContentBackgroundAlt2}"
+                            BorderBrush="{StaticResource ForegroundColor_Grey_Dark}"
+                            BorderThickness="1"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Visibility="{Binding EnableToggles,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            helpers:TextBoxBehavior.TripleClickSelectAll="True"
+                            TextWrapping="Wrap"
+                            KeyboardNavigation.TabIndex="-1"
+                            Watermark="stickers, buttons, leds"
+                            WatermarkTemplate="{StaticResource PlaceholderTemplate}"
+                            LostFocus="PartToggles_FocusLost" />
+
+                        <!-- Toggles: explanation -->
+                        <TextBlock
+                            Visibility="{Binding EnableToggles,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Grid.Row="5"
+                            Grid.Column="1"
+                            Text="Item part toggles (generate extra appearances in root_entity and .app)">
+                        </TextBlock>
 
 
                     </Grid>

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
@@ -163,6 +163,17 @@ namespace WolvenKit.Views.Dialogs.Windows
                 [.. textBox.Text.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
         }
 
+        private void PartToggles_FocusLost(object sender, RoutedEventArgs e)
+        {
+            if (sender is not SfTextBoxExt textBox || ViewModel is not AddArchiveXlFilesDialogViewModel model)
+            {
+                return;
+            }
+
+            model.Toggles =
+                [.. textBox.Text.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+        }
+
         private void HidingTags_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (ViewModel is not { } vm)

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
@@ -256,7 +256,8 @@ namespace WolvenKit.Views.Dialogs.Windows
 
         private void PrimaryMeshPathDropdown_OnChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (ViewModel is null || sender is not ComboBox { SelectedItem: string meshPath })
+            if (ViewModel is null || sender is not ComboBox { SelectedItem: string meshPath } ||
+                string.IsNullOrEmpty(meshPath))
             {
                 return;
             }
@@ -268,7 +269,8 @@ namespace WolvenKit.Views.Dialogs.Windows
 
         private void SecondaryMeshPathDropdown_OnChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (ViewModel is null || sender is not ComboBox { SelectedItem: string meshPath })
+            if (ViewModel is null || sender is not ComboBox { SelectedItem: string meshPath } ||
+                string.IsNullOrEmpty(meshPath))
             {
                 return;
             }

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using ReactiveUI;
@@ -152,17 +153,6 @@ namespace WolvenKit.Views.Dialogs.Windows
             model.SubSlot = tag;
         }
 
-        private void ItemVariants_FocusLost(object sender, RoutedEventArgs e)
-        {
-            if (sender is not SfTextBoxExt textBox || ViewModel is not AddArchiveXlFilesDialogViewModel model)
-            {
-                return;
-            }
-
-            model.Variants =
-                [.. textBox.Text.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
-        }
-
         private void PartToggles_FocusLost(object sender, RoutedEventArgs e)
         {
             if (sender is not SfTextBoxExt textBox || ViewModel is not AddArchiveXlFilesDialogViewModel model)
@@ -199,6 +189,40 @@ namespace WolvenKit.Views.Dialogs.Windows
             Process.Start(ps);
         }
 
+
+        private void ItemVariants_FocusLost(object sender, RoutedEventArgs e)
+        {
+            if (sender is not SfTextBoxExt textBox || ViewModel is not AddArchiveXlFilesDialogViewModel model)
+            {
+                return;
+            }
+
+            model.Variants =
+                [.. textBox.Text.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+        }
+
+        private void ItemVariants_OnKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Tab || ViewModel == null)
+            {
+                return;
+            }
+
+            ViewModel.PrimaryAppearanceMesh = "";
+            PrimaryMeshPathDropdown.ClearValue(Selector.SelectedItemProperty);
+        }
+
+        private void SecondaryItemVariants_OnKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Tab || ViewModel == null)
+            {
+                return;
+            }
+
+            ViewModel.SecondaryAppearanceMesh = "";
+            SecondaryMeshPathDropdown.ClearValue(Selector.SelectedItemProperty);
+        }
+
         private void SecondaryItemVariants_FocusLost(object sender, RoutedEventArgs e)
         {
             if (sender is not SfTextBoxExt textBox || ViewModel is not AddArchiveXlFilesDialogViewModel model)
@@ -208,6 +232,7 @@ namespace WolvenKit.Views.Dialogs.Windows
 
             model.SecondaryVariants =
                 [.. textBox.Text.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+            model.SecondaryAppearanceMesh = "";
         }
 
         private void ExistingFiles_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -237,6 +262,8 @@ namespace WolvenKit.Views.Dialogs.Windows
             }
 
             ViewModel.PrimaryAppearanceMesh = meshPath;
+            ViewModel.Variants?.Clear();
+            ItemVariantsTextBox.Clear();
         }
 
         private void SecondaryMeshPathDropdown_OnChanged(object sender, SelectionChangedEventArgs e)
@@ -247,6 +274,9 @@ namespace WolvenKit.Views.Dialogs.Windows
             }
 
             ViewModel.SecondaryAppearanceMesh = meshPath;
+            ViewModel.SecondaryVariants?.Clear();
+            SecondaryItemVariantsTextBox.Clear();
         }
+
     }
 }


### PR DESCRIPTION
# Axl generator: add toggles

## changes
- will now properly generate (and number) component names (closes #2870)
- will now properly generate (and number) mesh file names

## additions
AXL item generator can now add toggles (to generate extra appearances for partsOverrides)

<img width="959" height="1410" alt="image" src="https://github.com/user-attachments/assets/2735a2a3-082d-4a9e-8070-918310a59b8f" />

fixes #2884
