### PR TITLE
reduce compression memory allocation overhead and linq interations

### DIFF
--- a/WolvenKit.Core/Compression/KrakenNative.cs
+++ b/WolvenKit.Core/Compression/KrakenNative.cs
@@ -6,12 +6,15 @@ public static class KrakenNative
 {
     public static int Decompress(byte[] buffer, byte[] outputBuffer)
         => Kraken_Decompress(buffer, buffer.Length, outputBuffer, outputBuffer.Length);
-    
+
     public static unsafe int Decompress(byte* buffer, long bufferLength, byte* outputBuffer, long outputLength)
         => Kraken_Decompress(buffer, bufferLength, outputBuffer, outputLength);
 
     public static int Compress(byte[] buffer, byte[] outputBuffer, int level)
         => Kraken_Compress(buffer, buffer.Length, outputBuffer, level);
+
+    public static unsafe int Compress(byte* buffer, long bufferLength, byte* outputBuffer, int level)
+        => Kraken_Compress(buffer, bufferLength, outputBuffer, level);
 
     private const string dllName = "kraken";
 
@@ -21,7 +24,7 @@ public static class KrakenNative
         long bufferSize,
         byte* outputBuffer,
         long outputBufferSize);
-    
+
     // EXPORT int Kraken_Decompress(const byte* src, size_t src_len, byte* dst, size_t dst_len);
     [DllImport(dllName, CallingConvention = CallingConvention.StdCall)]
     private static extern int Kraken_Decompress(
@@ -37,4 +40,12 @@ public static class KrakenNative
        long bufferSize,
        byte[] outputBuffer,
        int level);
+
+    // EXPORT int Kraken_Compress(uint8* src, size_t src_len, byte* dst, int level);
+    [DllImport(dllName, CallingConvention = CallingConvention.StdCall)]
+    private static extern unsafe int Kraken_Compress(
+        byte* buffer,
+        long bufferSize,
+        byte* outputBuffer,
+        int level);
 }

--- a/WolvenKit.Core/Compression/Oodle.cs
+++ b/WolvenKit.Core/Compression/Oodle.cs
@@ -107,38 +107,42 @@ public static class Oodle
 
     public static Status CompressBuffer(byte[] rawBuf, out byte[] compBuf, CompressionLevel compressionLevel, bool forceCompression)
     {
-        if (forceCompression || rawBuf.Length > 256)
+        ArgumentNullException.ThrowIfNull(rawBuf);
+        ArgumentOutOfRangeException.ThrowIfZero(rawBuf.Length, nameof(rawBuf));
+
+        if (!forceCompression && rawBuf.Length <= 256)
         {
-            //var compressedBufferSizeNeeded = GetCompressedBufferSizeNeeded(rawBuf.Length);
-            //var compressedBuffer = new byte[compressedBufferSizeNeeded];
-            IEnumerable<byte> compressedBuffer = new List<byte>();
+            compBuf = rawBuf;
+            return Status.Uncompressed;
+        }
 
-            var compressedSize = Oodle.Compress(rawBuf, ref compressedBuffer, false, compressionLevel);
+        var maxCompressedSize = GetCompressedBufferSizeNeeded(rawBuf.Length);
+        byte[] compressedBuffer;
+        int compressedOffset;
 
-            byte[] outArray;
-            if (forceCompression && rawBuf.Length <= 256)
-            {
-                outArray = new byte[compressedSize + 10];
+        if (forceCompression && rawBuf.Length <= 256)
+        {
+            compressedBuffer = new byte[maxCompressedSize + 10];
+            compressedOffset = 10;
+            Array.Copy(BitConverter.GetBytes(KARK), 0, compressedBuffer, 0, 4);
+            Array.Copy(BitConverter.GetBytes(rawBuf.Length), 0, compressedBuffer, 4, 4);
+            Array.Copy(new byte[] { 0xCC, 0x06 }, 0, compressedBuffer, 8, 2);
+        }
+        else
+        {
+            compressedBuffer = new byte[maxCompressedSize + 8];
+            compressedOffset = 8;
+            Array.Copy(BitConverter.GetBytes(KARK), 0, compressedBuffer, 0, 4);
+            Array.Copy(BitConverter.GetBytes(rawBuf.Length), 0, compressedBuffer, 4, 4);
+        }
 
-                Array.Copy(BitConverter.GetBytes(KARK), 0, outArray, 0, 4);
-                Array.Copy(BitConverter.GetBytes(rawBuf.Length), 0, outArray, 4, 4);
-                Array.Copy(new byte[] { 0xCC, 0x06 }, 0, outArray, 8, 2);
-                Array.Copy(compressedBuffer.ToArray(), 0, outArray, 10, compressedSize);
-            }
-            else
-            {
-                outArray = new byte[compressedSize + 8];
+        var realSize = CallCompress(rawBuf, compressedBuffer, compressedOffset, compressionLevel);
 
-                Array.Copy(BitConverter.GetBytes(KARK), 0, outArray, 0, 4);
-                Array.Copy(BitConverter.GetBytes(rawBuf.Length), 0, outArray, 4, 4);
-                Array.Copy(compressedBuffer.ToArray(), 0, outArray, 8, compressedSize);
-            }
-
-            if (forceCompression || rawBuf.Length > outArray.Length)
-            {
-                compBuf = outArray;
-                return Status.Compressed;
-            }
+        if (forceCompression || rawBuf.Length > compressedBuffer.Length)
+        {
+            compBuf = new byte[realSize + compressedOffset];
+            Array.Copy(compressedBuffer, 0, compBuf, 0, realSize + compressedOffset);
+            return Status.Compressed;
         }
 
         compBuf = rawBuf;
@@ -175,64 +179,81 @@ public static class Oodle
         return false;
     }
 
-    public static int Compress(byte[] inputBuffer, ref IEnumerable<byte> outputBuffer, bool useRedHeader,
+    public static int Compress(byte[] inputBuffer, out byte[] outputBuffer, bool useRedHeader,
         CompressionLevel level = CompressionLevel.Normal, Compressor compressor = Compressor.Kraken)
     {
-        if (inputBuffer == null)
-        {
-            throw new ArgumentNullException(nameof(inputBuffer));
-        }
-        var inputCount = inputBuffer.Length;
-        if (inputCount <= 0 || inputCount > inputBuffer.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(inputCount));
-        }
-        if (outputBuffer == null)
-        {
-            throw new ArgumentNullException(nameof(outputBuffer));
-        }
+        ArgumentNullException.ThrowIfNull(inputBuffer);
+        ArgumentOutOfRangeException.ThrowIfZero(inputBuffer.Length, nameof(inputBuffer));
 
-        var result = 0;
-        var compressedBufferSizeNeeded = Oodle.GetCompressedBufferSizeNeeded(inputCount);
-        var compressedBuffer = new byte[compressedBufferSizeNeeded];
-
-        result = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? CompressionSettings.Get().UseOodle
-                ? OodleLib.OodleLZ_Compress(inputBuffer, compressedBuffer, compressor, level)
-                : KrakenNative.Compress(inputBuffer, compressedBuffer, (int)level)
-            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                ? KrakenNative.Compress(inputBuffer, compressedBuffer, (int)level)
-                : RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                            ? KrakenNative.Compress(inputBuffer, compressedBuffer, (int)level)
-                            : throw new NotImplementedException();
-
-
-        if (result == 0 || inputCount <= (result + 8))
-        {
-            outputBuffer = inputBuffer;
-            return outputBuffer.Count();
-        }
+        var maxCompressedSize = GetCompressedBufferSizeNeeded(inputBuffer.Length);
+        byte[] compressedBuffer;
+        var compressedOffset = 0;
 
         if (useRedHeader)
         {
-            // write KARK header
-            var writelist = new List<byte>()
-                    {
-                        0x4B, 0x41, 0x52, 0x4B  //KARK, TODO: make this dependent on the compression algo
-                    };
-            // write size
-            writelist.AddRange(BitConverter.GetBytes(inputCount));
-            // write compressed data
-            writelist.AddRange(compressedBuffer.Take(result));
-
-            outputBuffer = writelist;
+            compressedBuffer = new byte[maxCompressedSize + 8];
+            compressedOffset = 8;
+            Array.Copy(BitConverter.GetBytes(KARK), 0, compressedBuffer, 0, 4);
+            Array.Copy(BitConverter.GetBytes(inputBuffer.Length), 0, compressedBuffer, 4, 4);
         }
         else
         {
-            outputBuffer = compressedBuffer.Take(result);
+            compressedBuffer = new byte[maxCompressedSize];
         }
 
-        return outputBuffer.Count();
+        var realSize = CallCompress(inputBuffer, compressedBuffer, compressedOffset, level, compressor);
+
+        // should it really always be counting the header? It was like this before I touched it,
+        // so I'll leave it as it is for now
+        if (realSize != 0 && inputBuffer.Length > (realSize + 8))
+        {
+            outputBuffer = new byte[realSize + compressedOffset];
+            Array.Copy(compressedBuffer, 0, outputBuffer, 0, realSize + compressedOffset);
+            return outputBuffer.Length;
+        }
+
+        outputBuffer = inputBuffer;
+        return inputBuffer.Length;
+    }
+
+    /// <summary>
+    /// Compresses a buffer using the Kraken or Oodle library depending on the OS.
+    /// Caller should validate input.
+    /// </summary>
+    /// <param name="inputBuffer"></param>
+    /// <param name="outputBuffer"></param>
+    /// <param name="outputBufferOffset"></param>
+    /// <param name="level"></param>
+    /// <param name="compressor"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    private static unsafe int CallCompress(byte[] inputBuffer, byte[] outputBuffer, int outputBufferOffset,
+        CompressionLevel level = CompressionLevel.Normal, Compressor compressor = Compressor.Kraken)
+    {
+        int res;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && CompressionSettings.Get().UseOodle)
+        {
+            fixed (byte* inPtr = &inputBuffer[0])
+            fixed (byte* outPtr = &outputBuffer[outputBufferOffset])
+            {
+                res = OodleLib.OodleLZ_Compress(inPtr, inputBuffer.Length, outPtr, compressor, level);
+            }
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            fixed (byte* inPtr = &inputBuffer[0])
+            fixed (byte* outPtr = &outputBuffer[outputBufferOffset])
+            {
+                res = KrakenNative.Compress(inPtr, inputBuffer.Length, outPtr, (int)level);
+            }
+        }
+        else
+        {
+            throw new NotImplementedException();
+        }
+        return res;
     }
 
 
@@ -256,7 +277,7 @@ public static class Oodle
 
         return result;
     }
-    
+
     public static unsafe long Decompress(byte* inputBuffer, long inputBufferSize, byte* outputBuffer, long outputBufferSize)
     {
         int result;
@@ -589,11 +610,9 @@ public static class Oodle
         if (compress)
         {
             var inbuffer = File.ReadAllBytes(path);
-            IEnumerable<byte> outBuffer = new List<byte>();
+            var r = Oodle.Compress(inbuffer, out var outBuffer, true);
 
-            var r = Oodle.Compress(inbuffer, ref outBuffer, true);
-
-            File.WriteAllBytes(outpath, outBuffer.ToArray());
+            File.WriteAllBytes(outpath, outBuffer);
         }
 
         return 1;

--- a/WolvenKit.Core/Compression/Oodle.cs
+++ b/WolvenKit.Core/Compression/Oodle.cs
@@ -415,9 +415,11 @@ public static class Oodle
     /// <returns></returns>
     public static int GetCompressedBufferSizeNeeded(int count)
     {
-        var n = (((count + 0x3ffff + ((uint)((count + 0x3ffff) >> 0x1f) & 0x3ffff)) >> 0x12) * 0x112) + count;
-        //var n  = OodleNative.GetCompressedBufferSizeNeeded((long)count);
-        return (int)n;
+        if (CompressionSettings.Get().UseOodle)
+        {
+            return (int)OodleLib.OodleLZ_GetCompressedBufferSizeNeeded(count);
+        }
+        return (int)((((count + 0x3ffff + ((uint)((count + 0x3ffff) >> 0x1f) & 0x3ffff)) >> 0x12) * 0x112) + count);
     }
 
     private static bool TryCopyOodleLib(string? filePath)

--- a/WolvenKit.Core/Compression/OodleLib.cs
+++ b/WolvenKit.Core/Compression/OodleLib.cs
@@ -192,5 +192,11 @@ namespace WolvenKit.Core.Compression
                 outputBuffer,
                 level);
         }
+
+        public static long OodleLZ_GetCompressedBufferSizeNeeded(long size)
+        {
+            ArgumentNullException.ThrowIfNull(s_getCompressedBufferSizeNeeded);
+            return s_getCompressedBufferSizeNeeded(size);
+        }
     }
 }

--- a/WolvenKit.Core/Compression/OodleLib.cs
+++ b/WolvenKit.Core/Compression/OodleLib.cs
@@ -16,6 +16,7 @@ namespace WolvenKit.Core.Compression
         private static DecompressDelegateUnsafe? s_decompressUnsafe;
         private static GetCompressedBufferSizeNeededDelegate? s_getCompressedBufferSizeNeeded;
         private static CompressDelegate? s_compress;
+        private static CompressDelegateUnsafe? s_compressUnsafe;
 
         public static bool Load(string oodlepath)
         {
@@ -44,7 +45,7 @@ namespace WolvenKit.Core.Compression
                 s_pOodleLzDecompress,
                 typeof(DecompressDelegate)
             );
-            
+
             var decompressPtrUnsafe = Marshal.GetDelegateForFunctionPointer(
                 s_pOodleLzDecompress,
                 typeof(DecompressDelegateUnsafe)
@@ -52,7 +53,7 @@ namespace WolvenKit.Core.Compression
 
             s_decompress = (DecompressDelegate)decompressPtr;
             s_decompressUnsafe = (DecompressDelegateUnsafe)decompressPtrUnsafe;
-            
+
             s_getCompressedBufferSizeNeeded = (GetCompressedBufferSizeNeededDelegate)Marshal.GetDelegateForFunctionPointer(
                 s_pOodleLzGetCompressedBufferSizeNeeded,
                 typeof(GetCompressedBufferSizeNeededDelegate)
@@ -61,6 +62,10 @@ namespace WolvenKit.Core.Compression
                 s_pOodleLzCompress,
                 typeof(CompressDelegate)
             );
+
+            s_compressUnsafe = (CompressDelegateUnsafe)Marshal.GetDelegateForFunctionPointer(
+                s_pOodleLzCompress,
+                typeof(CompressDelegateUnsafe));
 
             return true;
         }
@@ -83,7 +88,7 @@ namespace WolvenKit.Core.Compression
             IntPtr decoderMemory = new(),
             long decoderMemorySize = 0,
             Oodle.ThreadPhase threadModule = Oodle.ThreadPhase.Unthreaded);
-        
+
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private unsafe delegate int DecompressDelegateUnsafe(
             byte* compBuf,
@@ -117,6 +122,19 @@ namespace WolvenKit.Core.Compression
             IntPtr scratchMem = new(),
             long scratchSize = 0);
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private unsafe delegate int CompressDelegateUnsafe(
+            Oodle.Compressor compressor,
+            byte* rawBuf,
+            long rawLen,
+            byte* compBuf,
+            CompressionLevel level,
+            IntPtr pOptions = new(),
+            IntPtr dictionaryBase = new(),
+            IntPtr lrm = new(),
+            IntPtr scratchMem = new(),
+            long scratchSize = 0);
+
         public static int OodleLZ_Decompress(
             byte[] inputBuffer,
             byte[] outputBuffer)
@@ -128,7 +146,7 @@ namespace WolvenKit.Core.Compression
                 outputBuffer,
                 outputBuffer.Length);
         }
-        
+
         public static unsafe int OodleLZ_Decompress(
             byte* inputBuffer,
             long inputLength,
@@ -136,7 +154,7 @@ namespace WolvenKit.Core.Compression
             long outputLength)
         {
             ArgumentNullException.ThrowIfNull(s_decompress);
-            
+
             return s_decompressUnsafe!(
                 inputBuffer,
                 inputLength,
@@ -155,6 +173,22 @@ namespace WolvenKit.Core.Compression
                 compressor,
                 inputBuffer,
                 inputBuffer.Length,
+                outputBuffer,
+                level);
+        }
+
+        public static unsafe int OodleLZ_Compress(
+            byte* inputBuffer,
+            long inputLength,
+            byte* outputBuffer,
+            Compressor compressor = Compressor.Kraken,
+            CompressionLevel level = CompressionLevel.Normal)
+        {
+            ArgumentNullException.ThrowIfNull(s_compressUnsafe);
+            return s_compressUnsafe(
+                compressor,
+                inputBuffer,
+                inputLength,
                 outputBuffer,
                 level);
         }

--- a/WolvenKit.Modkit/RED4/ModToolExtensions.cs
+++ b/WolvenKit.Modkit/RED4/ModToolExtensions.cs
@@ -26,13 +26,10 @@ namespace WolvenKit.Modkit.RED4
             }
             else
             {
-                IEnumerable<byte> outBuffer = new List<byte>();
-                var r = Oodle.Compress(inbuffer, ref outBuffer, true);
+                var r = Oodle.Compress(inbuffer, out var outBuffer, true);
 
-                var b = outBuffer.ToArray();
-
-                var crc = Crc32Algorithm.Compute(b);
-                bw.Write(b);
+                var crc = Crc32Algorithm.Compute(outBuffer);
+                bw.Write(outBuffer);
 
                 return ((uint)r, crc);
             }

--- a/WolvenKit.Modkit/RED4/Tasks/OodleTask.cs
+++ b/WolvenKit.Modkit/RED4/Tasks/OodleTask.cs
@@ -55,11 +55,10 @@ public partial class ConsoleFunctions
         if (compress)
         {
             var inbuffer = File.ReadAllBytes(path.FullName);
-            IEnumerable<byte> outBuffer = new List<byte>();
 
-            var r = Oodle.Compress(inbuffer, ref outBuffer, true);
+            Oodle.Compress(inbuffer, out var outBuffer, true);
 
-            File.WriteAllBytes(outpath.FullName, outBuffer.ToArray());
+            File.WriteAllBytes(outpath.FullName, outBuffer);
 
             _loggerService.Success($"Finished compressing: {outpath}");
         }

--- a/WolvenKit.RED4/Archive/Base/LxrsFooter.cs
+++ b/WolvenKit.RED4/Archive/Base/LxrsFooter.cs
@@ -11,7 +11,7 @@ public class LxrsFooter
 
     public const uint s_magic = 0x4C585253; //1397905484;
     private const uint s_version = 1;
-    
+
     public List<string> FileInfos { init; get; }
     private readonly Encoding _iso8859 = Encoding.GetEncoding("ISO-8859-1");
 
@@ -31,15 +31,12 @@ public class LxrsFooter
 
         var inBuffer = ms.ToByteArray();
 
-        IEnumerable<byte> outBuffer = new List<byte>();
-        var r = Oodle.Compress(inBuffer, ref outBuffer, false);
+        Oodle.Compress(inBuffer, out var outBuffer, false);
 
         bw.Write(inBuffer.Length);  // size
-        // avoid possible multiple enumerations
-        var outArray = outBuffer as byte[] ?? outBuffer.ToArray();
-        bw.Write(outArray.Length);  // zsize
+        bw.Write(outBuffer.Length);  // zsize
         bw.Write(FileInfos.Count);  // count
-        bw.Write(outArray);
+        bw.Write(outBuffer);
     }
 
     public void Read(BinaryReader br)
@@ -76,7 +73,7 @@ public class LxrsFooter
             // no compression
             buffer = inBuffer;
         }
-        
+
         using var ms = new MemoryStream(buffer);
         using var tempBr = new BinaryReader(ms);
         for (var i = 0; i < count; i++)

--- a/WolvenKit.RED4/Archive/IO/ArchiveWriter.cs
+++ b/WolvenKit.RED4/Archive/IO/ArchiveWriter.cs
@@ -166,7 +166,7 @@ public class ArchiveWriter
         #region write files
 
         HashSet<ulong> importsHashSet = new();
-        
+
 
         var progress = 0;
         foreach (var (hash, fileEntries) in fileDict)
@@ -424,13 +424,10 @@ public class ArchiveWriter
         }
         else
         {
-            IEnumerable<byte> outBuffer = new List<byte>();
-            var r = Oodle.Compress(inbuffer, ref outBuffer, true);
+            var r = Oodle.Compress(inbuffer, out var outBuffer, true);
 
-            var b = outBuffer.ToArray();
-
-            var crc = Crc32Algorithm.Compute(b);
-            bw.Write(b);
+            var crc = Crc32Algorithm.Compute(outBuffer);
+            bw.Write(outBuffer);
 
             return ((uint)r, crc);
         }


### PR DESCRIPTION
# reduce compression memory allocation overhead and linq interations

This pr aims to remove unnecessary memory allocations and linq iterations when compressing. 
It does not alter return logic, although it does change the return type of one of the compression methods from IEnumerable<byte> to byte[] (all consumers were using .ToArray() on it anyway). 

Though I am wondering if Oodle.cs at line 208 (`if (realSize != 0 && inputBuffer.Length > (realSize + 8))`) should always be checking for that addition 8 bytes as it seems like it would only be correct if the header is written which isn't always the case.

Reduced memory allocations from at worst 8 to 2 where one is the max possible compressed size and other is the real compressed size. 

It has passed anecdotal testing (wkit runs and packs a mod archive just fine) but will require a bunch more testing before it is ready to merge. 
Any feedback is welcome. 

