### PR TITLE
WIP: improve quest and scene editor perfomance

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/LazyQuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/LazyQuestPhaseGraphViewModel.cs
@@ -1,0 +1,51 @@
+using WolvenKit.App.Factories;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.App.ViewModels.Documents;
+
+public class LazyQuestPhaseGraphViewModel : RedDocumentTabViewModel
+{
+    private readonly questQuestPhaseResource _data;
+    private readonly IChunkViewmodelFactory _chunkViewmodelFactory;
+    private readonly INodeWrapperFactory _nodeWrapperFactory;
+    private bool _isMaterializing;
+
+    public LazyQuestPhaseGraphViewModel(
+        questQuestPhaseResource data,
+        RedDocumentViewModel parent,
+        IChunkViewmodelFactory chunkViewmodelFactory,
+        INodeWrapperFactory nodeWrapperFactory)
+        : base(parent, "Quest Phase Editor")
+    {
+        _data = data;
+        _chunkViewmodelFactory = chunkViewmodelFactory;
+        _nodeWrapperFactory = nodeWrapperFactory;
+    }
+
+    public override ERedDocumentItemType DocumentItemType => ERedDocumentItemType.MainFile;
+
+    public override RedDocumentItemType GetContentType() => RedDocumentItemType.Questphase;
+
+    public override void Load()
+    {
+        if (_isMaterializing)
+        {
+            return;
+        }
+
+        var index = Parent.TabItemViewModels.IndexOf(this);
+        if (index < 0)
+        {
+            return;
+        }
+
+        _isMaterializing = true;
+
+        var materialized = new QuestPhaseGraphViewModel(_data, Parent, _chunkViewmodelFactory, _nodeWrapperFactory, FilePath);
+
+        Parent.TabItemViewModels[index] = materialized;
+        Parent.SelectedIndex = index;
+        Parent.SelectedTabItemViewModel = materialized;
+    }
+}

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
@@ -55,9 +55,14 @@ namespace WolvenKit.App.ViewModels.Documents
         
         public int TotalInplacePhases => _questPhaseData.InplacePhases?.Count ?? 0;
 
-        public QuestPhaseGraphViewModel(questQuestPhaseResource data, RedDocumentViewModel parent, IChunkViewmodelFactory chunkViewmodelFactory, INodeWrapperFactory nodeWrapperFactory)
+        public QuestPhaseGraphViewModel(questQuestPhaseResource data, RedDocumentViewModel parent, IChunkViewmodelFactory chunkViewmodelFactory, INodeWrapperFactory nodeWrapperFactory, string? graphFilePath = null)
             : base(parent, "Quest Phase Editor")
         {
+            if (!string.IsNullOrWhiteSpace(graphFilePath))
+            {
+                FilePath = graphFilePath;
+            }
+
             _questPhaseData = data;
             
             var appViewModel = Locator.Current.GetService<AppViewModel>() ?? throw new ArgumentNullException(nameof(AppViewModel));
@@ -65,6 +70,7 @@ namespace WolvenKit.App.ViewModels.Documents
             var gameController = Locator.Current.GetService<IGameControllerFactory>() ?? throw new ArgumentNullException(nameof(IGameControllerFactory));
 
             RDTViewModel = new RDTDataViewModel(data, parent, appViewModel, chunkViewmodelFactory, settingsManager, gameController);
+            RDTViewModel.FilePath = FilePath;
             
             // Create MainGraph - handle cases where graph might be null
             try
@@ -75,6 +81,7 @@ namespace WolvenKit.App.ViewModels.Documents
                     
                     // Set document reference for property change syncing
                     MainGraph.DocumentViewModel = parent;
+                    ApplyGraphStateIdentity(MainGraph, graphFilePath);
 
                     // Ensure all nodes have DocumentViewModel reference for dirty tracking
                     foreach (var node in MainGraph.Nodes)
@@ -88,6 +95,7 @@ namespace WolvenKit.App.ViewModels.Documents
                     // Create an empty graph as fallback
                     MainGraph = new RedGraph(parent.Header, data);
                     MainGraph.DocumentViewModel = parent;
+                    ApplyGraphStateIdentity(MainGraph, graphFilePath);
                 }
             }
             catch (Exception ex)
@@ -96,6 +104,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 // Create an empty graph as fallback
                 MainGraph = new RedGraph(parent.Header, data);
                 MainGraph.DocumentViewModel = parent;
+                ApplyGraphStateIdentity(MainGraph, graphFilePath);
             }
 
             // Initialize navigation history with the main graph
@@ -110,6 +119,16 @@ namespace WolvenKit.App.ViewModels.Documents
             {
                 UpdateTabContent(SelectedTab);
             }
+        }
+
+        private void ApplyGraphStateIdentity(RedGraph graph, string? graphFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(graphFilePath))
+            {
+                return;
+            }
+
+            graph.StateParents = RedGraph.CreateStateSuffix("embedded", graphFilePath);
         }
 
         public void SetGraphLoaded()
@@ -264,4 +283,4 @@ namespace WolvenKit.App.ViewModels.Documents
             Dispose(false);
         }
     }
-} 
+}

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -272,7 +272,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
             .FirstOrDefault(x => x.DocumentItemType == ERedDocumentItemType.MainFile);
     }
 
-    protected void AddTabForRedType(RedBaseClass cls)
+    protected void AddTabForRedType(RedBaseClass cls, bool lazyEmbeddedGraphTabs = false, string? tabFilePath = null)
     {
         if (cls is CBitmapTexture xbm)
         {
@@ -341,10 +341,13 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
         if (cls is questQuestPhaseResource questPhaseResource)
         {
-            var combinedQuestPhaseTab = new QuestPhaseGraphViewModel(questPhaseResource, this, _chunkViewmodelFactory, _nodeWrapperFactory);
+            RedDocumentTabViewModel combinedQuestPhaseTab = lazyEmbeddedGraphTabs
+                ? new LazyQuestPhaseGraphViewModel(questPhaseResource, this, _chunkViewmodelFactory, _nodeWrapperFactory)
+                : new QuestPhaseGraphViewModel(questPhaseResource, this, _chunkViewmodelFactory, _nodeWrapperFactory);
+            combinedQuestPhaseTab.FilePath = tabFilePath ?? combinedQuestPhaseTab.FilePath;
             TabItemViewModels.Insert(0, combinedQuestPhaseTab);
 
-            if (_globals.Value.ENABLE_NODE_EDITOR)
+            if (_globals.Value.ENABLE_NODE_EDITOR && !lazyEmbeddedGraphTabs)
             {
                 TabItemViewModels.Add(new RDTGraphViewModel2(questPhaseResource, this, _nodeWrapperFactory));
             }
@@ -424,7 +427,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
                 vm.IsEmbeddedFile = true;
 
                 TabItemViewModels.Add(vm);
-                AddTabForRedType(file.Content);
+                AddTabForRedType(file.Content, true, vm.FilePath);
             }
         }
 
@@ -505,7 +508,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
             vm.IsEmbeddedFile = true;
 
             TabItemViewModels.Add(vm);
-            AddTabForRedType(file.Content);
+            AddTabForRedType(file.Content, true, vm.FilePath);
         }
     }
 

--- a/WolvenKit.App/ViewModels/GraphEditor/NodeViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/NodeViewModel.cs
@@ -51,6 +51,30 @@ public abstract partial class NodeViewModel : ObservableObject, IDisposable
     public ObservableCollection<InputConnectorViewModel> Input { get; } = new();
     public ObservableCollection<OutputConnectorViewModel> Output { get; } = new();
 
+    private static readonly ObservableCollection<InputConnectorViewModel> EmptyInput = new();
+    private static readonly ObservableCollection<OutputConnectorViewModel> EmptyOutput = new();
+
+    private bool _isLowDetail;
+    public bool IsLowDetail
+    {
+        get => _isLowDetail;
+        set
+        {
+            if (_isLowDetail == value)
+            {
+                return;
+            }
+
+            _isLowDetail = value;
+            OnPropertyChanged(nameof(IsLowDetail));
+            OnPropertyChanged(nameof(DisplayInput));
+            OnPropertyChanged(nameof(DisplayOutput));
+        }
+    }
+
+    public ObservableCollection<InputConnectorViewModel> DisplayInput => IsLowDetail ? EmptyInput : Input;
+    public ObservableCollection<OutputConnectorViewModel> DisplayOutput => IsLowDetail ? EmptyOutput : Output;
+
     [ObservableProperty]
     private bool _showUnusedSockets = true;
 
@@ -205,6 +229,9 @@ public abstract partial class NodeViewModel : ObservableObject, IDisposable
         // Ensure the Node Properties panel reflects the latest socket list
         if (propertyName is nameof(Input) or nameof(Output))
         {
+            OnPropertyChanged(nameof(DisplayInput));
+            OnPropertyChanged(nameof(DisplayOutput));
+
             // Notify that underlying data may have changed to refresh property panel bindings
             OnPropertyChanged(nameof(Data));
 

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -47,8 +47,7 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
             details.Add("Phase Resource", Path.GetFileName(_castedData.PhaseResource.DepotPath.GetResolvedText())!);
         }
         
-        // Add node count for the phase
-        var nodeCount = GetPhaseNodeCount();
+        var nodeCount = GetInlinePhaseNodeCount();
         if (nodeCount > 0)
         {
             details.Add("Total Nodes", nodeCount.ToString());
@@ -145,31 +144,13 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
     /// <summary>
     /// Get the total count of nodes in this phase graph
     /// </summary>
-    private int GetPhaseNodeCount()
+    private int GetInlinePhaseNodeCount()
     {
-        // Check embedded graph first
         if (_castedData.PhaseGraph?.Chunk != null)
         {
             return _castedData.PhaseGraph.Chunk.Nodes?.Count ?? 0;
         }
-        
-        // Check external phase resource
-        if (_castedData.PhaseResource.DepotPath != ResourcePath.Empty)
-        {
-            try
-            {
-                var cr2w = _archiveManager.GetCR2WFile(_castedData.PhaseResource.DepotPath);
-                if (cr2w is { RootChunk: questQuestPhaseResource res } && res.Graph?.Chunk != null)
-                {
-                    return res.Graph.Chunk.Nodes?.Count ?? 0;
-                }
-            }
-            catch (Exception)
-            {
-                // Silently fail if we can't load the resource
-            }
-        }
-        
+
         return 0;
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -34,6 +34,19 @@ public partial class RedGraph : IDisposable
 {
     private const double FallbackLayoutNodeWidth = 220;
     private const double FallbackLayoutNodeHeight = 70;
+    private const double DefaultLayoutNodeSeparation = 10;
+    private const double DefaultLayoutLayerSeparation = 30;
+    private const double EstimatedLayoutNodeSeparation = 40;
+    private const double EstimatedLayoutLayerSeparation = 70;
+    private const double EstimatedLayoutNodeMinWidth = 420;
+    private const double EstimatedLayoutNodeMaxWidth = 680;
+    private const double EstimatedLayoutNodeMinHeight = 120;
+    private const double EstimatedLayoutNodeMaxHeight = 720;
+    private const double EstimatedLayoutNodeBaseHeight = 82;
+    private const double EstimatedLayoutNodeHorizontalPadding = 96;
+    private const double EstimatedLayoutTextCharacterWidth = 7.2;
+    private const double EstimatedLayoutDetailRowHeight = 22;
+    private const double EstimatedLayoutSocketRowHeight = 18;
 
     private IRedType _data;
 
@@ -293,9 +306,9 @@ public partial class RedGraph : IDisposable
     {
         if (nodes.Count > 0 && Editor != null)
         {
-            if (nodes[0] is not NodeViewModel nvm)
+            if (nodes.OfType<NodeViewModel>().FirstOrDefault() is not { } nvm)
             {
-                throw new Exception();
+                return;
             }
 
             Editor.ViewportZoom = 1;
@@ -321,6 +334,7 @@ public partial class RedGraph : IDisposable
 
         // Extra height for external node ID (font + margin + padding)
         const double nodeIdExtraHeight = 35;
+        var hasEstimatedLayoutNodes = Nodes.Any(ShouldUseEstimatedLayoutSize);
 
         foreach (var node in Nodes)
         {
@@ -343,6 +357,8 @@ public partial class RedGraph : IDisposable
         var settings = new SugiyamaLayoutSettings
         {
             Transformation = PlaneTransformation.Rotation(Math.PI / 2),
+            NodeSeparation = hasEstimatedLayoutNodes ? EstimatedLayoutNodeSeparation : DefaultLayoutNodeSeparation,
+            LayerSeparation = hasEstimatedLayoutNodes ? EstimatedLayoutLayerSeparation : DefaultLayoutLayerSeparation,
             EdgeRoutingSettings = { EdgeRoutingMode = EdgeRoutingMode.Spline }
         };
 
@@ -375,11 +391,69 @@ public partial class RedGraph : IDisposable
         return new System.Windows.Rect(minX, minY, maxX - minX, maxY - minY);
     }
 
-    private static double GetLayoutNodeWidth(NodeViewModel node) =>
-        IsValidLayoutDimension(node.Size.Width) ? node.Size.Width : FallbackLayoutNodeWidth;
+    private static double GetLayoutNodeWidth(NodeViewModel node)
+    {
+        if (!ShouldUseEstimatedLayoutSize(node))
+        {
+            return node.Size.Width;
+        }
 
-    private static double GetLayoutNodeHeight(NodeViewModel node) =>
-        IsValidLayoutDimension(node.Size.Height) ? node.Size.Height : FallbackLayoutNodeHeight;
+        return EstimateLayoutNodeWidth(node);
+    }
+
+    private static double GetLayoutNodeHeight(NodeViewModel node)
+    {
+        if (!ShouldUseEstimatedLayoutSize(node))
+        {
+            return node.Size.Height;
+        }
+
+        return EstimateLayoutNodeHeight(node);
+    }
+
+    private static bool ShouldUseEstimatedLayoutSize(NodeViewModel node) =>
+        node.IsLowDetail
+        || !IsValidLayoutDimension(node.Size.Width)
+        || !IsValidLayoutDimension(node.Size.Height);
+
+    private static double EstimateLayoutNodeWidth(NodeViewModel node)
+    {
+        var longestTextLength = node.Title?.Length ?? 0;
+
+        foreach (var (key, value) in node.Details)
+        {
+            longestTextLength = Math.Max(longestTextLength, (key?.Length ?? 0) + (value?.Length ?? 0) + 2);
+        }
+
+        foreach (var connector in node.Input.Concat<BaseConnectorViewModel>(node.Output))
+        {
+            longestTextLength = Math.Max(longestTextLength, connector.Title?.Length ?? connector.Name?.Length ?? 0);
+        }
+
+        var estimatedWidth = EstimatedLayoutNodeHorizontalPadding + longestTextLength * EstimatedLayoutTextCharacterWidth;
+        return Math.Clamp(
+            Math.Max(estimatedWidth, FallbackLayoutNodeWidth),
+            EstimatedLayoutNodeMinWidth,
+            EstimatedLayoutNodeMaxWidth);
+    }
+
+    private static double EstimateLayoutNodeHeight(NodeViewModel node)
+    {
+        var visibleInputCount = node.Input.Count(connector => connector.IsVisible);
+        var visibleOutputCount = node.Output.Count(connector => connector.IsVisible);
+        var socketRows = Math.Max(visibleInputCount, visibleOutputCount);
+        var detailRows = node.Details.Count;
+
+        var estimatedHeight = EstimatedLayoutNodeBaseHeight
+                              + Math.Max(
+                                  detailRows * EstimatedLayoutDetailRowHeight,
+                                  socketRows * EstimatedLayoutSocketRowHeight);
+
+        return Math.Clamp(
+            Math.Max(estimatedHeight, FallbackLayoutNodeHeight),
+            EstimatedLayoutNodeMinHeight,
+            EstimatedLayoutNodeMaxHeight);
+    }
 
     private static bool IsValidLayoutDimension(double value) => value > 0 && double.IsFinite(value);
 

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Msagl.Core.Geometry.Curves;
@@ -99,6 +101,34 @@ public partial class RedGraph : IDisposable
         ItemsDragCompletedCommand = new RelayCommand(ItemsDragCompleted);
 
         _loggerService = Locator.Current.GetService<ILoggerService>();
+    }
+
+    public static string CreateStateSuffix(string prefix, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "";
+        }
+
+        var normalizedValue = value.Replace('\\', '/');
+        var name = Path.GetFileNameWithoutExtension(normalizedValue);
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = "graph";
+        }
+
+        var hash = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(normalizedValue.ToLowerInvariant())))[..12].ToLowerInvariant();
+        return $".{CreateSafeStateSegment(prefix)}.{CreateSafeStateSegment(name)}.{hash}";
+    }
+
+    private static string CreateSafeStateSegment(string value)
+    {
+        var safeChars = value
+            .Select(ch => char.IsLetterOrDigit(ch) || ch is '_' or '-' ? ch : '_')
+            .ToArray();
+
+        var safeValue = new string(safeChars).Trim('_');
+        return string.IsNullOrWhiteSpace(safeValue) ? "graph" : safeValue;
     }
 
     public void Connect()

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -32,6 +32,9 @@ public enum RedGraphType
 
 public partial class RedGraph : IDisposable
 {
+    private const double FallbackLayoutNodeWidth = 220;
+    private const double FallbackLayoutNodeHeight = 70;
+
     private IRedType _data;
 
     private uint _currentSceneNodeId;
@@ -321,8 +324,9 @@ public partial class RedGraph : IDisposable
 
         foreach (var node in Nodes)
         {
-            var layoutHeight = node.Size.Height + nodeIdExtraHeight;
-            var msaglNode = new Node(CurveFactory.CreateRectangle(node.Size.Width, layoutHeight, new Microsoft.Msagl.Core.Geometry.Point()))
+            var layoutWidth = GetLayoutNodeWidth(node);
+            var layoutHeight = GetLayoutNodeHeight(node) + nodeIdExtraHeight;
+            var msaglNode = new Node(CurveFactory.CreateRectangle(layoutWidth, layoutHeight, new Microsoft.Msagl.Core.Geometry.Point()))
             {
                 UserData = node
             };
@@ -353,20 +357,31 @@ public partial class RedGraph : IDisposable
         foreach (var node in graph.Nodes)
         {
             var nvm = (NodeViewModel)node.UserData;
+            var layoutWidth = GetLayoutNodeWidth(nvm);
+            var layoutHeight = GetLayoutNodeHeight(nvm);
+
             // Offset the Y position to account for the extra height added for node ID spacing
             nvm.Location = new System.Windows.Point(
-                node.Center.X - graph.BoundingBox.Center.X - (nvm.Size.Width / 2) + xOffset,
-                node.Center.Y - graph.BoundingBox.Center.Y - (nvm.Size.Height / 2) + yOffset + (nodeIdExtraHeight / 2));
+                node.Center.X - graph.BoundingBox.Center.X - (layoutWidth / 2) + xOffset,
+                node.Center.Y - graph.BoundingBox.Center.Y - (layoutHeight / 2) + yOffset + (nodeIdExtraHeight / 2));
 
             // Calculate bounds including the node ID space
-            maxX = Math.Max(maxX, nvm.Location.X + nvm.Size.Width);
+            maxX = Math.Max(maxX, nvm.Location.X + layoutWidth);
             minX = Math.Min(minX, nvm.Location.X);
-            maxY = Math.Max(maxY, nvm.Location.Y + nvm.Size.Height + nodeIdExtraHeight);
+            maxY = Math.Max(maxY, nvm.Location.Y + layoutHeight + nodeIdExtraHeight);
             minY = Math.Min(minY, nvm.Location.Y - nodeIdExtraHeight);
         }
 
         return new System.Windows.Rect(minX, minY, maxX - minX, maxY - minY);
     }
+
+    private static double GetLayoutNodeWidth(NodeViewModel node) =>
+        IsValidLayoutDimension(node.Size.Width) ? node.Size.Width : FallbackLayoutNodeWidth;
+
+    private static double GetLayoutNodeHeight(NodeViewModel node) =>
+        IsValidLayoutDimension(node.Size.Height) ? node.Size.Height : FallbackLayoutNodeHeight;
+
+    private static bool IsValidLayoutDimension(double value) => value > 0 && double.IsFinite(value);
 
     public void GraphStateLoad()
     {

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -1322,9 +1322,9 @@ namespace WolvenKit.Views.Documents
                 subGraph.DocumentViewModel ??= QuestPhaseGraphEditor?.Source.DocumentViewModel;
 
                 // Handle quest phase node state tracking
-                if (selectedNode.Data is questPhaseNodeDefinition { PhaseResource.IsSet: false } ph)
+                if (selectedNode.Data is questPhaseNodeDefinition ph)
                 {
-                    subGraph.StateParents = QuestPhaseGraphEditor?.Source.StateParents + "." + ph.Id;
+                    subGraph.StateParents = (QuestPhaseGraphEditor?.Source.StateParents ?? "") + GetPhaseNodeStateSuffix(ph);
                     subGraph.DocumentViewModel = QuestPhaseGraphEditor?.Source.DocumentViewModel;
                 }
 
@@ -1371,6 +1371,21 @@ namespace WolvenKit.Views.Documents
                     }), DispatcherPriority.Loaded);
                 }
             }
+        }
+
+        private static string GetPhaseNodeStateSuffix(questPhaseNodeDefinition phaseNode)
+        {
+            if (!phaseNode.PhaseResource.IsSet)
+            {
+                return "." + phaseNode.Id;
+            }
+
+            var depotPath = phaseNode.PhaseResource.DepotPath;
+            var stateValue = depotPath.IsResolvable
+                ? depotPath.GetResolvedText()!
+                : ((ulong)depotPath).ToString();
+
+            return RedGraph.CreateStateSuffix("phaseResource", stateValue);
         }
 
         /// <summary>

--- a/WolvenKit/Views/Documents/RDTGraphView2.xaml.cs
+++ b/WolvenKit/Views/Documents/RDTGraphView2.xaml.cs
@@ -56,11 +56,8 @@ public partial class RDTGraphView2
 
             if (Editor.SelectedNode.Data is questPhaseNodeDefinition ph)
             {
-                if (!ph.PhaseResource.IsSet)
-                {
-                    subGraph.StateParents = Editor.Source.StateParents + "." + ph.Id;
-                    subGraph.DocumentViewModel = Editor.Source.DocumentViewModel;
-                }
+                subGraph.StateParents = Editor.Source.StateParents + GetPhaseNodeStateSuffix(ph);
+                subGraph.DocumentViewModel = Editor.Source.DocumentViewModel;
             }
 
             ViewModel!.History.Add(subGraph);
@@ -90,6 +87,21 @@ public partial class RDTGraphView2
                 BuildBreadcrumb();
             }
         }
+    }
+
+    private static string GetPhaseNodeStateSuffix(questPhaseNodeDefinition phaseNode)
+    {
+        if (!phaseNode.PhaseResource.IsSet)
+        {
+            return "." + phaseNode.Id;
+        }
+
+        var depotPath = phaseNode.PhaseResource.DepotPath;
+        var stateValue = depotPath.IsResolvable
+            ? depotPath.GetResolvedText()!
+            : ((ulong)depotPath).ToString();
+
+        return RedGraph.CreateStateSuffix("phaseResource", stateValue);
     }
 
     private void BuildBreadcrumb()

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -379,6 +379,176 @@
                     </local:NodeTemplateSelector.SceneEndNode>
                 </local:NodeTemplateSelector>
 
+                <DataTemplate x:Key="LowDetailNodeContentTemplate" />
+
+                <DataTemplate x:Key="InputConnectorHeaderTemplate" DataType="{x:Type nodes:InputConnectorViewModel}">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Scene nodes: Show Title FIRST and BIG (socket name) -->
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource TextFillColorPrimary}"
+                            FontSize="14"
+                            FontWeight="Normal"
+                            Text="{Binding Title}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if no subtitle (quest nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!-- Scene nodes only: Show Subtitle SECOND and SMALL (coordinates) -->
+                        <TextBlock
+                            Margin="4,0,0,0"
+                            VerticalAlignment="Center"
+                            Foreground="#777777"
+                            FontSize="10"
+                            FontFamily="Consolas"
+                            Text="{Binding Subtitle}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if no subtitle (quest nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!-- Quest nodes: Show Title only (socket name) -->
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource TextFillColorPrimary}"
+                            FontSize="14"
+                            FontWeight="Normal"
+                            Text="{Binding Title}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if subtitle exists (scene nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </DataTemplate>
+
+                <DataTemplate x:Key="OutputConnectorHeaderTemplate" DataType="{x:Type nodes:OutputConnectorViewModel}">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Scene nodes only: Show Title as coordinate FIRST -->
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="#777777"
+                            FontSize="10"
+                            FontFamily="Consolas"
+                            Text="{Binding Title}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if no subtitle (quest nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!-- Scene nodes: Show Subtitle SECOND (socket name) -->
+                        <TextBlock
+                            Margin="4,0,0,0"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource TextFillColorPrimary}"
+                            FontSize="14"
+                            FontWeight="Normal"
+                            Text="{Binding Subtitle}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if no subtitle (quest nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <!-- Quest nodes: Show Title only (socket name) -->
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource TextFillColorPrimary}"
+                            FontSize="14"
+                            FontWeight="Normal"
+                            Text="{Binding Title}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Style.Triggers>
+                                        <!-- Hide if subtitle exists (scene nodes) -->
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                        <DataTrigger
+                                            Binding="{Binding Subtitle}"
+                                            Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </DataTemplate>
+
                 <DataTemplate DataType="{x:Type nodes:NodeViewModel}">
                     <nodify:Node
                         Content="{Binding}"
@@ -386,9 +556,9 @@
                         ContextMenuOpening="Node_ContextMenuOpening"
                         Header="{Binding}"
                         HeaderTemplate="{StaticResource DetailedHeaderTemplate}"
-                        Input="{Binding Input}"
+                        Input="{Binding DisplayInput}"
                         MouseDoubleClick="Node_OnMouseDoubleClick"
-                        Output="{Binding Output}">
+                        Output="{Binding DisplayOutput}">
                         <nodify:Node.ContextMenu>
                             <ContextMenu />
                         </nodify:Node.ContextMenu>
@@ -412,6 +582,13 @@
                                         <Setter Property="BorderBrush" Value="{StaticResource WolvenKitYellow}" />
                                         <Setter Property="BorderThickness" Value="2" />
                                     </DataTrigger>
+                                    <DataTrigger
+                                        Binding="{Binding IsLowDetail}"
+                                        Value="True">
+                                        <Setter Property="HeaderTemplate" Value="{StaticResource HeaderTemplate}" />
+                                        <Setter Property="ContentTemplateSelector" Value="{x:Null}" />
+                                        <Setter Property="ContentTemplate" Value="{StaticResource LowDetailNodeContentTemplate}" />
+                                    </DataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </nodify:Node.Style>
@@ -421,94 +598,13 @@
                                 <nodify:NodeInput
                                     Margin="0,2,0,2"
                                     Background="Transparent"
+                                    Header="{Binding}"
+                                    HeaderTemplate="{StaticResource InputConnectorHeaderTemplate}"
                                     Visibility="{Binding IsVisible,
                                                          Converter={StaticResource BooleanToVisibilityConverter}}"
                                     Anchor="{Binding Anchor,
                                                      Mode=OneWayToSource}"
                                     IsConnected="{Binding IsConnected}">
-                                    <nodify:NodeInput.Header>
-                                        <StackPanel Orientation="Horizontal">
-                                            <!-- Scene nodes: Show Title FIRST and BIG (socket name) -->
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                Foreground="{DynamicResource TextFillColorPrimary}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if no subtitle (quest nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-
-                                            <!-- Scene nodes only: Show Subtitle SECOND and SMALL (coordinates) -->
-                                            <TextBlock
-                                                Margin="4,0,0,0"
-                                                VerticalAlignment="Center"
-                                                Foreground="#777777"
-                                                FontSize="10"
-                                                FontFamily="Consolas"
-                                                Text="{Binding Subtitle}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if no subtitle (quest nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-
-                                            <!-- Quest nodes: Show Title only (socket name) -->
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                Foreground="{DynamicResource TextFillColorPrimary}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if subtitle exists (scene nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                        <Setter Property="Visibility" Value="Collapsed" />
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </nodify:NodeInput.Header>
                                 </nodify:NodeInput>
                             </DataTemplate>
                         </nodify:Node.InputConnectorTemplate>
@@ -516,94 +612,13 @@
                         <nodify:Node.OutputConnectorTemplate>
                             <DataTemplate DataType="{x:Type nodes:OutputConnectorViewModel}">
                                 <nodify:NodeOutput
+                                    Header="{Binding}"
+                                    HeaderTemplate="{StaticResource OutputConnectorHeaderTemplate}"
                                     Visibility="{Binding IsVisible,
                                                          Converter={StaticResource BooleanToVisibilityConverter}}"
                                     Anchor="{Binding Anchor,
                                                      Mode=OneWayToSource}"
                                     IsConnected="{Binding IsConnected}">
-                                    <nodify:NodeOutput.Header>
-                                        <StackPanel Orientation="Horizontal">
-                                            <!-- Scene nodes only: Show Title as coordinate FIRST -->
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                Foreground="#777777"
-                                                FontSize="10"
-                                                FontFamily="Consolas"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if no subtitle (quest nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-
-                                            <!-- Scene nodes: Show Subtitle SECOND (socket name) -->
-                                            <TextBlock
-                                                Margin="4,0,0,0"
-                                                VerticalAlignment="Center"
-                                                Foreground="{DynamicResource TextFillColorPrimary}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Text="{Binding Subtitle}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if no subtitle (quest nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-
-                                            <!-- Quest nodes: Show Title only (socket name) -->
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                Foreground="{DynamicResource TextFillColorPrimary}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if subtitle exists (scene nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                        <Setter Property="Visibility" Value="Collapsed" />
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </nodify:NodeOutput.Header>
                                 </nodify:NodeOutput>
                             </DataTemplate>
                         </nodify:Node.OutputConnectorTemplate>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -440,6 +440,26 @@ public partial class GraphEditorView : UserControl, INotifyPropertyChanged
         Source.GraphStateSave();
     }
 
+    internal void PrepareForClose()
+    {
+        var graph = Source;
+
+        _hydrationRequestVersion++;
+        _hydrationPassScheduled = false;
+        _allowViewportHydration = false;
+        _suppressHydrationUpdates = true;
+
+        SelectedNode = null;
+        SelectedNodes.Clear();
+
+        if (graph?.Editor == Editor)
+        {
+            graph.Editor = null;
+        }
+
+        SetCurrentValue(SourceProperty, null);
+    }
+
     private void ArrangeNodes()
     {
         if (Source == null)

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -30,8 +30,16 @@ namespace WolvenKit.Views.GraphEditor;
 /// <summary>
 /// Interaktionslogik für GraphEditorView.xaml
 /// </summary>
-public partial class GraphEditorView : UserControl
+public partial class GraphEditorView : UserControl, INotifyPropertyChanged
 {
+    private const double HydrationZoomThreshold = 0.2;
+    private const double HydrationViewportOverscanFactor = 0.45;
+    private const int HydrationVisualPressureThreshold = 250;
+    private const int InitialHydratedNodesPerPass = 36;
+    private const int ViewportHydratedNodesPerPass = 8;
+    private static readonly TimeSpan ViewportHydrationSettleDelay = TimeSpan.FromMilliseconds(180);
+    private static readonly TimeSpan HydrationContinuationDelay = TimeSpan.FromMilliseconds(80);
+
     public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
         nameof(Source), typeof(RedGraph), typeof(GraphEditorView), new PropertyMetadata(null, OnSourceChanged));
 
@@ -42,11 +50,18 @@ public partial class GraphEditorView : UserControl
             return;
         }
 
+        view.BeginInitialDetailLoad();
+        UpdateView(view);
+
         view.Dispatcher.BeginInvoke(new Action(() =>
         {
-            UpdateView(view);
             //view.Source?.ArrangeNodes();
         }), DispatcherPriority.ContextIdle);
+
+        view.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            view.AllowViewportHydration();
+        }), DispatcherPriority.ApplicationIdle);
     }
 
     private static void UpdateView(GraphEditorView view)
@@ -57,7 +72,281 @@ public partial class GraphEditorView : UserControl
         }
         view.Source.Editor = view.Editor;
         view.Source.GraphStateLoad();
+        view.EndInitialHydrationLoad();
+        view.UpdateHydration(0, false);
         //view.Editor.FitToScreen();
+    }
+
+    private void BeginInitialDetailLoad()
+    {
+        _suppressHydrationUpdates = true;
+        _hydrationPassScheduled = false;
+        _allowViewportHydration = false;
+        _hydrationRequestVersion++;
+        _isHydrationEnabled = ShouldUseHydration();
+        IsHighDetail = !_isHydrationEnabled;
+
+        foreach (var node in Source.Nodes)
+        {
+            node.IsLowDetail = _isHydrationEnabled;
+        }
+
+        if (_isHydrationEnabled)
+        {
+            UpdateLowDetailConnectionAnchors();
+        }
+
+    }
+
+    private void EndInitialHydrationLoad()
+    {
+        _suppressHydrationUpdates = false;
+    }
+
+    private void UpdateHydration(int maxViewportNodes, bool scheduleContinuation)
+    {
+        if (Source == null || _suppressHydrationUpdates)
+        {
+            return;
+        }
+
+        if (!_isHydrationEnabled)
+        {
+            if (!IsHighDetail)
+            {
+                HydrateAllNodes();
+            }
+
+            return;
+        }
+
+        var selectedHydrated = HydrateSelectedNodes();
+        var viewportHydrated = maxViewportNodes > 0 && _allowViewportHydration && Editor.ViewportZoom >= HydrationZoomThreshold
+            ? HydrateViewportNodes(maxViewportNodes, scheduleContinuation)
+            : 0;
+
+        UpdateLowDetailConnectionAnchors();
+        IsHighDetail = Source.Nodes.All(node => !node.IsLowDetail);
+    }
+
+    private void AllowViewportHydration()
+    {
+        _allowViewportHydration = true;
+        if (Editor.ViewportZoom >= HydrationZoomThreshold)
+        {
+            UpdateHydration(InitialHydratedNodesPerPass, true);
+        }
+    }
+
+    private void HydrateAllNodes()
+    {
+        if (Source == null)
+        {
+            return;
+        }
+
+        foreach (var node in Source.Nodes)
+        {
+            node.IsLowDetail = false;
+        }
+
+        IsHighDetail = true;
+    }
+
+    private bool ShouldUseHydration()
+        => Source is { GraphType: RedGraphType.Quest }
+           && Source.Title.EndsWith(".questphase", StringComparison.OrdinalIgnoreCase)
+           && GetGraphVisualPressure() >= HydrationVisualPressureThreshold;
+
+    private int GetGraphVisualPressure()
+    {
+        if (Source == null)
+        {
+            return 0;
+        }
+
+        return Source.Nodes.Count
+               + Source.Nodes.Sum(node => node.Input.Count)
+               + Source.Nodes.Sum(node => node.Output.Count)
+               + Source.Connections.Count;
+    }
+
+    private int HydrateSelectedNodes()
+    {
+        if (Source == null)
+        {
+            return 0;
+        }
+
+        var hydrated = 0;
+        if (SelectedNode != null)
+        {
+            hydrated += HydrateNode(SelectedNode) ? 1 : 0;
+        }
+
+        foreach (var node in SelectedNodes.OfType<NodeViewModel>())
+        {
+            hydrated += HydrateNode(node) ? 1 : 0;
+        }
+
+        return hydrated;
+    }
+
+    private int HydrateViewportNodes(int maxHydratedNodes, bool scheduleContinuation)
+    {
+        if (Source == null || !TryGetHydrationViewport(out var viewport))
+        {
+            return 0;
+        }
+
+        var viewportCenter = new System.Windows.Point(viewport.X + viewport.Width / 2, viewport.Y + viewport.Height / 2);
+        var candidates = Source.Nodes
+            .Where(node => node.IsLowDetail && IsNodeInHydrationViewport(node, viewport))
+            .OrderBy(node => GetDistanceSquaredToNodeCenter(node, viewportCenter))
+            .Take(maxHydratedNodes + 1)
+            .ToList();
+
+        var hydrated = 0;
+        foreach (var node in candidates.Take(maxHydratedNodes))
+        {
+            hydrated += HydrateNode(node) ? 1 : 0;
+        }
+
+        if (scheduleContinuation && candidates.Count > maxHydratedNodes)
+        {
+            ScheduleHydrationPass(maxHydratedNodes, scheduleContinuation);
+        }
+
+        return hydrated;
+    }
+
+    private bool HydrateNode(NodeViewModel node)
+    {
+        if (!node.IsLowDetail)
+        {
+            return false;
+        }
+
+        node.IsLowDetail = false;
+        return true;
+    }
+
+    private void ScheduleHydrationPass(int maxViewportNodes, bool scheduleContinuation)
+    {
+        if (_hydrationPassScheduled)
+        {
+            return;
+        }
+
+        var requestVersion = _hydrationRequestVersion;
+        _hydrationPassScheduled = true;
+        _ = Dispatcher.BeginInvoke(new Action(async () =>
+        {
+            await Task.Delay(HydrationContinuationDelay);
+            _hydrationPassScheduled = false;
+            if (requestVersion == _hydrationRequestVersion)
+            {
+                UpdateHydration(maxViewportNodes, scheduleContinuation);
+            }
+        }), DispatcherPriority.Background);
+    }
+
+    private void ScheduleSettledViewportHydration()
+    {
+        var requestVersion = ++_hydrationRequestVersion;
+        if (!_allowViewportHydration || !_isHydrationEnabled || Editor.ViewportZoom < HydrationZoomThreshold)
+        {
+            return;
+        }
+
+        _ = Dispatcher.BeginInvoke(new Action(async () =>
+        {
+            await Task.Delay(ViewportHydrationSettleDelay);
+            if (requestVersion == _hydrationRequestVersion)
+            {
+                UpdateHydration(ViewportHydratedNodesPerPass, false);
+            }
+        }), DispatcherPriority.Background);
+    }
+
+    private bool TryGetHydrationViewport(out System.Windows.Rect viewport)
+    {
+        viewport = System.Windows.Rect.Empty;
+        if (Editor.ViewportSize.Width <= 0 || Editor.ViewportSize.Height <= 0)
+        {
+            return false;
+        }
+
+        viewport = new System.Windows.Rect(Editor.ViewportLocation, Editor.ViewportSize);
+        viewport.Inflate(
+            viewport.Width * HydrationViewportOverscanFactor,
+            viewport.Height * HydrationViewportOverscanFactor);
+        return true;
+    }
+
+    private static bool IsNodeInHydrationViewport(NodeViewModel node, System.Windows.Rect viewport)
+    {
+        const double fallbackNodeWidth = 220;
+        const double fallbackNodeHeight = 70;
+
+        var width = node.Size.Width > 0 ? node.Size.Width : fallbackNodeWidth;
+        var height = node.Size.Height > 0 ? node.Size.Height : fallbackNodeHeight;
+        var nodeBounds = new System.Windows.Rect(node.Location, new System.Windows.Size(width, height));
+        return viewport.IntersectsWith(nodeBounds);
+    }
+
+    private static double GetDistanceSquaredToNodeCenter(NodeViewModel node, System.Windows.Point point)
+    {
+        const double fallbackNodeWidth = 220;
+        const double fallbackNodeHeight = 70;
+
+        var width = node.Size.Width > 0 ? node.Size.Width : fallbackNodeWidth;
+        var height = node.Size.Height > 0 ? node.Size.Height : fallbackNodeHeight;
+        var centerX = node.Location.X + width / 2;
+        var centerY = node.Location.Y + height / 2;
+        var deltaX = centerX - point.X;
+        var deltaY = centerY - point.Y;
+        return deltaX * deltaX + deltaY * deltaY;
+    }
+
+    private void UpdateLowDetailConnectionAnchors()
+    {
+        if (Source == null)
+        {
+            return;
+        }
+
+        const double fallbackNodeWidth = 220;
+        const double fallbackNodeHeight = 70;
+
+        var nodesById = Source.Nodes.ToDictionary(node => node.UniqueId);
+        foreach (var connection in Source.Connections)
+        {
+            if (!nodesById.TryGetValue(connection.Source.OwnerId, out var sourceNode) ||
+                !nodesById.TryGetValue(connection.Target.OwnerId, out var targetNode))
+            {
+                continue;
+            }
+
+            if (sourceNode.IsLowDetail)
+            {
+                var sourceWidth = sourceNode.Size.Width > 0 ? sourceNode.Size.Width : fallbackNodeWidth;
+                var sourceHeight = sourceNode.Size.Height > 0 ? sourceNode.Size.Height : fallbackNodeHeight;
+
+                connection.Source.Anchor = new System.Windows.Point(
+                    sourceNode.Location.X + sourceWidth,
+                    sourceNode.Location.Y + sourceHeight / 2);
+            }
+
+            if (targetNode.IsLowDetail)
+            {
+                var targetHeight = targetNode.Size.Height > 0 ? targetNode.Size.Height : fallbackNodeHeight;
+
+                connection.Target.Anchor = new System.Windows.Point(
+                    targetNode.Location.X,
+                    targetNode.Location.Y + targetHeight / 2);
+            }
+        }
     }
 
     public RedGraph Source
@@ -75,7 +364,6 @@ public partial class GraphEditorView : UserControl
     }
 
     private NodeViewModel _selectedNode;
-
     public NodeViewModel SelectedNode
     {
         get => _selectedNode;
@@ -85,6 +373,11 @@ public partial class GraphEditorView : UserControl
             {
                 // Update the global selection service
                 NodeSelectionService.Instance.SelectedNode = value;
+                if (value != null)
+                {
+                    HydrateNode(value);
+                    UpdateLowDetailConnectionAnchors();
+                }
             }
         }
     }
@@ -99,6 +392,19 @@ public partial class GraphEditorView : UserControl
 
     public System.Windows.Point ViewportLocation { get; set; }
 
+    private bool _isHighDetail;
+    private bool _suppressHydrationUpdates;
+    private bool _isHydrationEnabled;
+    private bool _hydrationPassScheduled;
+    private bool _allowViewportHydration;
+    private int _hydrationRequestVersion;
+
+    public bool IsHighDetail
+    {
+        get => _isHighDetail;
+        private set => SetField(ref _isHighDetail, value);
+    }
+
     private readonly AppViewModel _appViewModel;
 
     public GraphEditorView()
@@ -106,6 +412,7 @@ public partial class GraphEditorView : UserControl
         InitializeComponent();
 
         _appViewModel = Locator.Current.GetService<AppViewModel>();
+        Editor.ViewportUpdated += Editor_OnViewportUpdated;
 
         Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
             handler => Editor.ViewportUpdated += handler,
@@ -114,11 +421,16 @@ public partial class GraphEditorView : UserControl
             .ObserveOn(RxApp.MainThreadScheduler)
             .Subscribe(x =>
             {
-                ViewportUpdated();
+                SaveViewportState();
             });
     }
 
-    private void ViewportUpdated()
+    private void Editor_OnViewportUpdated(object sender, RoutedEventArgs e)
+    {
+        ScheduleSettledViewportHydration();
+    }
+
+    private void SaveViewportState()
     {
         if (Source == null)
         {

--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Xml;
 using ReactiveUI;
 using Splat;
@@ -24,6 +25,7 @@ using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Layout;
+using WolvenKit.Views.GraphEditor;
 using DockState = WolvenKit.App.Models.Docking.DockState;
 
 namespace WolvenKit.Views.Shell
@@ -690,6 +692,13 @@ namespace WolvenKit.Views.Shell
                     var control = (from ContentControl element in PART_DockingManager.Children
                                    where element.Content == item
                                    select element).FirstOrDefault();
+
+                    if (control is not null)
+                    {
+                        // Drop heavy graph bindings before the docking manager tears down the document visual tree
+                        DetachGraphEditorsForClose(control);
+                    }
+
                     PART_DockingManager.Children.Remove(control);
 
                     // set active document to null
@@ -745,6 +754,41 @@ namespace WolvenKit.Views.Shell
                 DockingManager.SetCanSerialize(control, element.CanSerialize);
 
                 PART_DockingManager.Children.Add(control);
+            }
+        }
+
+        private static void DetachGraphEditorsForClose(DependencyObject root)
+        {
+            foreach (var graphEditor in FindVisualChildren<GraphEditorView>(root))
+            {
+                graphEditor.PrepareForClose();
+            }
+        }
+
+        private static IEnumerable<T> FindVisualChildren<T>(DependencyObject root) where T : DependencyObject
+        {
+            var childCount = 0;
+            try
+            {
+                childCount = VisualTreeHelper.GetChildrenCount(root);
+            }
+            catch (InvalidOperationException)
+            {
+                yield break;
+            }
+
+            for (var i = 0; i < childCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is T typedChild)
+                {
+                    yield return typedChild;
+                }
+
+                foreach (var descendant in FindVisualChildren<T>(child))
+                {
+                    yield return descendant;
+                }
             }
         }
 


### PR DESCRIPTION
Improve quest and scene editor perfomance

Implemented so far:
- Avoid loading external phase resources just for the phase node count, phase nodes now only show counts for inline PhaseGraph data which is already in memory. Questphase files with such phase nodes had great improvement (upto 80%) in load time

- Lazy hydrate node details for large questphase graphs. Large questphase graphs now open with title level node visuals first and hydrate sockets/details later in small viewport-aware batches. This is a more general improvement across the board, about ~50% faster initial graph load/visual idle and faster first layout (Hydration is gated for heavier graphs only)

- Detach graph editors before document close teardown. Closing large graph tabs was notoriously slow, closing now clears heavy Nodify graph bindings before the docking manager removes the tab which moved expensive teardown out of Syncfusion’s removal path. Generally 70-80% faster close times on large graphs

- Embedded quest phases. Most of the biggest questphase files have tons of embedded questphases in them. So we now lazily materialize these graph tabs and also skip the legacy 'Graph View' tabs for embedded questphase resources.  Seems to be around 40-50% faster to load now. A small UX improvement here as well: the hover tooltips on embedded tabs will use the embedded resource paths. These tabs will also have better default layouts.

Next part: address/test scene files which tend to have much more nodes on a flatter surface, potentially explore virtualization 