### PR TITLE
publish to nexus and changelog handling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,5 @@
 
 **Additional notes:**
 closes_issue_number
+
+<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,62 @@ jobs:
       ##########################################
       # CHANGELOG
 
-      # compile changelog from !unreleased.yaml
-      - name: Generate changelog
+      - name: Ensure changelog is staged
+        shell: pwsh
         run: |
-          mkdir compiled-changelog
-          pip install pyyaml
-          python ".\tools\compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog\!unreleased.yaml" --out-md "compiled-changelog\CHANGELOG.md" --out-bb "compiled-changelog\CHANGELOG.txt" --changelog "CHANGELOG.md"
+          $branchExists = git ls-remote --exit-code --heads origin changelog-staging
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Changelog branch exists"
+          } else {
+            Write-Host "Changelog branch does not exist, please run stage changelog first"
+            exit 1
+          }
+
+      - name: Checkout changelog branch
+        run: |
+          git fetch origin changelog-staging
+          git checkout changelog-staging
+
+      - name: Read MD Version Changelog
+        id: md_changelog
+        shell: bash
+        run: |
+          {
+            echo 'content<<EOF'
+            cat compiled-changelog/CHANGELOG.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Read BB Version Changelog
+        id: bb_changelog
+        shell: bash
+        run: |
+          {
+            echo 'content<<EOF'
+            cat compiled-changelog/CHANGELOG.txt
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Read History Changelog
+        id: history_changelog
+        shell: bash
+        run: |
+          {
+            echo 'content<<EOF'
+            cat CHANGELOG.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Clean up Branches
+        run: |
+          git checkout main
+          git branch -D changelog-staging
+
+      - name: Write Changelog
+        shell: pwsh
+        env:
+          CHANGELOG: ${{ steps.history_changelog.outputs.content }}
+        run: Set-Content -Path "CHANGELOG.md" -Value $env:CHANGELOG
 
       - name: Name Unreleased
         shell: pwsh
@@ -78,8 +128,7 @@ jobs:
           cd changelog
           Copy-Item -Path "!template.yaml" -Destination "!unreleased.yaml"
 
-      # commit updated changelog
-      - name: Commit and Push
+      - name: Commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -91,11 +140,15 @@ jobs:
         run: git tag -a ${{env.VERSION_APP}} -m "Release ${{env.VERSION_APP}}"
 
       - name: Push changes
-        run: git push origin main --tags
+        run: |
+          git push origin --delete changelog-staging
+          git push origin main --tags
 
       - name: Populate Release Template
         shell: pwsh
-        run: (Get-Content RELEASE.md -Raw) -replace '{CHANGELOG}', (Get-Content compiled-changelog\CHANGELOG.md -Raw) | Set-Content RELEASE.md
+        env:
+          CHANGELOG: ${{ steps.md_changelog.outputs.content }}
+        run: (Get-Content RELEASE.md -Raw) -replace '{CHANGELOG}', $env:CHANGELOG | Set-Content RELEASE.md
 
       ##########################################
       # APP
@@ -159,35 +212,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read bbcode description file
-        id: desc
-        shell: bash
-        run: |
-          {
-            echo 'content<<EOF'
-            cat compiled-changelog/CHANGELOG.txt
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-
       - name: Upload Portable to Nexus Mods
         uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: 0 #TODO: set to correct group once new file is manually uploaded
+          file_group_id: 0 #TODO: update group_id once available
           filename: ${{ env.OUT_DIR }}/${{env.NAME}}-${{env.VERSION_APP}}.zip
           version: ${{env.VERSION_APP}}
           file_category: main
-          description: ${{ steps.desc.outputs.content }}
+          description: ${{ steps.bb_changelog.outputs.content }}
 
       - name: Upload Installer to Nexus Mods
         uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: 0 #TODO: set to correct group once new file is manually uploaded
+          file_group_id: 0 #TODO: update group_id once available
           filename: ${{ env.OUT_DIR }}/${{env.NAME}}Setup-${{env.VERSION_APP}}.exe
           version: ${{env.VERSION_APP}}
           file_category: optional
-          description: ${{ steps.desc.outputs.content }}
+          description: ${{ steps.bb_changelog.outputs.content }}
 
   publish-nugets:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read bbcode description file
+        id: desc
+        shell: bash
+        run: |
+          {
+            echo 'content<<EOF'
+            cat compiled-changelog/CHANGELOG.txt
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload Portable to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.5
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: 0 #TODO: set to correct group once new file is manually uploaded
+          filename: ${{ env.OUT_DIR }}/${{env.NAME}}-${{env.VERSION_APP}}.zip
+          version: ${{env.VERSION_APP}}
+          file_category: main
+          description: ${{ steps.desc.outputs.content }}
+
+      - name: Upload Installer to Nexus Mods
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.5
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_group_id: 0 #TODO: set to correct group once new file is manually uploaded
+          filename: ${{ env.OUT_DIR }}/${{env.NAME}}Setup-${{env.VERSION_APP}}.exe
+          version: ${{env.VERSION_APP}}
+          file_category: optional
+          description: ${{ steps.desc.outputs.content }}
+
   publish-nugets:
     runs-on: windows-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
-name: wkit-draft-release
+name: release
 on:
   workflow_dispatch:
-  push:
-    tags-ignore:
-      - "*-nightly*"
 
 env:
   PROJ: ./WolvenKit/WolvenKit.csproj
@@ -14,7 +11,6 @@ env:
 jobs:
   console-linux:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,9 +31,10 @@ jobs:
     runs-on: windows-latest
     needs: [console-linux]
     env:
-      VERSION_APP: ${{github.ref_name}} # this is the tag on tag push or the branch name on dispatch
       OUT_DIR: ./release
       NAME: WolvenKit
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,24 +46,56 @@ jobs:
       ##########################################
       # VERSIONS
 
-      # the CLI is versioned by its assemblyversion
-      - name: Get console version
-        uses: naminodarie/get-net-sdk-project-versions-action@v2
-        id: get_version_cli
-        with:
-          proj-path: ${{env.PROJC}}
-
-      # get the version for the portable from the tag
-      # only run on dispatch, otherwise the version is taken from the tag
+      # get the version from the app project
       - name: Get app version
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: naminodarie/get-net-sdk-project-versions-action@v2
         id: get_version
         with:
           proj-path: ${{env.PROJ}}
       - name: change version
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        shell: bash
         run: echo "VERSION_APP=${{steps.get_version.outputs.assembly-version}}" >> $GITHUB_ENV
+
+      ##########################################
+      # CHANGELOG
+
+      # compile changelog from !unreleased.yaml
+      - name: Generate changelog
+        run: |
+          mkdir compiled-changelog
+          pip install pyyaml
+          python ".\tools\compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog\!unreleased.yaml" --out-md "compiled-changelog\CHANGELOG.md" --out-bb "compiled-changelog\CHANGELOG.txt" --changelog "CHANGELOG.md"
+
+      - name: Name Unreleased
+        shell: pwsh
+        run: |
+          cd changelog
+          Rename-Item -Path "!unreleased.yaml" -NewName "${{env.VERSION_APP}}.yaml"
+
+      - name: Add Templated Unreleased
+        shell: pwsh
+        run: |
+          cd changelog
+          Copy-Item -Path "!template.yaml" -Destination "!unreleased.yaml"
+
+      # commit updated changelog
+      - name: Commit and Push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git add changelog\*.yaml
+          git commit -m "Update changelog for version ${{env.VERSION_APP}}" || echo "No changes to commit"
+
+      - name: Create Release Tag
+        run: git tag -a ${{env.VERSION_APP}} -m "Release ${{env.VERSION_APP}}"
+
+      - name: Push changes
+        run: git push origin main --tags
+
+      - name: Populate Release Template
+        shell: pwsh
+        run: (Get-Content RELEASE.md -Raw) -replace '{CHANGELOG}', (Get-Content compiled-changelog\CHANGELOG.md -Raw) | Set-Content RELEASE.md
 
       ##########################################
       # APP
@@ -84,7 +113,7 @@ jobs:
 
       ##########################################
       # UNPACKER
-      
+
       # Publish unpacker to .\publish_unpacker
       - name: publish unpacker
         run: dotnet publish ${{env.PROJU}} -o .\publish_unpacker -c Release -p:DebugType=None -p:DebugSymbols=false
@@ -110,33 +139,19 @@ jobs:
 
       # compress portables to OUT_DIR
       - run: Compress-Archive -Path .\publish\* -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}-${{env.VERSION_APP}}.zip
-      - run: Compress-Archive -Path .\publish_cli\* -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}.Console-${{steps.get_version_cli.outputs.assembly-version}}.zip
-      - run: Compress-Archive -Path ".\download\${{env.ARTIFACT_CLI_LIN}}\*" -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}.ConsoleLinux-${{steps.get_version_cli.outputs.assembly-version}}.zip
+      - run: Compress-Archive -Path .\publish_cli\* -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}.Console-${{env.VERSION_APP}}.zip
+      - run: Compress-Archive -Path ".\download\${{env.ARTIFACT_CLI_LIN}}\*" -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}.ConsoleLinux-${{env.VERSION_APP}}.zip
       - run: Compress-Archive -Path .\publish_unpacker\* -DestinationPath ${{ env.OUT_DIR }}/${{env.NAME}}.Unpacker-${{env.VERSION_APP}}.zip
 
       ##########################################
       # RELEASE
-      - name: Release tag
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          generate_release_notes: true
-          body_path: "RELEASE.md"
-          files: |
-            ${{ env.OUT_DIR }}/*.zip
-            ${{ env.OUT_DIR }}/*.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # dispatch release uses the version and not the ref
       - name: Release dispatch
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_APP }}
-          draft: true
-          generate_release_notes: true
+          draft: false
+          generate_release_notes: false
           body_path: "RELEASE.md"
           files: |
             ${{ env.OUT_DIR }}/*.zip
@@ -146,7 +161,6 @@ jobs:
 
   publish-nugets:
     runs-on: windows-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }} # only run on tags that are non-prerelease tags
 
     steps:
       - name: checkout
@@ -161,22 +175,22 @@ jobs:
       - name: Core
         continue-on-error: true
         run: dotnet nuget push .\WolvenKit.Core\nupkg\*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-      
+
       - run: dotnet pack .\WolvenKit.RED4\WolvenKit.RED4.csproj
       - name: RED4
         continue-on-error: true
         run: dotnet nuget push .\WolvenKit.RED4\nupkg\*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-  
+
       - run: dotnet pack .\WolvenKit.Modkit\WolvenKit.Modkit.csproj
       - name: Modkit
         continue-on-error: true
         run: dotnet nuget push .\WolvenKit.Modkit\nupkg\*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-  
+
       - run: dotnet pack .\WolvenKit.CLI\WolvenKit.CLI.csproj
       - name: CLI
         continue-on-error: true
         run: dotnet nuget push .\WolvenKit.CLI\nupkg\*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
-  
+
       - run: dotnet pack .\WolvenKit.Common\WolvenKit.Common.csproj
       - name: Common
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
         uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: 0 #TODO: update group_id once available
+          file_group_id: 2464501
           filename: ${{ env.OUT_DIR }}/${{env.NAME}}-${{env.VERSION_APP}}.zip
           version: ${{env.VERSION_APP}}
           file_category: main
@@ -226,7 +226,7 @@ jobs:
         uses: Nexus-Mods/upload-action@v1.0.0-beta.5
         with:
           api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_group_id: 0 #TODO: update group_id once available
+          file_group_id: 2464504
           filename: ${{ env.OUT_DIR }}/${{env.NAME}}Setup-${{env.VERSION_APP}}.exe
           version: ${{env.VERSION_APP}}
           file_category: optional

--- a/.github/workflows/stage-changelog.yml
+++ b/.github/workflows/stage-changelog.yml
@@ -1,0 +1,50 @@
+name: stage changelog
+on:
+  workflow_dispatch:
+
+env:
+  PROJ: ./WolvenKit/WolvenKit.csproj
+
+jobs:
+  stage-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Cleanup branch
+        run: |
+          git push origin --delete changelog-staging || true
+          git checkout -b changelog-staging
+
+      - name: Get app version
+        uses: naminodarie/get-net-sdk-project-versions-action@v2
+        id: get_version
+        with:
+          proj-path: ${{env.PROJ}}
+
+      - name: Set Version Variable
+        shell: bash
+        run: echo "VERSION_APP=${{steps.get_version.outputs.assembly-version}}" >> $GITHUB_ENV
+
+      - name: Generate changelog
+        run: |
+          mkdir compiled-changelog
+          pip install pyyaml
+          echo ${{env.VERSION_APP}}
+          python "tools/compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog/!unreleased.yaml" --out-md "compiled-changelog/CHANGELOG.md" --out-bb "compiled-changelog/CHANGELOG.txt" --changelog "CHANGELOG.md"
+
+      - name: Commit and Push
+        run: |
+          git add CHANGELOG.md
+          git add compiled-changelog/CHANGELOG.md
+          git add compiled-changelog/CHANGELOG.txt
+          git commit -m "Stage changelog for version ${{env.VERSION_APP}}" || echo "No changes to commit"
+          git push origin changelog-staging

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
-## Notable changes:
-- 
+{CHANGELOG}
+
 ------------------
 
 :question: Wiki: https://wiki.redmodding.org/wolvenkit

--- a/changelog/!template.yaml
+++ b/changelog/!template.yaml
@@ -1,0 +1,11 @@
+Template changelog entry:
+    # pick one
+    - type: "fix | add | change | remove"
+        # pick as many as apply
+      packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+        # your display author name
+      author: ""
+        # user facing change message
+      description: ""
+
+changes:

--- a/changelog/!template.yaml
+++ b/changelog/!template.yaml
@@ -1,7 +1,7 @@
 # Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
 Template changelog entry:
-    - type: "fix | add | change | remove"
-      packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+    - type: "security | deprecated | removed | added | fixed | changed"
+      packages: ["App", "CLI", "Nuget Packages"]
       pr-number: 0
       author: ""
       description: ""

--- a/changelog/!template.yaml
+++ b/changelog/!template.yaml
@@ -1,11 +1,9 @@
+# Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
 Template changelog entry:
-    # pick one
     - type: "fix | add | change | remove"
-        # pick as many as apply
       packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
-        # your display author name
+      pr-number: 0
       author: ""
-        # user facing change message
       description: ""
 
 changes:

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -1,0 +1,11 @@
+Template changelog entry:
+    # pick one
+    - type: "fix | add | change | remove"
+        # pick as many as apply
+      packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+        # your display author name
+      author: ""
+        # user facing change message
+      description: ""
+
+changes:

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -1,7 +1,7 @@
 # Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
 Template changelog entry:
-    - type: "fix | add | change | remove"
-      packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+    - type: "security | deprecated | removed | added | fixed | changed"
+      packages: ["App", "CLI", "Nuget Packages"]
       pr-number: 0
       author: ""
       description: ""

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -1,11 +1,9 @@
+# Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
 Template changelog entry:
-    # pick one
     - type: "fix | add | change | remove"
-        # pick as many as apply
       packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
-        # your display author name
+      pr-number: 0
       author: ""
-        # user facing change message
       description: ""
 
 changes:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,14 @@ export default defineConfig({
         ]
       },
       {
+        text: 'Maintaining',
+        collapsed: false,
+        items: [
+          { text: 'Homepage', link: '/maintaining/home' },
+          { text: 'Release Process', link: '/maintaining/release-process' },
+        ]
+      },
+      {
         text: 'Code Documentation',
         collapsed: false,
         items: [

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,8 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Homepage', link: '/contributing/home' },
+          { text: 'Pull Requests', link: '/contributing/pull-requests' },
+          { text: 'Keep a Changelog', link: '/contributing/keep-changelog' },
         ]
       },
       {

--- a/docs/code-documentation/home.md
+++ b/docs/code-documentation/home.md
@@ -1,5 +1,5 @@
 # Code Documentation
 
-This is a stub for the code documentation homepage, eventually this section will contain information regarding the code structure, code sytle, do's and don't and more.
+This is a stub for the code documentation homepage, eventually this section will contain information regarding the code structure, code style, do's and don't and more.
 
 As of now consider the [developer guide](../DEVELOPER%20GUIDE).

--- a/docs/contributing/home.md
+++ b/docs/contributing/home.md
@@ -1,5 +1,3 @@
 # Contributing
 
-This is a stub for the contributing homepage, eventually this section will contain information regarding the process of contributing including making making PRs, reviewing PRs, opening issues and more.
-
-As of now consider the [exisiting contributing documentation](../CONTRIBUTING), [code of conduct](../CODE_OF_CONDUCT) as well as the [developer guide](../DEVELOPER%20GUIDE).
+This section covers rules and guidelines for contributing to the WolvenKit project.

--- a/docs/contributing/keep-changelog.md
+++ b/docs/contributing/keep-changelog.md
@@ -1,0 +1,31 @@
+# Keep a Changelog
+
+Our changelog rules generally follow [keepachangelog.com](https://keepachangelog.com/en/1.1.0/).
+
+This project keeps the changelog in `.yaml` files within the `changelog` directory. The `!unreleased.yaml` file contains changes that are merged into main but have not been part of a stable release yet. 
+::: info
+This is the file that is modified as part of the pull request process. 
+:::
+::: warning
+`CHANGELOG.md` as well as `{VERSION}.yaml` files are auto generated as part of the release process and should not be manually modified.
+:::
+
+Each changelog entry should be added to the `changes:` array in the `!unreleased.yaml` file where each entry has the follwing structure:
+
+```yaml
+# This can be either `fix`, `add`, `change`, `remove`, or an arbitrary string although in that case it will always be ordered last.
+# Pick one
+- type: "fix | add | change | remove"
+    # List of projects that were affected by the given change. When picking what projects to choose dependencies should be considered,
+    # meaning a pull request introducing changes in e.g. `Core` should also contain the packages `App` and `CLI` as they depend on `Core`.
+    # Pick as many as apply.
+    packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+    # Pull request number associated with this change.
+    pr-number: 0
+    # Authors github username, necessary for proper attribution
+    author: ""
+    # User facing change description
+    description: ""
+```
+
+

--- a/docs/contributing/keep-changelog.md
+++ b/docs/contributing/keep-changelog.md
@@ -2,9 +2,9 @@
 
 Our changelog rules generally follow [keepachangelog.com](https://keepachangelog.com/en/1.1.0/).
 
-This project keeps the changelog in `.yaml` files within the `changelog` directory. The `!unreleased.yaml` file contains changes that are merged into main but have not been part of a stable release yet. 
+This project keeps the changelog in `.yaml` files within the `changelog` directory. The `!unreleased.yaml` file contains changes that are merged into main but have not been part of a stable release yet.
 ::: info
-This is the file that is modified as part of the pull request process. 
+This is the file that is modified as part of the pull request process.
 :::
 ::: warning
 `CHANGELOG.md` as well as `{VERSION}.yaml` files are auto generated as part of the release process and should not be manually modified.
@@ -13,13 +13,13 @@ This is the file that is modified as part of the pull request process.
 Each changelog entry should be added to the `changes:` array in the `!unreleased.yaml` file where each entry has the follwing structure:
 
 ```yaml
-# This can be either `fix`, `add`, `change`, `remove`, or an arbitrary string although in that case it will always be ordered last.
-# Pick one
-- type: "fix | add | change | remove"
-    # List of projects that were affected by the given change. When picking what projects to choose dependencies should be considered,
-    # meaning a pull request introducing changes in e.g. `Core` should also contain the packages `App` and `CLI` as they depend on `Core`.
+# This can be either `security`, `deprecated`, `removed`, `added`, `fixed`, or `changed`.
+# Pick one.
+- type: "security | deprecated | removed | added | fixed | changed"
+    # List of projects that were affected by the given change. Changes in nuget packages should include `App` and `CLI`.
+    # `Core`, `Common`, `RED4` and `Modkit` are considered nuget packages.
     # Pick as many as apply.
-    packages: ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+    packages: ["App", "CLI", "Nuget Packages"]
     # Pull request number associated with this change.
     pr-number: 0
     # Authors github username, necessary for proper attribution
@@ -27,5 +27,7 @@ Each changelog entry should be added to the `changes:` array in the `!unreleased
     # User facing change description
     description: ""
 ```
-
+::: info
+A Pull request can have multiple changelog entries.
+:::
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -1,0 +1,16 @@
+# Pull Requests
+
+## Target Branch
+All pull requests should be branching off of and targeting the main branch.
+
+Any PR branch may be merged into the dev branch (nightly) at any time without review. Once the pull request has been reviewed and merged into the main branch it will be automatically synced into the dev branch (nightly).
+
+## Content
+Pull requests should follow the [code of conduct](../CODE_OF_CONDUCT) as well as the [developer guide](../DEVELOPER%20GUIDE).
+
+Any pull request that contains user relevant changes (for the App and CLI projects that is the end user, for the projects that are also on nuget like Common or ModKit that is the developer using them) must update the changelog under `changelog\!unreleased.yaml`.
+Guidelines for adding to the changelog can be found [here](/contributing/keep-changelog). 
+::: info
+If you are a new contributor and are unsure how to correctly do so feel free to ask and you will be assistet. 
+:::
+

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -9,8 +9,8 @@ Any PR branch may be merged into the dev branch (nightly) at any time without re
 Pull requests should follow the [code of conduct](../CODE_OF_CONDUCT) as well as the [developer guide](../DEVELOPER%20GUIDE).
 
 Any pull request that contains user relevant changes (for the App and CLI projects that is the end user, for the projects that are also on nuget like Common or ModKit that is the developer using them) must update the changelog under `changelog\!unreleased.yaml`.
-Guidelines for adding to the changelog can be found [here](/contributing/keep-changelog). 
+Guidelines for adding to the changelog can be found [here](/contributing/keep-changelog).
 ::: info
-If you are a new contributor and are unsure how to correctly do so feel free to ask and you will be assistet. 
+If you are a new contributor and are unsure how to correctly do so, feel free to ask, and you will be assisted.
 :::
 

--- a/docs/maintaining/home.md
+++ b/docs/maintaining/home.md
@@ -1,0 +1,3 @@
+# Maintaining
+
+This section concerns itself with workflows for maintainers.

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -1,17 +1,26 @@
 # Release Process
 
-Stable releases are done by (or with the permission of) the project lead and are scheduled to be around the first every month.
+Stable releases are done by (or with the permission of) the project lead and are scheduled to be around the first of every month.
 
 Nightly releases get automatically build and released daily when changes on the `dev` branch are present.
 
-## Before Releasing
-Before releasing a new version via the release workflow the following things need to be ensured: 
-1. Project version is correct for the type of release according to semver (if it isn't bump it via the github action)
-2. All relevant change notes are staged in `changelog\!unreleased.yaml`
+## Verify Version
+Ensure the version upgrade conforms to semver in terms of minor and patch, avoid major releases for now.
+If the version needs to be changed run the `bump version` action.
 
-## Releasing 
-To release for all platforms (Nuget Packages, Github, Nexusmods) simply manually trigger the release workflow. It will create a new tag, compile the changelog, build the assets and release them. 
+## Staging the Changelog
+Before running the main `release` workflow `stage changelog` must be run to generate the changelog from the yaml source.
+Once the action is finished the changelog can be viewed in the `changelog-staging` branch, where the `CHANGELOG.md`, `compiled-changelog/CHANGELOG.md`, and `compiled-changelog/CHANGELOG.txt` are saved.
+At this stage the changelog should be verified and can be manually edited if needed.
+::: info
+Edits to the intermediate generated files should only include formatting changes.
+For content changes edit `changelog/!unreleased.yaml` on the main branch and run `stage changelog` again.
+:::
 
-## After Releasing 
-1. Bump the patch version by one (e.g. if the stable release was `8.17.2` bump it to `8.17.3`) for the nightly builds. If at the time of the next stable release it is decided that it is not just a patch bump the version again then. 
-2. Post the changelog from the github release in the `#updates` channel on the redmodding discord with links to all platforms and a ping to the `@Server-Participation` role.
+## Releasing
+To release for all platforms (Nuget Packages, Github, Nexusmods) manually trigger the release workflow. It will create a new tag, read the changelog from the previous step, build all assets and release them.
+
+## Post Release
+Bump the patch version by one (e.g., if the stable release was `8.17.2` bump it to `8.17.3`) for the nightly builds.
+
+Post the changelog from the GitHub release in the `#updates` channel on the redmodding discord with links to all platforms and a ping to the `@Server-Participation` role.

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -1,0 +1,17 @@
+# Release Process
+
+Stable releases are done by (or with the permission of) the project lead and are scheduled to be around the first every month.
+
+Nightly releases get automatically build and released daily when changes on the `dev` branch are present.
+
+## Before Releasing
+Before releasing a new version via the release workflow the following things need to be ensured: 
+1. Project version is correct for the type of release according to semver (if it isn't bump it via the github action)
+2. All relevant change notes are staged in `changelog\!unreleased.yaml`
+
+## Releasing 
+To release for all platforms (Nuget Packages, Github, Nexusmods) simply manually trigger the release workflow. It will create a new tag, compile the changelog, build the assets and release them. 
+
+## After Releasing 
+1. Bump the patch version by one (e.g. if the stable release was `8.17.2` bump it to `8.17.3`) for the nightly builds. If at the time of the next stable release it is decided that it is not just a patch bump the version again then. 
+2. Post the changelog from the github release in the `#updates` channel on the redmodding discord with links to all platforms and a ping to the `@Server-Participation` role.

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -18,7 +18,7 @@ For content changes edit `changelog/!unreleased.yaml` on the main branch and run
 :::
 
 ## Releasing
-To release for all platforms (Nuget Packages, Github, Nexusmods) manually trigger the release workflow. It will create a new tag, read the changelog from the previous step, build all assets and release them.
+To release for all platforms (Nuget Packages, GitHub, NexusMods), manually trigger the release workflow. It will create a new tag, read the changelog from the previous step, build all assets and release them.
 
 ## Post Release
 Bump the patch version by one (e.g., if the stable release was `8.17.2` bump it to `8.17.3`) for the nightly builds.

--- a/docs/meta-documentation/contributing.md
+++ b/docs/meta-documentation/contributing.md
@@ -1,16 +1,16 @@
 # Contributing
 
-This documentation uses [vitepress](https://vitepress.dev/) as such it supports markdown with custom extensions as outlined [here](https://vitepress.dev/guide/markdown).
+This documentation uses [vitepress](https://vitepress.dev/) as such it supports Markdown with custom extensions as outlined [here](https://vitepress.dev/guide/markdown).
 
 ::: warning
-`/docs/CODE_OF_CONDUCT.md`, `/docs/CONTRIBUTING.md` and `/docs/DEVELOPER GUIDE.md` are also served via the GitHub UI and as such should only contain GitHub compatible markdown. Documentation on GitHubs markdown flavor can be found [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+`/docs/CODE_OF_CONDUCT.md`, `/docs/CONTRIBUTING.md` and `/docs/DEVELOPER GUIDE.md` are also served via the GitHub UI and as such should only contain GitHub compatible Markdown. Documentation on GitHub Markdown flavor can be found [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 :::
 
 ### Writing Changes
 
-To write changes modify the markdown files in `/docs` and follow the regular pull request process to merge the changes into the main branch.
+To write changes, modify the Markdown files in `/docs` and follow the regular pull request process to merge the changes into the main branch.
 
-Once the changes are merged the site will be auto deployed.
+Once the changes are merged, the site will be auto-deployed.
 
 ::: warning
 When creating, renaming, moving or deleting files the sidebar config in `/docs/.vitepress/config.mts` should reflect the change.
@@ -18,7 +18,7 @@ When creating, renaming, moving or deleting files the sidebar config in `/docs/.
 
 ### Viewing Changes Locally
 
-To view changes locally run the following in a command line interface from the root of the repository.
+To view changes locally, run the following in a command line interface from the root of the repository.
 
 ```bash
 cd docs
@@ -29,5 +29,5 @@ npm run docs:dev
 This will install and run a vitepress instance on your localhost which reflects changes made as the files are saved.
 
 ::: info
-Viewing changes locally before opening a pull request is strongly recommended as it significantly reduces the chance of broken formatting going live. 
+Viewing changes locally before opening a pull request is strongly recommended as it significantly reduces the chance of broken formatting going live.
 :::

--- a/docs/meta-documentation/home.md
+++ b/docs/meta-documentation/home.md
@@ -1,3 +1,4 @@
 # Meta Documentation
 
-This is a stub for the meta documentation homepage, eventually this section will contain information regarding the layout, procedures and expectations for updating this wiki.
+This is a stub for the meta-documentation homepage; eventually this section will contain information regarding the layout, procedures and expectations for updating this wiki.
+Currently, it only contains a quick overview over the technical aspects of contribution.

--- a/tools/compile_changelog.py
+++ b/tools/compile_changelog.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+compile_changelog.py
+
+Compiles changelog/!unreleased.yaml into:
+  1. Appends a new versioned section to changelog.md
+  2. Writes current-changelog.md  (Markdown)
+  3. Writes current-changelog.txt (BBCode)
+
+Usage:
+    python compile_changelog.py --release 1.2.3
+    python compile_changelog.py --release 1.2.3 \
+        --input changelog/!unreleased.yaml \
+        --changelog changelog.md \
+        --out-md current-changelog.md \
+        --out-bb current-changelog.txt
+"""
+
+import argparse
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        "PyYAML is required.  Install it with:  pip install pyyaml"
+    )
+
+# ── canonical ordering ────────────────────────────────────────────────────────
+TYPE_ORDER = ["add", "change", "fix", "remove"]
+TYPE_LABELS = {
+    "add":    "Added",
+    "change": "Changed",
+    "fix":    "Fixed",
+    "remove": "Removed",
+}
+
+PACKAGE_ORDER = ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def load_changes(yaml_path: Path) -> list[dict]:
+    """Load and validate the unreleased YAML file."""
+    with yaml_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    if not data or not isinstance(data, dict):
+        sys.exit(f"ERROR: {yaml_path} is empty or not a valid YAML mapping.")
+
+    changes = data.get("changes") or []
+    if not changes:
+        print(f"WARNING: No changes found in {yaml_path}.  Output files will be empty sections.")
+    return changes
+
+
+def group_changes(changes: list[dict]) -> dict:
+    """
+    Returns a nested dict:
+        { package -> { type -> [ {description, author}, … ] } }
+    Entries without a package go under the sentinel key None.
+    """
+    grouped: dict = defaultdict(lambda: defaultdict(list))
+
+    for entry in changes:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type", "")).strip().lower()
+        packages   = entry.get("packages") or [None]
+        author     = str(entry.get("author", "")).strip()
+        description = str(entry.get("description", "")).strip()
+
+        if not description:
+            continue
+
+        for pkg in packages:
+            pkg_key = str(pkg).strip() if pkg else None
+            grouped[pkg_key][entry_type].append(
+                {"description": description, "author": author}
+            )
+
+    return grouped
+
+
+def ordered_packages(grouped: dict) -> list:
+    """Return packages in canonical order; unknowns appended alphabetically."""
+    known   = [p for p in PACKAGE_ORDER if p in grouped]
+    unknown = sorted(p for p in grouped if p not in PACKAGE_ORDER and p is not None)
+    no_pkg  = [None] if None in grouped else []
+    return known + unknown + no_pkg
+
+
+def ordered_types(type_dict: dict) -> list:
+    """Return change types in canonical order; unknowns appended."""
+    known   = [t for t in TYPE_ORDER if t in type_dict]
+    unknown = sorted(t for t in type_dict if t not in TYPE_ORDER)
+    return known + unknown
+
+
+# ── Markdown builder ──────────────────────────────────────────────────────────
+
+def build_markdown(version: str, grouped: dict) -> str:
+    lines = [f"## {version} — {date.today().isoformat()}", ""]
+
+    for pkg in ordered_packages(grouped):
+        pkg_label = pkg if pkg else "General"
+        lines.append(f"### {pkg_label}")
+        lines.append("")
+
+        for t in ordered_types(grouped[pkg]):
+            type_label = TYPE_LABELS.get(t, t.capitalize())
+            lines.append(f"#### {type_label}")
+            lines.append("")
+            for item in grouped[pkg][t]:
+                author = item["author"]
+                desc   = item["description"]
+                bullet = f"* {desc}"
+                if author:
+                    bullet += f" by @{author}"
+                lines.append(bullet)
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── BBCode builder ────────────────────────────────────────────────────────────
+
+def build_bbcode(version: str, grouped: dict) -> str:
+    lines = [
+        f"[b]{version} — {date.today().isoformat()}[/b]",
+        ""
+    ]
+
+    for pkg in ordered_packages(grouped):
+        pkg_label = pkg if pkg else "General"
+        lines.append(f"[b]{pkg_label}[/b]")
+        lines.append("")
+
+        for t in ordered_types(grouped[pkg]):
+            type_label = TYPE_LABELS.get(t, t.capitalize())
+            lines.append(f"[i]{type_label}[/i]")
+            lines.append("")
+            for item in grouped[pkg][t]:
+                author = item["author"]
+                desc   = item["description"]
+                bullet = f"[*] {desc}"
+                if author:
+                    bullet += f" by @{author}"
+                lines.append(bullet)
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── file I/O ──────────────────────────────────────────────────────────────────
+
+def prepend_to_changelog(changelog_path: Path, section: str) -> None:
+    """Prepend the new version section to the top of changelog.md."""
+    existing = ""
+    if changelog_path.exists():
+        existing = changelog_path.read_text(encoding="utf-8")
+
+    separator = "\n\n---\n\n" if existing.strip() else ""
+    changelog_path.write_text(section + separator + existing, encoding="utf-8")
+    print(f"  [ok] Updated  {changelog_path}")
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    print(f"  [ok] Wrote    {path}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Compile changelog/unreleased.yaml into versioned Markdown & BBCode."
+    )
+    p.add_argument(
+        "--release", "-r",
+        required=True,
+        help="Release version string, e.g. 1.2.3",
+    )
+    p.add_argument(
+        "--input", "-i",
+        default="changelog/!unreleased.yaml",
+        help="Path to unreleased.yaml  (default: changelog/unreleased.yaml)",
+    )
+    p.add_argument(
+        "--changelog", "-c",
+        default="changelog.md",
+        help="Path to the running changelog.md  (default: changelog.md)",
+    )
+    p.add_argument(
+        "--out-md",
+        default="current-changelog.md",
+        help="Output path for current-changelog.md  (default: current-changelog.md)",
+    )
+    p.add_argument(
+        "--out-bb",
+        default="current-changelog.txt",
+        help="Output path for current-changelog.txt  (default: current-changelog.txt)",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    version = args.release.strip()
+
+    input_path     = Path(args.input)
+    changelog_path = Path(args.changelog)
+    out_md_path    = Path(args.out_md)
+    out_bb_path    = Path(args.out_bb)
+
+    if not input_path.exists():
+        sys.exit(f"ERROR: Input file not found: {input_path}")
+
+    print(f"\nCompiling changelog for version {version} …\n")
+
+    changes = load_changes(input_path)
+    grouped = group_changes(changes)
+
+    md_section = build_markdown(version, grouped)
+    bb_section = build_bbcode(version, grouped)
+
+    prepend_to_changelog(changelog_path, md_section)
+    write_file(out_md_path, md_section)
+    write_file(out_bb_path, bb_section)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compile_changelog.py
+++ b/tools/compile_changelog.py
@@ -30,13 +30,7 @@ except ImportError:
     )
 
 # ── canonical ordering ────────────────────────────────────────────────────────
-TYPE_ORDER = ["add", "change", "fix", "remove"]
-TYPE_LABELS = {
-    "add":    "Added",
-    "change": "Changed",
-    "fix":    "Fixed",
-    "remove": "Removed",
-}
+TYPE_ORDER = ["security", "deprecated", "removed", "added", "fixed", "changed"]
 
 PACKAGE_ORDER = ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
 
@@ -107,21 +101,20 @@ def build_markdown(version: str, grouped: dict) -> str:
 
     for pkg in ordered_packages(grouped):
         pkg_label = pkg if pkg else "General"
-        lines.append(f"### {pkg_label}")
+        lines.append(f"**{pkg_label}**")
         lines.append("")
 
         for t in ordered_types(grouped[pkg]):
-            type_label = TYPE_LABELS.get(t, t.capitalize())
-            lines.append(f"#### {type_label}")
-            lines.append("")
+            type_label = t.capitalize()
             for item in grouped[pkg][t]:
                 author = item["author"]
                 desc   = item["description"]
-                bullet = f"* {desc}"
+                bullet = f"* *{type_label}*: {desc}"
                 if author:
                     bullet += f" by @{author}"
                 lines.append(bullet)
-            lines.append("")
+
+        lines.append("")
 
     return "\n".join(lines)
 
@@ -140,17 +133,16 @@ def build_bbcode(version: str, grouped: dict) -> str:
         lines.append("")
 
         for t in ordered_types(grouped[pkg]):
-            type_label = TYPE_LABELS.get(t, t.capitalize())
-            lines.append(f"[i]{type_label}[/i]")
-            lines.append("")
+            type_label = t.capitalize()
             for item in grouped[pkg][t]:
                 author = item["author"]
                 desc   = item["description"]
-                bullet = f"[*] {desc}"
+                bullet = f"[*] [i]{type_label}[/i]: {desc}"
                 if author:
                     bullet += f" by @{author}"
                 lines.append(bullet)
-            lines.append("")
+
+        lines.append("")
 
     return "\n".join(lines)
 

--- a/tools/compile_changelog.py
+++ b/tools/compile_changelog.py
@@ -32,7 +32,7 @@ except ImportError:
 # ── canonical ordering ────────────────────────────────────────────────────────
 TYPE_ORDER = ["security", "deprecated", "removed", "added", "fixed", "changed"]
 
-PACKAGE_ORDER = ["App", "CLI", "Core", "Common", "ModKit", "RED4"]
+PACKAGE_ORDER = ["App", "CLI", "Nuget Packages"]
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# publish to nexus and changelog handling
**Implemented:**
- publishing to nexus via the publish workflow 
    - waiting on @rfuzzo to upload the current release to nexus so it generates a group_id for the api, and to provide a nexusmods api key in the repo secrets
- release github action no longer creates a github draft release (as neither nugets nor nexusmods support it)
- release github action no longer triggers on tag pushes, instead it is manually dispatched and creates a new tag based on the app assembly version
- changelog compilation
   - devs add changes to `changelog\!unreleased.yaml` following the template
   - as part of the release action the changelog gets compiled into a user facing format and used as the release notes for the github and nexusmods release as well as getting appended to `CHANGELOG.md`
- documentation on the developer docs regarding the aforementioned changes 

Release notes on github and nexusmods will look as follows:
<img width="1156" height="1078" alt="image" src="https://github.com/user-attachments/assets/cac8a281-01a5-4650-a3bc-a7a6d052cd04" />
<img width="1075" height="929" alt="image" src="https://github.com/user-attachments/assets/5e01471a-51c6-433f-beca-7073137d9a40" />
