### PR TITLE
fix: copy materials from other mesh

### DIFF
--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -480,4 +480,6 @@ public static partial class ArchiveXlHelper
         };
         // @formatter:on
     }
+
+
 }

--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -480,6 +480,4 @@ public static partial class ArchiveXlHelper
         };
         // @formatter:on
     }
-
-
 }

--- a/WolvenKit.App/Helpers/ChunkViewModel/CvmMaterialTools.cs
+++ b/WolvenKit.App/Helpers/ChunkViewModel/CvmMaterialTools.cs
@@ -833,4 +833,72 @@ public class CvmMaterialTools
 
         appearanceChunks.First().Tab?.Parent.SetIsDirty(true);
     }
+
+    public static IMaterial EmbeddedToDefault(IMaterial mat)
+    {
+        if (mat is not CMaterialInstance material)
+        {
+            return mat;
+        }
+
+        if (material.BaseMaterial.Flags == InternalEnums.EImportFlags.Embedded)
+        {
+            material.BaseMaterial =
+                new CResourceReference<IMaterial>(material.BaseMaterial.DepotPath, InternalEnums.EImportFlags.Default);
+        }
+
+        for (var i = 0; i < material.Values.Count; i++)
+        {
+            var kvp = material.Values[i];
+
+            if (kvp.Value is not IRedRef { Flags: InternalEnums.EImportFlags.Soft } redRef)
+            {
+                continue;
+            }
+
+            material.Values[i] = new CKeyValuePair(kvp.Key, UnEmbedResourceReference(kvp.Value));
+        }
+
+        return material;
+    }
+
+    public static IRedType UnEmbedResourceReference(IRedType cvpValue)
+    {
+        if (cvpValue is not IRedRef original)
+        {
+            return cvpValue;
+        }
+
+        var redType = cvpValue.RedType.Split(":").Last();
+
+        // @formatter:off
+        if (cvpValue is IRedResourceReference)
+        {
+            return redType switch
+            {
+                "Multilayer_Setup" => new CResourceReference<Multilayer_Setup>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "Multilayer_Mask" => new CResourceReference<Multilayer_Mask>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "ITexture" => new CResourceReference<ITexture>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "CGradient" => new CResourceReference<CGradient>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "CFoliageProfile" => new CResourceReference<CFoliageProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "CHairProfile" => new CResourceReference<CHairProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "CSkinProfile" => new CResourceReference<CSkinProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                "CTerrainSetup" => new CResourceReference<CTerrainSetup>(original.DepotPath, InternalEnums.EImportFlags.Default),
+                _ => original
+            };
+        }
+        return redType switch
+        {
+            "Multilayer_Setup" => new CResourceAsyncReference<Multilayer_Setup>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "Multilayer_Mask" => new CResourceAsyncReference<Multilayer_Mask>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "ITexture" => new CResourceAsyncReference<ITexture>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "CGradient" => new CResourceAsyncReference<CGradient>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "CFoliageProfile" => new CResourceAsyncReference<CFoliageProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "CHairProfile" => new CResourceAsyncReference<CHairProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "CSkinProfile" => new CResourceAsyncReference<CSkinProfile>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            "CTerrainSetup" => new CResourceAsyncReference<CTerrainSetup>(original.DepotPath, InternalEnums.EImportFlags.Default),
+            _ => (IRedResourceAsyncReference) original
+        };
+        // @formatter:on
+    }
 }

--- a/WolvenKit.App/Helpers/ChunkViewModel/CvmMaterialTools.cs
+++ b/WolvenKit.App/Helpers/ChunkViewModel/CvmMaterialTools.cs
@@ -565,6 +565,7 @@ public class CvmMaterialTools
         }
     }
 
+
     public void UnDynamifyMaterials(ChunkViewModel? cvm)
     {
         if (cvm?.ResolvedData is not CMesh mesh ||
@@ -778,16 +779,23 @@ public class CvmMaterialTools
         return ret;
     }
 
-    public int FindHighestMaterialIndex(ChunkViewModel materialDefinitionArray, bool isLocalInstance)
+    public static int FindHighestMaterialIndex(CArray<CMeshMaterialEntry> materialEntries, bool isLocalMaterial)
     {
-        if (materialDefinitionArray.ResolvedData is not CArray<CMeshMaterialEntry> array)
+        if (materialEntries.Count == 0)
         {
             return -1;
         }
 
-        return array.ToList()
-            .Where(m => m.IsLocalInstance == isLocalInstance)
-            .Max(m => m.Index);
+        var existingIndices = materialEntries
+            .Select(m => m.IsLocalInstance == isLocalMaterial ? m.Index : -1)
+            .ToList();
+
+        if (existingIndices.Count == 0)
+        {
+            existingIndices.Add(-1);
+        }
+
+        return existingIndices.Max();
     }
 
     public void AddTagsToMeshAppearances(List<ChunkViewModel> chunks, List<string> tagList)

--- a/WolvenKit.App/Helpers/ChunkViewModel/CvmTools.cs
+++ b/WolvenKit.App/Helpers/ChunkViewModel/CvmTools.cs
@@ -37,9 +37,6 @@ public class CvmTools : ICvmTools
     public void AddMaterialAndDefinition(ChunkViewModel cvm, string newName) =>
         _cvmMaterialTools.AddMaterialAndDefinition(cvm, newName);
 
-    public int FindHighestMaterialIndex(ChunkViewModel materialDefinitionArray, bool isLocalInstance) =>
-        _cvmMaterialTools.FindHighestMaterialIndex(materialDefinitionArray, isLocalInstance);
-
     public void AddTagsToMeshAppearances(List<ChunkViewModel> chunks, List<string> tagList) =>
         _cvmMaterialTools.AddTagsToMeshAppearances(chunks, tagList);
 

--- a/WolvenKit.App/Helpers/ChunkViewModel/ICvmTools.cs
+++ b/WolvenKit.App/Helpers/ChunkViewModel/ICvmTools.cs
@@ -19,7 +19,6 @@ public interface ICvmTools
     void AdjustSubmeshCount(ChunkViewModel cvm);
     void UnDynamifyMaterials(ChunkViewModel? cvm);
     void AddMaterialAndDefinition(ChunkViewModel cvm, string newName);
-    int FindHighestMaterialIndex(ChunkViewModel materialDefinitionArray, bool isLocalInstance);
     void AddTagsToMeshAppearances(List<ChunkViewModel> chunks, List<string> tagList);
 
     #endregion

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes;
+using WolvenKit.Common.Services;
 using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.Modkit.Scripting;
 using CollectionExtensions = HelixToolkit.SharpDX.Core.CollectionExtensions;
@@ -41,6 +42,7 @@ internal class MultilayerProperties
 public class DocumentTools
 {
     private readonly ILoggerService _loggerService;
+    private readonly INotificationService _notificationService;
     private readonly Cr2WTools _cr2WTools;
     private readonly MeshTools _meshTools;
     private readonly IArchiveManager _archiveManager;
@@ -65,7 +67,7 @@ public class DocumentTools
 
     public DocumentTools(ILoggerService loggerService, Cr2WTools cr2WTools, IArchiveManager archiveManager,
         IProjectManager projectManager, MeshTools meshTools, ProjectResourceTools projectResourceTools,
-        ISettingsManager settingsManager)
+        ISettingsManager settingsManager, INotificationService notificationService)
     {
         _loggerService = loggerService;
         _cr2WTools = cr2WTools;
@@ -74,6 +76,7 @@ public class DocumentTools
         _meshTools = meshTools;
         _projectResourceTools = projectResourceTools;
         _settingsManager = settingsManager;
+        _notificationService = notificationService;
     }
 
 
@@ -1139,10 +1142,10 @@ public class DocumentTools
         mesh.PreloadLocalMaterialInstances.Clear();
     }
 
-    public bool AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
+    public int AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
         string destPath = "")
     {
-        var wasChanged = false;
+        var wasChanged = 0;
 
         if (sourceCr2W is null)
         {
@@ -1167,7 +1170,7 @@ public class DocumentTools
         if (!hasMaterials)
         {
             _loggerService.Error($"source file {sourcePath} does not have materials!");
-            return false;
+            return 0;
         }
 
         // ReSharper disable ForCanBeConvertedToForeach
@@ -1182,7 +1185,7 @@ public class DocumentTools
             appearances.Add(sourceMesh.Appearances[i]);
         }
 
-        wasChanged = wasChanged || destMesh.Appearances.Count != appearances.Count;
+        wasChanged += appearances.Count - destMesh.Appearances.Count;
         destMesh.Appearances = appearances;
 
         CArray<CMeshMaterialEntry> materialEntries = [];
@@ -1214,21 +1217,31 @@ public class DocumentTools
             }
         }
 
-        wasChanged = wasChanged || destMesh.MaterialEntries.Count != materialEntries.Count;
+        wasChanged += materialEntries.Count - destMesh.MaterialEntries.Count;
         destMesh.MaterialEntries = materialEntries;
 
         CArray<IMaterial> localMaterials = [];
-        for (var i = 0; i < destMesh.LocalMaterialBuffer.Materials.Count; i++)
+        foreach (var material in destMesh.LocalMaterialBuffer.Materials)
         {
-            localMaterials.Add(destMesh.LocalMaterialBuffer.Materials[i]);
+            localMaterials.Add(material);
         }
 
-        for (var i = 0; i < sourceMesh.LocalMaterialBuffer.Materials.Count; i++)
+        foreach (var material in sourceMesh.LocalMaterialBuffer.Materials)
         {
-            localMaterials.Add(sourceMesh.LocalMaterialBuffer.Materials[i]);
+            localMaterials.Add(material);
         }
 
-        wasChanged = wasChanged || destMesh.LocalMaterialBuffer.Materials.Count != localMaterials.Count;
+        foreach (var material in destMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk).OfType<IMaterial>())
+        {
+            localMaterials.Add(material);
+        }
+
+        foreach (var material in sourceMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk).OfType<IMaterial>())
+        {
+            localMaterials.Add(material);
+        }
+
+        wasChanged += localMaterials.Count - destMesh.LocalMaterialBuffer.Materials.Count;
         destMesh.LocalMaterialBuffer.Materials = localMaterials;
 
         CArray<CResourceAsyncReference<IMaterial>> externalMaterials = [];
@@ -1242,7 +1255,7 @@ public class DocumentTools
             externalMaterials.Add(sourceMesh.ExternalMaterials[i]);
         }
 
-        wasChanged = wasChanged || destMesh.ExternalMaterials.Count != externalMaterials.Count;
+        wasChanged += destMesh.ExternalMaterials.Count - externalMaterials.Count;
         destMesh.ExternalMaterials = externalMaterials;
 
         CArray<CResourceReference<IMaterial>> preloadExternalMaterials = [];
@@ -1250,15 +1263,13 @@ public class DocumentTools
         {
             preloadExternalMaterials.Add(destMesh.PreloadExternalMaterials[i]);
         }
-
         for (var i = 0; i < sourceMesh.PreloadExternalMaterials.Count; i++)
         {
             preloadExternalMaterials.Add(sourceMesh.PreloadExternalMaterials[i]);
         }
 
-        wasChanged = wasChanged || destMesh.PreloadExternalMaterials.Count != preloadExternalMaterials.Count;
+        wasChanged += destMesh.PreloadExternalMaterials.Count - preloadExternalMaterials.Count;
         destMesh.PreloadExternalMaterials = preloadExternalMaterials;
-
 
         CArray<CHandle<IMaterial>> preloadLocalMaterialInstances = [];
         for (var i = 0; i < destMesh.PreloadLocalMaterialInstances.Count; i++)
@@ -1271,7 +1282,7 @@ public class DocumentTools
             preloadLocalMaterialInstances.Add(sourceMesh.PreloadLocalMaterialInstances[i]);
         }
 
-        wasChanged = wasChanged || destMesh.PreloadLocalMaterialInstances.Count != preloadLocalMaterialInstances.Count;
+        wasChanged += destMesh.PreloadLocalMaterialInstances.Count - preloadLocalMaterialInstances.Count;
         destMesh.PreloadLocalMaterialInstances = preloadLocalMaterialInstances;
 
         // ReSharper restore ForCanBeConvertedToForeach
@@ -1317,25 +1328,33 @@ public class DocumentTools
             ClearMeshMaterials(destCr2W);
         }
 
-        if (!meshPaths.Select(sourceMeshPath =>
-                AppendMeshMaterials(GetCr2W(sourceMeshPath), destCr2W, sourcePath, destPath)).Contains(true))
+        var numChanges = meshPaths.Select(sourceMeshPath =>
+            AppendMeshMaterials(GetCr2W(sourceMeshPath), destCr2W, sourcePath, destPath)).Sum();
+
+        if (numChanges == 0)
         {
+            _loggerService.Info("No materials were copied");
+            _notificationService.Info("No materials were copied");
             return false;
         }
 
         if (!_cr2WTools.WriteCr2W(destCr2W, activeProject.GetAbsolutePath(destPath)))
         {
             _loggerService.Error($"Failed writing changes to {destPath}");
+            _notificationService.Error($"Failed writing changes to {destPath}");
             return false;
         }
 
         if (meshPaths.Count == 1)
         {
-            _loggerService.Success($"Copied materials from {meshPaths[0]}");
+            _loggerService.Success($"Copied {numChanges} entries from {meshPaths[0]}");
+            _notificationService.Success($"Copied {numChanges} entries from {meshPaths[0]}");
         }
         else
         {
-            _loggerService.Success($"Copied materials from the following files: \n\t {string.Join("\n\t", meshPaths)}");
+            _loggerService.Success(
+                $"Copied {numChanges} entries from the following files: \n\t {string.Join("\n\t", meshPaths)}");
+            _notificationService.Success($"Copied {numChanges} entries from files (check log for detail)");
         }
 
         return true;

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -13,6 +13,7 @@ using System;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes;
 using WolvenKit.Common.Services;
+using WolvenKit.Interfaces.Extensions;
 using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.Modkit.Scripting;
 using CollectionExtensions = HelixToolkit.SharpDX.Core.CollectionExtensions;
@@ -1142,7 +1143,7 @@ public class DocumentTools
         mesh.PreloadLocalMaterialInstances.Clear();
     }
 
-    public int AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
+    private int AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
         string destPath = "")
     {
         var wasChanged = 0;
@@ -1174,30 +1175,11 @@ public class DocumentTools
         }
 
         // ReSharper disable ForCanBeConvertedToForeach
-        CArray<CHandle<meshMeshAppearance>> appearances = [];
-        for (var i = 0; i < destMesh.Appearances.Count; i++)
-        {
-            appearances.Add(destMesh.Appearances[i]);
-        }
-
-        for (var i = 0; i < sourceMesh.Appearances.Count; i++)
-        {
-            appearances.Add(sourceMesh.Appearances[i]);
-        }
-
-        wasChanged += appearances.Count - destMesh.Appearances.Count;
-        destMesh.Appearances = appearances;
 
         CArray<CMeshMaterialEntry> materialEntries = [];
-        for (var i = 0; i < destMesh.MaterialEntries.Count; i++)
-        {
-            materialEntries.Add(destMesh.MaterialEntries[i]);
-        }
+        var materialNameCollisions = CopyMaterialDefinitions();
 
-        for (var i = 0; i < sourceMesh.MaterialEntries.Count; i++)
-        {
-            materialEntries.Add(sourceMesh.MaterialEntries[i]);
-        }
+        CopyMeshAppearances();
 
         // now reindex properties
         var localMaterialIndex = 0;
@@ -1220,10 +1202,15 @@ public class DocumentTools
         wasChanged += materialEntries.Count - destMesh.MaterialEntries.Count;
         destMesh.MaterialEntries = materialEntries;
 
+        #region localMaterialCopy
+
+        var usePreloadLocalMaterials = destMesh.PreloadLocalMaterialInstances.Count > 0;
+        var usePreloadExternalMaterials = destMesh.PreloadLocalMaterialInstances.Count > 0;
+
         CArray<IMaterial> localMaterials = [];
         foreach (var material in destMesh.LocalMaterialBuffer.Materials)
         {
-            localMaterials.Add(material);
+            localMaterials.Add(CvmMaterialTools.EmbeddedToDefault(material));
         }
 
         foreach (var material in sourceMesh.LocalMaterialBuffer.Materials)
@@ -1241,9 +1228,24 @@ public class DocumentTools
             localMaterials.Add(material);
         }
 
-        wasChanged += localMaterials.Count - destMesh.LocalMaterialBuffer.Materials.Count;
-        destMesh.LocalMaterialBuffer.Materials = localMaterials;
+        if (usePreloadLocalMaterials)
+        {
+            wasChanged += localMaterials.Count - destMesh.PreloadLocalMaterialInstances.Count;
+            destMesh.PreloadLocalMaterialInstances.Clear();
+            foreach (var m in localMaterials)
+            {
+                destMesh.PreloadLocalMaterialInstances.Add(new CHandle<IMaterial>() { Chunk = m });
+            }
+        }
+        else
+        {
+            wasChanged += localMaterials.Count - destMesh.LocalMaterialBuffer.Materials.Count;
+            destMesh.LocalMaterialBuffer.Materials = localMaterials;
+        }
 
+        #endregion
+
+        #region externalMaterialCopy
         CArray<CResourceAsyncReference<IMaterial>> externalMaterials = [];
         for (var i = 0; i < destMesh.ExternalMaterials.Count; i++)
         {
@@ -1255,39 +1257,108 @@ public class DocumentTools
             externalMaterials.Add(sourceMesh.ExternalMaterials[i]);
         }
 
-        wasChanged += destMesh.ExternalMaterials.Count - externalMaterials.Count;
-        destMesh.ExternalMaterials = externalMaterials;
-
-        CArray<CResourceReference<IMaterial>> preloadExternalMaterials = [];
         for (var i = 0; i < destMesh.PreloadExternalMaterials.Count; i++)
         {
-            preloadExternalMaterials.Add(destMesh.PreloadExternalMaterials[i]);
+            externalMaterials.Add(destMesh.PreloadExternalMaterials[i]);
         }
+
         for (var i = 0; i < sourceMesh.PreloadExternalMaterials.Count; i++)
         {
-            preloadExternalMaterials.Add(sourceMesh.PreloadExternalMaterials[i]);
+            externalMaterials.Add(sourceMesh.PreloadExternalMaterials[i]);
         }
 
-        wasChanged += destMesh.PreloadExternalMaterials.Count - preloadExternalMaterials.Count;
-        destMesh.PreloadExternalMaterials = preloadExternalMaterials;
-
-        CArray<CHandle<IMaterial>> preloadLocalMaterialInstances = [];
-        for (var i = 0; i < destMesh.PreloadLocalMaterialInstances.Count; i++)
+        if (usePreloadExternalMaterials)
         {
-            preloadLocalMaterialInstances.Add(destMesh.PreloadLocalMaterialInstances[i]);
+            wasChanged += externalMaterials.Count - destMesh.PreloadExternalMaterials.Count;
+            destMesh.PreloadExternalMaterials.Clear();
+            foreach (var m in externalMaterials)
+            {
+                destMesh.PreloadExternalMaterials.Add(new CResourceReference<IMaterial>(m.DepotPath, m.Flags));
+            }
         }
-
-        for (var i = 0; i < sourceMesh.PreloadLocalMaterialInstances.Count; i++)
+        else
         {
-            preloadLocalMaterialInstances.Add(sourceMesh.PreloadLocalMaterialInstances[i]);
+            wasChanged += externalMaterials.Count - destMesh.ExternalMaterials.Count;
+            destMesh.ExternalMaterials = externalMaterials;
         }
 
-        wasChanged += destMesh.PreloadLocalMaterialInstances.Count - preloadLocalMaterialInstances.Count;
-        destMesh.PreloadLocalMaterialInstances = preloadLocalMaterialInstances;
-
-        // ReSharper restore ForCanBeConvertedToForeach
+        #endregion
 
         return wasChanged;
+
+        void CopyMeshAppearances()
+        {
+            CArray<CHandle<meshMeshAppearance>> appearances = [];
+            for (var i = 0; i < destMesh.Appearances.Count; i++)
+            {
+                appearances.Add(destMesh.Appearances[i]);
+            }
+
+            for (var i = 0; i < sourceMesh.Appearances.Count; i++)
+            {
+                var appearance = sourceMesh.Appearances[i];
+                if (materialNameCollisions.Count == 0 || appearance.Chunk is null)
+                {
+                    appearances.Add(appearance);
+                    continue;
+                }
+
+                // deal with material name collisions
+                var appearanceChunkNames = appearance.Chunk.ChunkMaterials
+                    .Select(c => c.GetResolvedText() ?? "")
+                    .Select(c => materialNameCollisions.TryGetValue(c, out var newC) ? newC : c)
+                    .Select(c => (CName)c)
+                    .ToArray();
+                appearance.Chunk.ChunkMaterials.Clear();
+                foreach (var cn in appearanceChunkNames)
+                {
+                    appearance.Chunk.ChunkMaterials.Add(cn);
+                }
+
+                appearances.Add(appearance);
+            }
+
+            wasChanged += appearances.Count - destMesh.Appearances.Count;
+            destMesh.Appearances = appearances;
+        }
+
+        Dictionary<string, string> CopyMaterialDefinitions()
+        {
+            HashSet<string> materialNames = [];
+            Dictionary<string, string> nameCollisions = [];
+
+            for (var i = 0; i < destMesh.MaterialEntries.Count; i++)
+            {
+                var materialEntry = destMesh.MaterialEntries[i];
+                var materialName = materialEntry.Name.GetResolvedText() ?? "sourceMaterial" + i;
+                materialEntries.Add(materialEntry);
+                materialNames.Add(materialName);
+            }
+
+            for (var i = 0; i < sourceMesh.MaterialEntries.Count; i++)
+            {
+                var materialEntry = destMesh.MaterialEntries[i];
+                var materialName = materialEntry.Name.GetResolvedText() ?? "destMaterial" + i;
+                var originalMaterialName = materialName;
+                var materialNameIndex = 0;
+                while (materialNames.Contains(materialName))
+                {
+                    materialNameIndex += 1;
+                    materialName = $"{originalMaterialName}_{materialNameIndex}";
+                }
+
+                materialNames.Add(materialName);
+                materialEntries.Add(materialEntry);
+                if (materialName != originalMaterialName)
+                {
+                    nameCollisions.Add(originalMaterialName, materialName);
+                }
+            }
+
+            return nameCollisions;
+        }
+
+        // ReSharper restore ForCanBeConvertedToForeach
     }
 
     public bool CopyMeshMaterials(string? sourcePath, string destPath, bool? append)
@@ -1317,7 +1388,6 @@ public class DocumentTools
         var destCr2W = GetCr2W(destPath) ??
                        throw new InvalidDataException($"target file {destPath} not found. Can't copy...");
 
-
         if (destCr2W.RootChunk is not CMesh destMesh)
         {
             throw new InvalidDataException($"target file {destPath} is not a valid mesh.");
@@ -1328,8 +1398,71 @@ public class DocumentTools
             ClearMeshMaterials(destCr2W);
         }
 
-        var numChanges = meshPaths.Select(sourceMeshPath =>
-            AppendMeshMaterials(GetCr2W(sourceMeshPath), destCr2W, sourcePath, destPath)).Sum();
+        var numChanges = 0;
+        for (var i = 0; i < meshPaths.Count; i++)
+        {
+            numChanges += AppendMeshMaterials(GetCr2W(meshPaths[i]), destCr2W, sourcePath, destPath);
+
+            if (i >= meshPaths.Count + 1)
+            {
+                continue;
+            }
+
+            // append separators to appearances, materialNames, materials
+            var separatorString =
+                $"----- merged_from_{Path.GetFileNameWithoutExtension(meshPaths[i]).ToFileName()}";
+            destMesh.Appearances.Add(new CHandle<meshMeshAppearance>()
+            {
+                Chunk = new meshMeshAppearance() { Name = separatorString }
+            });
+
+            if (destMesh.LocalMaterialBuffer.Materials.Count > 0 || destMesh.PreloadLocalMaterialInstances.Count > 0)
+            {
+                destMesh.MaterialEntries.Add(new CMeshMaterialEntry()
+                {
+                    Name = separatorString,
+                    IsLocalInstance = true,
+                    Index = destMesh.MaterialEntries.Where(e => e.IsLocalInstance).Select(e => e.Index)
+                        .Max(),
+                });
+
+                var matInstance = new CMaterialInstance();
+
+                if (destMesh.PreloadLocalMaterialInstances.Count > 0)
+                {
+                    destMesh.PreloadLocalMaterialInstances.Add(new CHandle<IMaterial>() { Chunk = matInstance });
+                }
+                else
+                {
+                    destMesh.LocalMaterialBuffer.Materials.Add(matInstance);
+                }
+            }
+
+            if (destMesh.ExternalMaterials.Count <= 0 && destMesh.PreloadExternalMaterials.Count <= 0)
+            {
+                continue;
+            }
+
+            {
+                destMesh.MaterialEntries.Add(new CMeshMaterialEntry()
+                {
+                    Name = separatorString,
+                    IsLocalInstance = false,
+                    Index = destMesh.MaterialEntries.Where(e => !e.IsLocalInstance).Select(e => e.Index)
+                        .Max(),
+                });
+
+                if (destMesh.ExternalMaterials.Count > 0)
+                {
+                    destMesh.ExternalMaterials.Add(new CResourceAsyncReference<IMaterial>(ResourcePath.Empty));
+                }
+                else
+                {
+                    destMesh.PreloadExternalMaterials.Add(new CResourceReference<IMaterial>(ResourcePath.Empty));
+                }
+            }
+        }
+
 
         if (numChanges == 0)
         {

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1144,9 +1144,13 @@ public class DocumentTools
     }
 
     private int AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
-        string destPath = "")
+        string destPath = "", bool appendSeparator = false)
     {
         var wasChanged = 0;
+
+        // append separators to appearances, materialNames, materials
+        var separatorString =
+            $"----- merged_from_{Path.GetFileNameWithoutExtension(sourcePath).ToFileName()}";
 
         if (sourceCr2W is null)
         {
@@ -1176,10 +1180,7 @@ public class DocumentTools
 
         // ReSharper disable ForCanBeConvertedToForeach
 
-        CArray<CMeshMaterialEntry> materialEntries = [];
-        var materialNameCollisions = CopyMaterialDefinitions();
-
-        CopyMeshAppearances();
+        var materialEntries = CollectMaterialDefinitions(out var materialNameCollisions);
 
         // now reindex properties
         var localMaterialIndex = 0;
@@ -1200,35 +1201,18 @@ public class DocumentTools
         }
 
         wasChanged += materialEntries.Count - destMesh.MaterialEntries.Count;
-        destMesh.MaterialEntries = materialEntries;
 
-        #region localMaterialCopy
+        destMesh.MaterialEntries.Clear();
+        materialEntries.ForEach(e => destMesh.MaterialEntries.Add(e));
 
-        var usePreloadLocalMaterials = destMesh.PreloadLocalMaterialInstances.Count > 0;
-        var usePreloadExternalMaterials = destMesh.PreloadLocalMaterialInstances.Count > 0;
+        var appearances = CopyMeshAppearances();
 
-        CArray<IMaterial> localMaterials = [];
-        foreach (var material in destMesh.LocalMaterialBuffer.Materials)
-        {
-            localMaterials.Add(CvmMaterialTools.EmbeddedToDefault(material));
-        }
+        wasChanged += appearances.Count - destMesh.Appearances.Count;
+        destMesh.Appearances = appearances;
 
-        foreach (var material in sourceMesh.LocalMaterialBuffer.Materials)
-        {
-            localMaterials.Add(material);
-        }
+        var localMaterials = CollectLocalMaterials();
 
-        foreach (var material in destMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk).OfType<IMaterial>())
-        {
-            localMaterials.Add(material);
-        }
-
-        foreach (var material in sourceMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk).OfType<IMaterial>())
-        {
-            localMaterials.Add(material);
-        }
-
-        if (usePreloadLocalMaterials)
+        if (destMesh.PreloadLocalMaterialInstances.Count > 0)
         {
             wasChanged += localMaterials.Count - destMesh.PreloadLocalMaterialInstances.Count;
             destMesh.PreloadLocalMaterialInstances.Clear();
@@ -1243,37 +1227,16 @@ public class DocumentTools
             destMesh.LocalMaterialBuffer.Materials = localMaterials;
         }
 
-        #endregion
+        var externalMaterials = CollectExternalMaterials();
 
-        #region externalMaterialCopy
-        CArray<CResourceAsyncReference<IMaterial>> externalMaterials = [];
-        for (var i = 0; i < destMesh.ExternalMaterials.Count; i++)
-        {
-            externalMaterials.Add(destMesh.ExternalMaterials[i]);
-        }
-
-        for (var i = 0; i < sourceMesh.ExternalMaterials.Count; i++)
-        {
-            externalMaterials.Add(sourceMesh.ExternalMaterials[i]);
-        }
-
-        for (var i = 0; i < destMesh.PreloadExternalMaterials.Count; i++)
-        {
-            externalMaterials.Add(destMesh.PreloadExternalMaterials[i]);
-        }
-
-        for (var i = 0; i < sourceMesh.PreloadExternalMaterials.Count; i++)
-        {
-            externalMaterials.Add(sourceMesh.PreloadExternalMaterials[i]);
-        }
-
-        if (usePreloadExternalMaterials)
+        if (destMesh.PreloadExternalMaterials.Count > 0)
         {
             wasChanged += externalMaterials.Count - destMesh.PreloadExternalMaterials.Count;
             destMesh.PreloadExternalMaterials.Clear();
             foreach (var m in externalMaterials)
             {
-                destMesh.PreloadExternalMaterials.Add(new CResourceReference<IMaterial>(m.DepotPath, m.Flags));
+                destMesh.PreloadExternalMaterials.Add(
+                    new CResourceReference<IMaterial>(m.DepotPath, m.Flags));
             }
         }
         else
@@ -1282,16 +1245,100 @@ public class DocumentTools
             destMesh.ExternalMaterials = externalMaterials;
         }
 
-        #endregion
-
         return wasChanged;
 
-        void CopyMeshAppearances()
+        CArray<IMaterial> CollectLocalMaterials()
         {
-            CArray<CHandle<meshMeshAppearance>> appearances = [];
+            CArray<IMaterial> ret = [];
+            foreach (var material in destMesh.LocalMaterialBuffer.Materials)
+            {
+                ret.Add(CvmMaterialTools.EmbeddedToDefault(material));
+            }
+
+            foreach (var material in destMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk)
+                         .OfType<IMaterial>())
+            {
+                ret.Add(material);
+            }
+
+            if (sourceMesh.LocalMaterialBuffer.Materials.Count == 0 &&
+                sourceMesh.PreloadLocalMaterialInstances.Count == 0)
+            {
+                return ret;
+            }
+
+            if (appendSeparator)
+            {
+                ret.Add(new CMaterialInstance()
+                {
+                    BaseMaterial = new CResourceReference<IMaterial>(@"base\fx\_shaders\invisible.mt"),
+                });
+            }
+
+            foreach (var material in sourceMesh.LocalMaterialBuffer.Materials)
+            {
+                ret.Add(material);
+            }
+
+            foreach (var material in sourceMesh.PreloadLocalMaterialInstances.Select(m => m.Chunk)
+                         .OfType<IMaterial>())
+            {
+                ret.Add(material);
+            }
+
+            return ret;
+        }
+
+        CArray<CResourceAsyncReference<IMaterial>> CollectExternalMaterials()
+        {
+            CArray<CResourceAsyncReference<IMaterial>> ret = [];
+            for (var i = 0; i < destMesh.ExternalMaterials.Count; i++)
+            {
+                ret.Add(destMesh.ExternalMaterials[i]);
+            }
+
+            for (var i = 0; i < destMesh.PreloadExternalMaterials.Count; i++)
+            {
+                ret.Add(destMesh.PreloadExternalMaterials[i]);
+            }
+
+            if (sourceMesh.ExternalMaterials.Count == 0 && sourceMesh.PreloadExternalMaterials.Count == 0)
+            {
+                return ret;
+            }
+
+            if (appendSeparator)
+            {
+                ret.Add(new CResourceAsyncReference<IMaterial>(ResourcePath.Empty));
+            }
+
+            for (var i = 0; i < sourceMesh.ExternalMaterials.Count; i++)
+            {
+                ret.Add(sourceMesh.ExternalMaterials[i]);
+            }
+
+            for (var i = 0; i < sourceMesh.PreloadExternalMaterials.Count; i++)
+            {
+                ret.Add(sourceMesh.PreloadExternalMaterials[i]);
+            }
+
+            return ret;
+        }
+
+        CArray<CHandle<meshMeshAppearance>> CopyMeshAppearances()
+        {
+            CArray<CHandle<meshMeshAppearance>> ret = [];
             for (var i = 0; i < destMesh.Appearances.Count; i++)
             {
-                appearances.Add(destMesh.Appearances[i]);
+                ret.Add(destMesh.Appearances[i]);
+            }
+
+            if (appendSeparator && sourceMesh.Appearances.Count > 0)
+            {
+                ret.Add(new CHandle<meshMeshAppearance>()
+                {
+                    Chunk = new meshMeshAppearance() { Name = separatorString, ChunkMaterials = [] }
+                });
             }
 
             for (var i = 0; i < sourceMesh.Appearances.Count; i++)
@@ -1299,7 +1346,7 @@ public class DocumentTools
                 var appearance = sourceMesh.Appearances[i];
                 if (materialNameCollisions.Count == 0 || appearance.Chunk is null)
                 {
-                    appearances.Add(appearance);
+                    ret.Add(appearance);
                     continue;
                 }
 
@@ -1315,29 +1362,46 @@ public class DocumentTools
                     appearance.Chunk.ChunkMaterials.Add(cn);
                 }
 
-                appearances.Add(appearance);
+                ret.Add(appearance);
             }
 
-            wasChanged += appearances.Count - destMesh.Appearances.Count;
-            destMesh.Appearances = appearances;
+            return ret;
         }
 
-        Dictionary<string, string> CopyMaterialDefinitions()
+        List<CMeshMaterialEntry> CollectMaterialDefinitions(out Dictionary<string, string> nameCollisions)
         {
+            List<CMeshMaterialEntry> ret = [];
             HashSet<string> materialNames = [];
-            Dictionary<string, string> nameCollisions = [];
+            nameCollisions = [];
 
+            // not checking for material name collisions in the original mesh
             for (var i = 0; i < destMesh.MaterialEntries.Count; i++)
             {
                 var materialEntry = destMesh.MaterialEntries[i];
                 var materialName = materialEntry.Name.GetResolvedText() ?? "sourceMaterial" + i;
-                materialEntries.Add(materialEntry);
+                ret.Add(materialEntry);
                 materialNames.Add(materialName);
+            }
+
+            if (sourceMesh.MaterialEntries.Count == 0)
+            {
+                return ret;
+            }
+
+            if (appendSeparator)
+            {
+                ret.Add(new CMeshMaterialEntry()
+                {
+                    Name = separatorString,
+                    IsLocalInstance = false,
+                    Index =
+                        (CUInt16)(CvmMaterialTools.FindHighestMaterialIndex(destMesh.MaterialEntries, false) + 1),
+                });
             }
 
             for (var i = 0; i < sourceMesh.MaterialEntries.Count; i++)
             {
-                var materialEntry = destMesh.MaterialEntries[i];
+                var materialEntry = sourceMesh.MaterialEntries[i];
                 var materialName = materialEntry.Name.GetResolvedText() ?? "destMaterial" + i;
                 var originalMaterialName = materialName;
                 var materialNameIndex = 0;
@@ -1348,14 +1412,14 @@ public class DocumentTools
                 }
 
                 materialNames.Add(materialName);
-                materialEntries.Add(materialEntry);
+                ret.Add(materialEntry);
                 if (materialName != originalMaterialName)
                 {
                     nameCollisions.Add(originalMaterialName, materialName);
                 }
             }
 
-            return nameCollisions;
+            return ret;
         }
 
         // ReSharper restore ForCanBeConvertedToForeach
@@ -1398,71 +1462,9 @@ public class DocumentTools
             ClearMeshMaterials(destCr2W);
         }
 
-        var numChanges = 0;
-        for (var i = 0; i < meshPaths.Count; i++)
-        {
-            numChanges += AppendMeshMaterials(GetCr2W(meshPaths[i]), destCr2W, sourcePath, destPath);
-
-            if (i >= meshPaths.Count + 1)
-            {
-                continue;
-            }
-
-            // append separators to appearances, materialNames, materials
-            var separatorString =
-                $"----- merged_from_{Path.GetFileNameWithoutExtension(meshPaths[i]).ToFileName()}";
-            destMesh.Appearances.Add(new CHandle<meshMeshAppearance>()
-            {
-                Chunk = new meshMeshAppearance() { Name = separatorString }
-            });
-
-            if (destMesh.LocalMaterialBuffer.Materials.Count > 0 || destMesh.PreloadLocalMaterialInstances.Count > 0)
-            {
-                destMesh.MaterialEntries.Add(new CMeshMaterialEntry()
-                {
-                    Name = separatorString,
-                    IsLocalInstance = true,
-                    Index = destMesh.MaterialEntries.Where(e => e.IsLocalInstance).Select(e => e.Index)
-                        .Max(),
-                });
-
-                var matInstance = new CMaterialInstance();
-
-                if (destMesh.PreloadLocalMaterialInstances.Count > 0)
-                {
-                    destMesh.PreloadLocalMaterialInstances.Add(new CHandle<IMaterial>() { Chunk = matInstance });
-                }
-                else
-                {
-                    destMesh.LocalMaterialBuffer.Materials.Add(matInstance);
-                }
-            }
-
-            if (destMesh.ExternalMaterials.Count <= 0 && destMesh.PreloadExternalMaterials.Count <= 0)
-            {
-                continue;
-            }
-
-            {
-                destMesh.MaterialEntries.Add(new CMeshMaterialEntry()
-                {
-                    Name = separatorString,
-                    IsLocalInstance = false,
-                    Index = destMesh.MaterialEntries.Where(e => !e.IsLocalInstance).Select(e => e.Index)
-                        .Max(),
-                });
-
-                if (destMesh.ExternalMaterials.Count > 0)
-                {
-                    destMesh.ExternalMaterials.Add(new CResourceAsyncReference<IMaterial>(ResourcePath.Empty));
-                }
-                else
-                {
-                    destMesh.PreloadExternalMaterials.Add(new CResourceReference<IMaterial>(ResourcePath.Empty));
-                }
-            }
-        }
-
+        var numChanges = meshPaths.Select((t, i) =>
+            AppendMeshMaterials(GetCr2W(t), destCr2W, sourcePath, destPath, i < meshPaths.Count + 1)
+        ).Sum();
 
         if (numChanges == 0)
         {

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1154,18 +1154,21 @@ public class DocumentTools
 
         if (sourceCr2W is null)
         {
+            _notificationService.Error($"source file {sourcePath} not found. Can't copy...");
             _loggerService.Error($"source file {sourcePath} not found. Can't copy...");
             return wasChanged;
         }
 
         if (destCr2W is null)
         {
+            _notificationService.Error($"target file {destCr2W} not found. Can't copy...");
             _loggerService.Error($"target file {destCr2W} not found. Can't copy...");
             return wasChanged;
         }
 
         if (sourceCr2W.RootChunk is not CMesh sourceMesh || destCr2W.RootChunk is not CMesh destMesh)
         {
+            _notificationService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
             _loggerService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
             return wasChanged;
         }
@@ -1174,6 +1177,7 @@ public class DocumentTools
 
         if (!hasMaterials)
         {
+            _notificationService.Error($"source file {sourcePath} does not have materials!");
             _loggerService.Error($"source file {sourcePath} does not have materials!");
             return 0;
         }

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1438,7 +1438,7 @@ public class DocumentTools
     /// <param name="addSeparator">Add separators? (Will only be set when copying _from_, not when copying _to_)</param>
     /// <returns>bool as success</returns>
     /// <exception cref="InvalidDataException"></exception>
-    public bool CopyMeshMaterials(string? sourcePath, string destPath, bool append = false, bool addSeparator = false)
+    public bool CopyMeshMaterials(string? sourcePath, string destPath, bool append = false)
     {
         if (_projectManager.ActiveProject is not { } activeProject)
         {
@@ -1481,7 +1481,7 @@ public class DocumentTools
                 destCr2W,
                 sourcePath,
                 destPath,
-                addSeparator && i < meshPaths.Count + 1
+                append && i < meshPaths.Count + 1
             )
         ).Sum();
 

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1425,7 +1425,16 @@ public class DocumentTools
         // ReSharper restore ForCanBeConvertedToForeach
     }
 
-    public bool CopyMeshMaterials(string? sourcePath, string destPath, bool? append)
+    /// <summary>
+    /// Copies materials from a source mesh to a dest mesh. Can replace or append.
+    /// </summary>
+    /// <param name="sourcePath">source path (file to copy FROM)</param>
+    /// <param name="destPath">dest path (file to copy TO)</param>
+    /// <param name="append">append materials from source mesh instead of replacing them?</param>
+    /// <param name="addSeparator">Add separators? (Will only be set when copying _from_, not when copying _to_)</param>
+    /// <returns>bool as success</returns>
+    /// <exception cref="InvalidDataException"></exception>
+    public bool CopyMeshMaterials(string? sourcePath, string destPath, bool append = false, bool addSeparator = false)
     {
         if (_projectManager.ActiveProject is not { } activeProject)
         {
@@ -1457,13 +1466,19 @@ public class DocumentTools
             throw new InvalidDataException($"target file {destPath} is not a valid mesh.");
         }
 
-        if (append != true)
+        if (!append)
         {
             ClearMeshMaterials(destCr2W);
         }
 
         var numChanges = meshPaths.Select((t, i) =>
-            AppendMeshMaterials(GetCr2W(t), destCr2W, sourcePath, destPath, i < meshPaths.Count + 1)
+            AppendMeshMaterials(
+                GetCr2W(t),
+                destCr2W,
+                sourcePath,
+                destPath,
+                addSeparator && i < meshPaths.Count + 1
+            )
         ).Sum();
 
         if (numChanges == 0)

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1143,10 +1143,18 @@ public class DocumentTools
         mesh.PreloadLocalMaterialInstances.Clear();
     }
 
+    /// <summary>
+    /// Appends materials from source to dest
+    /// </summary>
+    /// <param name="sourceCr2W"></param>
+    /// <param name="destCr2W"></param>
+    /// <param name="sourcePath"></param>
+    /// <param name="destPath"></param>
+    /// <param name="appendSeparator">Optionally: append separator appearances / materials for every new mesh</param>
+    /// <returns>number of changed parameters across the files</returns>
     private int AppendMeshMaterials(CR2WFile? sourceCr2W, CR2WFile? destCr2W, string sourcePath = "",
         string destPath = "", bool appendSeparator = false)
     {
-        var wasChanged = 0;
 
         // append separators to appearances, materialNames, materials
         var separatorString =
@@ -1154,23 +1162,23 @@ public class DocumentTools
 
         if (sourceCr2W is null)
         {
-            _notificationService.Error($"source file {sourcePath} not found. Can't copy...");
-            _loggerService.Error($"source file {sourcePath} not found. Can't copy...");
-            return wasChanged;
+            _notificationService.Error($"Source file {sourcePath} not found. Can't copy.");
+            _loggerService.Error($"Source file {sourcePath} not found. Can't copy.");
+            return 0;
         }
 
         if (destCr2W is null)
         {
             _notificationService.Error($"target file {destCr2W} not found. Can't copy...");
             _loggerService.Error($"target file {destCr2W} not found. Can't copy...");
-            return wasChanged;
+            return 0;
         }
 
         if (sourceCr2W.RootChunk is not CMesh sourceMesh || destCr2W.RootChunk is not CMesh destMesh)
         {
             _notificationService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
             _loggerService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
-            return wasChanged;
+            return 0;
         }
 
         var hasMaterials = sourceMesh.MaterialEntries.Count > 0;
@@ -1182,6 +1190,7 @@ public class DocumentTools
             return 0;
         }
 
+        var numChangedEntries = 0;
         // ReSharper disable ForCanBeConvertedToForeach
 
         var materialEntries = CollectMaterialDefinitions(out var materialNameCollisions);
@@ -1204,21 +1213,21 @@ public class DocumentTools
             }
         }
 
-        wasChanged += materialEntries.Count - destMesh.MaterialEntries.Count;
+        numChangedEntries += materialEntries.Count - destMesh.MaterialEntries.Count;
 
         destMesh.MaterialEntries.Clear();
         materialEntries.ForEach(e => destMesh.MaterialEntries.Add(e));
 
         var appearances = CopyMeshAppearances();
 
-        wasChanged += appearances.Count - destMesh.Appearances.Count;
+        numChangedEntries += appearances.Count - destMesh.Appearances.Count;
         destMesh.Appearances = appearances;
 
         var localMaterials = CollectLocalMaterials();
 
         if (destMesh.PreloadLocalMaterialInstances.Count > 0)
         {
-            wasChanged += localMaterials.Count - destMesh.PreloadLocalMaterialInstances.Count;
+            numChangedEntries += localMaterials.Count - destMesh.PreloadLocalMaterialInstances.Count;
             destMesh.PreloadLocalMaterialInstances.Clear();
             foreach (var m in localMaterials)
             {
@@ -1227,7 +1236,7 @@ public class DocumentTools
         }
         else
         {
-            wasChanged += localMaterials.Count - destMesh.LocalMaterialBuffer.Materials.Count;
+            numChangedEntries += localMaterials.Count - destMesh.LocalMaterialBuffer.Materials.Count;
             destMesh.LocalMaterialBuffer.Materials = localMaterials;
         }
 
@@ -1235,7 +1244,7 @@ public class DocumentTools
 
         if (destMesh.PreloadExternalMaterials.Count > 0)
         {
-            wasChanged += externalMaterials.Count - destMesh.PreloadExternalMaterials.Count;
+            numChangedEntries += externalMaterials.Count - destMesh.PreloadExternalMaterials.Count;
             destMesh.PreloadExternalMaterials.Clear();
             foreach (var m in externalMaterials)
             {
@@ -1245,11 +1254,11 @@ public class DocumentTools
         }
         else
         {
-            wasChanged += externalMaterials.Count - destMesh.ExternalMaterials.Count;
+            numChangedEntries += externalMaterials.Count - destMesh.ExternalMaterials.Count;
             destMesh.ExternalMaterials = externalMaterials;
         }
 
-        return wasChanged;
+        return numChangedEntries;
 
         CArray<IMaterial> CollectLocalMaterials()
         {
@@ -1406,7 +1415,7 @@ public class DocumentTools
             for (var i = 0; i < sourceMesh.MaterialEntries.Count; i++)
             {
                 var materialEntry = sourceMesh.MaterialEntries[i];
-                var materialName = materialEntry.Name.GetResolvedText() ?? "destMaterial" + i;
+                var materialName = materialEntry.Name.GetResolvedText() ?? $"destMaterial{i}";
                 var originalMaterialName = materialName;
                 var materialNameIndex = 0;
                 while (materialNames.Contains(materialName))
@@ -1435,7 +1444,6 @@ public class DocumentTools
     /// <param name="sourcePath">source path (file to copy FROM)</param>
     /// <param name="destPath">dest path (file to copy TO)</param>
     /// <param name="append">append materials from source mesh instead of replacing them?</param>
-    /// <param name="addSeparator">Add separators? (Will only be set when copying _from_, not when copying _to_)</param>
     /// <returns>bool as success</returns>
     /// <exception cref="InvalidDataException"></exception>
     public bool CopyMeshMaterials(string? sourcePath, string destPath, bool append = false)

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1169,22 +1169,22 @@ public class DocumentTools
 
         if (destCr2W is null)
         {
-            _notificationService.Error($"target file {destCr2W} not found. Can't copy...");
-            _loggerService.Error($"target file {destCr2W} not found. Can't copy...");
+            _notificationService.Error($"Target file {destCr2W} not found. Can't copy...");
+            _loggerService.Error($"Target file {destCr2W} not found. Can't copy...");
             return 0;
         }
 
         if (sourceCr2W.RootChunk is not CMesh sourceMesh || destCr2W.RootChunk is not CMesh destMesh)
         {
-            _notificationService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
-            _loggerService.Error($"source file {sourcePath} or target file {destPath} is not a valid mesh.");
+            _notificationService.Error($"Source file {sourcePath} or target file {destPath} is not a valid mesh.");
+            _loggerService.Error($"Source file {sourcePath} or target file {destPath} is not a valid mesh.");
             return 0;
         }
 
         if (sourceMesh.MaterialEntries.Count == 0)
         {
-            _notificationService.Error($"source file {sourcePath} does not have materials!");
-            _loggerService.Error($"source file {sourcePath} does not have materials!");
+            _notificationService.Error($"Source file {sourcePath} does not have materials!");
+            _loggerService.Error($"Source file {sourcePath} does not have materials!");
             return 0;
         }
 

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1181,9 +1181,7 @@ public class DocumentTools
             return 0;
         }
 
-        var hasMaterials = sourceMesh.MaterialEntries.Count > 0;
-
-        if (!hasMaterials)
+        if (sourceMesh.MaterialEntries.Count == 0)
         {
             _notificationService.Error($"source file {sourcePath} does not have materials!");
             _loggerService.Error($"source file {sourcePath} does not have materials!");

--- a/WolvenKit.App/Helpers/DocumentTools.cs
+++ b/WolvenKit.App/Helpers/DocumentTools.cs
@@ -1158,7 +1158,7 @@ public class DocumentTools
 
         // append separators to appearances, materialNames, materials
         var separatorString =
-            $"----- merged_from_{Path.GetFileNameWithoutExtension(sourcePath).ToFileName()}";
+            $"----- merged_from_{Path.GetFileNameWithoutExtension(sourcePath).ToArchiveFileName()}";
 
         if (sourceCr2W is null)
         {

--- a/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
@@ -18,41 +18,48 @@ namespace WolvenKit.App.ViewModels.Dialogs;
 /// </summary>
 public partial class CopyMeshAppearancesDialogViewModel : ObservableObject
 {
-    [ObservableProperty] private string? _selectedOption = "";
     [ObservableProperty] private string _wikiLink = WikiLinks.MeshMaterials;
     [ObservableProperty] private bool _isAppend = false;
     [ObservableProperty] private bool _useArchiveXlPatchMesh = false;
 
     private List<string>? _options;
-    [ObservableProperty] private Dictionary<string, string>? _optionsDict;
+    [ObservableProperty] private Dictionary<string, bool>? _optionsDict;
 
+    public List<string> SelectedOptions { get; set; } = [];
+
+    public string? SelectedOption { get; set; }
 
     // enable save button?
     [ObservableProperty] private bool _canSave;
 
 
-    public CopyMeshAppearancesDialogViewModel(List<string> options)
+    public CopyMeshAppearancesDialogViewModel(List<string> options, List<string> previousSelection)
     {
         _options = options;
-        OptionsDict = options.ToDictionary(k => k, v => v);
+        OptionsDict = options.ToDictionary(k => k, previousSelection.Contains);
+        SelectedOption = previousSelection.FirstOrDefault() ?? "";
     }
+
 
 
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
-        SetSaveButtonState();
+        if (e.PropertyName != nameof(CanSave))
+        {
+            SetSaveButtonState();
+        }
     }
 
-    private void SetSaveButtonState()
+    public void SetSaveButtonState()
     {
-        if (string.IsNullOrEmpty(SelectedOption))
+        if (SelectedOptions.Count == 0)
         {
             CanSave = false;
             return;
         }
 
         // If the mesh value is okay, we can save here
-        CanSave = !string.IsNullOrEmpty(SelectedOption) && SelectedOption.EndsWith(".mesh");
+        CanSave = SelectedOptions.Any((sel) => !string.IsNullOrEmpty(sel) && sel.EndsWith(".mesh"));
     }
 }

--- a/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
@@ -39,6 +39,8 @@ public partial class CopyMeshAppearancesDialogViewModel : ObservableObject
         _options = options;
         OptionsDict = options.ToDictionary(k => k, previousSelection.Contains);
         SelectedOption = lastSelectedOption;
+
+        SetSaveButtonState();
     }
 
 

--- a/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
@@ -53,6 +53,12 @@ public partial class CopyMeshAppearancesDialogViewModel : ObservableObject
 
     public void SetSaveButtonState()
     {
+        if (SelectedOption?.EndsWith(".mesh") == true)
+        {
+            CanSave = true;
+            return;
+        }
+
         if (SelectedOptions.Count == 0)
         {
             CanSave = false;

--- a/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
@@ -33,11 +33,12 @@ public partial class CopyMeshAppearancesDialogViewModel : ObservableObject
     [ObservableProperty] private bool _canSave;
 
 
-    public CopyMeshAppearancesDialogViewModel(List<string> options, List<string> previousSelection)
+    public CopyMeshAppearancesDialogViewModel(List<string> options, List<string> previousSelection,
+        string lastSelectedOption)
     {
         _options = options;
         OptionsDict = options.ToDictionary(k => k, previousSelection.Contains);
-        SelectedOption = previousSelection.FirstOrDefault() ?? "";
+        SelectedOption = lastSelectedOption;
     }
 
 

--- a/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/CopyMeshAppearancesDialogViewModel.cs
@@ -69,4 +69,26 @@ public partial class CopyMeshAppearancesDialogViewModel : ObservableObject
         // If the mesh value is okay, we can save here
         CanSave = SelectedOptions.Any((sel) => !string.IsNullOrEmpty(sel) && sel.EndsWith(".mesh"));
     }
+
+    /// <summary>
+    /// Get all selected options. If the AXL patch button was clicked, selection list will be [""]
+    /// </summary>
+    public List<string> GetAllSelectedOptions()
+    {
+        if (UseArchiveXlPatchMesh)
+        {
+            return [""];
+        }
+
+        SelectedOptions ??= [];
+
+        if (string.IsNullOrEmpty(SelectedOption) || !SelectedOption.Contains(".mesh"))
+        {
+            return SelectedOptions;
+        }
+
+        SelectedOption.Split(';').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToList()
+            .ForEach(SelectedOptions.Add);
+        return SelectedOptions.Distinct().ToList();
+    }
 }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -3536,7 +3536,8 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                 ResolvedData is CMeshMaterialEntry materialDefinition:
             {
                 var materialIndex =
-                    _cvmTools.FindHighestMaterialIndex(Parent, materialDefinition.IsLocalInstance);
+                    CvmMaterialTools.FindHighestMaterialIndex(materialDefinitionArray,
+                        materialDefinition.IsLocalInstance);
                 SetDataIndexProperty(materialIndex + 1);
                 break;
             }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -3574,6 +3574,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         CalculateProperties();
         CalculateDescriptor();
         CalculateValue();
+        CalculateIsDefault();
 
         if (IsArray)
         {

--- a/WolvenKit.sln.DotSettings
+++ b/WolvenKit.sln.DotSettings
@@ -37,6 +37,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=crui/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cruid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=darra/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=detes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dmod/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dynamify/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=egexp/@EntryIndexedValue">True</s:Boolean>

--- a/WolvenKit/Themes/App.Styles.xaml
+++ b/WolvenKit/Themes/App.Styles.xaml
@@ -287,6 +287,13 @@
     </Style>
 
     <Style
+        x:Key="WolvenkitExplanationStyle"
+        TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{StaticResource ForegroundColor_Grey1}" />
+        <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginBottom}" />
+    </Style>
+
+    <Style
         x:Key="WolvenKitTabControl"
         BasedOn="{StaticResource SyncfusionDocumentTabControlExtStyle}"
         TargetType="{x:Type syncfusion:TabControlExt}">

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
@@ -6,6 +6,7 @@
     xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
     xmlns:converters="clr-namespace:WolvenKit.Converters"
     xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
+    xmlns:templates="clr-namespace:WolvenKit.Views.Templates"
     Title="Select .mesh file(s)"
     SizeToContent="WidthAndHeight"
     DataContext="{Binding RelativeSource={RelativeSource Self},
@@ -91,17 +92,16 @@
                         VerticalAlignment="Top"
                         Text="Select .mesh file(s)" />
 
-                    <editors:FilterableDropdownMenu
-                        x:Name="Dropdown"
+                    <!-- Checklist -->
+                    <templates:FilterableChecklistMenu
+                        x:Name="FilterableChecklistMenu"
                         Grid.Row="2"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
-                        Options="{Binding Options,
-                                          UpdateSourceTrigger=PropertyChanged}"
-                        IsInline="False"
-                        IsShowLabel="False"
-                        SelectedOption="{Binding SelectedOption}"
-                        KeyboardNavigation.TabIndex="-1" />
+                        MaxHeight="{StaticResource WolvenkitControlMinWidth}"
+                        CheckboxOptionsAndStates="{Binding OptionsDict}"
+                        SelectionChanged="ChecklistMenu_OnSelectionChanged"
+                        KeyboardNavigation.TabIndex="1" />
 
                     <TextBlock
                         Grid.Row="4"
@@ -133,6 +133,7 @@
                         FontSize="{DynamicResource WolvenKitFontBody}"
                         Text="{Binding SelectedOption,
                                        Mode=TwoWay}"
+                        LostFocus="TextBox_OnFocusLost"
                         KeyboardNavigation.TabIndex="-1" />
 
                 </Grid>

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
@@ -11,7 +11,7 @@
     SizeToContent="WidthAndHeight"
     DataContext="{Binding RelativeSource={RelativeSource Self},
                           Path=ViewModel}"
-    FocusManager.FocusedElement="{Binding ElementName=NpcNameTextbox}"
+    FocusManager.FocusedElement="{Binding ElementName=TextBox}"
     WindowStartupLocation="CenterScreen"
     Topmost="True">
 
@@ -63,6 +63,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="10" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="10" />
                     </Grid.RowDefinitions>
 
@@ -85,7 +86,7 @@
                     <!-- ======================================================== -->
 
                     <TextBlock
-                        Grid.Row="2"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Margin="{DynamicResource WolvenKitMarginTop}"
                         Padding="{DynamicResource WolvenKitMarginTinyLeft}"
@@ -95,23 +96,23 @@
                     <!-- Checklist -->
                     <templates:FilterableChecklistMenu
                         x:Name="FilterableChecklistMenu"
-                        Grid.Row="2"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
-                        MaxHeight="{StaticResource WolvenkitControlMinWidth}"
+                        MaxHeight="{StaticResource WolvenKitDialogHeightSmall}"
                         CheckboxOptionsAndStates="{Binding OptionsDict}"
                         SelectionChanged="ChecklistMenu_OnSelectionChanged"
                         KeyboardNavigation.TabIndex="1" />
 
                     <TextBlock
-                        Grid.Row="4"
+                        Grid.Row="2"
                         Grid.Column="0"
                         Margin="{DynamicResource WolvenKitMarginTiny}"
                         VerticalAlignment="Bottom"
                         Text="Append (don't overwrite)" />
 
                     <CheckBox
-                        Grid.Row="4"
+                        Grid.Row="2"
                         Grid.Column="1"
                         Margin="{DynamicResource WolvenKitMarginTinyTop}"
                         IsChecked="{Binding IsAppend}"
@@ -136,6 +137,14 @@
                         KeyUp="TextBox_OnChange"
                         LostFocus="TextBox_OnChange"
                         KeyboardNavigation.TabIndex="-1" />
+
+                    <TextBlock
+                        Grid.Row="7"
+                        Grid.Column="1"
+                        Style="{DynamicResource WolvenkitExplanationStyle}"
+                        Margin="{DynamicResource WolvenKitMarginTiny}"
+                        VerticalAlignment="Bottom"
+                        Text="You can separate multiple entries with ;" />
 
                 </Grid>
             </syncfusion:WizardPage>

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
@@ -133,7 +133,8 @@
                         FontSize="{DynamicResource WolvenKitFontBody}"
                         Text="{Binding SelectedOption,
                                        Mode=TwoWay}"
-                        LostFocus="TextBox_OnFocusLost"
+                        KeyUp="TextBox_OnChange"
+                        LostFocus="TextBox_OnChange"
                         KeyboardNavigation.TabIndex="-1" />
 
                 </Grid>

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
@@ -36,9 +36,7 @@
 
         <syncfusion:WizardControl
             CancelButtonCancelsWindow="True"
-            FinishButtonClosesWindow="True"
-            FinishEnabled="{Binding CanSave,
-                                    UpdateSourceTrigger=PropertyChanged}">
+            FinishButtonClosesWindow="True">
 
             <syncfusion:WizardPage
                 BackVisibility="Collapsed"
@@ -47,7 +45,9 @@
                 HelpVisibility="Collapsed"
                 NextVisibility="Collapsed"
                 PreviewKeyDown="WizardPage_PreviewKeyDown"
-                PageType="Exterior">
+                PageType="Exterior"
+                FinishEnabled="{Binding CanSave,
+                                        UpdateSourceTrigger=PropertyChanged}">
                 <Grid
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch">

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml
@@ -60,7 +60,7 @@
                         <RowDefinition Height="10" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="10" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
                         <RowDefinition Height="10" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
@@ -99,7 +99,6 @@
                         Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
-                        MaxHeight="{StaticResource WolvenKitDialogHeightSmall}"
                         CheckboxOptionsAndStates="{Binding OptionsDict}"
                         SelectionChanged="ChecklistMenu_OnSelectionChanged"
                         KeyboardNavigation.TabIndex="1" />

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Input;
 using ReactiveUI;
 using System.Reactive.Disposables;
+using Syncfusion.Windows.Controls.Input;
 using WolvenKit.App.ViewModels.Dialogs;
 using Window = System.Windows.Window;
 
@@ -11,16 +12,16 @@ namespace WolvenKit.Views.Dialogs
 {
     public partial class CopyMeshAppearancesDialog : IViewFor<CopyMeshAppearancesDialogViewModel>
     {
-        private static string s_lastSelectedOption;
+        private static List<string> s_lastSelectedOptions = [];
         private static bool s_lastAppend;
 
         public CopyMeshAppearancesDialog(List<string> options)
         {
             InitializeComponent();
 
-            ViewModel = new CopyMeshAppearancesDialogViewModel(options)
+            ViewModel = new CopyMeshAppearancesDialogViewModel(options, s_lastSelectedOptions)
             {
-                IsAppend = s_lastAppend, SelectedOption = s_lastSelectedOption
+                IsAppend = s_lastAppend
             };
             DataContext = ViewModel;
 
@@ -28,15 +29,11 @@ namespace WolvenKit.Views.Dialogs
             {
                 this.Bind(ViewModel,
                         x => x.SelectedOption,
-                        x => x.Dropdown.SelectedOption)
-                    .DisposeWith(disposables);
-                this.Bind(ViewModel,
-                        x => x.SelectedOption,
                         x => x.TextBox.Text)
                     .DisposeWith(disposables);
                 this.Bind(ViewModel,
                         x => x.OptionsDict,
-                        x => x.Dropdown.Options)
+                        x => x.FilterableChecklistMenu.CheckboxOptionsAndStates)
                     .DisposeWith(disposables);
             });
         }
@@ -59,7 +56,7 @@ namespace WolvenKit.Views.Dialogs
 
             if (!string.IsNullOrEmpty(ViewModel.SelectedOption))
             {
-                s_lastSelectedOption = ViewModel.SelectedOption;
+                s_lastSelectedOptions = ViewModel.SelectedOptions;
             }
 
             // save bool flags
@@ -99,6 +96,32 @@ namespace WolvenKit.Views.Dialogs
             ViewModel.UseArchiveXlPatchMesh = true;
             DialogResult = true;
             Close();
+        }
+
+        private void ChecklistMenu_OnSelectionChanged(object _, List<string> selection)
+        {
+            if (ViewModel is null)
+            {
+                return;
+            }
+
+            ViewModel.SelectedOptions ??= [];
+
+            ViewModel.SelectedOptions.Clear();
+            ViewModel.SelectedOptions.AddRange(selection);
+            ViewModel.SetSaveButtonState();
+        }
+
+        private void TextBox_OnFocusLost(object sender, RoutedEventArgs e)
+        {
+            if (sender is not SfTextBoxExt tb || ViewModel is null)
+            {
+                return;
+            }
+
+            ViewModel.SelectedOptions.Clear();
+            ViewModel.SelectedOptions.Add(tb.Text);
+            ViewModel.SetSaveButtonState();
         }
     }
 }

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
@@ -4,8 +4,9 @@ using System.Windows;
 using System.Windows.Input;
 using ReactiveUI;
 using System.Reactive.Disposables;
-using Syncfusion.Windows.Controls.Input;
+using System.Windows.Controls;
 using WolvenKit.App.ViewModels.Dialogs;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using Window = System.Windows.Window;
 
 namespace WolvenKit.Views.Dialogs
@@ -112,15 +113,20 @@ namespace WolvenKit.Views.Dialogs
             ViewModel.SetSaveButtonState();
         }
 
-        private void TextBox_OnFocusLost(object sender, RoutedEventArgs e)
+        private void TextBox_OnChange(object sender, RoutedEventArgs e)
         {
-            if (sender is not SfTextBoxExt tb || ViewModel is null)
+            if (sender is not TextBox tb || ViewModel is null)
             {
                 return;
             }
 
-            ViewModel.SelectedOptions.Clear();
-            ViewModel.SelectedOptions.Add(tb.Text);
+            if (tb.Text.EndsWith(".mesh", StringComparison.OrdinalIgnoreCase))
+            {
+                ViewModel.SelectedOptions.Clear();
+                ViewModel.SelectedOptions.Add(tb.Text);
+                ViewModel.SelectedOption = tb.Text;
+            }
+
             ViewModel.SetSaveButtonState();
         }
     }

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
@@ -14,13 +14,14 @@ namespace WolvenKit.Views.Dialogs
     public partial class CopyMeshAppearancesDialog : IViewFor<CopyMeshAppearancesDialogViewModel>
     {
         private static List<string> s_lastSelectedOptions = [];
+        private static string s_lastSelectedOption = "";
         private static bool s_lastAppend;
 
         public CopyMeshAppearancesDialog(List<string> options)
         {
             InitializeComponent();
 
-            ViewModel = new CopyMeshAppearancesDialogViewModel(options, s_lastSelectedOptions)
+            ViewModel = new CopyMeshAppearancesDialogViewModel(options, s_lastSelectedOptions, s_lastSelectedOption)
             {
                 IsAppend = s_lastAppend
             };
@@ -55,9 +56,15 @@ namespace WolvenKit.Views.Dialogs
                 return;
             }
 
-            if (!string.IsNullOrEmpty(ViewModel.SelectedOption))
+            if (string.IsNullOrEmpty(ViewModel.SelectedOption))
             {
                 s_lastSelectedOptions = ViewModel.SelectedOptions;
+                s_lastSelectedOption = "";
+            }
+            else
+            {
+                s_lastSelectedOptions = [];
+                s_lastSelectedOption = ViewModel.SelectedOption;
             }
 
             // save bool flags

--- a/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/CopyMeshAppearancesDialog.xaml.cs
@@ -122,18 +122,13 @@ namespace WolvenKit.Views.Dialogs
 
         private void TextBox_OnChange(object sender, RoutedEventArgs e)
         {
-            if (sender is not TextBox tb || ViewModel is null)
+            if (sender is not TextBox tb || ViewModel is null ||
+                !tb.Text.Contains(".mesh", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
 
-            if (tb.Text.EndsWith(".mesh", StringComparison.OrdinalIgnoreCase))
-            {
-                ViewModel.SelectedOptions.Clear();
-                ViewModel.SelectedOptions.Add(tb.Text);
-                ViewModel.SelectedOption = tb.Text;
-            }
-
+            ViewModel.SelectedOption = tb.Text;
             ViewModel.SetSaveButtonState();
         }
     }

--- a/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/AddArchiveXlFilesDialog.xaml
@@ -71,13 +71,6 @@
                 </Style>
 
                 <Style
-                    x:Key="ExplanationStyle"
-                    TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor_Grey1}" />
-                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginBottom}" />
-                </Style>
-
-                <Style
                     x:Key="LabelStyle"
                     TargetType="TextBlock">
                     <Setter Property="VerticalAlignment" Value="Center" />
@@ -168,7 +161,7 @@
                         <TextBlock
                             Grid.Row="1"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Where do you want to equip your item?" />
 
                         <!-- Item name -->
@@ -190,7 +183,7 @@
                         <TextBlock
                             Grid.Row="4"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="This will be used to generate your item's spawn code and internal names." />
 
                         <!-- Item Subtype -->
@@ -220,7 +213,7 @@
                         <TextBlock
                             Grid.Row="7"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Select a specific item type (e.g. if you need specific footstep sounds)" />
 
                         <!-- EqEx Type -->
@@ -242,7 +235,7 @@
                         <TextBlock
                             Grid.Row="10"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Select an EquipmentEx slot (supports filtering)" />
 
                         <!-- Hiding tags -->
@@ -266,7 +259,7 @@
                         <TextBlock
                             Grid.Row="13"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Hide player body parts?" />
 
                         <!-- GS tags -->
@@ -294,7 +287,7 @@
                         <TextBlock
                             Grid.Row="16"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Add tags for fine-tuning garment support?" />
 
                         <!-- Hide in First Person -->
@@ -313,7 +306,7 @@
                         <TextBlock
                             Grid.Row="19"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Check to have your item visible in third person only (useful for face masks or helmets)" />
 
                         <!-- Force Hair -->
@@ -336,7 +329,7 @@
                         <TextBlock
                             Grid.Row="22"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Visibility="{Binding IsHeadItem,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}"
                             Text="Check to force-display hair (head items hide player hair by default)" />
@@ -465,7 +458,7 @@
                         <TextBlock
                             Grid.Row="3"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Use two variant fields" />
 
 
@@ -484,7 +477,7 @@
                         <TextBlock
                             Grid.Row="6"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Read appearances from existing files?" />
                     </Grid>
 
@@ -577,7 +570,7 @@
                             <TextBlock Text="Item variants (separate with comma)">
                                 <TextBlock.Style>
                                     <Style
-                                        BasedOn="{StaticResource ExplanationStyle}"
+                                        BasedOn="{StaticResource WolvenkitExplanationStyle}"
                                         TargetType="TextBlock">
                                         <Style.Triggers>
                                             <DataTrigger
@@ -647,7 +640,7 @@
                                 Text="Secondary item variants (separate by comma)">
                                 <TextBlock.Style>
                                     <Style
-                                        BasedOn="{StaticResource ExplanationStyle}"
+                                        BasedOn="{StaticResource WolvenkitExplanationStyle}"
                                         TargetType="TextBlock">
                                         <Style.Triggers>
                                             <DataTrigger
@@ -677,7 +670,7 @@
                         <TextBlock
                             Grid.Row="5"
                             Grid.Column="1"
-                            Style="{StaticResource ExplanationStyle}"
+                            Style="{StaticResource WolvenkitExplanationStyle}"
                             Text="Toggle parts, e.g. 'stickers'. Generated values will be 'on' and 'off'." />
 
                         <!-- Toggles -->

--- a/WolvenKit/Views/Dialogs/Windows/AddPropFileDialog.xaml
+++ b/WolvenKit/Views/Dialogs/Windows/AddPropFileDialog.xaml
@@ -71,12 +71,6 @@
                 </Style>
 
                 <Style
-                    x:Key="ExplanationStyle"
-                    TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor_Grey1}" />
-                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginBottom}" />
-                </Style>
-                <Style
                     x:Key="LabelHeaderStyle"
                     TargetType="Label">
                     <Setter Property="BorderBrush" Value="{DynamicResource WolvenKitBorderBrush}" />
@@ -226,7 +220,7 @@
                         Grid.Row="5"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Project folder for your files (will be created)" />
 
                     <!-- prop name -->
@@ -251,7 +245,7 @@
                         Grid.Row="8"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Human-readable name (for AMM registration)" />
 
                     <CheckBox
@@ -333,7 +327,7 @@
                         Grid.Row="13"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Check boxes to read appearances from mesh file(s) instead of entering them by hand" />
 
 
@@ -366,7 +360,7 @@
                     <TextBlock
                         Grid.Row="16"
                         Grid.Column="1"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Comma-separated list (only available without reading from mesh files)" />
 
 
@@ -433,7 +427,7 @@
                         Grid.Row="19"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Check box(es) to generate appearance names in mesh file(s)" />
 
                     <!-- Meshes for components -->
@@ -564,7 +558,7 @@
                     <TextBlock
                         Grid.Row="36"
                         Grid.Column="1"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Move .mesh files to folder" />
 
                     <Label
@@ -582,7 +576,7 @@
                     <TextBlock
                         Grid.Row="39"
                         Grid.Column="1"
-                        Style="{StaticResource ExplanationStyle}"
+                        Style="{StaticResource WolvenkitExplanationStyle}"
                         Text="Clean up non-existing entries from worldbuilder .txt files" />
 
                     <TextBlock

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml
@@ -371,7 +371,7 @@
                                          RelativeSource={RelativeSource Self},
                                          Mode=OneWay,
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Header="Copy materials from other mesh"
+                    Header="Copy materials from other mesh(es)"
                     Click="OnCopyMaterialsFromMeshClick"
                     Command="{Binding CopyMaterialFromMeshCommand}">
                     <MenuItem.Icon>
@@ -389,7 +389,7 @@
                                          RelativeSource={RelativeSource Self},
                                          Mode=OneWay,
                                          Converter={StaticResource BooleanToVisibilityConverter}}"
-                    Header="Copy materials to other meshes"
+                    Header="Copy materials to other mesh(es)"
                     Click="OnCopyMaterialsToMeshesClick"
                     Command="{Binding CopyMaterialToMeshesCommand}">
                     <MenuItem.Icon>

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -298,32 +298,57 @@ namespace WolvenKit.Views.Documents
                 return;
             }
 
-            if (ViewModel?.RootChunk is not ChunkViewModel { ResolvedData: CMesh mesh } || ViewModel.FilePath is null ||
+            if (ViewModel?.FilePath is not string currentPath ||
+                ViewModel?.RootChunk is not ChunkViewModel { ResolvedData: CMesh mesh } || ViewModel.FilePath is null ||
                 _projectManager.ActiveProject is not { } project)
             {
                 return;
             }
 
-            var files = _documentTools.CollectProjectFiles(".mesh").Where(f => f != ViewModel.FilePath)
-                .ToList();
+            var otherMeshFiles =
+                _documentTools.CollectProjectFiles(".mesh")
+                    .Where(f => !currentPath.EndsWith(f))
+                    .Distinct()
+                    .ToList();
 
-
-            if (Interactions.ShowCopyMeshAppearancesDialogue(files) is not { } dialog)
+            if (Interactions.ShowCopyMeshAppearancesDialogue(otherMeshFiles) is not { } dialog ||
+                dialog.SelectedOptions.Count == 0)
             {
                 return;
             }
 
             try
             {
+                List<string> failedMeshes = [];
+                var meshIdx = 0;
+                foreach (var sourcePath in dialog.SelectedOptions)
+                {
+                    // First copy operation needs to consider IsAppend
+                    if (!_documentTools.CopyMeshMaterials(sourcePath, currentPath, meshIdx > 0 || dialog.IsAppend))
+                    {
+                        failedMeshes.Add(sourcePath);
+                    }
+
+                    meshIdx += 1;
+                }
+
                 // Only reload if we wrote anything
-                if (_documentTools.CopyMeshMaterials(dialog.SelectedOption, ViewModel.FilePath, dialog.IsAppend))
+                if (failedMeshes.Count != dialog.SelectedOptions.Count)
                 {
                     ViewModel.CurrentTab?.Parent.Reload(true);
                 }
-                else if (dialog.UseArchiveXlPatchMesh)
+
+                if (failedMeshes.Count == 0)
                 {
+                    return;
+                }
+
+                if (dialog.UseArchiveXlPatchMesh)
+                {
+                    _notificationService.Error(
+                        "Failed to copy mesh materials from ArchiveXL patch mesh (see log for detes)");
                     _loggerService.Error(
-                        "Failed to copy mesh materials from patch mesh. Try picking a mesh, or adding the file path directly.");
+                        "Failed to copy mesh materials from patch mesh (source mesh not found, or you have moved the file in your mod). Please pick the file path in the dialogue.");
                 }
                 else
                 {
@@ -374,16 +399,27 @@ namespace WolvenKit.Views.Documents
                 return;
             }
 
-            var failedMeshes = selected.Where(mesh => !_documentTools.CopyMeshMaterials(currentPath, mesh, false)).ToList();
+            var failedMeshes = selected.Where(mesh =>
+                !_documentTools.CopyMeshMaterials(currentPath, mesh, false)
+            ).ToList();
 
             var output = StringHelper.Stringify(selected.Where(s => !failedMeshes.Contains(s)).ToList(), true);
 
-            if (failedMeshes.Count > 0)
+            if (failedMeshes.Count == 0)
             {
-                output = output + "\nMaterial copy failed for:" + StringHelper.Stringify(failedMeshes, true);
+                _loggerService.Success($"Copied materials from {currentPath} to {output}");
+                _notificationService.Success(
+                    $"Copied materials from {currentPath} to {selected.Count} file(s). Check the log for details.");
+                return;
             }
 
-            _loggerService.Success($"Copied materials from {currentPath} to {output}");
+            output = output + ", but there were problems:\nMaterial copy failed for:" +
+                     StringHelper.Stringify(failedMeshes, true);
+
+            _notificationService.Warning(
+                $"Copied materials from {currentPath} to {selected.Count} files, but there were problems. Check the log for details.");
+            _loggerService.Warning($"Copied materials from {currentPath} to {output}");
+
         }
 
         private void UnDynamifyMaterials(ChunkViewModel? cvm)

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -323,12 +323,12 @@ namespace WolvenKit.Views.Documents
                 var meshIdx = 0;
                 foreach (var sourcePath in dialog.SelectedOptions)
                 {
+                    var isAppend = meshIdx > 0 || dialog.IsAppend;
                     // First copy operation needs to consider IsAppend
                     if (!_documentTools.CopyMeshMaterials(
                             sourcePath,
                             currentPath,
-                            meshIdx > 0 || dialog.IsAppend,
-                            true))
+                            isAppend))
                     {
                         failedMeshes.Add(sourcePath);
                     }
@@ -404,7 +404,7 @@ namespace WolvenKit.Views.Documents
             }
 
             var failedMeshes = selected.Where(mesh =>
-                !_documentTools.CopyMeshMaterials(currentPath, mesh, false, false)
+                !_documentTools.CopyMeshMaterials(currentPath, mesh, false)
             ).ToList();
 
             var output = StringHelper.Stringify(selected.Where(s => !failedMeshes.Contains(s)).ToList(), true);

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -324,7 +324,11 @@ namespace WolvenKit.Views.Documents
                 foreach (var sourcePath in dialog.SelectedOptions)
                 {
                     // First copy operation needs to consider IsAppend
-                    if (!_documentTools.CopyMeshMaterials(sourcePath, currentPath, meshIdx > 0 || dialog.IsAppend))
+                    if (!_documentTools.CopyMeshMaterials(
+                            sourcePath,
+                            currentPath,
+                            meshIdx > 0 || dialog.IsAppend,
+                            true))
                     {
                         failedMeshes.Add(sourcePath);
                     }
@@ -400,7 +404,7 @@ namespace WolvenKit.Views.Documents
             }
 
             var failedMeshes = selected.Where(mesh =>
-                !_documentTools.CopyMeshMaterials(currentPath, mesh, false)
+                !_documentTools.CopyMeshMaterials(currentPath, mesh, false, false)
             ).ToList();
 
             var output = StringHelper.Stringify(selected.Where(s => !failedMeshes.Contains(s)).ToList(), true);

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -317,34 +317,34 @@ namespace WolvenKit.Views.Documents
                 return;
             }
 
+            var selectedOptions = dialog.SelectedOptions;
+            if (dialog.UseArchiveXlPatchMesh)
+            {
+                selectedOptions.Clear();
+                selectedOptions.Add("");
+            }
+            else if (selectedOptions.Count == 0 && dialog.SelectedOption?.EndsWith(".mesh") == true)
+            {
+                selectedOptions.Add(dialog.SelectedOption);
+            }
+
+            if (selectedOptions.Count == 0)
+            {
+                _loggerService.Info("No meshes selected, aborting");
+                _notificationService.Info("No meshes selected, aborting");
+                return;
+            }
+
             try
             {
-                List<string> failedMeshes = [];
-                var meshIdx = 0;
-                foreach (var sourcePath in dialog.SelectedOptions)
-                {
-                    var isAppend = meshIdx > 0 || dialog.IsAppend;
-                    // First copy operation needs to consider IsAppend
-                    if (!_documentTools.CopyMeshMaterials(
-                            sourcePath,
-                            currentPath,
-                            isAppend))
-                    {
-                        failedMeshes.Add(sourcePath);
-                    }
-
-                    meshIdx += 1;
-                }
+                var isDirty = selectedOptions.Aggregate(false,
+                    (current, sourcePath) =>
+                        _documentTools.CopyMeshMaterials(sourcePath, ViewModel.FilePath, dialog.IsAppend) || current);
 
                 // Only reload if we wrote anything
-                if (failedMeshes.Count != dialog.SelectedOptions.Count)
+                if (isDirty)
                 {
                     ViewModel.CurrentTab?.Parent.Reload(true);
-                }
-
-                if (failedMeshes.Count == 0)
-                {
-                    return;
                 }
 
                 if (dialog.UseArchiveXlPatchMesh)

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -324,16 +324,7 @@ namespace WolvenKit.Views.Documents
                 return;
             }
 
-            var selectedOptions = dialog.SelectedOptions;
-            if (dialog.UseArchiveXlPatchMesh)
-            {
-                selectedOptions.Clear();
-                selectedOptions.Add("");
-            }
-            else if (selectedOptions.Count == 0 && dialog.SelectedOption?.EndsWith(".mesh") == true)
-            {
-                selectedOptions.Add(dialog.SelectedOption);
-            }
+            var selectedOptions = dialog.GetAllSelectedOptions();
 
             if (selectedOptions.Count == 0)
             {
@@ -344,9 +335,11 @@ namespace WolvenKit.Views.Documents
 
             try
             {
-                var isDirty = selectedOptions.Aggregate(false,
-                    (current, sourcePath) =>
-                        _documentTools.CopyMeshMaterials(sourcePath, ViewModel.FilePath, dialog.IsAppend) || current);
+                var isDirty = selectedOptions
+                    .Select((sourcePath, index) => (sourcePath, index))
+                    .Aggregate(false, (current, item) =>
+                        _documentTools.CopyMeshMaterials(item.sourcePath, ViewModel.FilePath,
+                            dialog.IsAppend || item.index > 0) || current);
 
                 // Only reload if we wrote anything
                 if (isDirty)

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -318,8 +318,7 @@ namespace WolvenKit.Views.Documents
                     .Distinct()
                     .ToList();
 
-            if (Interactions.ShowCopyMeshAppearancesDialogue(otherMeshFiles) is not { } dialog ||
-                dialog.SelectedOptions.Count == 0)
+            if (Interactions.ShowCopyMeshAppearancesDialogue(otherMeshFiles) is not { } dialog)
             {
                 return;
             }

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -345,6 +345,7 @@ namespace WolvenKit.Views.Documents
                 if (isDirty)
                 {
                     ViewModel.CurrentTab?.Parent.Reload(true);
+                    return;
                 }
 
                 if (dialog.UseArchiveXlPatchMesh)

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -32,3 +32,8 @@ changes:
       pr-number: 2934
       author: "manavortex"
       description: "When generating a radio, the folder in resources will now be created"
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 2883
+      author: "manavortex"
+      description: "'Copy materials from other mesh' now reliably works for multiselect"

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -7,3 +7,8 @@ Template changelog entry:
       description: ""
 
 changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 2917
+      author: "manavortex"
+      description: "'copy materials' logic"


### PR DESCRIPTION
# fix: copy materials from other mesh

### General changes
"Copy materials to/from other mesh(es)" has gotten some love: 
- Added better user feedback via notification service
- Will now consider name collisions (if your mesh already has a material `default`, the material definition will be renamed to `default_1`, and the name will be replaced in all appearances)

#### Copying from: 
- can do multiple meshes now (rather than just one)
- if copying from multiple files, will generate separator appearances 
<img width="1117" height="1219" alt="image" src="https://github.com/user-attachments/assets/12275b67-5450-4ef5-a40c-32a6b068aee1" />



**Additional notes:**
closes #2880
closes #2881 
closes #2879 
