### PR TITLE
fix "create item codes from yaml"

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/MenuBarViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Extensions;
@@ -80,7 +81,7 @@ public partial class MenuBarViewModel : ObservableObject
 
         foreach (var file in files)
         {
-            allItems.AddRange(YamlHelper.GetItemRecordsFromYaml(project.GetAbsolutePath(file)));
+            allItems.AddRange(YamlHelper.GetItemRecordsFromYaml(Path.Join(project.ResourcesDirectory, file)));
         }
 
         return allItems;

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -7,3 +7,8 @@ Template changelog entry:
       description: ""
 
 changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 2917
+      author: "manavortex"
+      description: "Fixed 'create item codes from yaml'"


### PR DESCRIPTION
# fix "create item codes from yaml"

Yaml paths will now point at the correct folder