### PR TITLE
MlmaskTools.cs / MlmaskImportTools.cs update

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -2,984 +2,2009 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using WolvenKit.Common;
-using WolvenKit.Common.DDS;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using SharpGLTF.Schema2;
+using WolvenKit.Common.Model.Arguments;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
-using WolvenKit.Core.Interfaces;
+using WolvenKit.Modkit.RED4.GeneralStructs;
+using WolvenKit.Modkit.RED4.RigFile;
+using WolvenKit.Modkit.RED4.Tools;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Archive.IO;
-using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
+using Mat4 = System.Numerics.Matrix4x4;
+using Quat = System.Numerics.Quaternion;
+using Vec2 = System.Numerics.Vector2;
+using Vec3 = System.Numerics.Vector3;
+using Vec4 = System.Numerics.Vector4;
 
-namespace WolvenKit.Modkit.RED4.MLMask
+namespace WolvenKit.Modkit.RED4
 {
-    public class MLMASK
+    public partial class ModTools
     {
-        private const uint s_headerLength = 148;
-        private MlMaskContainer _mlmask;
-        private readonly ILoggerService _logger;
-
-        public MLMASK(MlMaskContainer mlMask, ILoggerService logger)
+        //WIP does not do the thing yet
+        public bool ImportRig(FileInfo inGltfFile, Stream rigStream, GltfImportArgs args)
         {
-            _mlmask = mlMask;
-            _logger = logger;
-        }
+            var cr2w = _parserService.ReadRed4File(rigStream);
 
-        public void Import(FileInfo txtImageList, FileInfo outFile)
-        {
-            var lines = File.ReadAllLines(txtImageList.FullName);
-            var baseDir = txtImageList.Directory.NotNull();
-
-            uint targetAtlasWidth = 0;
-            uint targetAtlasHeight = 0;
-            uint targetTileSize = 16;
-
-            var filePaths = new List<string>();
-
-            foreach (var line in lines)
+            if (cr2w is not { RootChunk: animRig rig })
             {
-                var trimmed = line.Trim();
-                if (string.IsNullOrWhiteSpace(trimmed))
-                    continue;
-
-                if (trimmed.StartsWith("#"))
-                {
-                    if (trimmed.Contains("AtlasWidth="))
-                        targetAtlasWidth = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("AtlasHeight="))
-                        targetAtlasHeight = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("MaskTileSize="))
-                        targetTileSize = ParseHeaderValue(trimmed);
-
-                    continue;
-                }
-
-                if (trimmed.Contains("=")) continue;
-
-                filePaths.Add(trimmed);
+                return false;
             }
 
-            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
+            var model = ModelRoot.Load(inGltfFile.FullName, new ReadSettings(args.ValidationMode));
 
-            if (files.Count == 0)
-                throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
+            //VerifyGLTF(model);
 
-            _mlmask = new MlMaskContainer();
-            _mlmask.PreferredTileSize = targetTileSize;
-            _mlmask.PreferredAtlasWidth = targetAtlasWidth;
-            _mlmask.PreferredAtlasHeight = targetAtlasHeight;
+            List<LogicalChildOfRoot> armature;
 
-            var textures = new List<RawTexContainer>();
+            var joints = new List<(Node Joint, Mat4 InverseBindMatrix)>();
+            var jointlist = new List<Node>();
+            var jointnames = new List<string>();
+            var jointparentnames = new List<string>();
+            var ibm = new List<Mat4>();
+            var wm = new List<Mat4>();
 
-            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
-            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
 
-            if (needsLayer0)
+            if (model.LogicalSkins.Count > 0)
             {
-                uint whiteW = 1024u;
-                uint whiteH = 1024u;
-
-                if (files.Count > 0)
+                armature = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => (LogicalChildOfRoot)model.LogicalSkins[0]).ToList();
+                joints = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_)).ToList();
+                jointlist = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint).ToList();
+                jointnames = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.Name).ToList();
+                jointparentnames = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.VisualParent.Name).ToList();
+                ibm = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).InverseBindMatrix).ToList();
+                wm = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.WorldMatrix).ToList();
+            }
+            else
+            {
+                if (model.LogicalNodes.Count > 0)
                 {
-                    var firstReal = files[0];
-                    if (File.Exists(firstReal))
+                    armature = Enumerable.Range(0, model.LogicalNodes.Count).Select(_ => (LogicalChildOfRoot)model.LogicalNodes[_]).ToList();
+                    jointlist = Enumerable.Range(0, armature.Count).Select(_ => (Node)armature[_]).ToList();
+                    jointnames = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).Name).ToList();
+                    jointparentnames = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).VisualParent is null
+                                                                        ? "firstbone" : ((Node)armature[_]).VisualParent.Name).ToList();
+                    wm = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).WorldMatrix).ToList();
+
+                    for (var i = 0; i < wm.Count; i++)
                     {
-                        try
+                        var temp = new Mat4();
+                        Mat4.Invert(wm[i], out temp);
+                        ibm.Add(temp);
+                    }
+                    //ibm = Enumerable.Range(0, wm.Count).Select(_ => Mat4.Invert( wm[_], out ibm[_] )).ToList();
+                    joints = Enumerable.Range(0, armature.Count).Select(_ => (jointlist[_], ibm[_])).ToList();
+                }
+            }
+
+            int[]? GetLevels(string root = "Root")
+            {
+                var rootIndex = jointnames.IndexOf("Root");
+                var treeLevel = new int[jointnames.Count];
+
+                if (jointparentnames[rootIndex].Contains("Armature"))
+                {
+                    void rec(string parent, int level)
+                    {
+                        var tIndex = Enumerable.Range(0, jointnames.Count).Where(i => jointparentnames[i] == parent).ToList();
+                        foreach (var ind in tIndex)
                         {
-                            using var probe = RedImage.LoadFromFile(firstReal);
-                            if (probe != null)
-                            {
-                                whiteW = (uint)probe.Metadata.Width;
-                                whiteH = (uint)probe.Metadata.Height;
-                            }
+                            treeLevel[ind] = level;
+                            rec(jointnames[ind], level + 1);
                         }
-                        catch { }
                     }
+                    rec(root, 0);
+                    return treeLevel;
                 }
-
-                var whitePixels = new byte[whiteW * whiteH];
-                Array.Fill(whitePixels, (byte)255);
-                textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
-                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH} (inferred from first provided layer metadata)");
+                return null;
             }
 
-            for (var fileIdx = 0; fileIdx < files.Count; fileIdx++)
+            Mat4.Invert(joints[1].Joint.WorldMatrix, out var inversedWorldMatrix);
+            Mat4.Invert(joints[1].Joint.LocalMatrix, out var inversedLocalMatrix);
+
+            var oriRotM = Mat4.CreateFromQuaternion(joints[1].Joint.LocalTransform.Rotation);
+            var oriScaM = Mat4.CreateScale(joints[1].Joint.LocalTransform.Scale);
+            var oriTraM = Mat4.CreateTranslation(joints[1].Joint.LocalTransform.Translation);
+
+            var rotM = oriScaM * joints[1].InverseBindMatrix * oriTraM;
+            Mat4.Invert(rotM, out rotM);
+
+            var manualTRS = oriTraM * oriRotM * oriScaM;
+            Mat4.Invert(manualTRS, out var inversedManualTRS);
+
+            var manualRotM = oriScaM * inversedManualTRS * oriTraM;
+            Mat4.Invert(manualRotM, out manualRotM);
+
+            var inv2 = oriTraM * rotM * oriScaM;
+
+            var localInvRotM = oriScaM * inversedLocalMatrix * oriTraM;
+            Mat4.Invert(localInvRotM, out localInvRotM);
+
+            var rotationVector = Quat.CreateFromRotationMatrix(rotM);
+            var manualRotationVector = Quat.CreateFromRotationMatrix(manualRotM);
+            var localRotationVector = Quat.CreateFromRotationMatrix(localInvRotM);
+
+            var levels = GetLevels("Root");
+            if (levels is not null)
             {
-                var f = files[fileIdx];
-                if (!File.Exists(f)) throw new FileNotFoundException($"File not found: {f}");
-
-                try
+                for (var i = 0; i < rig.BoneNames.Count; i++)
                 {
-                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2001, $"Could not load image: {f}");
+                    var currentBone = rig.BoneNames[i];
+                    var index = jointnames.IndexOf(currentBone.ToString().NotNull());
+                    var parindex = jointnames.IndexOf(jointlist[index].VisualParent.Name);
+                    var transform = rig.BoneTransforms[i].NotNull();
 
-                    if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
-                        image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
-
-                    uint imgW = (uint)image.Metadata.Width;
-                    uint imgH = (uint)image.Metadata.Height;
-
-                    using var ms = new MemoryStream(image.SaveToDDSMemory());
-                    using var br = new BinaryReader(ms);
-                    ms.Seek(s_headerLength, SeekOrigin.Begin);
-                    var pixels = br.ReadBytes((int)(imgW * imgH));
-
-                    var isBlank = IsBlankLayer(pixels);
-
-                    if (isBlank)
                     {
-                        textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
-                        continue;
+                        /*
+                        transform.Rotation.I = jointlist[index].LocalTransform.Rotation.X;
+                        transform.Rotation.J = -jointlist[index].LocalTransform.Rotation.Z;
+                        transform.Rotation.K = jointlist[index].LocalTransform.Rotation.Y;
+                        transform.Rotation.R = jointlist[index].LocalTransform.Rotation.W;
+
+                        transform.Scale.W = 1;
+                        transform.Scale.X = jointlist[index].LocalTransform.Scale.X;
+                        transform.Scale.Y = jointlist[index].LocalTransform.Scale.Y;
+                        transform.Scale.Z = jointlist[index].LocalTransform.Scale.Z;
+
+                        transform.Translation.W = i == 0 ? 1 : 0;
+                        transform.Translation.X = jointlist[index].LocalTransform.Translation.X;
+                        transform.Translation.Y = -jointlist[index].LocalTransform.Translation.Z;
+                        transform.Translation.Z = jointlist[index].LocalTransform.Translation.Y;
+                        */
+                    } //gotta figure out those rotations
+
+                    var oriR = transform.Rotation;
+                    var oriRquat = new Quat(oriR.I, oriR.J, oriR.K, oriR.R);
+                    var newR = jointlist[index].LocalTransform.Rotation;
+                    var parR = jointlist[index].VisualParent.LocalTransform.Rotation;
+
+                    var oriT = transform.Translation;
+                    var oriTvec = new Vec4(oriT.X, oriT.Y, oriT.Z, oriT.W);
+                    var newT = jointlist[index].LocalTransform.Translation;
+                    var parT = jointlist[index].VisualParent.LocalTransform.Translation;
+
+                    var herewegoagane = parR * newR;
+
+
+                    var quatM = Mat4.CreateFromQuaternion(oriRquat);
+
+                    var d = newR - oriRquat + new Quat(0, 0, 0, 1);
+                    var p = newR * oriRquat;
+                    var e = d == p;
+                    var esmall = (d - p).Length() < 0.001;
+
+                    var level = levels[index];
+
+                    {/*
+                        var nya = System.Numerics.Vector3.Transform(tr, parR);
+
+                        //var rr = jointlist[index].VisualParent.VisualParent.LocalTransform.Rotation;
+                        var nye = System.Numerics.Vector3.Transform(tr, parR * rr);
+                        var rrr = jointlist[index].VisualParent.VisualParent.VisualParent.LocalTransform.Rotation;
+                        var ya = System.Numerics.Vector3.Transform(tr, parR * rr * rrr);
+
+                        var (r, s, t) = (new Quat(), new Vec3(), new Vec3());
+                        var tinverse = new Mat4();
+                        Mat4.Invert(jointlist[index].VisualParent.WorldMatrix, out tinverse);
+                        Mat4.Decompose(tinverse, out s, out r, out t);
+
+                        var yaya = System.Numerics.Vector3.Transform(tr, r * parR);*/
                     }
 
-                    textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
-                }
-                catch (WolvenKitException e)
-                {
-                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale)");
+                    /*Mat4 TRSFromRig(QsTransform parTr)
+                    {
+                        var (r, s, t) = (parTr.Rotation, parTr.Scale, parTr.Translation);
+
+                        var R = Mat4.CreateFromQuaternion(new Quat(r.R, r.I, r.J, r.K));
+                        var S = Mat4.CreateScale(new Vec3(s.X, s.Y, s.Z));
+                        var T = Mat4.CreateTranslation(new Vec3(t.X, t.Y, t.Z));
+                        var M = T * R * S;
+                        return M;
+                    }
+
+                    if (index > -1 && parindex > -1)
+                    {
+                        var parM = TRSFromRig(rig.BoneTransforms[parindex]);
+                        Mat4.Invert(parM, out var parMinv);
+                        var M = TRSFromRig(rig.BoneTransforms[index]);
+                        Mat4.Invert(jointlist[index].VisualParent.WorldMatrix, out var tinverse);
+                        Mat4.Decompose(parMinv * M, out var s, out var r, out var t);
+                    }*/
+
+                    Quat AllOriginalRotations(int i)
+                    {
+                        var wquat = transform.Rotation;
+                        var quat = new Quat(wquat.I, wquat.J, wquat.K, wquat.R);
+                        return (rig.BoneNames[i] == "Root") ? quat : AllOriginalRotations(rig.BoneParentIndexes[i]) * quat;
+                    }
+
+                    var oriAllR = AllOriginalRotations(i);
+                    var oriParAllR = oriAllR * Quat.Inverse(oriRquat);
+                    var yetatr = Vec4.Transform(newT, oriAllR);
+
+                    Quat AllRotations(Node node)
+                    {
+                        var quat = node.LocalTransform.Rotation;
+                        return (node.Name == "Root") ? quat : AllRotations(node.VisualParent) * quat;
+                    }
+
+                    var infinya = AllRotations(jointlist[index]);
+                    var finit = Vec4.Transform(newT, infinya);
+                    var aynifni = Vec4.Transform(newT, Quat.Inverse(infinya));
+
+
+                    var before = transform.Translation.DeepCopy();
+
+                    //level = 0;
+
+                    var x90 = Quat.CreateFromAxisAngle(Vec3.UnitX, (float)Math.PI / 2);
+                    var y90 = Quat.CreateFromAxisAngle(Vec3.UnitY, (float)Math.PI / 2);
+                    var z90 = Quat.CreateFromAxisAngle(Vec3.UnitZ, (float)Math.PI / 2);
+
+
+                    //works only for the rig of the kusanagi bike
+                    transform.Translation = level == 1 ? Vec4.Transform(newT, x90) :
+                                                        level is 3 or
+                                                        4 ? Vec4.Transform(newT, new Quat(0, 1, 0, 0) * x90) :
+                                                        level == 5 ? Vec4.Transform(newT, x90) :
+                                                        level == 6 ? Vec4.Transform(newT, z90) :
+                                                        level == 8 ? Vec4.Transform(newT, y90 * new Quat(0, 0, 0, 1)) : // Quat(0, 0, 0, 1) is z90 * z90
+                                                        new Vec4(newT.X, newT.Y, newT.Z, 0);
+
+                    transform.Translation.W = i == 0 ? 1 : 0;
+
+                    /*
+                    transform.Translation.X = level == 6 ? -newT.Y :
+                                                          level == 8 ? newT.Z :
+                                                          newT.X;
+                    transform.Translation.Y = level == 1 ? newT.Z :
+                                                          level == 3 ? -newT.Z :
+                                                          level == 4 ? -newT.Z :
+                                                          level == 5 ? -newT.Z :
+                                                          level == 6 ? newT.X :
+                                                          level == 8 ? -newT.Y :
+                                                          newT.Y;
+                    transform.Translation.Z = level == 1 ? newT.Y :
+                                                          level == 3 ? -newT.Y :
+                                                          level == 4 ? -newT.Y :
+                                                          level == 5 ? newT.Y :
+                                                          level == 8 ? newT.X :
+                                                          newT.Z;
+                    */
+
+                    var after = transform.Translation;
                 }
             }
+            var ms = new MemoryStream();
+            using var writer = new CR2WWriter(ms, Encoding.UTF8, true) { LoggerService = _loggerService };
+            writer.WriteFile(cr2w);
+            ms.Seek(0, SeekOrigin.Begin);
 
-            _mlmask.Layers = textures.ToArray();
+            rigStream.SetLength(0);
+            ms.CopyTo(rigStream);
 
-            Create();
-            Write(outFile);
-
-            _logger.Info("Import complete. Keep your original .masklist file for round-trip export.");
-        }
-
-        internal static bool IsBlankLayer(byte[] pixels)
-        {
-            if (pixels == null || pixels.Length == 0) return true;
-            var first = pixels[0];
-            for (int i = 1; i < pixels.Length; i++)
-                if (pixels[i] != first) return false;
             return true;
         }
 
-        internal static uint ParseHeaderValue(string line)
+
+        public bool ImportMesh(FileInfo inGltfFile, Stream inMeshStream, GltfImportArgs args)
         {
-            var parts = line.Split('=');
-            return parts.Length > 1 ? uint.Parse(parts[1].Trim()) : 0;
-        }
+            var cr2w = _parserService.ReadRed4File(inMeshStream);
 
-        internal static byte[] UpscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
-        {
-            var dst = new byte[dstW * dstH];
-            var scaleX = (double)srcW / dstW;
-            var scaleY = (double)srcH / dstH;
-
-            for (uint y = 0; y < dstH; y++)
-                for (uint x = 0; x < dstW; x++)
-                {
-                    var srcX = (uint)(x * scaleX);
-                    var srcY = (uint)(y * scaleY);
-                    dst[x + y * dstW] = src[srcX + srcY * srcW];
-                }
-            return dst;
-        }
-
-        #region Core Methods
-
-        private void Write(FileInfo f)
-        {
-            var cr2w = new CR2WFile();
-            var mask = new Multilayer_Mask { CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC };
-            cr2w.RootChunk = mask;
-
-            var blob = new rendRenderMultilayerMaskBlobPC
+            if (cr2w is not { RootChunk: CMesh meshBlob } || meshBlob.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendBlob)
             {
-                Header = new rendRenderMultilayerMaskBlobHeader
+                return false;
+            }
+
+            // https://github.com/WolvenKit/WolvenKit/issues/1870
+            rendBlob.Header.OpacityMicromaps.Clear();
+
+            var originalRig = args.Rig?.FirstOrDefault();
+
+            if (File.Exists(Path.ChangeExtension(inGltfFile.FullName, ".Material.json")) && (args.ImportMaterialOnly || args.ImportMaterials))
+            {
+                WriteMatToMesh(ref cr2w, File.ReadAllText(Path.ChangeExtension(inGltfFile.FullName, ".Material.json")));
+                if (args.ImportMaterialOnly)
                 {
-                    Version = 3,
-                    AtlasWidth = _mlmask.AtlasWidth,
-                    AtlasHeight = _mlmask.AtlasHeight,
-                    NumLayers = (uint)_mlmask.Layers!.Length,
-                    MaskWidth = _mlmask.WidthHigh,
-                    MaskHeight = _mlmask.HeightHigh,
-                    MaskWidthLow = _mlmask.WidthLow,
-                    MaskHeightLow = _mlmask.HeightLow,
-                    MaskTileSize = _mlmask.TileSize,
-                    Flags = 2
-                },
-                AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer!),
-                TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer!)
+                    var matOnlyStream = new MemoryStream();
+
+                    //cr2w.Write(new BinaryWriter(matOnlyStream));
+                    using var writer = new CR2WWriter(matOnlyStream) { LoggerService = _loggerService };
+                    writer.WriteFile(cr2w);
+
+
+                    matOnlyStream.Seek(0, SeekOrigin.Begin);
+                    //if (outStream != null)
+                    //{
+                    //    matOnlyStream.CopyTo(outStream);
+                    //}
+                    //else
+                    {
+                        inMeshStream.SetLength(0);
+                        matOnlyStream.CopyTo(inMeshStream);
+                    }
+                    return true;
+                }
+
+            }
+
+            var model = ModelRoot.Load(inGltfFile.FullName, new ReadSettings(args.ValidationMode));
+
+            if (model.LogicalSkins.Count > 0 && originalRig != null)
+            {
+                var jointArray = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => model.LogicalSkins[0].GetJoint(_).Joint).ToArray();
+
+                if (cr2w.RootChunk is CMesh root)
+                {
+                    for (var i = 0; i < root.BoneNames.Count; i++)
+                    {
+                        var foundBone = jointArray.FirstOrDefault(x => root.BoneNames[i] == x.Name);
+                        if (foundBone is not null)
+                        {
+                            System.Numerics.Matrix4x4.Invert(foundBone.WorldMatrix, out var inversedWorldMatrix);
+
+                            root.BoneRigMatrices[i] = inversedWorldMatrix;
+                            root.BoneRigMatrices[i].NotNull().W.Y = -inversedWorldMatrix.M43;
+                            root.BoneRigMatrices[i].NotNull().W.Z = inversedWorldMatrix.M42;
+                            //component Y and -Z are being swapped in vector W
+                            //should probably figure out why
+                        }
+                    }
+                }
+            }
+
+            VerifyGLTF(model, args);
+
+            var meshes = new List<RawMeshContainer>();
+            foreach (var node in model.LogicalNodes)
+            {
+                if (node.Mesh != null)
+                {
+                    meshes.Add(GltfMeshToRawContainer(node, args));
+                }
+                else if (args.FillEmpty)
+                {
+                    meshes.Add(CreateEmptyMesh(node.Name));
+                }
+            }
+            meshes = meshes.OrderBy(mesh => mesh.name).ToList();
+
+            var max = new Vec3(float.MinValue, float.MinValue, float.MinValue);
+            var min = new Vec3(float.MaxValue, float.MaxValue, float.MaxValue);
+
+            foreach (var p in meshes)
+            {
+                ArgumentNullException.ThrowIfNull(p.positions);
+                foreach (var q in p.positions.ToList())
+                {
+                    max.X = Math.Max(q.X, max.X);
+                    max.Y = Math.Max(q.Y, max.Y);
+                    max.Z = Math.Max(q.Z, max.Z);
+                }
+            }
+
+            foreach (var p in meshes)
+            {
+                ArgumentNullException.ThrowIfNull(p.positions);
+                foreach (var q in p.positions.ToList())
+                {
+                    min.X = Math.Min(q.X, min.X);
+                    min.Y = Math.Min(q.Y, min.Y);
+                    min.Z = Math.Min(q.Z, min.Z);
+                }
+            }
+
+            // GarmentSupport not accounted here. Might be an issue?
+            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1504
+            meshBlob.BoundingBox.Min = new Vector4 { X = min.X, Y = min.Y, Z = min.Z, W = 1f };
+            meshBlob.BoundingBox.Max = new Vector4 { X = max.X, Y = max.Y, Z = max.Z, W = 1f };
+
+            var quantScale = new Vec4((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2, 0);
+            var quantTrans = new Vec4((max.X + min.X) / 2, (max.Y + min.Y) / 2, (max.Z + min.Z) / 2, 1);
+
+
+            RawArmature? incomingJoints = null;
+            RawArmature? existingJoints = null;
+            if (originalRig != null)
+            {
+
+                using var msss = new MemoryStream(rendBlob.RenderBuffer.Buffer.GetBytes());
+
+                var meshesinfo = MeshTools.GetMeshesinfo(rendBlob, cr2w.RootChunk as CMesh);
+
+                var expMeshesss = MeshTools.ContainRawMesh(msss, meshesinfo, true);
+
+                foreach (var mesh in meshes)
+                {
+                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
+                    Array.Clear(mesh.boneindices, 0, mesh.boneindices.Length);
+                }
+
+                incomingJoints = MeshTools.GetOrphanRig(meshBlob);
+
+                using var msr = new MemoryStream();
+                originalRig.Extract(msr);
+                existingJoints = RIG.ProcessRig(_parserService.ReadRed4File(msr));
+            }
+            else
+            {
+                existingJoints = MeshTools.GetOrphanRig(meshBlob);
+                if (model.LogicalSkins.Count > 0 && model.LogicalSkins[0].JointsCount > 0)
+                {
+                    incomingJoints = new RawArmature
+                    {
+                        BoneCount = model.LogicalSkins[0].JointsCount,
+                        Names = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => model.LogicalSkins[0].GetJoint(_).Joint.Name).ToArray()
+                    };
+                }
+            }
+
+
+            try
+            {
+                MeshTools.UpdateMeshJoints(ref meshes, existingJoints, incomingJoints);
+            }
+            catch (WolvenKitException e)
+            {
+                throw new WolvenKitException(e.ErrorCode,
+                    $"You're trying to import bones into a mesh that doesn't have them. Wolvenkit can't create bones — please remove them in Blender, or import into a different file: {e.Message}");
+            }
+
+            UpdateSkinningParamCloth(ref meshes, ref cr2w, args);
+
+            UpdateGarmentSupportParameters(meshes, meshBlob, args.ImportGarmentSupport, args.IgnoreGarmentSupportUVParam);
+
+            var expMeshes = meshes.Select(_ => RawMeshToRE4Mesh(_, quantScale, quantTrans)).ToList();
+
+            var meshBuffer = new MemoryStream();
+            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer, args);
+
+            meshesInfo.quantScale = quantScale;
+            meshesInfo.quantTrans = quantTrans;
+
+            MemoryStream ms;
+
+            if (originalRig != null)
+            {
+                var tt = model.LogicalSkins.Count >= 2
+                    ? Enumerable.Range(0, model.LogicalSkins[1].JointsCount).Select(_ => model.LogicalSkins[1].GetJoint(_).Joint.WorldMatrix).ToArray()
+                    : null;
+
+                var tJointNames = model.LogicalSkins.Count >= 2 ?
+                    Enumerable.Range(0, model.LogicalSkins[1].JointsCount).Select(_ => model.LogicalSkins[1].GetJoint(_).Joint.Name).ToArray()
+                    : null;
+                ms = GetEditedCr2wFile(cr2w, meshesInfo, meshBuffer, tt, tJointNames);
+            }
+            else
+            {
+                ms = GetEditedCr2wFile(cr2w, meshesInfo, meshBuffer);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+            //if (outStream != null)
+            //{
+            //    ms.CopyTo(outStream);
+            //}
+            //else
+            {
+                inMeshStream.SetLength(0);
+                ms.CopyTo(inMeshStream);
+            }
+            return true;
+        }
+
+        private static RawMeshContainer CreateEmptyMesh(string name)
+        {
+            var meshContainer = new RawMeshContainer
+            {
+                boneindices = new ushort[3, 0],
+                colors0 = new Vec4[3],
+                colors1 = Array.Empty<Vec4>(),
+                garmentMorph = Array.Empty<Vec3>(),
+                indices = new uint[3],
+                materialNames = null,
+                name = name,
+                normals = new Vec3[3],
+                positions = new Vec3[3],
+                tangents = new Vec4[3],
+                texCoords0 = new Vec2[3],
+                texCoords1 = new Vec2[3],
+                weightCount = 0,
+                weights = new float[3, 0]
             };
 
-            mask.RenderResourceBlob.RenderResourceBlobPC = blob;
+            meshContainer.indices[0] = 2;
+            meshContainer.indices[1] = 0;
+            meshContainer.indices[2] = 1;
 
-            var dir = f.Directory ?? throw new InvalidOperationException("File directory is null");
-            if (!Directory.Exists(dir.FullName)) Directory.CreateDirectory(dir.FullName);
+            meshContainer.texCoords0[0] = new Vec2(1, 1);
+            meshContainer.texCoords0[1] = new Vec2(0, 0);
+            meshContainer.texCoords0[2] = new Vec2(1, 0);
 
-            using var fs = new FileStream(f.FullName, FileMode.Create, FileAccess.Write);
-            using var writer = new CR2WWriter(fs) { LoggerService = _logger };
-            writer.WriteFile(cr2w);
+            for (var i = 0; i < 3; i++)
+            {
+                meshContainer.colors0[i] = new Vec4(1, 1, 1, 1);
+                meshContainer.normals[i] = new Vec3(0, 0, 1);
+                meshContainer.positions[i] = new Vec3(0, 0, 0);
+                meshContainer.tangents[i] = new Vec4(1, 0, 0, -1);
+                meshContainer.texCoords1[i] = new Vec2(0, 1);
+            }
+
+            return meshContainer;
         }
 
-        /// <summary>
-        /// Writes the tile index data (TilesData buffer) for one resolution level (high or low).
-        /// For each tile, it records:
-        /// - The starting index in the data list where this tile's layer entries begin.
-        /// - For each layer present in the tile: packed atlas position (dx, dy) + scaling shifts (sx, sy).
-        /// - A bitmask indicating which layers are active in this tile.
-        /// </summary>
-        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
+        // TODO: https://github.com/WolvenKit/WolvenKit/issues/1505
+        // Maintaining compatibility but need to review if we really want to support empties via nodes
+        private RawMeshContainer GltfMeshToRawContainer(Node node, GltfImportArgs args)
         {
-            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
-            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
-
-            for (uint ty = 0; ty < heightInTiles0; ty++)
+            if (node.Mesh != null)
             {
-                for (uint tx = 0; tx < widthInTiles0; tx++)
+                return GltfMeshToRawContainer(node.Mesh, args);
+            }
+
+            if (args.ShowVerboseLogOutput)
+            {
+                _loggerService.Warning($"Node {node.Name} has no mesh, creating empty mesh (this is probably wrong.)");
+            }
+
+            return CreateEmptyMesh(node.Name);
+
+        }
+
+        private RawMeshContainer GltfMeshToRawContainer(Mesh mesh, GltfImportArgs args)
+        {
+            var accessors = mesh.Primitives[0].VertexAccessors.Keys.ToList();
+
+            var parenting = mesh.VisualParents.ToList();
+
+            if (parenting.Count > 1)
+            {
+                throw new ArgumentException($"Mesh {mesh.Name} has more than one parent node! Duplicate the mesh instead of sharing it.");
+            }
+
+            var node = parenting[0];
+
+            if (mesh.Name != node.Name && args.ShowVerboseLogOutput)
+            {
+                _loggerService.Warning($"Mesh name `{mesh.Name}` does not match parent node name `{node.Name}`. Using {(args.OverrideMeshNameWithNodeName ? "NODE" : "MESH")} name.");
+            }
+
+            var meshContainer = new RawMeshContainer
+            {
+                name = args.OverrideMeshNameWithNodeName ? node.Name : mesh.Name,
+
+                // Copying PNT w/ RHS to LHS Y+ to Z+
+                positions = mesh.Primitives[0].GetVertices("POSITION").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),
+                normals = mesh.Primitives[0].GetVertices("NORMAL").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),
+                tangents = mesh.Primitives[0].GetVertices("TANGENT").AsVector4Array().ToList().AsParallel().Select(p => new Vec4(p.X, -p.Z, p.Y, p.W)).ToArray(),
+
+                // Blender glTF omits alpha if possible
+                colors0 = accessors.Contains("COLOR_0")
+                            ? (mesh.Primitives[0].GetVertices("COLOR_0").Attribute.Dimensions == DimensionType.VEC4
+                                ? mesh.Primitives[0].GetVertices("COLOR_0").AsVector4Array().ToArray()
+                                : mesh.Primitives[0].GetVertices("COLOR_0").AsVector3Array().Select(vec3 => new Vec4(vec3, 1)).ToArray())
+                            : [],
+                colors1 = accessors.Contains("COLOR_1")
+                            ? (mesh.Primitives[0].GetVertices("COLOR_1").Attribute.Dimensions == DimensionType.VEC4
+                                ? mesh.Primitives[0].GetVertices("COLOR_1").AsVector4Array().ToArray()
+                                : mesh.Primitives[0].GetVertices("COLOR_1").AsVector3Array().Select(vec3 => new Vec4(vec3, 1)).ToArray())
+                            : [],
+
+                texCoords0 = accessors.Contains("TEXCOORD_0") ? mesh.Primitives[0].GetVertices("TEXCOORD_0").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
+                texCoords1 = accessors.Contains("TEXCOORD_1") ? mesh.Primitives[0].GetVertices("TEXCOORD_1").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
+
+                garmentSupportWeight = accessors.Contains("_GARMENTSUPPORTWEIGHT") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTWEIGHT").AsVector4Array().ToArray() : Array.Empty<Vec4>(),
+                garmentSupportCap = accessors.Contains("_GARMENTSUPPORTCAP") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTCAP").AsVector4Array().ToArray() : Array.Empty<Vec4>()
+            };
+
+            var indicesList = mesh.Primitives[0].GetIndices().ToList();
+
+            if (mesh.Name.ToLower().Contains("double"))
+            {
+                meshContainer.indices = new uint[indicesList.Count * 2];
+                for (var i = 0; i < indicesList.Count; i += 3)
                 {
-                    var tileIdx = tx + (ty * widthInTiles0);
-                    var layersBeg = (uint)tilesDataList.Count;
-                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
+                    // RHS to LHS face orientations
+                    meshContainer.indices[i] = indicesList[i + 1];
+                    meshContainer.indices[i + 1] = indicesList[i];
+                    meshContainer.indices[i + 2] = indicesList[i + 2];
 
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
-
-                    uint layersMask = 0;
-                    for (var i = 0; i < numLayers; i++)
-                    {
-                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
-                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
-                        var atlasX = position & widthInTilesGrayUp;
-                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
-                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
-                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
-
-                        uint puts = 0;
-                        puts |= atlasX;
-                        puts |= atlasY << 10;
-                        puts |= widthShift << 20;
-                        puts |= heightShift << 24;
-
-                        tilesDataList.Add(puts);
-                        layersMask |= 1u << (int)layerIdx;
-                    }
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
+                    meshContainer.indices[indicesList.Count + i] = indicesList[i];
+                    meshContainer.indices[indicesList.Count + i + 1] = indicesList[i + 1];
+                    meshContainer.indices[indicesList.Count + i + 2] = indicesList[i + 2];
                 }
             }
-        }
-
-        private void InitializeMaskLayers()
-        {
-            if (_mlmask.Layers == null) return;
-
-            for (uint i = 0; i < _mlmask.Layers.Length; i++)
+            else
             {
-                _mlmask.Layers[i].WidthInTiles0 = (_mlmask.Layers[i].Width + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.Layers[i].HeightInTiles0 = (_mlmask.Layers[i].Height + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.Layers[i].Tiles = new List<Tile>();
-
-                for (uint y = 0; y < _mlmask.Layers[i].HeightInTiles0; y++)
+                meshContainer.indices = new uint[indicesList.Count];
+                for (var i = 0; i < indicesList.Count; i += 3)
                 {
-                    for (uint x = 0; x < _mlmask.Layers[i].WidthInTiles0; x++)
-                    {
-                        var tile = new Tile
-                        {
-                            AtlasInPosition = uint.MaxValue,
-                            AtlasUnCompressed = new byte[_mlmask.AtlasTileSize * _mlmask.AtlasTileSize]
-                        };
-
-                        if (i == 0)
-                        {
-                            tile.RangeMin = 255;
-                            tile.RangeMax = 255;
-                            Array.Fill(tile.AtlasUnCompressed, (byte)255);
-                        }
-                        else
-                        {
-                            tile.RangeMin = 255;
-                            tile.RangeMax = 0;
-                            for (uint yy = 0; yy < _mlmask.AtlasTileSize; yy++)
-                            {
-                                for (uint xx = 0; xx < _mlmask.AtlasTileSize; xx++)
-                                {
-                                    var v = GetPixelFromLayer(i, x, y, (int)xx - 1, (int)yy - 1);
-                                    tile.AtlasUnCompressed[xx + (yy * _mlmask.AtlasTileSize)] = v;
-                                    tile.RangeMin = Math.Min(tile.RangeMin, v);
-                                    tile.RangeMax = Math.Max(tile.RangeMax, v);
-                                }
-                            }
-                        }
-                        _mlmask.Layers[i].Tiles.Add(tile);
-                    }
+                    // RHS to LHS face orientations
+                    meshContainer.indices[i] = indicesList[i + 1];
+                    meshContainer.indices[i + 1] = indicesList[i];
+                    meshContainer.indices[i + 2] = indicesList[i + 2];
                 }
             }
-        }
 
-        private byte GetPixelFromLayer(uint layerIdx, uint tx, uint ty, int x, int y)
-        {
-            if (layerIdx == 0) return 255;
-
-            var xx = (int)(tx * _mlmask.TileSize) + x;
-            var yy = (int)(ty * _mlmask.TileSize) + y;
-            xx = Math.Clamp(xx, 0, (int)_mlmask.Layers![layerIdx].Width - 1);
-            yy = Math.Clamp(yy, 0, (int)_mlmask.Layers[layerIdx].Height - 1);
-            return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
-        }
-
-        /// <summary>
-        /// Builds all internal data structures required to write a valid .mlmask file.
-        /// Calculates global resolution bounds, classifies layers into high/low tile sets,
-        /// packs tiles into the atlas, and generates the final compressed buffers.
-        /// </summary>
-        private void Create()
-        {
-            if (_mlmask.Layers == null) return;
-
-            _mlmask.WidthHigh = 0;
-            _mlmask.HeightHigh = 0;
-            foreach (var lay in _mlmask.Layers)
+            var jointCount = 0;
+            var weightCount = 0;
+            foreach (var accessor in accessors)
             {
-                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
-                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
-            }
-
-            // Metadata-driven: WidthLow/HeightLow are derived from actual layer image sizes
-            _mlmask.WidthLow = uint.MaxValue;
-            _mlmask.HeightLow = uint.MaxValue;
-            foreach (var lay in _mlmask.Layers)
-            {
-                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
-                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
-            }
-
-            for (var i = 0; i < _mlmask.Layers.Length; i++)
-            {
-                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
-                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
-            }
-
-            uint startAtlasTileSize = (_mlmask.PreferredTileSize > 0)
-                ? _mlmask.PreferredTileSize + 2
-                : 16u;
-
-            uint tempAtlasTileSize = startAtlasTileSize;
-            while (true)
-            {
-                _mlmask.AtlasTileSize = tempAtlasTileSize;
-                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
-                tempAtlasTileSize += 16;
-
-                _mlmask.MaskTilesHigh = null;
-                _mlmask.MaskTilesLow = null;
-                _mlmask.AtlasTiles.Clear();
-                _mlmask.AtlasWidth = 0;
-                _mlmask.AtlasHeight = 0;
-                _mlmask.AtlasTilesCount = 0;
-
-                InitializeMaskLayers();
-
-                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-
-                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
-                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
-                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
-
-                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
-                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
-                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
-
-                CleanTileLayers();
-
-                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
-            }
-
-            CalculateAtlasProportionForPacking();
-            CreateAtlasBuffer();
-
-            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
-            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
-            var tilesDataList = new List<uint>();
-
-            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
-                tilesDataList.Add(0U);
-
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            foreach (var l in tilesDataList) bw.Write(l);
-            _mlmask.TilesBuffer = ms.ToArray();
-        }
-
-        /// <summary>
-        /// Distributes layers into high-resolution or low-resolution tile sets.
-        /// A layer is considered "low" if its resolution is smaller than WidthHigh.
-        /// This affects which tile grid (MaskTilesHigh or MaskTilesLow) the layer's tiles are added to.
-        /// </summary>
-        private void CleanTileLayers()
-        {
-            if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
-
-            for (uint I = 0; I < _mlmask.Layers.Length; I++)
-            {
-                if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
+                if (accessor.StartsWith("JOINTS_"))
                 {
-                    for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
-                    {
-                        for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
-                        {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+                    jointCount++;
+                }
 
-                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
-                            {
-                                var layer = new TileView
-                                {
-                                    LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
-                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
-                                };
-                                _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
-                            }
-                        }
+                if (accessor.StartsWith("WEIGHTS_"))
+                {
+                    weightCount++;
+                }
+            }
+
+            if (jointCount != weightCount)
+            {
+                throw new Exception("Number of JOINTS does not match the number of WEIGHTS");
+            }
+
+            var joints0 = accessors.Contains("JOINTS_0") ? mesh.Primitives[0].GetVertices("JOINTS_0").AsVector4Array().ToList() : null;
+
+            var joints1 = accessors.Contains("JOINTS_1") ? mesh.Primitives[0].GetVertices("JOINTS_1").AsVector4Array().ToList() : null;
+
+            var weights0 = accessors.Contains("WEIGHTS_0") ? mesh.Primitives[0].GetVertices("WEIGHTS_0").AsVector4Array().ToList() : null;
+
+            var weights1 = accessors.Contains("WEIGHTS_1") ? mesh.Primitives[0].GetVertices("WEIGHTS_1").AsVector4Array().ToList() : null;
+
+            meshContainer.weightCount = 0;
+
+            if (joints0 != null)
+            {
+                meshContainer.weightCount += 4;
+            }
+
+            if (joints1 != null)
+            {
+                meshContainer.weightCount += 4;
+            }
+
+            var vertCount = meshContainer.positions.Length;
+            meshContainer.boneindices = new ushort[vertCount, meshContainer.weightCount];
+            meshContainer.weights = new float[vertCount, meshContainer.weightCount];
+
+            for (var i = 0; i < vertCount; i++)
+            {
+                if (joints0 != null && weights0 is not null && i < joints0.Count)
+                {
+                    meshContainer.boneindices[i, 0] = (ushort)joints0[i].X;
+                    meshContainer.boneindices[i, 1] = (ushort)joints0[i].Y;
+                    meshContainer.boneindices[i, 2] = (ushort)joints0[i].Z;
+                    meshContainer.boneindices[i, 3] = (ushort)joints0[i].W;
+
+                    meshContainer.weights[i, 0] = weights0[i].X;
+                    meshContainer.weights[i, 1] = weights0[i].Y;
+                    meshContainer.weights[i, 2] = weights0[i].Z;
+                    meshContainer.weights[i, 3] = weights0[i].W;
+                }
+                if (joints1 != null && weights1 is not null && i < joints1.Count)
+                {
+                    meshContainer.boneindices[i, 4] = (ushort)joints1[i].X;
+                    meshContainer.boneindices[i, 5] = (ushort)joints1[i].Y;
+                    meshContainer.boneindices[i, 6] = (ushort)joints1[i].Z;
+                    meshContainer.boneindices[i, 7] = (ushort)joints1[i].W;
+
+                    meshContainer.weights[i, 4] = weights1[i].X;
+                    meshContainer.weights[i, 5] = weights1[i].Y;
+                    meshContainer.weights[i, 6] = weights1[i].Z;
+                    meshContainer.weights[i, 7] = weights1[i].W;
+                }
+            }
+
+            meshContainer.garmentMorph = [];
+
+            if (mesh.Extras?.Deserialize<MeshExtras>() is { } extras)
+            {
+                if (extras.TargetNames != null)
+                {
+                    ExtractMorphTargets(meshContainer, mesh, extras, args);
+                }
+            }
+
+            return meshContainer;
+        }
+
+        private static void ExtractMorphTargets(RawMeshContainer meshContainer, Mesh mesh, MeshExtras extras, GltfImportArgs args)
+        {
+            if (extras.TargetNames == null)
+            {
+                return;
+            }
+
+            if (extras.TargetNames.Length != mesh.Primitives[0].MorphTargetsCount)
+            {
+                throw new Exception($"{nameof(MeshExtras)} targetNames count doesn't match morphTarget count");
+            }
+
+            for (var i = 0; i < extras.TargetNames.Length; i++)
+            {
+                if (args.ImportGarmentSupport && extras.TargetNames[i] is "GarmentSupport")
+                {
+                    meshContainer.garmentMorph = GetVector3List(i, "POSITION").Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray();
+                }
+            }
+
+            return;
+
+            List<Vec3> GetVector3List(int morphTargetIndex, string attributeKey)
+            {
+                var idx = mesh.Primitives[0].GetMorphTargetAccessors(morphTargetIndex).Keys.ToList().IndexOf(attributeKey);
+                var extraDataList = mesh.Primitives[0].GetMorphTargetAccessors(morphTargetIndex).Values.ToList()[idx].AsVector3Array().ToList();
+
+                return extraDataList;
+            }
+        }
+
+        private static Re4MeshContainer RawMeshToRE4Mesh(RawMeshContainer mesh, Vec4 qScale, Vec4 qTrans)
+        {
+            var re4Mesh = new Re4MeshContainer
+            {
+                name = mesh.name
+            };
+
+            ArgumentNullException.ThrowIfNull(mesh.positions);
+            ArgumentNullException.ThrowIfNull(mesh.normals);
+            ArgumentNullException.ThrowIfNull(mesh.tangents);
+            ArgumentNullException.ThrowIfNull(mesh.texCoords0);
+            ArgumentNullException.ThrowIfNull(mesh.texCoords1);
+            ArgumentNullException.ThrowIfNull(mesh.colors0);
+            ArgumentNullException.ThrowIfNull(mesh.boneindices);
+            ArgumentNullException.ThrowIfNull(mesh.weights);
+            ArgumentNullException.ThrowIfNull(mesh.garmentMorph);
+            ArgumentNullException.ThrowIfNull(mesh.indices);
+
+            var vertCount = mesh.positions.Length;
+            re4Mesh.ExpVerts = new short[vertCount, 3];
+
+            for (var i = 0; i < vertCount; i++)
+            {
+                var x = qScale.X != 0 ? (mesh.positions[i].X - qTrans.X) / qScale.X : 0;
+                var y = qScale.Y != 0 ? (mesh.positions[i].Y - qTrans.Y) / qScale.Y : 0;
+                var z = qScale.Z != 0 ? (mesh.positions[i].Z - qTrans.Z) / qScale.Z : 0;
+                re4Mesh.ExpVerts[i, 0] = Convert.ToInt16(Math.Clamp(x, -1, 1) * short.MaxValue);
+                re4Mesh.ExpVerts[i, 1] = Convert.ToInt16(Math.Clamp(y, -1, 1) * short.MaxValue);
+                re4Mesh.ExpVerts[i, 2] = Convert.ToInt16(Math.Clamp(z, -1, 1) * short.MaxValue);
+            }
+
+            // converting normals struct
+            re4Mesh.Nor32s = new uint[vertCount];
+            for (var i = 0; i < vertCount; i++)
+            {
+                var v = mesh.normals[i]; // for normal w == 0
+                re4Mesh.Nor32s[i] = Converters.Vec3ToU32(v);
+            }
+
+            // converting tangents struct
+            re4Mesh.Tan32s = new uint[vertCount];
+            for (var i = 0; i < vertCount; i++)
+            {
+                var v = mesh.tangents[i]; // for tangents w == 1 or -1
+                re4Mesh.Tan32s[i] = Converters.Vec4ToU32(v);
+            }
+
+            re4Mesh.uv0s = new ushort[vertCount, 2];
+            for (var i = 0; i < mesh.texCoords0.Length; i++)
+            {
+                re4Mesh.uv0s[i, 0] = Converters.converthf(mesh.texCoords0[i].X);
+                re4Mesh.uv0s[i, 1] = Converters.converthf((mesh.texCoords0[i].Y * -1) + 1);
+            }
+
+            re4Mesh.uv1s = new ushort[vertCount, 2];
+            for (var i = 0; i < mesh.texCoords1.Length; i++)
+            {
+                re4Mesh.uv1s[i, 0] = Converters.converthf(mesh.texCoords1[i].X);
+                re4Mesh.uv1s[i, 1] = Converters.converthf(mesh.texCoords1[i].Y);
+            }
+
+            re4Mesh.colors = new byte[vertCount, 4];
+            for (var i = 0; i < mesh.colors0.Length; i++)
+            {
+                re4Mesh.colors[i, 0] = Convert.ToByte(mesh.colors0[i].X * 255);
+                re4Mesh.colors[i, 1] = Convert.ToByte(mesh.colors0[i].Y * 255);
+                re4Mesh.colors[i, 2] = Convert.ToByte(mesh.colors0[i].Z * 255);
+                re4Mesh.colors[i, 3] = Convert.ToByte(mesh.colors0[i].W * 255);
+            }
+
+            re4Mesh.weightcount = mesh.weightCount;
+
+            re4Mesh.boneindices = new byte[vertCount, re4Mesh.weightcount];
+            for (var i = 0; i < vertCount; i++)
+            {
+                for (var e = 0; e < re4Mesh.weightcount; e++)
+                {
+                    re4Mesh.boneindices[i, e] = Convert.ToByte(mesh.boneindices[i, e]); // mesh.boneindices are supposed to be processed
+                }
+            }
+            // (updated according to the mesh bones rather than rig bones) before putting here
+
+            re4Mesh.weights = new byte[vertCount, re4Mesh.weightcount];
+            for (var i = 0; i < vertCount; i++)
+            {
+                for (var e = 0; e < re4Mesh.weightcount; e++)
+                {
+                    re4Mesh.weights[i, e] = Convert.ToByte(mesh.weights[i, e] * 255);
+                }
+                // weight summing can cause problems here, sometimes sum >= 256, idk how to fix them yet
+            }
+
+            // extradata/ morphoffsetbs
+            re4Mesh.garmentMorph = new ushort[0, 0];
+            if (mesh.garmentMorph.Length > 0)
+            {
+                re4Mesh.garmentMorph = new ushort[vertCount, 3];
+                for (var i = 0; i < vertCount; i++)
+                {
+                    re4Mesh.garmentMorph[i, 0] = Converters.converthf(mesh.garmentMorph[i].X);
+                    re4Mesh.garmentMorph[i, 1] = Converters.converthf(mesh.garmentMorph[i].Y);
+                    re4Mesh.garmentMorph[i, 2] = Converters.converthf(mesh.garmentMorph[i].Z);
+                }
+            }
+
+            re4Mesh.indices = new ushort[mesh.indices.Length];
+            for (var i = 0; i < mesh.indices.Length; i++)
+            {
+                if (mesh.indices[i] <= ushort.MaxValue)
+                {
+                    re4Mesh.indices[i] = Convert.ToUInt16(mesh.indices[i]);
+                }
+                else
+                {
+                    throw new Exception($"Too many vertices ({mesh.indices[i]}) in submesh - max is {ushort.MaxValue}");
+                }
+            }
+
+            return re4Mesh;
+        }
+
+        private static MeshesInfo BufferWriter(List<Re4MeshContainer> expMeshes, ref MemoryStream ms, GltfImportArgs args)
+        {
+            var meshesInfo = new MeshesInfo(expMeshes.Count);
+
+            var bw = new BinaryWriter(ms);
+            for (var i = 0; i < expMeshes.Count; i++)
+            {
+                var expMesh = expMeshes[i];
+
+                ArgumentNullException.ThrowIfNull(expMesh.ExpVerts);
+                ArgumentNullException.ThrowIfNull(expMesh.garmentMorph);
+                ArgumentNullException.ThrowIfNull(expMesh.boneindices);
+                ArgumentNullException.ThrowIfNull(expMesh.weights);
+                ArgumentNullException.ThrowIfNull(expMesh.uv0s);
+                ArgumentNullException.ThrowIfNull(expMesh.Nor32s);
+                ArgumentNullException.ThrowIfNull(expMesh.Tan32s);
+                ArgumentNullException.ThrowIfNull(expMesh.colors);
+                ArgumentNullException.ThrowIfNull(expMesh.uv1s);
+
+                var vertCount = expMesh.ExpVerts.Length / 3;
+
+                meshesInfo.vertCounts[i] = (uint)vertCount;
+                meshesInfo.posnOffsets[i] = (uint)ms.Position;
+
+                meshesInfo.vpStrides[i] = (expMesh.weightcount * 2) + 8;
+                meshesInfo.weightCounts[i] = expMesh.weightcount;
+
+                if (expMesh.garmentMorph.Length > 0)
+                {
+                    meshesInfo.garmentSupportExists[i] = true;
+                    meshesInfo.vpStrides[i] += 8;
+                }
+
+                for (var e = 0; e < vertCount; e++)
+                {
+                    bw.Write(expMesh.ExpVerts[e, 0]);
+                    bw.Write(expMesh.ExpVerts[e, 1]);
+                    bw.Write(expMesh.ExpVerts[e, 2]);
+                    bw.Write((short)32767);
+                    for (var eye = 0; eye < expMesh.weightcount; eye++)
+                    {
+                        bw.Write(expMesh.boneindices[e, eye]);
+                    }
+
+                    for (var eye = 0; eye < expMesh.weightcount; eye++)
+                    {
+                        bw.Write(expMesh.weights[e, eye]);
+                    }
+
+                    if (meshesInfo.garmentSupportExists[i])
+                    {
+                        bw.Write(expMesh.garmentMorph[e, 0]);
+                        bw.Write(expMesh.garmentMorph[e, 1]);
+                        bw.Write(expMesh.garmentMorph[e, 2]);
+                        bw.Write((ushort)0);
+                    }
+                }
+
+                long paddingLen = 0;
+
+                // 16 bytes Padding between vertexBlock and uv0, if required
+                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
+                bw.Write(new byte[paddingLen]);
+
+                // writing tx0s
+                meshesInfo.tex0Offsets[i] = (uint)ms.Position;
+                for (var e = 0; e < vertCount; e++)
+                {
+                    bw.Write(expMesh.uv0s[e, 0]);
+                    bw.Write(expMesh.uv0s[e, 1]);
+                }
+
+                // 16 bytes Padding between uv0 and normals, if required
+                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
+                bw.Write(new byte[paddingLen]);
+
+                // writing normals and tangents
+                meshesInfo.normalOffsets[i] = (uint)ms.Position;
+                for (var e = 0; e < vertCount; e++)
+                {
+                    bw.Write(expMesh.Nor32s[e]);
+                    bw.Write(expMesh.Tan32s[e]);
+                }
+
+                // 16 bytes Padding between nors/tans and colors/uv1s, if required
+                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
+                bw.Write(new byte[paddingLen]);
+
+                // writing colors and tx1s
+                meshesInfo.colorOffsets[i] = (uint)ms.Position;
+                for (var e = 0; e < vertCount; e++)
+                {
+
+                    bw.Write(expMesh.colors[e, 0]);
+                    bw.Write(expMesh.colors[e, 1]);
+                    bw.Write(expMesh.colors[e, 2]);
+                    bw.Write(expMesh.colors[e, 3]);
+
+
+                    // Temp fix for improved lighting geomertry
+                    /*
+                    bw.Write((byte)0);
+                    bw.Write((byte)0);
+                    bw.Write((byte)0);
+                    bw.Write((byte)0);
+                    */
+                    bw.Write(expMesh.uv1s[e, 0]);
+                    bw.Write(expMesh.uv1s[e, 1]);
+                }
+
+                // 16 bytes Padding if necessary
+                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
+                bw.Write(new byte[paddingLen]);
+
+                // for the unusual lightblocker data
+                /*
+                unknownOffsets[i] = (UInt32)ms.Position;
+
+                for (int e = 0; e < vertCount; e++)
+                {
+                    bw.Write((float)0f);
+                }
+                */
+                meshesInfo.vertBufferSize = (uint)ms.Length;
+
+                // this padding writer if that unusual lightblocker data is written
+                /*
+                // padding writer if necessary
+                if (((UInt64)ms.Length % 16) != 0)
+                {
+                    int zeroesCount = (int)((((UInt64)ms.Length / 16) + 1) * 16 - (UInt64)ms.Length);
+                    Byte[] bytes = new Byte[zeroesCount];
+                    bw.Write(bytes);
+                }
+                */
+            }
+
+            meshesInfo.indexBufferOffset = (uint)ms.Position;
+            for (var i = 0; i < expMeshes.Count; i++)
+            {
+                var mesh = expMeshes[i];
+
+                ArgumentNullException.ThrowIfNull(mesh.indices);
+
+                var indCount = mesh.indices.Length;
+                meshesInfo.indCounts[i] = (uint)indCount;
+
+                meshesInfo.indicesOffsets[i] = (uint)ms.Position;
+                for (var e = 0; e < indCount; e++)
+                {
+                    bw.Write(mesh.indices[e]);
+                }
+            }
+            meshesInfo.indexBufferSize = (uint)ms.Length - meshesInfo.indexBufferOffset;
+
+
+            for (var i = 0; i < meshesInfo.meshCount; i++)
+            {
+                var mesh = expMeshes[i];
+
+                ArgumentNullException.ThrowIfNull(mesh.name);
+
+                if (mesh.name.Contains("LOD"))
+                {
+                    var idx = mesh.name.IndexOf("LOD_", StringComparison.Ordinal);
+                    if (idx < mesh.name.Length - 1)
+                    {
+                        var lod = Convert.ToUInt32(mesh.name.Substring(idx + 4, 1));
+                        meshesInfo.LODLvl[i] = lod;
                     }
                 }
                 else
                 {
-                    for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
-                    {
-                        for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
-                        {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
-
-                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
-                            {
-                                var layer = new TileView
-                                {
-                                    LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
-                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
-                                };
-                                _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
-                            }
-                        }
-                    }
+                    meshesInfo.LODLvl[i] = 1;
                 }
             }
+
+            return meshesInfo;
         }
 
-        private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
+        private MemoryStream GetEditedCr2wFile(CR2WFile cr2w, MeshesInfo info, MemoryStream buffer, Mat4[]? inverseBindMatrices = null, string[]? boneNames = null)
+        //private static MemoryStream GetEditedCr2wFile(CR2WFile cr2w, MeshesInfo info, MemoryStream buffer)
         {
-            if (_mlmask.Layers == null) return 0;
-
-            var tileIndex = tx + (ty * _mlmask.Layers[layerIdx].WidthInTiles0);
-
-            if (_mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
+            rendRenderMeshBlob? blob = null;
+            if (cr2w.RootChunk is CMesh obj1 && obj1.RenderResourceBlob.Chunk is rendRenderMeshBlob obj2)
             {
-                BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
-
-                var recursiveHash = FNV1A.FnvHashInitial;
-                for (uint y = 0; y < _mlmask.AtlasTileSize / 4; y++)
-                {
-                    for (uint x = 0; x < _mlmask.AtlasTileSize / 4; x++)
-                    {
-                        var compressedBlock = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
-                        var color32 = new float[16];
-                        D3DX.D3DXDecodeBC4U(ref color32, compressedBlock);
-                        var color8 = new byte[16];
-                        for (uint i = 0; i < 16; i++) color8[i] = (byte)(color32[i] * 255.0f);
-                        recursiveHash = FNV1A.HashReadOnlySpan(color8, recursiveHash);
-                    }
-                }
-
-                if (!_mlmask.AtlasTiles.TryGetValue(recursiveHash, out var atlasView))
-                {
-                    atlasView = new TileView
-                    {
-                        AtlasInPosition = _mlmask.AtlasTilesCount++,
-                        LayerIndex = layerIdx,
-                        LayerTileIndex = tileIndex
-                    };
-                    _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
-                }
-
-                var z = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex];
-                z.AtlasInPosition = atlasView.AtlasInPosition;
-                _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
+                blob = obj2;
             }
-            return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
-        }
 
-        /// <summary>
-        /// Calculates the optimal atlas dimensions.
-        /// First tries to reuse the original atlas size from the .masklist (for round-trip fidelity).
-        /// If that doesn't fit, falls back to a minimum-waste power-of-2-friendly packing algorithm.
-        /// </summary>
-        private void CalculateAtlasProportionForPacking()
-        {
-            _mlmask.AtlasWidth = 0;
-            _mlmask.AtlasHeight = 0;
-
-            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0)
+            if (cr2w.RootChunk is MorphTargetMesh obj3 && obj3.Blob.Chunk is rendRenderMorphTargetMeshBlob obj4 && obj4.BaseBlob.Chunk is rendRenderMeshBlob obj5)
             {
-                var widthInTiles = _mlmask.PreferredAtlasWidth / _mlmask.AtlasTileSize;
-                if (widthInTiles > 0)
-                {
-                    var neededRows = (_mlmask.AtlasTilesCount + widthInTiles - 1) / widthInTiles;
-                    var requiredHeight = neededRows * _mlmask.AtlasTileSize;
+                blob = obj5;
+            }
 
-                    if (requiredHeight <= _mlmask.PreferredAtlasHeight)
+            ArgumentNullException.ThrowIfNull(blob, nameof(blob));
+
+            // removing BS topology data which causes a lot of issues with improved facial lighting geometry, vertex colors uroborus and what not
+            if (blob.Header.Topology is not null)
+            {
+                blob.Header.Topology.Clear();
+                for (var i = 0; i < info.meshCount; i++)
+                {
+                    blob.Header.Topology.Add(new rendTopologyData());
+                }
+            }
+
+            if (blob.Header.RenderLODs is not null)
+            {
+                if (blob.Header.RenderLODs.Count > info.LODLvl.Distinct().Count())
+                {
+                    blob.Header.RenderLODs = new CArray<CFloat> (blob.Header.RenderLODs.Take(info.LODLvl.Distinct().Count()).ToList());
+                }
+
+                while (blob.Header.RenderLODs.Count < info.LODLvl.Distinct().Count())
+                {
+                    if (blob.Header.RenderLODs.Count == 0)
                     {
-                        _mlmask.AtlasWidth = _mlmask.PreferredAtlasWidth;
-                        _mlmask.AtlasHeight = _mlmask.PreferredAtlasHeight;
-                        _logger.Info($"Reusing original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight}");
-                        return;
+                        blob.Header.RenderLODs.Add(0f);
                     }
                     else
                     {
-                        _logger.Info($"Original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} is insufficient for the current layer content ({_mlmask.AtlasTilesCount} unique tiles). Calculating a larger atlas...");
+                        blob.Header.RenderLODs.Add(blob.Header.RenderLODs.Max() * 2f);
+                    }
+                }
+            }
+            if (cr2w.RootChunk is CMesh { LodLevelInfo: not null } cMeshBlob)
+            {
+                if (cMeshBlob.LodLevelInfo.Count > info.LODLvl.Distinct().Count())
+                {
+                    cMeshBlob.LodLevelInfo = new CArray<CFloat> (cMeshBlob.LodLevelInfo.Take(info.LODLvl.Distinct().Count()).ToList());
+                }
+
+                while (cMeshBlob.LodLevelInfo.Count < info.LODLvl.Distinct().Count())
+                {
+                    if (cMeshBlob.LodLevelInfo.Count == 0)
+                    {
+                        cMeshBlob.LodLevelInfo.Add(0f);
+                    }
+                    else
+                    {
+                        cMeshBlob.LodLevelInfo.Add(cMeshBlob.LodLevelInfo.Max() * 2f);
                     }
                 }
             }
 
-            uint widthTry = 16384;
-            var emptyArea = uint.MaxValue;
+            //source mesh renderMasks for updation
+            var renderMasks = blob.Header.RenderChunkInfos.Select(s => s.RenderMask).ToList();
 
-            while (widthTry >= _mlmask.AtlasTileSize)
+            // removing existing rendChunks
+            blob.Header.RenderChunkInfos.Clear();
+
+            // adding new rendChunks
+            for (var i = 0; i < info.meshCount; i++)
             {
-                var widthInTiles0 = widthTry / _mlmask.AtlasTileSize;
-                var heightTry = (_mlmask.AtlasTilesCount + widthInTiles0 - 1) / widthInTiles0 * _mlmask.AtlasTileSize;
-
-                var widthUp = RoundUpPowerOf2(widthTry);
-                var heightUp = RoundUpPowerOf2(heightTry);
-
-                var currEmptyArea = (widthUp * heightUp) - (_mlmask.AtlasTilesCount * _mlmask.AtlasTileSize * _mlmask.AtlasTileSize);
-                if (currEmptyArea <= emptyArea)
+                var chunk = new rendChunk
                 {
-                    _mlmask.AtlasWidth = widthTry;
-                    _mlmask.AtlasHeight = heightTry;
-                    emptyArea = currEmptyArea;
-                }
-
-                if (widthTry <= heightTry) break;
-                widthTry /= 2;
-            }
-
-            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
-                throw new Exception("Atlas too large (over 16k)");
-
-            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0 &&
-                (_mlmask.AtlasWidth != _mlmask.PreferredAtlasWidth || _mlmask.AtlasHeight != _mlmask.PreferredAtlasHeight))
-            {
-                _logger.Info($"Atlas size automatically increased from {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} to accommodate new layer content.");
-            }
-            else if (_mlmask.PreferredAtlasWidth == 0 || _mlmask.PreferredAtlasHeight == 0)
-            {
-                _logger.Info($"Atlas size set to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight}.");
-            }
-        }
-
-        private void CreateAtlasBuffer()
-        {
-            if (_mlmask.Layers == null || _mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
-                throw new Exception("Unable to generate MLmask atlas data");
-
-            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
-            var widthInBlocks0 = _mlmask.AtlasWidth / 4;
-            var heightInBlocks0 = _mlmask.AtlasHeight / 4;
-            var widthInTiles0 = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-
-            var data = new ulong[widthInBlocks0 * heightInBlocks0];
-
-            foreach (var atlasTile in _mlmask.AtlasTiles.Values)
-            {
-                var sourceLayer = _mlmask.Layers[atlasTile.LayerIndex];
-                var tileSource = sourceLayer.Tiles[(int)atlasTile.LayerTileIndex];
-
-                var position = atlasTile.AtlasInPosition;
-                var tx = position % widthInTiles0;
-                var ty = position / widthInTiles0;
-                var bx = tx * tileSizeInBlocks0;
-                var by = ty * tileSizeInBlocks0;
-
-                var destinationIdx = bx + (by * widthInBlocks0);
-                for (uint i = 0; i < tileSizeInBlocks0; i++)
-                {
-                    Array.Copy(tileSource.AtlasBlockCompressed, i * tileSizeInBlocks0, data, destinationIdx, tileSizeInBlocks0);
-                    destinationIdx += widthInBlocks0;
-                }
-            }
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            foreach (var d in data) bw.Write(d);
-            _mlmask.AtlasBuffer = ms.ToArray();
-        }
-
-        private void BlockCompressLocalTile(ref RawTexContainer layer, uint tileIdx)
-        {
-            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
-            var tx = tileIdx % layer.WidthInTiles0;
-            var ty = tileIdx / layer.WidthInTiles0;
-
-            var layerTile = layer.Tiles[(int)tileIdx];
-            layerTile.AtlasBlockCompressed = new ulong[tileSizeInBlocks0 * tileSizeInBlocks0];
-
-            for (uint yBlock = 0; yBlock < tileSizeInBlocks0; yBlock++)
-            {
-                for (uint xBlock = 0; xBlock < tileSizeInBlocks0; xBlock++)
-                {
-                    var referenceData = new List<float>();
-                    var toBBCValues = new float[16];
-
-                    for (uint j = 0; j < 4; j++)
+                    LodMask = (byte)info.LODLvl[i],
+                    RenderMask = renderMasks[i >= renderMasks.Count ? 0 : i],
+                    // based upon VertexBlock, subject to change, incremental will be good, for weightcount ++ etc
+                    // VertexFactory is really important to be taken care of properly
+                    VertexFactory = 2,
+                    NumIndices = info.indCounts[i],
+                    NumVertices = (ushort)info.vertCounts[i],
+                    ChunkIndices = new rendIndexBufferChunk
                     {
-                        for (uint i = 0; i < 4; i++)
+                        Pe = Enums.GpuWrapApieIndexBufferChunkType.IBCT_IndexUShort,
+                        TeOffset = info.indicesOffsets[i] - info.indexBufferOffset
+                    },
+                    ChunkVertices = new rendVertexBufferChunk()
+                };
+
+                chunk.ChunkVertices.ByteOffsets.Add(info.posnOffsets[i]);
+                chunk.ChunkVertices.ByteOffsets.Add(info.tex0Offsets[i]);
+                chunk.ChunkVertices.ByteOffsets.Add(info.normalOffsets[i]);
+                chunk.ChunkVertices.ByteOffsets.Add(info.colorOffsets[i]);
+                chunk.ChunkVertices.ByteOffsets.Add(info.unknownOffsets[i]);
+
+                chunk.ChunkVertices.VertexLayout = new GpuWrapApiVertexLayoutDesc
+                {
+                    //hash is not understood/no-interest, subject to change
+                    Hash = 0
+                };
+
+                // Position
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 0,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Position,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Short4N
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // Joint0
+                if (info.weightCounts[i] > 0)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 0,
+                        UsageIndex = 0,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinIndices,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4
+                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+
+                    // subject to change, maybe, VertexFactory is weird
+                    chunk.VertexFactory++;
+                }
+
+                // joint1
+                if (info.weightCounts[i] > 4)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 0,
+                        UsageIndex = 1,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinIndices,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4
+                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+
+                    // subject to change, maybe, VertexFactory is weird
+                    chunk.VertexFactory++;
+                }
+
+                // weight0
+                if (info.weightCounts[i] > 0)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 0,
+                        UsageIndex = 0,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinWeights,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N
+                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+                }
+                // weight1
+                if (info.weightCounts[i] > 4)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 0,
+                        UsageIndex = 1,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinWeights,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N
+                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+                }
+
+                // tx0coords
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 1,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_TexCoord,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // normals
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 2,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Normal,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // tangents
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 2,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Tangent,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // color
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 3,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Color,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Color
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // tx1coords
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 3,
+                    UsageIndex = 1,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_TexCoord,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2
+                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                });
+
+                // extra data/ morphoffsets
+                if (info.garmentSupportExists[i])
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        // fishy
+                        StreamIndex = 0,
+                        UsageIndex = 0,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_ExtraData,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_4
+                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+
+                    // subject to change, maybe, VertexFactory is weird, extra data ads 2 to this
+                    chunk.VertexFactory += 2;
+                }
+
+                // instanceTransforms
+                for (byte e = 0; e < 3; e++)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 7,
+                        UsageIndex = e,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_InstanceTransform,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float4,
+                        StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerInstance
+                    });
+                }
+
+                // instanceSkinningDatas
+                if (info.weightCounts[i] > 0)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 7,
+                        UsageIndex = 0,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_InstanceSkinningData,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UInt4,
+                        StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerInstance
+                    });
+                }
+
+                // LightBlockerIntensity
+                if (info.unknownOffsets[i] != 0)
+                {
+                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                    {
+                        StreamIndex = 4,
+                        UsageIndex = 0,
+                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_LightBlockerIntensity,
+                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float1,
+                        // StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
+                    });
+
+                    // for lightblocker its 24, after testing some files, somtimes unknownoffsets[4] is used for destruction indices and some paint instead of lightblocker, so this needs to be taken care of
+                    chunk.VertexFactory += 24;
+                }
+
+
+                // Invalid, Required
+                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
+                {
+                    StreamIndex = 0,
+                    UsageIndex = 0,
+                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Invalid,
+                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Invalid,
+                    StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_Invalid
+                });
+
+                chunk.ChunkVertices.VertexLayout.SlotStrides = new CStatic<CUInt8>(8);
+                for (var j = 0; j < 8; j++)
+                {
+                    chunk.ChunkVertices.VertexLayout.SlotStrides.Add(0);
+                }
+
+                foreach (var element in chunk.ChunkVertices.VertexLayout.Elements)
+                {
+                    chunk.ChunkVertices.VertexLayout.SlotStrides[element.StreamIndex] += GetDataSize(element.Type);
+                }
+
+                var slotMask = 0;
+                for (var j = 0; j < chunk.ChunkVertices.VertexLayout.SlotStrides.Count; j++)
+                {
+                    if (chunk.ChunkVertices.VertexLayout.SlotStrides[j] > 0)
+                    {
+                        slotMask |= (1 << j);
+                    }
+                }
+                chunk.ChunkVertices.VertexLayout.SlotMask = (uint)slotMask;
+
+                // Adding Chunk
+                blob.Header.RenderChunkInfos.Add(chunk);
+            }
+
+            blob.Header.QuantizationScale.X = info.quantScale.X;
+            blob.Header.QuantizationScale.Y = info.quantScale.Y;
+            blob.Header.QuantizationScale.Z = info.quantScale.Z;
+            blob.Header.QuantizationOffset.X = info.quantTrans.X;
+            blob.Header.QuantizationOffset.Y = info.quantTrans.Y;
+            blob.Header.QuantizationOffset.Z = info.quantTrans.Z;
+
+            blob.Header.VertexBufferSize = info.vertBufferSize;
+            blob.Header.IndexBufferSize = info.indexBufferSize;
+            blob.Header.IndexBufferOffset = info.indexBufferOffset;
+
+            blob.RenderBuffer.Buffer.SetBytes(buffer.ToArray());
+
+            if (cr2w.RootChunk is CMesh root && inverseBindMatrices != null)
+            {
+                for (var i = 0; i < blob.Header.BonePositions.Count; i++)
+                {
+                    if (boneNames is not null)
+                    {
+                        var index = Array.FindIndex(boneNames, x => x.Contains(root.BoneNames[i].ToString().NotNull()) && x.Length == root.BoneNames[i].Length);
+
+                        var position = blob.Header.BonePositions[i].NotNull();
+
+                        position.X = inverseBindMatrices[index].M41;
+                        position.Y = -inverseBindMatrices[index].M43;
+                        position.Z = inverseBindMatrices[index].M42;
+                        position.W = inverseBindMatrices[index].M44;
+                        //position = root.BoneRigMatrices[i].W;
+                    }
+                }
+            }
+
+            var ms = new MemoryStream();
+            using var writer = new CR2WWriter(ms, Encoding.UTF8, true) { LoggerService = _loggerService };
+            writer.WriteFile(cr2w);
+
+            return ms;
+        }
+
+        private static CUInt8 GetDataSize(Enums.GpuWrapApiVertexPackingePackingType type) =>
+            type switch
+            {
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Invalid => 0,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float1 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float2 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float3 => 12,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float4 => 16,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_4 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort1 => 2,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort2 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort4 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort4N => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Short1 => 2,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Short2 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Short4 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Short4N => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt1 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt2 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt3 => 12,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt4 => 16,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Int1 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Int2 => 8,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Int3 => 12,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Int4 => 16,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Color => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte1 => 1,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte1F => 1,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Byte4N => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4 => 4,
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Index16 => throw new NotImplementedException(),
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Index32 => throw new NotImplementedException(),
+                Enums.GpuWrapApiVertexPackingePackingType.PT_Max => throw new NotImplementedException(),
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
+
+        private const string s_gltfError = "One or more geometry entries in GLTF";
+        private static void VerifyGLTF(ModelRoot model, GltfImportArgs args)
+        {
+            if (model.LogicalMeshes.Count < 1)
+            {
+                throw new Exception("Provided glTF doesn't contain any 3D Meshes");
+            }
+            /*if (model.LogicalSkins.Count > 1)
+            {
+                throw new Exception($"Armature Count: {model.LogicalSkins.Count}, Only 1 Armature is allowed");
+            }*/
+
+            var lods = new List<uint>();
+
+            // #2403: LOD_0 is okay for cars, so we're checking before throwing an exception
+            var lodsFromMeshNames = model.LogicalMeshes.Select(x =>
+                {
+                    var matches = Regex.Matches(x.Name, @"\d+");
+                    return matches.Count > 0 ? matches[^1].Value : null;
+                })
+                .Where(x => x is not null)
+                .Distinct()
+                .Select(x => uint.Parse(x!))
+                .ToList();
+
+            foreach (var m in model.LogicalMeshes)
+            {
+                var accessors = m.Primitives[0].VertexAccessors.Keys.ToList();
+
+                if (!accessors.Contains("POSITION"))
+                {
+                    throw new InvalidDataException($"{s_gltfError} do not contain vertices.");
+                }
+                if (!accessors.Contains("NORMAL"))
+                {
+                    throw new InvalidDataException($"{s_gltfError} do not contain Normals data.");
+                }
+                if (!accessors.Contains("TANGENT"))
+                {
+                    throw new InvalidDataException(
+                        $"{s_gltfError} do not contain Tangents data. Make sure to triangulate your mesh!");
+                }
+                if (m.Primitives[0].GetIndices().ToList().Count < 3)
+                {
+                    throw new InvalidDataException(
+                        $"{s_gltfError} contain less than 3 vertices. Please import at least a triangle!");
+                }
+                var name = m.Name;
+                uint lod = 0;
+
+                if (name.Contains("LOD"))
+                {
+                    var idx = name.IndexOf("LOD_");
+                    if (idx < name.Length - 1)
+                    {
+                        if (!uint.TryParse(name.AsSpan(idx + 4, 1), out lod))
                         {
-                            var px = (xBlock * 4) + i;
-                            var py = (yBlock * 4) + j;
-                            var v = layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
-                            toBBCValues[i + (j * 4)] = v;
-                            referenceData.Add(v);
+                            throw new Exception("Invalid Geometry/sub mesh name: " + name + " , Character after \"LOD_\" should be 1 or 2 or 4 or 8, Representing the Level of Detail (LOD) of the submesh.");
                         }
+
+                        if (lod is not 1 and not 2 and not 4 and not 8
+                            && (lod is not 0 && !lodsFromMeshNames.Contains(lod)))
+                        {
+                            throw new Exception("Invalid Geometry/sub mesh name: " + name + " , Character after \"LOD_\"  should be 1 or 2 or 4 or 8, Representing the Level of Detail (LOD) of the submesh.");
+                        }
+
+                        lods.Add(lod);
                     }
-
-                    if (tx > 0 && xBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
-                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
-
-                    if (ty > 0 && yBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
-                    else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
-
-                    ulong blockCompressed = 0;
-                    D3DX.D3DXEncodeBC4U(ref blockCompressed, toBBCValues, referenceData);
-                    layerTile.AtlasBlockCompressed[xBlock + (yBlock * tileSizeInBlocks0)] = blockCompressed;
-                }
-            }
-            layer.Tiles[(int)tileIdx] = layerTile;
-        }
-
-        private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty, uint xBlock, uint yBlock)
-        {
-            for (uint j = 0; j < 4; j++)
-            {
-                for (uint i = 0; i < 4; i++)
-                {
-                    var px = (xBlock * 4) + i;
-                    var py = (yBlock * 4) + j;
-                    var v = layer.Tiles[(int)(tx + (ty * layer.WidthInTiles0))].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
-                    referenceData.Add(v);
-                }
-            }
-        }
-
-        private static uint RoundUpPowerOf2(uint v)
-        {
-            v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16;
-            return ++v;
-        }
-
-        #endregion Core Methods
-
-        #region Structs
-
-        public struct RawTexContainer
-        {
-            public byte[] Pixels;
-            public uint Width;
-            public uint Height;
-            public List<Tile> Tiles;
-            public uint WidthShift;
-            public uint HeightShift;
-            public uint WidthInTiles0;
-            public uint HeightInTiles0;
-        }
-
-        public struct Tile
-        {
-            public byte RangeMin;
-            public byte RangeMax;
-            public byte[] AtlasUnCompressed;
-            public ulong[] AtlasBlockCompressed;
-            public uint AtlasInPosition;
-        }
-
-        public struct MaskTile
-        {
-            public List<TileView> Layers;
-        }
-
-        public struct TileView
-        {
-            public uint LayerIndex;
-            public uint AtlasInPosition;
-            public uint LayerTileIndex;
-        }
-
-        public class MlMaskContainer
-        {
-            public RawTexContainer[]? Layers;
-            public MaskTile[]? MaskTilesHigh;
-            public Dictionary<ulong, TileView> AtlasTiles = new();
-            public MaskTile[]? MaskTilesLow;
-            public uint AtlasTileSize;
-            public uint AtlasWidth;
-            public uint AtlasHeight;
-            public uint HeightHigh;
-            public uint WidthLow;
-            public uint HeightInTilesHigh;
-            public uint WidthInTilesLow;
-            public uint HeightLow;
-            public byte[]? AtlasBuffer;
-            public byte[]? TilesBuffer;
-            public uint WidthInTilesHigh;
-            public uint HeightInTilesLow;
-            public uint TileSize;
-            public uint WidthHigh;
-            public uint AtlasTilesCount;
-
-            public uint PreferredTileSize;
-            public uint PreferredAtlasWidth;
-            public uint PreferredAtlasHeight;
-        }
-
-        #endregion Structs
-
-        #region FNV1A
-
-        internal class FNV1A
-        {
-            public const ulong FnvHashInitial = 0xCBF29CE484222325;
-            public const ulong FnvHashPrime = 0x00000100000001B3;
-            public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
-            {
-                foreach (var b in source)
-                    unchecked { hash = (hash ^ b) * FnvHashPrime; }
-                return hash;
-            }
-        }
-
-        #endregion FNV1A
-
-        #region D3DX
-
-        internal class D3DX
-        {
-            [StructLayout(LayoutKind.Explicit, Size = 8)]
-            public struct BC4_UNORM
-            {
-                public float R(int offset)
-                {
-                    var index = GetIndex(offset);
-                    return DecodeFromIndex(index);
-                }
-
-                public float DecodeFromIndex(uint index)
-                {
-                    if (index == 0) return Red_0 / 255.0f;
-                    if (index == 1) return Red_1 / 255.0f;
-
-                    var fred0 = Red_0 / 255.0f;
-                    var fred1 = Red_1 / 255.0f;
-
-                    if (Red_0 > Red_1)
-                    {
-                        index--;
-                        return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
-                    }
-
-                    if (index == 6) return 0.0f;
-                    if (index == 7) return 1.0f;
-
-                    index--;
-                    return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
-                }
-
-                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
-
-                public void SetIndex(int uOffset, int uIndex)
-                {
-                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
-                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
-                }
-
-                [FieldOffset(0)] public ulong Data;
-                [FieldOffset(0)] public byte Red_0;
-                [FieldOffset(1)] public byte Red_1;
-                [FieldOffset(2)] public byte Index0;
-                [FieldOffset(3)] public byte Index1;
-                [FieldOffset(4)] public byte Index2;
-                [FieldOffset(5)] public byte Index3;
-                [FieldOffset(6)] public byte Index4;
-                [FieldOffset(7)] public byte Index5;
-            }
-
-            public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
-            {
-                var pBC4 = new BC4_UNORM();
-                FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
-                FindClosestUNORM(ref pBC4, refData);
-                resultantBlock = pBC4.Data;
-            }
-
-            private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
-            {
-                const float MIN_NORM = 0f;
-                const float MAX_NORM = 1f;
-
-                var fBlockMax = theTexelsU[0];
-                var fBlockMin = theTexelsU[0];
-                for (var i = 0; i < numTexels; ++i)
-                {
-                    if (theTexelsU[i] < fBlockMin) fBlockMin = theTexelsU[i];
-                    else if (theTexelsU[i] > fBlockMax) fBlockMax = theTexelsU[i];
-                }
-
-                var bUsing4BlockCodec = MIN_NORM == fBlockMin || MAX_NORM == fBlockMax;
-                float fStart = 0, fEnd = 0;
-
-                if (!bUsing4BlockCodec)
-                {
-                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
-                    var iStart = Convert.ToByte(fStart * 255.0f);
-                    var iEnd = Convert.ToByte(fEnd * 255.0f);
-                    endpointU_0 = iEnd;
-                    endpointU_1 = iStart;
                 }
                 else
                 {
-                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
-                    var iStart = Convert.ToByte(fStart * 255.0f);
-                    var iEnd = Convert.ToByte(fEnd * 255.0f);
-                    endpointU_1 = iEnd;
-                    endpointU_0 = iStart;
+                    lods.Add(1);
                 }
             }
-
-            private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
+            if (!lods.Contains(1))
             {
-                float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
-                float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
-                float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
-                float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
+                throw new Exception("None of the Geometry/submeshes are of 1 Level of Detail or (LOD 1) in provided GLTF");
+            }
+        }
+        private static void UpdateSkinningParamCloth(ref List<RawMeshContainer> meshes, ref CR2WFile cr2w, GltfImportArgs args)
+        {
+            var cMesh = (CMesh)cr2w.RootChunk;
 
-                var pC = 6 == cSteps ? pC6 : pC8;
-                var pD = 6 == cSteps ? pD6 : pD8;
-
-                const float maxValue = 1.0f;
-                const float minValue = 0.0f;
-
-                var fX = maxValue;
-                var fY = minValue;
-
-                if (8 == cSteps)
+            // #2403: LOD_0 is okay for cars, so we're checking
+            var lodsFromMeshNames = meshes.Select(x =>
                 {
-                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                    var matches = Regex.Matches(x.name ?? "", @"\d+");
+                    return matches.Count > 0 ? matches[^1].Value : null;
+                })
+                .Where(x => x is not null)
+                .Distinct()
+                .Select(x => uint.Parse(x!))
+                .ToList();
+
+
+            var lodLvl = new uint[meshes.Count];
+            for (var i = 0; i < meshes.Count; i++)
+            {
+                var mesh = meshes[i];
+
+                ArgumentNullException.ThrowIfNull(mesh.name);
+
+                if (mesh.name.Contains("LOD"))
+                {
+                    var idx = mesh.name.IndexOf("LOD_", StringComparison.Ordinal);
+                    if (idx < mesh.name.Length - 1)
                     {
-                        if (pPoints[iPoint] < fX) fX = pPoints[iPoint];
-                        if (pPoints[iPoint] > fY) fY = pPoints[iPoint];
+                        if (!uint.TryParse(mesh.name.AsSpan(idx + 4, 1), out var lod) ||
+                            (lod is not 1 and not 2 and not 4 and not 8 &&
+                             (lod is not 0 && !lodsFromMeshNames.Contains(lod))))
+                        {
+                            throw new Exception(
+                                $"Invalid submesh name: {mesh.name}, Character after \"LOD_\" should be 1 or 2 or 4 or 8 to indicate submesh Level of Detail");
+                        }
+
+                        lodLvl[i] = lod;
                     }
                 }
                 else
                 {
-                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
-                    {
-                        if (pPoints[iPoint] < fX && pPoints[iPoint] > minValue) fX = pPoints[iPoint];
-                        if (pPoints[iPoint] > fY && pPoints[iPoint] < maxValue) fY = pPoints[iPoint];
-                    }
-                    if (fX == fY) fY = maxValue;
+                    lodLvl[i] = 1;
                 }
 
-                var fSteps = Convert.ToSingle(cSteps - 1);
-
-                for (var iIteration = 0; iIteration < 8; iIteration++)
-                {
-                    if (fY - fX < 1.0f / 256.0f) break;
-
-                    var fScale = fSteps / (fY - fX);
-                    var pSteps = new float[8];
-
-                    for (var iStep = 0; iStep < cSteps; iStep++)
-                        pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
-
-                    if (6 == cSteps)
-                    {
-                        pSteps[6] = minValue;
-                        pSteps[7] = maxValue;
-                    }
-
-                    var dX = 0.0f;
-                    var dY = 0.0f;
-                    var d2X = 0.0f;
-                    var d2Y = 0.0f;
-
-                    for (uint iPoint = 0; iPoint < numTexels; iPoint++)
-                    {
-                        var fDot = (pPoints[(int)iPoint] - fX) * fScale;
-                        uint iStep;
-
-                        if (fDot <= 0.0f)
-                            iStep = 6 == cSteps && pPoints[(int)iPoint] <= fX * 0.5f ? (uint)6 : 0;
-                        else if (fDot >= fSteps)
-                            iStep = 6 == cSteps && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f ? 7 : cSteps - 1;
-                        else
-                            iStep = (uint)(fDot + 0.5f);
-
-                        if (iStep < cSteps)
-                        {
-                            var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
-                            dX += pC[iStep] * fDiff;
-                            d2X += pC[iStep] * pC[iStep];
-                            dY += pD[iStep] * fDiff;
-                            d2Y += pD[iStep] * pD[iStep];
-                        }
-                    }
-
-                    if (d2X > 0.0f) fX -= dX / d2X;
-                    if (d2Y > 0.0f) fY -= dY / d2Y;
-
-                    if (fX > fY) (fY, fX) = (fX, fY);
-
-                    if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f) break;
-                }
-
-                pX = fX < minValue ? minValue : fX > maxValue ? maxValue : fX;
-                pY = fY < minValue ? minValue : fY > maxValue ? maxValue : fY;
             }
 
-            private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
-            {
-                const uint numPixelsPerBlock = 16;
-                var rGradient = new float[8];
-                for (uint i = 0; i < 8; ++i)
-                    rGradient[i] = pBC.DecodeFromIndex(i);
+            // TODO: What should happen here?
+            /*int meshBufferIdx = cr2w.Chunks.OfType<rendRenderMeshBlob>().First().RenderBuffer.Pointer - 1;
+            int materialBufferIdx = cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Pointer - 1;
+            if (cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Buffer.MemSize == 0)
+                materialBufferIdx = int.MaxValue;
 
-                for (uint i = 0; i < numPixelsPerBlock; ++i)
+            int buffCount = cr2w.Buffers.Count;
+
+            for (int i = 0, idx = 0; i < buffCount; i++, idx++)
+            {
+                if (idx != meshBufferIdx && idx != materialBufferIdx)
                 {
-                    uint uBestIndex = 0;
-                    float fBestDelta = 100000;
-                    for (uint uIndex = 0; uIndex < 8; uIndex++)
-                    {
-                        var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
-                        if (fCurrentDelta < fBestDelta)
-                        {
-                            uBestIndex = uIndex;
-                            fBestDelta = fCurrentDelta;
-                        }
-                    }
-                    pBC.SetIndex((int)i, (int)uBestIndex);
+                    cr2w.Buffers.Remove(cr2w.Buffers[idx]);
+                    if (idx < meshBufferIdx)
+                        meshBufferIdx--;
+                    if (idx < materialBufferIdx)
+                        materialBufferIdx--;
+                    idx--;
                 }
             }
+            if (cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Buffer.MemSize == 0)
+                materialBufferIdx = 0;
 
-            public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
+            cr2w.Chunks.OfType<rendRenderMeshBlob>().First().RenderBuffer.Pointer = meshBufferIdx + 1;
+            cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Pointer = materialBufferIdx + 1;*/
+
+            var clothBlob = cMesh.Parameters.FirstOrDefault(x => x is not null && x.Chunk is meshMeshParamCloth);
+            var clothGraphicalBlob = cMesh.Parameters.FirstOrDefault(x => x is not null && x.Chunk is meshMeshParamCloth_Graphical);
+
+            if (clothBlob != null)
             {
-                const uint numPixelsPerBlock = 16;
-                var pBC4 = new BC4_UNORM { Data = pBC };
-                for (var i = 0; i < numPixelsPerBlock; ++i)
-                    pColor[i] = pBC4.R(i);
+                var blob = (meshMeshParamCloth)clothBlob.Chunk.NotNull();
+                blob.Chunks = new CArray<meshPhxClothChunkData>();
+                foreach (var mesh in meshes)
+                {
+                    ArgumentNullException.ThrowIfNull(mesh.name);
+                    ArgumentNullException.ThrowIfNull(mesh.positions);
+                    ArgumentNullException.ThrowIfNull(mesh.indices);
+                    ArgumentNullException.ThrowIfNull(mesh.weights);
+                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
+                    ArgumentNullException.ThrowIfNull(mesh.normals);
+
+                    var chunk = new meshPhxClothChunkData();
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.positions[e].X);
+                            bw.Write(mesh.positions[e].Y);
+                            bw.Write(mesh.positions[e].Z);
+                        }
+
+                        chunk.Positions = new DataBuffer(buffer.ToArray());
+                    }
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        foreach (var i in mesh.indices)
+                        {
+                            bw.Write(Convert.ToUInt16(i));
+                        }
+
+                        chunk.Indices = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 0)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.weights[e, 0]);
+                            bw.Write(mesh.weights[e, 1]);
+                            bw.Write(mesh.weights[e, 2]);
+                            bw.Write(mesh.weights[e, 3]);
+                        }
+
+                        chunk.SkinWeights = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 0)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 0]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 1]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 2]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 3]));
+                        }
+
+                        chunk.SkinIndices = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 4)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.weights[e, 4]);
+                            bw.Write(mesh.weights[e, 5]);
+                            bw.Write(mesh.weights[e, 6]);
+                            bw.Write(mesh.weights[e, 7]);
+                        }
+
+                        chunk.SkinWeightsExt = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 4)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 4]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 5]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 6]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 7]));
+                        }
+
+                        chunk.SkinIndicesExt = new DataBuffer(buffer.ToArray());
+                    }
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.normals.Length; e++)
+                        {
+                            bw.Write(mesh.normals[e].X);
+                            bw.Write(mesh.normals[e].Y);
+                            bw.Write(mesh.normals[e].Z);
+                        }
+
+                        chunk.Normals = new DataBuffer(buffer.ToArray());
+                    }
+                    blob.Chunks.Add(chunk);
+                    mesh.weightCount = 0;
+                }
+                blob.LodChunkIndices = new CArray<CArray<CUInt16>>
+                {
+                    new()
+                };
+                if (lodLvl.Contains(2U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                if (lodLvl.Contains(4U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                if (lodLvl.Contains(8U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                for (ushort i = 0; i < lodLvl.Length; i++)
+                {
+                    if (lodLvl[i] == 1)
+                    {
+                        blob.LodChunkIndices[0].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 2)
+                    {
+                        blob.LodChunkIndices[1].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 4)
+                    {
+                        blob.LodChunkIndices[2].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 8)
+                    {
+                        blob.LodChunkIndices[3].NotNull().Add(i);
+                    }
+                }
+            }
+            if (clothGraphicalBlob != null)
+            {
+                var blob = (meshMeshParamCloth_Graphical)clothGraphicalBlob.Chunk.NotNull();
+                blob.Chunks = new CArray<meshGfxClothChunkData>();
+                foreach (var mesh in meshes)
+                {
+                    ArgumentNullException.ThrowIfNull(mesh.name);
+                    ArgumentNullException.ThrowIfNull(mesh.positions);
+                    ArgumentNullException.ThrowIfNull(mesh.indices);
+                    ArgumentNullException.ThrowIfNull(mesh.weights);
+                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
+                    ArgumentNullException.ThrowIfNull(mesh.colors1);
+
+                    var chunk = new meshGfxClothChunkData();
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.positions[e].X);
+                            bw.Write(mesh.positions[e].Y);
+                            bw.Write(mesh.positions[e].Z);
+                        }
+
+                        chunk.Positions = new DataBuffer(buffer.ToArray());
+                    }
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        foreach (var i in mesh.indices)
+                        {
+                            bw.Write(Convert.ToUInt16(i));
+                        }
+
+                        chunk.Indices = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 0)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.weights[e, 0]);
+                            bw.Write(mesh.weights[e, 1]);
+                            bw.Write(mesh.weights[e, 2]);
+                            bw.Write(mesh.weights[e, 3]);
+                        }
+
+                        chunk.SkinWeights = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 0)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 0]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 1]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 2]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 3]));
+                        }
+
+                        chunk.SkinIndices = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 4)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(mesh.weights[e, 4]);
+                            bw.Write(mesh.weights[e, 5]);
+                            bw.Write(mesh.weights[e, 6]);
+                            bw.Write(mesh.weights[e, 7]);
+                        }
+
+                        chunk.SkinWeightsExt = new DataBuffer(buffer.ToArray());
+                    }
+                    if (mesh.weightCount > 4)
+                    {
+                        var buffer = new MemoryStream();
+                        var bw = new BinaryWriter(buffer);
+                        for (var e = 0; e < mesh.positions.Length; e++)
+                        {
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 4]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 5]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 6]));
+                            bw.Write(Convert.ToByte(mesh.boneindices[e, 7]));
+                        }
+
+                        chunk.SkinIndicesExt = new DataBuffer(buffer.ToArray());
+                    }
+                    {
+                        chunk.Simulation = new CArray<CUInt16>();
+                        for (ushort e = 0; e < mesh.colors1.Length; e++)
+                        {
+                            if (mesh.colors1[e].X > 0.01f)
+                            {
+                                chunk.Simulation.Add(e);
+                            }
+                        }
+                    }
+                    blob.Chunks.Add(chunk);
+                    mesh.weightCount = 0;
+                }
+                blob.LodChunkIndices = new CArray<CArray<CUInt16>>
+                {
+                    new()
+                };
+                if (lodLvl.Contains(2U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                if (lodLvl.Contains(4U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                if (lodLvl.Contains(8U))
+                {
+                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
+                }
+                for (ushort i = 0; i < lodLvl.Length; i++)
+                {
+                    if (lodLvl[i] == 1)
+                    {
+                        blob.LodChunkIndices[0].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 2)
+                    {
+                        blob.LodChunkIndices[1].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 4)
+                    {
+                        blob.LodChunkIndices[2].NotNull().Add(i);
+                    }
+                    if (lodLvl[i] == 8)
+                    {
+                        blob.LodChunkIndices[3].NotNull().Add(i);
+                    }
+                }
             }
         }
 
-        #endregion D3DX
+        #region Parameter: GarmentSupport
+
+        private void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CMesh cMesh, bool importGarmentSupport = true, bool ignoreGarmentSupportUVParam = true)
+        {
+            for (var i = cMesh.Parameters.Count - 1; i >= 0; i--)
+            {
+                if (cMesh.Parameters[i] is { Chunk: meshMeshParamGarmentSupport } or { Chunk: garmentMeshParamGarment })
+                {
+                    cMesh.Parameters.RemoveAt(i);
+                }
+            }
+
+            if (!importGarmentSupport)
+            {
+                return;
+            }
+
+            var missingMorphData = new List<string>();
+            foreach (var rawMeshContainer in meshes)
+            {
+                if (rawMeshContainer.garmentMorph?.Length == 0)
+                {
+                    missingMorphData.Add(rawMeshContainer.name!);
+                }
+            }
+
+            if (missingMorphData.Count == meshes.Count)
+            {
+                _loggerService.Warning("Garment support is enabled, but the model doesn't contain any morph data. Please ensure all meshes have garment morph data before enabling garment support. Skipping GS Parameters!");
+                return;
+            }
+
+            // Not sure if valid or not. Parameters where removed before, so I kept it this way. Remove below if needed - Seb E. Roth
+            if (missingMorphData.Count > 0)
+            {
+                _loggerService.Warning($"Garment support is enabled, but the following submeshes do not have garment morph data: {string.Join(", ", missingMorphData)}. Please ensure all meshes have garment morph data before enabling garment support. Skipping GS Parameters!");
+                return;
+            }
+
+            var meshMeshParamGarmentSupportData = new meshMeshParamGarmentSupport
+            {
+                ChunkCapVertices = [],
+                CustomMorph = true
+            };
+            cMesh.Parameters.Add(meshMeshParamGarmentSupportData);
+
+            var garmentMeshParamGarmentData = new garmentMeshParamGarment
+            {
+                Chunks = []
+            };
+            cMesh.Parameters.Add(garmentMeshParamGarmentData);
+
+            foreach (var mesh in meshes)
+            {
+                UpdateGarmentSupportParameters(mesh, meshMeshParamGarmentSupportData, garmentMeshParamGarmentData, ignoreGarmentSupportUVParam);
+            }
+        }
+
+        private static void UpdateGarmentSupportParameters(RawMeshContainer mesh, meshMeshParamGarmentSupport garmentMeshBlobChunk, garmentMeshParamGarment garmentBlobChunk, bool ignoreGarmentSupportUVParam = true)
+        {
+            ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.indices, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.garmentMorph, nameof(mesh));
+            ArgumentNullException.ThrowIfNull(mesh.texCoords0, nameof(mesh));
+
+            var vertBuffer = new MemoryStream();
+            var vertBw = new BinaryWriter(vertBuffer);
+
+            var indBuffer = new MemoryStream();
+            var indBw = new BinaryWriter(indBuffer);
+
+            var morphBuffer = new MemoryStream();
+            var morphBw = new BinaryWriter(morphBuffer);
+
+            var flagBuffer = new MemoryStream();
+            var flagBw = new BinaryWriter(flagBuffer);
+
+            var uvBuffer = new MemoryStream();
+            var uvBw = new BinaryWriter(uvBuffer);
+
+            var capVertices = new CArray<CUInt32>();
+
+            for (var v = 0; v < mesh.positions.Length; v++)
+            {
+                vertBw.Write(mesh.positions[v].X);
+                vertBw.Write(mesh.positions[v].Y);
+                vertBw.Write(mesh.positions[v].Z);
+
+                morphBw.Write(mesh.garmentMorph[v].X);
+                morphBw.Write(mesh.garmentMorph[v].Y);
+                morphBw.Write(mesh.garmentMorph[v].Z);
+
+                var vertexHasValidCap = mesh.garmentSupportCap?.Length > v && mesh.garmentSupportCap[v].X >= .5f;
+                flagBw.Write(Convert.ToByte(mesh.garmentSupportWeight?.Length > v ? mesh.garmentSupportWeight[v].X * 255 : 0));
+                flagBw.Write(Convert.ToByte(vertexHasValidCap ? 1 : 0));
+                flagBw.Write((byte)0);
+                flagBw.Write((byte)0);
+                if (vertexHasValidCap)
+                {
+                    capVertices.Add(Convert.ToUInt32(v));
+                }
+
+                uvBw.Write(mesh.texCoords0[v].X);
+                uvBw.Write(1 - mesh.texCoords0[v].Y);
+            }
+
+            foreach (var i in mesh.indices)
+            {
+                indBw.Write(Convert.ToUInt16(i));
+            }
+
+            garmentMeshBlobChunk.ChunkCapVertices.Add(capVertices);
+
+            garmentBlobChunk.Chunks.Add(new garmentMeshParamGarmentChunkData
+            {
+                GarmentFlags = new DataBuffer(flagBuffer.ToArray()),
+                Indices = new DataBuffer(indBuffer.ToArray()),
+                MorphOffsets = new DataBuffer(morphBuffer.ToArray()),
+                Vertices = new DataBuffer(vertBuffer.ToArray()),
+                Uv = ignoreGarmentSupportUVParam ? null : new DataBuffer(uvBuffer.ToArray()),
+                NumVertices = Convert.ToUInt32(mesh.positions.Length),
+                LodMask = 1
+            });
+        }
+
+        #endregion Parameter: GarmentSupport
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MeshImportTools.cs
@@ -2,2009 +2,984 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-using SharpGLTF.Schema2;
-using WolvenKit.Common.Model.Arguments;
+using System.Runtime.InteropServices;
+using WolvenKit.Common;
+using WolvenKit.Common.DDS;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
-using WolvenKit.Modkit.RED4.GeneralStructs;
-using WolvenKit.Modkit.RED4.RigFile;
-using WolvenKit.Modkit.RED4.Tools;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.Archive.IO;
+using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
-using Mat4 = System.Numerics.Matrix4x4;
-using Quat = System.Numerics.Quaternion;
-using Vec2 = System.Numerics.Vector2;
-using Vec3 = System.Numerics.Vector3;
-using Vec4 = System.Numerics.Vector4;
 
-namespace WolvenKit.Modkit.RED4
+namespace WolvenKit.Modkit.RED4.MLMask
 {
-    public partial class ModTools
+    public class MLMASK
     {
-        //WIP does not do the thing yet
-        public bool ImportRig(FileInfo inGltfFile, Stream rigStream, GltfImportArgs args)
+        private const uint s_headerLength = 148;
+        private MlMaskContainer _mlmask;
+        private readonly ILoggerService _logger;
+
+        public MLMASK(MlMaskContainer mlMask, ILoggerService logger)
         {
-            var cr2w = _parserService.ReadRed4File(rigStream);
-
-            if (cr2w is not { RootChunk: animRig rig })
-            {
-                return false;
-            }
-
-            var model = ModelRoot.Load(inGltfFile.FullName, new ReadSettings(args.ValidationMode));
-
-            //VerifyGLTF(model);
-
-            List<LogicalChildOfRoot> armature;
-
-            var joints = new List<(Node Joint, Mat4 InverseBindMatrix)>();
-            var jointlist = new List<Node>();
-            var jointnames = new List<string>();
-            var jointparentnames = new List<string>();
-            var ibm = new List<Mat4>();
-            var wm = new List<Mat4>();
-
-
-            if (model.LogicalSkins.Count > 0)
-            {
-                armature = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => (LogicalChildOfRoot)model.LogicalSkins[0]).ToList();
-                joints = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_)).ToList();
-                jointlist = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint).ToList();
-                jointnames = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.Name).ToList();
-                jointparentnames = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.VisualParent.Name).ToList();
-                ibm = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).InverseBindMatrix).ToList();
-                wm = Enumerable.Range(0, armature.Count).Select(_ => ((Skin)armature[_]).GetJoint(_).Joint.WorldMatrix).ToList();
-            }
-            else
-            {
-                if (model.LogicalNodes.Count > 0)
-                {
-                    armature = Enumerable.Range(0, model.LogicalNodes.Count).Select(_ => (LogicalChildOfRoot)model.LogicalNodes[_]).ToList();
-                    jointlist = Enumerable.Range(0, armature.Count).Select(_ => (Node)armature[_]).ToList();
-                    jointnames = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).Name).ToList();
-                    jointparentnames = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).VisualParent is null
-                                                                        ? "firstbone" : ((Node)armature[_]).VisualParent.Name).ToList();
-                    wm = Enumerable.Range(0, armature.Count).Select(_ => ((Node)armature[_]).WorldMatrix).ToList();
-
-                    for (var i = 0; i < wm.Count; i++)
-                    {
-                        var temp = new Mat4();
-                        Mat4.Invert(wm[i], out temp);
-                        ibm.Add(temp);
-                    }
-                    //ibm = Enumerable.Range(0, wm.Count).Select(_ => Mat4.Invert( wm[_], out ibm[_] )).ToList();
-                    joints = Enumerable.Range(0, armature.Count).Select(_ => (jointlist[_], ibm[_])).ToList();
-                }
-            }
-
-            int[]? GetLevels(string root = "Root")
-            {
-                var rootIndex = jointnames.IndexOf("Root");
-                var treeLevel = new int[jointnames.Count];
-
-                if (jointparentnames[rootIndex].Contains("Armature"))
-                {
-                    void rec(string parent, int level)
-                    {
-                        var tIndex = Enumerable.Range(0, jointnames.Count).Where(i => jointparentnames[i] == parent).ToList();
-                        foreach (var ind in tIndex)
-                        {
-                            treeLevel[ind] = level;
-                            rec(jointnames[ind], level + 1);
-                        }
-                    }
-                    rec(root, 0);
-                    return treeLevel;
-                }
-                return null;
-            }
-
-            Mat4.Invert(joints[1].Joint.WorldMatrix, out var inversedWorldMatrix);
-            Mat4.Invert(joints[1].Joint.LocalMatrix, out var inversedLocalMatrix);
-
-            var oriRotM = Mat4.CreateFromQuaternion(joints[1].Joint.LocalTransform.Rotation);
-            var oriScaM = Mat4.CreateScale(joints[1].Joint.LocalTransform.Scale);
-            var oriTraM = Mat4.CreateTranslation(joints[1].Joint.LocalTransform.Translation);
-
-            var rotM = oriScaM * joints[1].InverseBindMatrix * oriTraM;
-            Mat4.Invert(rotM, out rotM);
-
-            var manualTRS = oriTraM * oriRotM * oriScaM;
-            Mat4.Invert(manualTRS, out var inversedManualTRS);
-
-            var manualRotM = oriScaM * inversedManualTRS * oriTraM;
-            Mat4.Invert(manualRotM, out manualRotM);
-
-            var inv2 = oriTraM * rotM * oriScaM;
-
-            var localInvRotM = oriScaM * inversedLocalMatrix * oriTraM;
-            Mat4.Invert(localInvRotM, out localInvRotM);
-
-            var rotationVector = Quat.CreateFromRotationMatrix(rotM);
-            var manualRotationVector = Quat.CreateFromRotationMatrix(manualRotM);
-            var localRotationVector = Quat.CreateFromRotationMatrix(localInvRotM);
-
-            var levels = GetLevels("Root");
-            if (levels is not null)
-            {
-                for (var i = 0; i < rig.BoneNames.Count; i++)
-                {
-                    var currentBone = rig.BoneNames[i];
-                    var index = jointnames.IndexOf(currentBone.ToString().NotNull());
-                    var parindex = jointnames.IndexOf(jointlist[index].VisualParent.Name);
-                    var transform = rig.BoneTransforms[i].NotNull();
-
-                    {
-                        /*
-                        transform.Rotation.I = jointlist[index].LocalTransform.Rotation.X;
-                        transform.Rotation.J = -jointlist[index].LocalTransform.Rotation.Z;
-                        transform.Rotation.K = jointlist[index].LocalTransform.Rotation.Y;
-                        transform.Rotation.R = jointlist[index].LocalTransform.Rotation.W;
-
-                        transform.Scale.W = 1;
-                        transform.Scale.X = jointlist[index].LocalTransform.Scale.X;
-                        transform.Scale.Y = jointlist[index].LocalTransform.Scale.Y;
-                        transform.Scale.Z = jointlist[index].LocalTransform.Scale.Z;
-
-                        transform.Translation.W = i == 0 ? 1 : 0;
-                        transform.Translation.X = jointlist[index].LocalTransform.Translation.X;
-                        transform.Translation.Y = -jointlist[index].LocalTransform.Translation.Z;
-                        transform.Translation.Z = jointlist[index].LocalTransform.Translation.Y;
-                        */
-                    } //gotta figure out those rotations
-
-                    var oriR = transform.Rotation;
-                    var oriRquat = new Quat(oriR.I, oriR.J, oriR.K, oriR.R);
-                    var newR = jointlist[index].LocalTransform.Rotation;
-                    var parR = jointlist[index].VisualParent.LocalTransform.Rotation;
-
-                    var oriT = transform.Translation;
-                    var oriTvec = new Vec4(oriT.X, oriT.Y, oriT.Z, oriT.W);
-                    var newT = jointlist[index].LocalTransform.Translation;
-                    var parT = jointlist[index].VisualParent.LocalTransform.Translation;
-
-                    var herewegoagane = parR * newR;
-
-
-                    var quatM = Mat4.CreateFromQuaternion(oriRquat);
-
-                    var d = newR - oriRquat + new Quat(0, 0, 0, 1);
-                    var p = newR * oriRquat;
-                    var e = d == p;
-                    var esmall = (d - p).Length() < 0.001;
-
-                    var level = levels[index];
-
-                    {/*
-                        var nya = System.Numerics.Vector3.Transform(tr, parR);
-
-                        //var rr = jointlist[index].VisualParent.VisualParent.LocalTransform.Rotation;
-                        var nye = System.Numerics.Vector3.Transform(tr, parR * rr);
-                        var rrr = jointlist[index].VisualParent.VisualParent.VisualParent.LocalTransform.Rotation;
-                        var ya = System.Numerics.Vector3.Transform(tr, parR * rr * rrr);
-
-                        var (r, s, t) = (new Quat(), new Vec3(), new Vec3());
-                        var tinverse = new Mat4();
-                        Mat4.Invert(jointlist[index].VisualParent.WorldMatrix, out tinverse);
-                        Mat4.Decompose(tinverse, out s, out r, out t);
-
-                        var yaya = System.Numerics.Vector3.Transform(tr, r * parR);*/
-                    }
-
-                    /*Mat4 TRSFromRig(QsTransform parTr)
-                    {
-                        var (r, s, t) = (parTr.Rotation, parTr.Scale, parTr.Translation);
-
-                        var R = Mat4.CreateFromQuaternion(new Quat(r.R, r.I, r.J, r.K));
-                        var S = Mat4.CreateScale(new Vec3(s.X, s.Y, s.Z));
-                        var T = Mat4.CreateTranslation(new Vec3(t.X, t.Y, t.Z));
-                        var M = T * R * S;
-                        return M;
-                    }
-
-                    if (index > -1 && parindex > -1)
-                    {
-                        var parM = TRSFromRig(rig.BoneTransforms[parindex]);
-                        Mat4.Invert(parM, out var parMinv);
-                        var M = TRSFromRig(rig.BoneTransforms[index]);
-                        Mat4.Invert(jointlist[index].VisualParent.WorldMatrix, out var tinverse);
-                        Mat4.Decompose(parMinv * M, out var s, out var r, out var t);
-                    }*/
-
-                    Quat AllOriginalRotations(int i)
-                    {
-                        var wquat = transform.Rotation;
-                        var quat = new Quat(wquat.I, wquat.J, wquat.K, wquat.R);
-                        return (rig.BoneNames[i] == "Root") ? quat : AllOriginalRotations(rig.BoneParentIndexes[i]) * quat;
-                    }
-
-                    var oriAllR = AllOriginalRotations(i);
-                    var oriParAllR = oriAllR * Quat.Inverse(oriRquat);
-                    var yetatr = Vec4.Transform(newT, oriAllR);
-
-                    Quat AllRotations(Node node)
-                    {
-                        var quat = node.LocalTransform.Rotation;
-                        return (node.Name == "Root") ? quat : AllRotations(node.VisualParent) * quat;
-                    }
-
-                    var infinya = AllRotations(jointlist[index]);
-                    var finit = Vec4.Transform(newT, infinya);
-                    var aynifni = Vec4.Transform(newT, Quat.Inverse(infinya));
-
-
-                    var before = transform.Translation.DeepCopy();
-
-                    //level = 0;
-
-                    var x90 = Quat.CreateFromAxisAngle(Vec3.UnitX, (float)Math.PI / 2);
-                    var y90 = Quat.CreateFromAxisAngle(Vec3.UnitY, (float)Math.PI / 2);
-                    var z90 = Quat.CreateFromAxisAngle(Vec3.UnitZ, (float)Math.PI / 2);
-
-
-                    //works only for the rig of the kusanagi bike
-                    transform.Translation = level == 1 ? Vec4.Transform(newT, x90) :
-                                                        level is 3 or
-                                                        4 ? Vec4.Transform(newT, new Quat(0, 1, 0, 0) * x90) :
-                                                        level == 5 ? Vec4.Transform(newT, x90) :
-                                                        level == 6 ? Vec4.Transform(newT, z90) :
-                                                        level == 8 ? Vec4.Transform(newT, y90 * new Quat(0, 0, 0, 1)) : // Quat(0, 0, 0, 1) is z90 * z90
-                                                        new Vec4(newT.X, newT.Y, newT.Z, 0);
-
-                    transform.Translation.W = i == 0 ? 1 : 0;
-
-                    /*
-                    transform.Translation.X = level == 6 ? -newT.Y :
-                                                          level == 8 ? newT.Z :
-                                                          newT.X;
-                    transform.Translation.Y = level == 1 ? newT.Z :
-                                                          level == 3 ? -newT.Z :
-                                                          level == 4 ? -newT.Z :
-                                                          level == 5 ? -newT.Z :
-                                                          level == 6 ? newT.X :
-                                                          level == 8 ? -newT.Y :
-                                                          newT.Y;
-                    transform.Translation.Z = level == 1 ? newT.Y :
-                                                          level == 3 ? -newT.Y :
-                                                          level == 4 ? -newT.Y :
-                                                          level == 5 ? newT.Y :
-                                                          level == 8 ? newT.X :
-                                                          newT.Z;
-                    */
-
-                    var after = transform.Translation;
-                }
-            }
-            var ms = new MemoryStream();
-            using var writer = new CR2WWriter(ms, Encoding.UTF8, true) { LoggerService = _loggerService };
-            writer.WriteFile(cr2w);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            rigStream.SetLength(0);
-            ms.CopyTo(rigStream);
-
-            return true;
+            _mlmask = mlMask;
+            _logger = logger;
         }
 
-
-        public bool ImportMesh(FileInfo inGltfFile, Stream inMeshStream, GltfImportArgs args)
+        public void Import(FileInfo txtImageList, FileInfo outFile)
         {
-            var cr2w = _parserService.ReadRed4File(inMeshStream);
+            var lines = File.ReadAllLines(txtImageList.FullName);
+            var baseDir = txtImageList.Directory.NotNull();
 
-            if (cr2w is not { RootChunk: CMesh meshBlob } || meshBlob.RenderResourceBlob.Chunk is not rendRenderMeshBlob rendBlob)
+            uint targetAtlasWidth = 0;
+            uint targetAtlasHeight = 0;
+            uint targetTileSize = 16;
+
+            var filePaths = new List<string>();
+
+            foreach (var line in lines)
             {
-                return false;
-            }
+                var trimmed = line.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                    continue;
 
-            // https://github.com/WolvenKit/WolvenKit/issues/1870
-            rendBlob.Header.OpacityMicromaps.Clear();
-
-            var originalRig = args.Rig?.FirstOrDefault();
-
-            if (File.Exists(Path.ChangeExtension(inGltfFile.FullName, ".Material.json")) && (args.ImportMaterialOnly || args.ImportMaterials))
-            {
-                WriteMatToMesh(ref cr2w, File.ReadAllText(Path.ChangeExtension(inGltfFile.FullName, ".Material.json")));
-                if (args.ImportMaterialOnly)
+                if (trimmed.StartsWith("#"))
                 {
-                    var matOnlyStream = new MemoryStream();
+                    if (trimmed.Contains("AtlasWidth="))
+                        targetAtlasWidth = ParseHeaderValue(trimmed);
+                    else if (trimmed.Contains("AtlasHeight="))
+                        targetAtlasHeight = ParseHeaderValue(trimmed);
+                    else if (trimmed.Contains("MaskTileSize="))
+                        targetTileSize = ParseHeaderValue(trimmed);
 
-                    //cr2w.Write(new BinaryWriter(matOnlyStream));
-                    using var writer = new CR2WWriter(matOnlyStream) { LoggerService = _loggerService };
-                    writer.WriteFile(cr2w);
-
-
-                    matOnlyStream.Seek(0, SeekOrigin.Begin);
-                    //if (outStream != null)
-                    //{
-                    //    matOnlyStream.CopyTo(outStream);
-                    //}
-                    //else
-                    {
-                        inMeshStream.SetLength(0);
-                        matOnlyStream.CopyTo(inMeshStream);
-                    }
-                    return true;
+                    continue;
                 }
 
+                if (trimmed.Contains("=")) continue;
+
+                filePaths.Add(trimmed);
             }
 
-            var model = ModelRoot.Load(inGltfFile.FullName, new ReadSettings(args.ValidationMode));
+            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
 
-            if (model.LogicalSkins.Count > 0 && originalRig != null)
+            if (files.Count == 0)
+                throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
+
+            _mlmask = new MlMaskContainer();
+            _mlmask.PreferredTileSize = targetTileSize;
+            _mlmask.PreferredAtlasWidth = targetAtlasWidth;
+            _mlmask.PreferredAtlasHeight = targetAtlasHeight;
+
+            var textures = new List<RawTexContainer>();
+
+            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
+            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
+
+            if (needsLayer0)
             {
-                var jointArray = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => model.LogicalSkins[0].GetJoint(_).Joint).ToArray();
+                uint whiteW = 1024u;
+                uint whiteH = 1024u;
 
-                if (cr2w.RootChunk is CMesh root)
+                if (files.Count > 0)
                 {
-                    for (var i = 0; i < root.BoneNames.Count; i++)
+                    var firstReal = files[0];
+                    if (File.Exists(firstReal))
                     {
-                        var foundBone = jointArray.FirstOrDefault(x => root.BoneNames[i] == x.Name);
-                        if (foundBone is not null)
+                        try
                         {
-                            System.Numerics.Matrix4x4.Invert(foundBone.WorldMatrix, out var inversedWorldMatrix);
-
-                            root.BoneRigMatrices[i] = inversedWorldMatrix;
-                            root.BoneRigMatrices[i].NotNull().W.Y = -inversedWorldMatrix.M43;
-                            root.BoneRigMatrices[i].NotNull().W.Z = inversedWorldMatrix.M42;
-                            //component Y and -Z are being swapped in vector W
-                            //should probably figure out why
-                        }
-                    }
-                }
-            }
-
-            VerifyGLTF(model, args);
-
-            var meshes = new List<RawMeshContainer>();
-            foreach (var node in model.LogicalNodes)
-            {
-                if (node.Mesh != null)
-                {
-                    meshes.Add(GltfMeshToRawContainer(node, args));
-                }
-                else if (args.FillEmpty)
-                {
-                    meshes.Add(CreateEmptyMesh(node.Name));
-                }
-            }
-            meshes = meshes.OrderBy(mesh => mesh.name).ToList();
-
-            var max = new Vec3(float.MinValue, float.MinValue, float.MinValue);
-            var min = new Vec3(float.MaxValue, float.MaxValue, float.MaxValue);
-
-            foreach (var p in meshes)
-            {
-                ArgumentNullException.ThrowIfNull(p.positions);
-                foreach (var q in p.positions.ToList())
-                {
-                    max.X = Math.Max(q.X, max.X);
-                    max.Y = Math.Max(q.Y, max.Y);
-                    max.Z = Math.Max(q.Z, max.Z);
-                }
-            }
-
-            foreach (var p in meshes)
-            {
-                ArgumentNullException.ThrowIfNull(p.positions);
-                foreach (var q in p.positions.ToList())
-                {
-                    min.X = Math.Min(q.X, min.X);
-                    min.Y = Math.Min(q.Y, min.Y);
-                    min.Z = Math.Min(q.Z, min.Z);
-                }
-            }
-
-            // GarmentSupport not accounted here. Might be an issue?
-            // TODO: https://github.com/WolvenKit/WolvenKit/issues/1504
-            meshBlob.BoundingBox.Min = new Vector4 { X = min.X, Y = min.Y, Z = min.Z, W = 1f };
-            meshBlob.BoundingBox.Max = new Vector4 { X = max.X, Y = max.Y, Z = max.Z, W = 1f };
-
-            var quantScale = new Vec4((max.X - min.X) / 2, (max.Y - min.Y) / 2, (max.Z - min.Z) / 2, 0);
-            var quantTrans = new Vec4((max.X + min.X) / 2, (max.Y + min.Y) / 2, (max.Z + min.Z) / 2, 1);
-
-
-            RawArmature? incomingJoints = null;
-            RawArmature? existingJoints = null;
-            if (originalRig != null)
-            {
-
-                using var msss = new MemoryStream(rendBlob.RenderBuffer.Buffer.GetBytes());
-
-                var meshesinfo = MeshTools.GetMeshesinfo(rendBlob, cr2w.RootChunk as CMesh);
-
-                var expMeshesss = MeshTools.ContainRawMesh(msss, meshesinfo, true);
-
-                foreach (var mesh in meshes)
-                {
-                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
-                    Array.Clear(mesh.boneindices, 0, mesh.boneindices.Length);
-                }
-
-                incomingJoints = MeshTools.GetOrphanRig(meshBlob);
-
-                using var msr = new MemoryStream();
-                originalRig.Extract(msr);
-                existingJoints = RIG.ProcessRig(_parserService.ReadRed4File(msr));
-            }
-            else
-            {
-                existingJoints = MeshTools.GetOrphanRig(meshBlob);
-                if (model.LogicalSkins.Count > 0 && model.LogicalSkins[0].JointsCount > 0)
-                {
-                    incomingJoints = new RawArmature
-                    {
-                        BoneCount = model.LogicalSkins[0].JointsCount,
-                        Names = Enumerable.Range(0, model.LogicalSkins[0].JointsCount).Select(_ => model.LogicalSkins[0].GetJoint(_).Joint.Name).ToArray()
-                    };
-                }
-            }
-
-
-            try
-            {
-                MeshTools.UpdateMeshJoints(ref meshes, existingJoints, incomingJoints);
-            }
-            catch (WolvenKitException e)
-            {
-                throw new WolvenKitException(e.ErrorCode,
-                    $"You're trying to import bones into a mesh that doesn't have them. Wolvenkit can't create bones — please remove them in Blender, or import into a different file: {e.Message}");
-            }
-
-            UpdateSkinningParamCloth(ref meshes, ref cr2w, args);
-
-            UpdateGarmentSupportParameters(meshes, meshBlob, args.ImportGarmentSupport, args.IgnoreGarmentSupportUVParam);
-
-            var expMeshes = meshes.Select(_ => RawMeshToRE4Mesh(_, quantScale, quantTrans)).ToList();
-
-            var meshBuffer = new MemoryStream();
-            var meshesInfo = BufferWriter(expMeshes, ref meshBuffer, args);
-
-            meshesInfo.quantScale = quantScale;
-            meshesInfo.quantTrans = quantTrans;
-
-            MemoryStream ms;
-
-            if (originalRig != null)
-            {
-                var tt = model.LogicalSkins.Count >= 2
-                    ? Enumerable.Range(0, model.LogicalSkins[1].JointsCount).Select(_ => model.LogicalSkins[1].GetJoint(_).Joint.WorldMatrix).ToArray()
-                    : null;
-
-                var tJointNames = model.LogicalSkins.Count >= 2 ?
-                    Enumerable.Range(0, model.LogicalSkins[1].JointsCount).Select(_ => model.LogicalSkins[1].GetJoint(_).Joint.Name).ToArray()
-                    : null;
-                ms = GetEditedCr2wFile(cr2w, meshesInfo, meshBuffer, tt, tJointNames);
-            }
-            else
-            {
-                ms = GetEditedCr2wFile(cr2w, meshesInfo, meshBuffer);
-            }
-
-            ms.Seek(0, SeekOrigin.Begin);
-            //if (outStream != null)
-            //{
-            //    ms.CopyTo(outStream);
-            //}
-            //else
-            {
-                inMeshStream.SetLength(0);
-                ms.CopyTo(inMeshStream);
-            }
-            return true;
-        }
-
-        private static RawMeshContainer CreateEmptyMesh(string name)
-        {
-            var meshContainer = new RawMeshContainer
-            {
-                boneindices = new ushort[3, 0],
-                colors0 = new Vec4[3],
-                colors1 = Array.Empty<Vec4>(),
-                garmentMorph = Array.Empty<Vec3>(),
-                indices = new uint[3],
-                materialNames = null,
-                name = name,
-                normals = new Vec3[3],
-                positions = new Vec3[3],
-                tangents = new Vec4[3],
-                texCoords0 = new Vec2[3],
-                texCoords1 = new Vec2[3],
-                weightCount = 0,
-                weights = new float[3, 0]
-            };
-
-            meshContainer.indices[0] = 2;
-            meshContainer.indices[1] = 0;
-            meshContainer.indices[2] = 1;
-
-            meshContainer.texCoords0[0] = new Vec2(1, 1);
-            meshContainer.texCoords0[1] = new Vec2(0, 0);
-            meshContainer.texCoords0[2] = new Vec2(1, 0);
-
-            for (var i = 0; i < 3; i++)
-            {
-                meshContainer.colors0[i] = new Vec4(1, 1, 1, 1);
-                meshContainer.normals[i] = new Vec3(0, 0, 1);
-                meshContainer.positions[i] = new Vec3(0, 0, 0);
-                meshContainer.tangents[i] = new Vec4(1, 0, 0, -1);
-                meshContainer.texCoords1[i] = new Vec2(0, 1);
-            }
-
-            return meshContainer;
-        }
-
-        // TODO: https://github.com/WolvenKit/WolvenKit/issues/1505
-        // Maintaining compatibility but need to review if we really want to support empties via nodes
-        private RawMeshContainer GltfMeshToRawContainer(Node node, GltfImportArgs args)
-        {
-            if (node.Mesh != null)
-            {
-                return GltfMeshToRawContainer(node.Mesh, args);
-            }
-
-            if (args.ShowVerboseLogOutput)
-            {
-                _loggerService.Warning($"Node {node.Name} has no mesh, creating empty mesh (this is probably wrong.)");
-            }
-
-            return CreateEmptyMesh(node.Name);
-
-        }
-
-        private RawMeshContainer GltfMeshToRawContainer(Mesh mesh, GltfImportArgs args)
-        {
-            var accessors = mesh.Primitives[0].VertexAccessors.Keys.ToList();
-
-            var parenting = mesh.VisualParents.ToList();
-
-            if (parenting.Count > 1)
-            {
-                throw new ArgumentException($"Mesh {mesh.Name} has more than one parent node! Duplicate the mesh instead of sharing it.");
-            }
-
-            var node = parenting[0];
-
-            if (mesh.Name != node.Name && args.ShowVerboseLogOutput)
-            {
-                _loggerService.Warning($"Mesh name `{mesh.Name}` does not match parent node name `{node.Name}`. Using {(args.OverrideMeshNameWithNodeName ? "NODE" : "MESH")} name.");
-            }
-
-            var meshContainer = new RawMeshContainer
-            {
-                name = args.OverrideMeshNameWithNodeName ? node.Name : mesh.Name,
-
-                // Copying PNT w/ RHS to LHS Y+ to Z+
-                positions = mesh.Primitives[0].GetVertices("POSITION").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),
-                normals = mesh.Primitives[0].GetVertices("NORMAL").AsVector3Array().ToList().AsParallel().Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray(),
-                tangents = mesh.Primitives[0].GetVertices("TANGENT").AsVector4Array().ToList().AsParallel().Select(p => new Vec4(p.X, -p.Z, p.Y, p.W)).ToArray(),
-
-                // Blender glTF omits alpha if possible
-                colors0 = accessors.Contains("COLOR_0")
-                            ? (mesh.Primitives[0].GetVertices("COLOR_0").Attribute.Dimensions == DimensionType.VEC4
-                                ? mesh.Primitives[0].GetVertices("COLOR_0").AsVector4Array().ToArray()
-                                : mesh.Primitives[0].GetVertices("COLOR_0").AsVector3Array().Select(vec3 => new Vec4(vec3, 1)).ToArray())
-                            : [],
-                colors1 = accessors.Contains("COLOR_1")
-                            ? (mesh.Primitives[0].GetVertices("COLOR_1").Attribute.Dimensions == DimensionType.VEC4
-                                ? mesh.Primitives[0].GetVertices("COLOR_1").AsVector4Array().ToArray()
-                                : mesh.Primitives[0].GetVertices("COLOR_1").AsVector3Array().Select(vec3 => new Vec4(vec3, 1)).ToArray())
-                            : [],
-
-                texCoords0 = accessors.Contains("TEXCOORD_0") ? mesh.Primitives[0].GetVertices("TEXCOORD_0").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
-                texCoords1 = accessors.Contains("TEXCOORD_1") ? mesh.Primitives[0].GetVertices("TEXCOORD_1").AsVector2Array().ToArray() : Array.Empty<Vec2>(),
-
-                garmentSupportWeight = accessors.Contains("_GARMENTSUPPORTWEIGHT") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTWEIGHT").AsVector4Array().ToArray() : Array.Empty<Vec4>(),
-                garmentSupportCap = accessors.Contains("_GARMENTSUPPORTCAP") ? mesh.Primitives[0].GetVertices("_GARMENTSUPPORTCAP").AsVector4Array().ToArray() : Array.Empty<Vec4>()
-            };
-
-            var indicesList = mesh.Primitives[0].GetIndices().ToList();
-
-            if (mesh.Name.ToLower().Contains("double"))
-            {
-                meshContainer.indices = new uint[indicesList.Count * 2];
-                for (var i = 0; i < indicesList.Count; i += 3)
-                {
-                    // RHS to LHS face orientations
-                    meshContainer.indices[i] = indicesList[i + 1];
-                    meshContainer.indices[i + 1] = indicesList[i];
-                    meshContainer.indices[i + 2] = indicesList[i + 2];
-
-                    meshContainer.indices[indicesList.Count + i] = indicesList[i];
-                    meshContainer.indices[indicesList.Count + i + 1] = indicesList[i + 1];
-                    meshContainer.indices[indicesList.Count + i + 2] = indicesList[i + 2];
-                }
-            }
-            else
-            {
-                meshContainer.indices = new uint[indicesList.Count];
-                for (var i = 0; i < indicesList.Count; i += 3)
-                {
-                    // RHS to LHS face orientations
-                    meshContainer.indices[i] = indicesList[i + 1];
-                    meshContainer.indices[i + 1] = indicesList[i];
-                    meshContainer.indices[i + 2] = indicesList[i + 2];
-                }
-            }
-
-            var jointCount = 0;
-            var weightCount = 0;
-            foreach (var accessor in accessors)
-            {
-                if (accessor.StartsWith("JOINTS_"))
-                {
-                    jointCount++;
-                }
-
-                if (accessor.StartsWith("WEIGHTS_"))
-                {
-                    weightCount++;
-                }
-            }
-
-            if (jointCount != weightCount)
-            {
-                throw new Exception("Number of JOINTS does not match the number of WEIGHTS");
-            }
-
-            var joints0 = accessors.Contains("JOINTS_0") ? mesh.Primitives[0].GetVertices("JOINTS_0").AsVector4Array().ToList() : null;
-
-            var joints1 = accessors.Contains("JOINTS_1") ? mesh.Primitives[0].GetVertices("JOINTS_1").AsVector4Array().ToList() : null;
-
-            var weights0 = accessors.Contains("WEIGHTS_0") ? mesh.Primitives[0].GetVertices("WEIGHTS_0").AsVector4Array().ToList() : null;
-
-            var weights1 = accessors.Contains("WEIGHTS_1") ? mesh.Primitives[0].GetVertices("WEIGHTS_1").AsVector4Array().ToList() : null;
-
-            meshContainer.weightCount = 0;
-
-            if (joints0 != null)
-            {
-                meshContainer.weightCount += 4;
-            }
-
-            if (joints1 != null)
-            {
-                meshContainer.weightCount += 4;
-            }
-
-            var vertCount = meshContainer.positions.Length;
-            meshContainer.boneindices = new ushort[vertCount, meshContainer.weightCount];
-            meshContainer.weights = new float[vertCount, meshContainer.weightCount];
-
-            for (var i = 0; i < vertCount; i++)
-            {
-                if (joints0 != null && weights0 is not null && i < joints0.Count)
-                {
-                    meshContainer.boneindices[i, 0] = (ushort)joints0[i].X;
-                    meshContainer.boneindices[i, 1] = (ushort)joints0[i].Y;
-                    meshContainer.boneindices[i, 2] = (ushort)joints0[i].Z;
-                    meshContainer.boneindices[i, 3] = (ushort)joints0[i].W;
-
-                    meshContainer.weights[i, 0] = weights0[i].X;
-                    meshContainer.weights[i, 1] = weights0[i].Y;
-                    meshContainer.weights[i, 2] = weights0[i].Z;
-                    meshContainer.weights[i, 3] = weights0[i].W;
-                }
-                if (joints1 != null && weights1 is not null && i < joints1.Count)
-                {
-                    meshContainer.boneindices[i, 4] = (ushort)joints1[i].X;
-                    meshContainer.boneindices[i, 5] = (ushort)joints1[i].Y;
-                    meshContainer.boneindices[i, 6] = (ushort)joints1[i].Z;
-                    meshContainer.boneindices[i, 7] = (ushort)joints1[i].W;
-
-                    meshContainer.weights[i, 4] = weights1[i].X;
-                    meshContainer.weights[i, 5] = weights1[i].Y;
-                    meshContainer.weights[i, 6] = weights1[i].Z;
-                    meshContainer.weights[i, 7] = weights1[i].W;
-                }
-            }
-
-            meshContainer.garmentMorph = [];
-
-            if (mesh.Extras?.Deserialize<MeshExtras>() is { } extras)
-            {
-                if (extras.TargetNames != null)
-                {
-                    ExtractMorphTargets(meshContainer, mesh, extras, args);
-                }
-            }
-
-            return meshContainer;
-        }
-
-        private static void ExtractMorphTargets(RawMeshContainer meshContainer, Mesh mesh, MeshExtras extras, GltfImportArgs args)
-        {
-            if (extras.TargetNames == null)
-            {
-                return;
-            }
-
-            if (extras.TargetNames.Length != mesh.Primitives[0].MorphTargetsCount)
-            {
-                throw new Exception($"{nameof(MeshExtras)} targetNames count doesn't match morphTarget count");
-            }
-
-            for (var i = 0; i < extras.TargetNames.Length; i++)
-            {
-                if (args.ImportGarmentSupport && extras.TargetNames[i] is "GarmentSupport")
-                {
-                    meshContainer.garmentMorph = GetVector3List(i, "POSITION").Select(p => new Vec3(p.X, -p.Z, p.Y)).ToArray();
-                }
-            }
-
-            return;
-
-            List<Vec3> GetVector3List(int morphTargetIndex, string attributeKey)
-            {
-                var idx = mesh.Primitives[0].GetMorphTargetAccessors(morphTargetIndex).Keys.ToList().IndexOf(attributeKey);
-                var extraDataList = mesh.Primitives[0].GetMorphTargetAccessors(morphTargetIndex).Values.ToList()[idx].AsVector3Array().ToList();
-
-                return extraDataList;
-            }
-        }
-
-        private static Re4MeshContainer RawMeshToRE4Mesh(RawMeshContainer mesh, Vec4 qScale, Vec4 qTrans)
-        {
-            var re4Mesh = new Re4MeshContainer
-            {
-                name = mesh.name
-            };
-
-            ArgumentNullException.ThrowIfNull(mesh.positions);
-            ArgumentNullException.ThrowIfNull(mesh.normals);
-            ArgumentNullException.ThrowIfNull(mesh.tangents);
-            ArgumentNullException.ThrowIfNull(mesh.texCoords0);
-            ArgumentNullException.ThrowIfNull(mesh.texCoords1);
-            ArgumentNullException.ThrowIfNull(mesh.colors0);
-            ArgumentNullException.ThrowIfNull(mesh.boneindices);
-            ArgumentNullException.ThrowIfNull(mesh.weights);
-            ArgumentNullException.ThrowIfNull(mesh.garmentMorph);
-            ArgumentNullException.ThrowIfNull(mesh.indices);
-
-            var vertCount = mesh.positions.Length;
-            re4Mesh.ExpVerts = new short[vertCount, 3];
-
-            for (var i = 0; i < vertCount; i++)
-            {
-                var x = qScale.X != 0 ? (mesh.positions[i].X - qTrans.X) / qScale.X : 0;
-                var y = qScale.Y != 0 ? (mesh.positions[i].Y - qTrans.Y) / qScale.Y : 0;
-                var z = qScale.Z != 0 ? (mesh.positions[i].Z - qTrans.Z) / qScale.Z : 0;
-                re4Mesh.ExpVerts[i, 0] = Convert.ToInt16(Math.Clamp(x, -1, 1) * short.MaxValue);
-                re4Mesh.ExpVerts[i, 1] = Convert.ToInt16(Math.Clamp(y, -1, 1) * short.MaxValue);
-                re4Mesh.ExpVerts[i, 2] = Convert.ToInt16(Math.Clamp(z, -1, 1) * short.MaxValue);
-            }
-
-            // converting normals struct
-            re4Mesh.Nor32s = new uint[vertCount];
-            for (var i = 0; i < vertCount; i++)
-            {
-                var v = mesh.normals[i]; // for normal w == 0
-                re4Mesh.Nor32s[i] = Converters.Vec3ToU32(v);
-            }
-
-            // converting tangents struct
-            re4Mesh.Tan32s = new uint[vertCount];
-            for (var i = 0; i < vertCount; i++)
-            {
-                var v = mesh.tangents[i]; // for tangents w == 1 or -1
-                re4Mesh.Tan32s[i] = Converters.Vec4ToU32(v);
-            }
-
-            re4Mesh.uv0s = new ushort[vertCount, 2];
-            for (var i = 0; i < mesh.texCoords0.Length; i++)
-            {
-                re4Mesh.uv0s[i, 0] = Converters.converthf(mesh.texCoords0[i].X);
-                re4Mesh.uv0s[i, 1] = Converters.converthf((mesh.texCoords0[i].Y * -1) + 1);
-            }
-
-            re4Mesh.uv1s = new ushort[vertCount, 2];
-            for (var i = 0; i < mesh.texCoords1.Length; i++)
-            {
-                re4Mesh.uv1s[i, 0] = Converters.converthf(mesh.texCoords1[i].X);
-                re4Mesh.uv1s[i, 1] = Converters.converthf(mesh.texCoords1[i].Y);
-            }
-
-            re4Mesh.colors = new byte[vertCount, 4];
-            for (var i = 0; i < mesh.colors0.Length; i++)
-            {
-                re4Mesh.colors[i, 0] = Convert.ToByte(mesh.colors0[i].X * 255);
-                re4Mesh.colors[i, 1] = Convert.ToByte(mesh.colors0[i].Y * 255);
-                re4Mesh.colors[i, 2] = Convert.ToByte(mesh.colors0[i].Z * 255);
-                re4Mesh.colors[i, 3] = Convert.ToByte(mesh.colors0[i].W * 255);
-            }
-
-            re4Mesh.weightcount = mesh.weightCount;
-
-            re4Mesh.boneindices = new byte[vertCount, re4Mesh.weightcount];
-            for (var i = 0; i < vertCount; i++)
-            {
-                for (var e = 0; e < re4Mesh.weightcount; e++)
-                {
-                    re4Mesh.boneindices[i, e] = Convert.ToByte(mesh.boneindices[i, e]); // mesh.boneindices are supposed to be processed
-                }
-            }
-            // (updated according to the mesh bones rather than rig bones) before putting here
-
-            re4Mesh.weights = new byte[vertCount, re4Mesh.weightcount];
-            for (var i = 0; i < vertCount; i++)
-            {
-                for (var e = 0; e < re4Mesh.weightcount; e++)
-                {
-                    re4Mesh.weights[i, e] = Convert.ToByte(mesh.weights[i, e] * 255);
-                }
-                // weight summing can cause problems here, sometimes sum >= 256, idk how to fix them yet
-            }
-
-            // extradata/ morphoffsetbs
-            re4Mesh.garmentMorph = new ushort[0, 0];
-            if (mesh.garmentMorph.Length > 0)
-            {
-                re4Mesh.garmentMorph = new ushort[vertCount, 3];
-                for (var i = 0; i < vertCount; i++)
-                {
-                    re4Mesh.garmentMorph[i, 0] = Converters.converthf(mesh.garmentMorph[i].X);
-                    re4Mesh.garmentMorph[i, 1] = Converters.converthf(mesh.garmentMorph[i].Y);
-                    re4Mesh.garmentMorph[i, 2] = Converters.converthf(mesh.garmentMorph[i].Z);
-                }
-            }
-
-            re4Mesh.indices = new ushort[mesh.indices.Length];
-            for (var i = 0; i < mesh.indices.Length; i++)
-            {
-                if (mesh.indices[i] <= ushort.MaxValue)
-                {
-                    re4Mesh.indices[i] = Convert.ToUInt16(mesh.indices[i]);
-                }
-                else
-                {
-                    throw new Exception($"Too many vertices ({mesh.indices[i]}) in submesh - max is {ushort.MaxValue}");
-                }
-            }
-
-            return re4Mesh;
-        }
-
-        private static MeshesInfo BufferWriter(List<Re4MeshContainer> expMeshes, ref MemoryStream ms, GltfImportArgs args)
-        {
-            var meshesInfo = new MeshesInfo(expMeshes.Count);
-
-            var bw = new BinaryWriter(ms);
-            for (var i = 0; i < expMeshes.Count; i++)
-            {
-                var expMesh = expMeshes[i];
-
-                ArgumentNullException.ThrowIfNull(expMesh.ExpVerts);
-                ArgumentNullException.ThrowIfNull(expMesh.garmentMorph);
-                ArgumentNullException.ThrowIfNull(expMesh.boneindices);
-                ArgumentNullException.ThrowIfNull(expMesh.weights);
-                ArgumentNullException.ThrowIfNull(expMesh.uv0s);
-                ArgumentNullException.ThrowIfNull(expMesh.Nor32s);
-                ArgumentNullException.ThrowIfNull(expMesh.Tan32s);
-                ArgumentNullException.ThrowIfNull(expMesh.colors);
-                ArgumentNullException.ThrowIfNull(expMesh.uv1s);
-
-                var vertCount = expMesh.ExpVerts.Length / 3;
-
-                meshesInfo.vertCounts[i] = (uint)vertCount;
-                meshesInfo.posnOffsets[i] = (uint)ms.Position;
-
-                meshesInfo.vpStrides[i] = (expMesh.weightcount * 2) + 8;
-                meshesInfo.weightCounts[i] = expMesh.weightcount;
-
-                if (expMesh.garmentMorph.Length > 0)
-                {
-                    meshesInfo.garmentSupportExists[i] = true;
-                    meshesInfo.vpStrides[i] += 8;
-                }
-
-                for (var e = 0; e < vertCount; e++)
-                {
-                    bw.Write(expMesh.ExpVerts[e, 0]);
-                    bw.Write(expMesh.ExpVerts[e, 1]);
-                    bw.Write(expMesh.ExpVerts[e, 2]);
-                    bw.Write((short)32767);
-                    for (var eye = 0; eye < expMesh.weightcount; eye++)
-                    {
-                        bw.Write(expMesh.boneindices[e, eye]);
-                    }
-
-                    for (var eye = 0; eye < expMesh.weightcount; eye++)
-                    {
-                        bw.Write(expMesh.weights[e, eye]);
-                    }
-
-                    if (meshesInfo.garmentSupportExists[i])
-                    {
-                        bw.Write(expMesh.garmentMorph[e, 0]);
-                        bw.Write(expMesh.garmentMorph[e, 1]);
-                        bw.Write(expMesh.garmentMorph[e, 2]);
-                        bw.Write((ushort)0);
-                    }
-                }
-
-                long paddingLen = 0;
-
-                // 16 bytes Padding between vertexBlock and uv0, if required
-                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
-                bw.Write(new byte[paddingLen]);
-
-                // writing tx0s
-                meshesInfo.tex0Offsets[i] = (uint)ms.Position;
-                for (var e = 0; e < vertCount; e++)
-                {
-                    bw.Write(expMesh.uv0s[e, 0]);
-                    bw.Write(expMesh.uv0s[e, 1]);
-                }
-
-                // 16 bytes Padding between uv0 and normals, if required
-                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
-                bw.Write(new byte[paddingLen]);
-
-                // writing normals and tangents
-                meshesInfo.normalOffsets[i] = (uint)ms.Position;
-                for (var e = 0; e < vertCount; e++)
-                {
-                    bw.Write(expMesh.Nor32s[e]);
-                    bw.Write(expMesh.Tan32s[e]);
-                }
-
-                // 16 bytes Padding between nors/tans and colors/uv1s, if required
-                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
-                bw.Write(new byte[paddingLen]);
-
-                // writing colors and tx1s
-                meshesInfo.colorOffsets[i] = (uint)ms.Position;
-                for (var e = 0; e < vertCount; e++)
-                {
-
-                    bw.Write(expMesh.colors[e, 0]);
-                    bw.Write(expMesh.colors[e, 1]);
-                    bw.Write(expMesh.colors[e, 2]);
-                    bw.Write(expMesh.colors[e, 3]);
-
-
-                    // Temp fix for improved lighting geomertry
-                    /*
-                    bw.Write((byte)0);
-                    bw.Write((byte)0);
-                    bw.Write((byte)0);
-                    bw.Write((byte)0);
-                    */
-                    bw.Write(expMesh.uv1s[e, 0]);
-                    bw.Write(expMesh.uv1s[e, 1]);
-                }
-
-                // 16 bytes Padding if necessary
-                paddingLen = ((ms.Length + 15U) & (~15)) - ms.Length;
-                bw.Write(new byte[paddingLen]);
-
-                // for the unusual lightblocker data
-                /*
-                unknownOffsets[i] = (UInt32)ms.Position;
-
-                for (int e = 0; e < vertCount; e++)
-                {
-                    bw.Write((float)0f);
-                }
-                */
-                meshesInfo.vertBufferSize = (uint)ms.Length;
-
-                // this padding writer if that unusual lightblocker data is written
-                /*
-                // padding writer if necessary
-                if (((UInt64)ms.Length % 16) != 0)
-                {
-                    int zeroesCount = (int)((((UInt64)ms.Length / 16) + 1) * 16 - (UInt64)ms.Length);
-                    Byte[] bytes = new Byte[zeroesCount];
-                    bw.Write(bytes);
-                }
-                */
-            }
-
-            meshesInfo.indexBufferOffset = (uint)ms.Position;
-            for (var i = 0; i < expMeshes.Count; i++)
-            {
-                var mesh = expMeshes[i];
-
-                ArgumentNullException.ThrowIfNull(mesh.indices);
-
-                var indCount = mesh.indices.Length;
-                meshesInfo.indCounts[i] = (uint)indCount;
-
-                meshesInfo.indicesOffsets[i] = (uint)ms.Position;
-                for (var e = 0; e < indCount; e++)
-                {
-                    bw.Write(mesh.indices[e]);
-                }
-            }
-            meshesInfo.indexBufferSize = (uint)ms.Length - meshesInfo.indexBufferOffset;
-
-
-            for (var i = 0; i < meshesInfo.meshCount; i++)
-            {
-                var mesh = expMeshes[i];
-
-                ArgumentNullException.ThrowIfNull(mesh.name);
-
-                if (mesh.name.Contains("LOD"))
-                {
-                    var idx = mesh.name.IndexOf("LOD_", StringComparison.Ordinal);
-                    if (idx < mesh.name.Length - 1)
-                    {
-                        var lod = Convert.ToUInt32(mesh.name.Substring(idx + 4, 1));
-                        meshesInfo.LODLvl[i] = lod;
-                    }
-                }
-                else
-                {
-                    meshesInfo.LODLvl[i] = 1;
-                }
-            }
-
-            return meshesInfo;
-        }
-
-        private MemoryStream GetEditedCr2wFile(CR2WFile cr2w, MeshesInfo info, MemoryStream buffer, Mat4[]? inverseBindMatrices = null, string[]? boneNames = null)
-        //private static MemoryStream GetEditedCr2wFile(CR2WFile cr2w, MeshesInfo info, MemoryStream buffer)
-        {
-            rendRenderMeshBlob? blob = null;
-            if (cr2w.RootChunk is CMesh obj1 && obj1.RenderResourceBlob.Chunk is rendRenderMeshBlob obj2)
-            {
-                blob = obj2;
-            }
-
-            if (cr2w.RootChunk is MorphTargetMesh obj3 && obj3.Blob.Chunk is rendRenderMorphTargetMeshBlob obj4 && obj4.BaseBlob.Chunk is rendRenderMeshBlob obj5)
-            {
-                blob = obj5;
-            }
-
-            ArgumentNullException.ThrowIfNull(blob, nameof(blob));
-
-            // removing BS topology data which causes a lot of issues with improved facial lighting geometry, vertex colors uroborus and what not
-            if (blob.Header.Topology is not null)
-            {
-                blob.Header.Topology.Clear();
-                for (var i = 0; i < info.meshCount; i++)
-                {
-                    blob.Header.Topology.Add(new rendTopologyData());
-                }
-            }
-
-            if (blob.Header.RenderLODs is not null)
-            {
-                if (blob.Header.RenderLODs.Count > info.LODLvl.Distinct().Count())
-                {
-                    blob.Header.RenderLODs = new CArray<CFloat> (blob.Header.RenderLODs.Take(info.LODLvl.Distinct().Count()).ToList());
-                }
-
-                while (blob.Header.RenderLODs.Count < info.LODLvl.Distinct().Count())
-                {
-                    if (blob.Header.RenderLODs.Count == 0)
-                    {
-                        blob.Header.RenderLODs.Add(0f);
-                    }
-                    else
-                    {
-                        blob.Header.RenderLODs.Add(blob.Header.RenderLODs.Max() * 2f);
-                    }
-                }
-            }
-            if (cr2w.RootChunk is CMesh { LodLevelInfo: not null } cMeshBlob)
-            {
-                if (cMeshBlob.LodLevelInfo.Count > info.LODLvl.Distinct().Count())
-                {
-                    cMeshBlob.LodLevelInfo = new CArray<CFloat> (cMeshBlob.LodLevelInfo.Take(info.LODLvl.Distinct().Count()).ToList());
-                }
-
-                while (cMeshBlob.LodLevelInfo.Count < info.LODLvl.Distinct().Count())
-                {
-                    if (cMeshBlob.LodLevelInfo.Count == 0)
-                    {
-                        cMeshBlob.LodLevelInfo.Add(0f);
-                    }
-                    else
-                    {
-                        cMeshBlob.LodLevelInfo.Add(cMeshBlob.LodLevelInfo.Max() * 2f);
-                    }
-                }
-            }
-
-            //source mesh renderMasks for updation
-            var renderMasks = blob.Header.RenderChunkInfos.Select(s => s.RenderMask).ToList();
-
-            // removing existing rendChunks
-            blob.Header.RenderChunkInfos.Clear();
-
-            // adding new rendChunks
-            for (var i = 0; i < info.meshCount; i++)
-            {
-                var chunk = new rendChunk
-                {
-                    LodMask = (byte)info.LODLvl[i],
-                    RenderMask = renderMasks[i >= renderMasks.Count ? 0 : i],
-                    // based upon VertexBlock, subject to change, incremental will be good, for weightcount ++ etc
-                    // VertexFactory is really important to be taken care of properly
-                    VertexFactory = 2,
-                    NumIndices = info.indCounts[i],
-                    NumVertices = (ushort)info.vertCounts[i],
-                    ChunkIndices = new rendIndexBufferChunk
-                    {
-                        Pe = Enums.GpuWrapApieIndexBufferChunkType.IBCT_IndexUShort,
-                        TeOffset = info.indicesOffsets[i] - info.indexBufferOffset
-                    },
-                    ChunkVertices = new rendVertexBufferChunk()
-                };
-
-                chunk.ChunkVertices.ByteOffsets.Add(info.posnOffsets[i]);
-                chunk.ChunkVertices.ByteOffsets.Add(info.tex0Offsets[i]);
-                chunk.ChunkVertices.ByteOffsets.Add(info.normalOffsets[i]);
-                chunk.ChunkVertices.ByteOffsets.Add(info.colorOffsets[i]);
-                chunk.ChunkVertices.ByteOffsets.Add(info.unknownOffsets[i]);
-
-                chunk.ChunkVertices.VertexLayout = new GpuWrapApiVertexLayoutDesc
-                {
-                    //hash is not understood/no-interest, subject to change
-                    Hash = 0
-                };
-
-                // Position
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 0,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Position,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Short4N
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // Joint0
-                if (info.weightCounts[i] > 0)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 0,
-                        UsageIndex = 0,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinIndices,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4
-                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-
-                    // subject to change, maybe, VertexFactory is weird
-                    chunk.VertexFactory++;
-                }
-
-                // joint1
-                if (info.weightCounts[i] > 4)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 0,
-                        UsageIndex = 1,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinIndices,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4
-                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-
-                    // subject to change, maybe, VertexFactory is weird
-                    chunk.VertexFactory++;
-                }
-
-                // weight0
-                if (info.weightCounts[i] > 0)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 0,
-                        UsageIndex = 0,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinWeights,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N
-                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-                }
-                // weight1
-                if (info.weightCounts[i] > 4)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 0,
-                        UsageIndex = 1,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_SkinWeights,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N
-                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-                }
-
-                // tx0coords
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 1,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_TexCoord,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // normals
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 2,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Normal,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // tangents
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 2,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Tangent,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // color
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 3,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Color,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Color
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // tx1coords
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 3,
-                    UsageIndex = 1,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_TexCoord,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2
-                    //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                });
-
-                // extra data/ morphoffsets
-                if (info.garmentSupportExists[i])
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        // fishy
-                        StreamIndex = 0,
-                        UsageIndex = 0,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_ExtraData,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_4
-                        //StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-
-                    // subject to change, maybe, VertexFactory is weird, extra data ads 2 to this
-                    chunk.VertexFactory += 2;
-                }
-
-                // instanceTransforms
-                for (byte e = 0; e < 3; e++)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 7,
-                        UsageIndex = e,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_InstanceTransform,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float4,
-                        StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerInstance
-                    });
-                }
-
-                // instanceSkinningDatas
-                if (info.weightCounts[i] > 0)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 7,
-                        UsageIndex = 0,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_InstanceSkinningData,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_UInt4,
-                        StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerInstance
-                    });
-                }
-
-                // LightBlockerIntensity
-                if (info.unknownOffsets[i] != 0)
-                {
-                    chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                    {
-                        StreamIndex = 4,
-                        UsageIndex = 0,
-                        Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_LightBlockerIntensity,
-                        Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Float1,
-                        // StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_PerVertex
-                    });
-
-                    // for lightblocker its 24, after testing some files, somtimes unknownoffsets[4] is used for destruction indices and some paint instead of lightblocker, so this needs to be taken care of
-                    chunk.VertexFactory += 24;
-                }
-
-
-                // Invalid, Required
-                chunk.ChunkVertices.VertexLayout.Elements.Add(new GpuWrapApiVertexPackingPackingElement
-                {
-                    StreamIndex = 0,
-                    UsageIndex = 0,
-                    Usage = Enums.GpuWrapApiVertexPackingePackingUsage.PS_Invalid,
-                    Type = Enums.GpuWrapApiVertexPackingePackingType.PT_Invalid,
-                    StreamType = Enums.GpuWrapApiVertexPackingEStreamType.ST_Invalid
-                });
-
-                chunk.ChunkVertices.VertexLayout.SlotStrides = new CStatic<CUInt8>(8);
-                for (var j = 0; j < 8; j++)
-                {
-                    chunk.ChunkVertices.VertexLayout.SlotStrides.Add(0);
-                }
-
-                foreach (var element in chunk.ChunkVertices.VertexLayout.Elements)
-                {
-                    chunk.ChunkVertices.VertexLayout.SlotStrides[element.StreamIndex] += GetDataSize(element.Type);
-                }
-
-                var slotMask = 0;
-                for (var j = 0; j < chunk.ChunkVertices.VertexLayout.SlotStrides.Count; j++)
-                {
-                    if (chunk.ChunkVertices.VertexLayout.SlotStrides[j] > 0)
-                    {
-                        slotMask |= (1 << j);
-                    }
-                }
-                chunk.ChunkVertices.VertexLayout.SlotMask = (uint)slotMask;
-
-                // Adding Chunk
-                blob.Header.RenderChunkInfos.Add(chunk);
-            }
-
-            blob.Header.QuantizationScale.X = info.quantScale.X;
-            blob.Header.QuantizationScale.Y = info.quantScale.Y;
-            blob.Header.QuantizationScale.Z = info.quantScale.Z;
-            blob.Header.QuantizationOffset.X = info.quantTrans.X;
-            blob.Header.QuantizationOffset.Y = info.quantTrans.Y;
-            blob.Header.QuantizationOffset.Z = info.quantTrans.Z;
-
-            blob.Header.VertexBufferSize = info.vertBufferSize;
-            blob.Header.IndexBufferSize = info.indexBufferSize;
-            blob.Header.IndexBufferOffset = info.indexBufferOffset;
-
-            blob.RenderBuffer.Buffer.SetBytes(buffer.ToArray());
-
-            if (cr2w.RootChunk is CMesh root && inverseBindMatrices != null)
-            {
-                for (var i = 0; i < blob.Header.BonePositions.Count; i++)
-                {
-                    if (boneNames is not null)
-                    {
-                        var index = Array.FindIndex(boneNames, x => x.Contains(root.BoneNames[i].ToString().NotNull()) && x.Length == root.BoneNames[i].Length);
-
-                        var position = blob.Header.BonePositions[i].NotNull();
-
-                        position.X = inverseBindMatrices[index].M41;
-                        position.Y = -inverseBindMatrices[index].M43;
-                        position.Z = inverseBindMatrices[index].M42;
-                        position.W = inverseBindMatrices[index].M44;
-                        //position = root.BoneRigMatrices[i].W;
-                    }
-                }
-            }
-
-            var ms = new MemoryStream();
-            using var writer = new CR2WWriter(ms, Encoding.UTF8, true) { LoggerService = _loggerService };
-            writer.WriteFile(cr2w);
-
-            return ms;
-        }
-
-        private static CUInt8 GetDataSize(Enums.GpuWrapApiVertexPackingePackingType type) =>
-            type switch
-            {
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Invalid => 0,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float1 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float2 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float3 => 12,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float4 => 16,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_2 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Float16_4 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort1 => 2,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort2 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort4 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UShort4N => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Short1 => 2,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Short2 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Short4 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Short4N => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt1 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt2 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt3 => 12,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UInt4 => 16,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Int1 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Int2 => 8,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Int3 => 12,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Int4 => 16,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Color => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte1 => 1,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte1F => 1,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_UByte4N => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Byte4N => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Dec4 => 4,
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Index16 => throw new NotImplementedException(),
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Index32 => throw new NotImplementedException(),
-                Enums.GpuWrapApiVertexPackingePackingType.PT_Max => throw new NotImplementedException(),
-                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-            };
-
-        private const string s_gltfError = "One or more geometry entries in GLTF";
-        private static void VerifyGLTF(ModelRoot model, GltfImportArgs args)
-        {
-            if (model.LogicalMeshes.Count < 1)
-            {
-                throw new Exception("Provided glTF doesn't contain any 3D Meshes");
-            }
-            /*if (model.LogicalSkins.Count > 1)
-            {
-                throw new Exception($"Armature Count: {model.LogicalSkins.Count}, Only 1 Armature is allowed");
-            }*/
-
-            var lods = new List<uint>();
-
-            // #2403: LOD_0 is okay for cars, so we're checking before throwing an exception
-            var lodsFromMeshNames = model.LogicalMeshes.Select(x =>
-                {
-                    var matches = Regex.Matches(x.Name, @"\d+");
-                    return matches.Count > 0 ? matches[^1].Value : null;
-                })
-                .Where(x => x is not null)
-                .Distinct()
-                .Select(x => uint.Parse(x!))
-                .ToList();
-
-            foreach (var m in model.LogicalMeshes)
-            {
-                var accessors = m.Primitives[0].VertexAccessors.Keys.ToList();
-
-                if (!accessors.Contains("POSITION"))
-                {
-                    throw new InvalidDataException($"{s_gltfError} do not contain vertices.");
-                }
-                if (!accessors.Contains("NORMAL"))
-                {
-                    throw new InvalidDataException($"{s_gltfError} do not contain Normals data.");
-                }
-                if (!accessors.Contains("TANGENT"))
-                {
-                    throw new InvalidDataException(
-                        $"{s_gltfError} do not contain Tangents data. Make sure to triangulate your mesh!");
-                }
-                if (m.Primitives[0].GetIndices().ToList().Count < 3)
-                {
-                    throw new InvalidDataException(
-                        $"{s_gltfError} contain less than 3 vertices. Please import at least a triangle!");
-                }
-                var name = m.Name;
-                uint lod = 0;
-
-                if (name.Contains("LOD"))
-                {
-                    var idx = name.IndexOf("LOD_");
-                    if (idx < name.Length - 1)
-                    {
-                        if (!uint.TryParse(name.AsSpan(idx + 4, 1), out lod))
-                        {
-                            throw new Exception("Invalid Geometry/sub mesh name: " + name + " , Character after \"LOD_\" should be 1 or 2 or 4 or 8, Representing the Level of Detail (LOD) of the submesh.");
-                        }
-
-                        if (lod is not 1 and not 2 and not 4 and not 8
-                            && (lod is not 0 && !lodsFromMeshNames.Contains(lod)))
-                        {
-                            throw new Exception("Invalid Geometry/sub mesh name: " + name + " , Character after \"LOD_\"  should be 1 or 2 or 4 or 8, Representing the Level of Detail (LOD) of the submesh.");
-                        }
-
-                        lods.Add(lod);
-                    }
-                }
-                else
-                {
-                    lods.Add(1);
-                }
-            }
-            if (!lods.Contains(1))
-            {
-                throw new Exception("None of the Geometry/submeshes are of 1 Level of Detail or (LOD 1) in provided GLTF");
-            }
-        }
-        private static void UpdateSkinningParamCloth(ref List<RawMeshContainer> meshes, ref CR2WFile cr2w, GltfImportArgs args)
-        {
-            var cMesh = (CMesh)cr2w.RootChunk;
-
-            // #2403: LOD_0 is okay for cars, so we're checking
-            var lodsFromMeshNames = meshes.Select(x =>
-                {
-                    var matches = Regex.Matches(x.name ?? "", @"\d+");
-                    return matches.Count > 0 ? matches[^1].Value : null;
-                })
-                .Where(x => x is not null)
-                .Distinct()
-                .Select(x => uint.Parse(x!))
-                .ToList();
-
-
-            var lodLvl = new uint[meshes.Count];
-            for (var i = 0; i < meshes.Count; i++)
-            {
-                var mesh = meshes[i];
-
-                ArgumentNullException.ThrowIfNull(mesh.name);
-
-                if (mesh.name.Contains("LOD"))
-                {
-                    var idx = mesh.name.IndexOf("LOD_", StringComparison.Ordinal);
-                    if (idx < mesh.name.Length - 1)
-                    {
-                        if (!uint.TryParse(mesh.name.AsSpan(idx + 4, 1), out var lod) ||
-                            (lod is not 1 and not 2 and not 4 and not 8 &&
-                             (lod is not 0 && !lodsFromMeshNames.Contains(lod))))
-                        {
-                            throw new Exception(
-                                $"Invalid submesh name: {mesh.name}, Character after \"LOD_\" should be 1 or 2 or 4 or 8 to indicate submesh Level of Detail");
-                        }
-
-                        lodLvl[i] = lod;
-                    }
-                }
-                else
-                {
-                    lodLvl[i] = 1;
-                }
-
-            }
-
-            // TODO: What should happen here?
-            /*int meshBufferIdx = cr2w.Chunks.OfType<rendRenderMeshBlob>().First().RenderBuffer.Pointer - 1;
-            int materialBufferIdx = cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Pointer - 1;
-            if (cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Buffer.MemSize == 0)
-                materialBufferIdx = int.MaxValue;
-
-            int buffCount = cr2w.Buffers.Count;
-
-            for (int i = 0, idx = 0; i < buffCount; i++, idx++)
-            {
-                if (idx != meshBufferIdx && idx != materialBufferIdx)
-                {
-                    cr2w.Buffers.Remove(cr2w.Buffers[idx]);
-                    if (idx < meshBufferIdx)
-                        meshBufferIdx--;
-                    if (idx < materialBufferIdx)
-                        materialBufferIdx--;
-                    idx--;
-                }
-            }
-            if (cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Buffer.MemSize == 0)
-                materialBufferIdx = 0;
-
-            cr2w.Chunks.OfType<rendRenderMeshBlob>().First().RenderBuffer.Pointer = meshBufferIdx + 1;
-            cr2w.Chunks.OfType<CMesh>().First().LocalMaterialBuffer.RawData.Pointer = materialBufferIdx + 1;*/
-
-            var clothBlob = cMesh.Parameters.FirstOrDefault(x => x is not null && x.Chunk is meshMeshParamCloth);
-            var clothGraphicalBlob = cMesh.Parameters.FirstOrDefault(x => x is not null && x.Chunk is meshMeshParamCloth_Graphical);
-
-            if (clothBlob != null)
-            {
-                var blob = (meshMeshParamCloth)clothBlob.Chunk.NotNull();
-                blob.Chunks = new CArray<meshPhxClothChunkData>();
-                foreach (var mesh in meshes)
-                {
-                    ArgumentNullException.ThrowIfNull(mesh.name);
-                    ArgumentNullException.ThrowIfNull(mesh.positions);
-                    ArgumentNullException.ThrowIfNull(mesh.indices);
-                    ArgumentNullException.ThrowIfNull(mesh.weights);
-                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
-                    ArgumentNullException.ThrowIfNull(mesh.normals);
-
-                    var chunk = new meshPhxClothChunkData();
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.positions[e].X);
-                            bw.Write(mesh.positions[e].Y);
-                            bw.Write(mesh.positions[e].Z);
-                        }
-
-                        chunk.Positions = new DataBuffer(buffer.ToArray());
-                    }
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        foreach (var i in mesh.indices)
-                        {
-                            bw.Write(Convert.ToUInt16(i));
-                        }
-
-                        chunk.Indices = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 0)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.weights[e, 0]);
-                            bw.Write(mesh.weights[e, 1]);
-                            bw.Write(mesh.weights[e, 2]);
-                            bw.Write(mesh.weights[e, 3]);
-                        }
-
-                        chunk.SkinWeights = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 0)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 0]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 1]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 2]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 3]));
-                        }
-
-                        chunk.SkinIndices = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 4)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.weights[e, 4]);
-                            bw.Write(mesh.weights[e, 5]);
-                            bw.Write(mesh.weights[e, 6]);
-                            bw.Write(mesh.weights[e, 7]);
-                        }
-
-                        chunk.SkinWeightsExt = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 4)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 4]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 5]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 6]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 7]));
-                        }
-
-                        chunk.SkinIndicesExt = new DataBuffer(buffer.ToArray());
-                    }
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.normals.Length; e++)
-                        {
-                            bw.Write(mesh.normals[e].X);
-                            bw.Write(mesh.normals[e].Y);
-                            bw.Write(mesh.normals[e].Z);
-                        }
-
-                        chunk.Normals = new DataBuffer(buffer.ToArray());
-                    }
-                    blob.Chunks.Add(chunk);
-                    mesh.weightCount = 0;
-                }
-                blob.LodChunkIndices = new CArray<CArray<CUInt16>>
-                {
-                    new()
-                };
-                if (lodLvl.Contains(2U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                if (lodLvl.Contains(4U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                if (lodLvl.Contains(8U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                for (ushort i = 0; i < lodLvl.Length; i++)
-                {
-                    if (lodLvl[i] == 1)
-                    {
-                        blob.LodChunkIndices[0].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 2)
-                    {
-                        blob.LodChunkIndices[1].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 4)
-                    {
-                        blob.LodChunkIndices[2].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 8)
-                    {
-                        blob.LodChunkIndices[3].NotNull().Add(i);
-                    }
-                }
-            }
-            if (clothGraphicalBlob != null)
-            {
-                var blob = (meshMeshParamCloth_Graphical)clothGraphicalBlob.Chunk.NotNull();
-                blob.Chunks = new CArray<meshGfxClothChunkData>();
-                foreach (var mesh in meshes)
-                {
-                    ArgumentNullException.ThrowIfNull(mesh.name);
-                    ArgumentNullException.ThrowIfNull(mesh.positions);
-                    ArgumentNullException.ThrowIfNull(mesh.indices);
-                    ArgumentNullException.ThrowIfNull(mesh.weights);
-                    ArgumentNullException.ThrowIfNull(mesh.boneindices);
-                    ArgumentNullException.ThrowIfNull(mesh.colors1);
-
-                    var chunk = new meshGfxClothChunkData();
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.positions[e].X);
-                            bw.Write(mesh.positions[e].Y);
-                            bw.Write(mesh.positions[e].Z);
-                        }
-
-                        chunk.Positions = new DataBuffer(buffer.ToArray());
-                    }
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        foreach (var i in mesh.indices)
-                        {
-                            bw.Write(Convert.ToUInt16(i));
-                        }
-
-                        chunk.Indices = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 0)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.weights[e, 0]);
-                            bw.Write(mesh.weights[e, 1]);
-                            bw.Write(mesh.weights[e, 2]);
-                            bw.Write(mesh.weights[e, 3]);
-                        }
-
-                        chunk.SkinWeights = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 0)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 0]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 1]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 2]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 3]));
-                        }
-
-                        chunk.SkinIndices = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 4)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(mesh.weights[e, 4]);
-                            bw.Write(mesh.weights[e, 5]);
-                            bw.Write(mesh.weights[e, 6]);
-                            bw.Write(mesh.weights[e, 7]);
-                        }
-
-                        chunk.SkinWeightsExt = new DataBuffer(buffer.ToArray());
-                    }
-                    if (mesh.weightCount > 4)
-                    {
-                        var buffer = new MemoryStream();
-                        var bw = new BinaryWriter(buffer);
-                        for (var e = 0; e < mesh.positions.Length; e++)
-                        {
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 4]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 5]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 6]));
-                            bw.Write(Convert.ToByte(mesh.boneindices[e, 7]));
-                        }
-
-                        chunk.SkinIndicesExt = new DataBuffer(buffer.ToArray());
-                    }
-                    {
-                        chunk.Simulation = new CArray<CUInt16>();
-                        for (ushort e = 0; e < mesh.colors1.Length; e++)
-                        {
-                            if (mesh.colors1[e].X > 0.01f)
+                            using var probe = RedImage.LoadFromFile(firstReal);
+                            if (probe != null)
                             {
-                                chunk.Simulation.Add(e);
+                                whiteW = (uint)probe.Metadata.Width;
+                                whiteH = (uint)probe.Metadata.Height;
+                            }
+                        }
+                        catch { }
+                    }
+                }
+
+                var whitePixels = new byte[whiteW * whiteH];
+                Array.Fill(whitePixels, (byte)255);
+                textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
+                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH} (inferred from first provided layer metadata)");
+            }
+
+            for (var fileIdx = 0; fileIdx < files.Count; fileIdx++)
+            {
+                var f = files[fileIdx];
+                if (!File.Exists(f)) throw new FileNotFoundException($"File not found: {f}");
+
+                try
+                {
+                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2001, $"Could not load image: {f}");
+
+                    if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
+                        image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
+
+                    uint imgW = (uint)image.Metadata.Width;
+                    uint imgH = (uint)image.Metadata.Height;
+
+                    using var ms = new MemoryStream(image.SaveToDDSMemory());
+                    using var br = new BinaryReader(ms);
+                    ms.Seek(s_headerLength, SeekOrigin.Begin);
+                    var pixels = br.ReadBytes((int)(imgW * imgH));
+
+                    var isBlank = IsBlankLayer(pixels);
+
+                    if (isBlank)
+                    {
+                        textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
+                        continue;
+                    }
+
+                    textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
+                }
+                catch (WolvenKitException e)
+                {
+                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale)");
+                }
+            }
+
+            _mlmask.Layers = textures.ToArray();
+
+            Create();
+            Write(outFile);
+
+            _logger.Info("Import complete. Keep your original .masklist file for round-trip export.");
+        }
+
+        internal static bool IsBlankLayer(byte[] pixels)
+        {
+            if (pixels == null || pixels.Length == 0) return true;
+            var first = pixels[0];
+            for (int i = 1; i < pixels.Length; i++)
+                if (pixels[i] != first) return false;
+            return true;
+        }
+
+        internal static uint ParseHeaderValue(string line)
+        {
+            var parts = line.Split('=');
+            return parts.Length > 1 ? uint.Parse(parts[1].Trim()) : 0;
+        }
+
+        internal static byte[] UpscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
+        {
+            var dst = new byte[dstW * dstH];
+            var scaleX = (double)srcW / dstW;
+            var scaleY = (double)srcH / dstH;
+
+            for (uint y = 0; y < dstH; y++)
+                for (uint x = 0; x < dstW; x++)
+                {
+                    var srcX = (uint)(x * scaleX);
+                    var srcY = (uint)(y * scaleY);
+                    dst[x + y * dstW] = src[srcX + srcY * srcW];
+                }
+            return dst;
+        }
+
+        #region Core Methods
+
+        private void Write(FileInfo f)
+        {
+            var cr2w = new CR2WFile();
+            var mask = new Multilayer_Mask { CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC };
+            cr2w.RootChunk = mask;
+
+            var blob = new rendRenderMultilayerMaskBlobPC
+            {
+                Header = new rendRenderMultilayerMaskBlobHeader
+                {
+                    Version = 3,
+                    AtlasWidth = _mlmask.AtlasWidth,
+                    AtlasHeight = _mlmask.AtlasHeight,
+                    NumLayers = (uint)_mlmask.Layers!.Length,
+                    MaskWidth = _mlmask.WidthHigh,
+                    MaskHeight = _mlmask.HeightHigh,
+                    MaskWidthLow = _mlmask.WidthLow,
+                    MaskHeightLow = _mlmask.HeightLow,
+                    MaskTileSize = _mlmask.TileSize,
+                    Flags = 2
+                },
+                AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer!),
+                TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer!)
+            };
+
+            mask.RenderResourceBlob.RenderResourceBlobPC = blob;
+
+            var dir = f.Directory ?? throw new InvalidOperationException("File directory is null");
+            if (!Directory.Exists(dir.FullName)) Directory.CreateDirectory(dir.FullName);
+
+            using var fs = new FileStream(f.FullName, FileMode.Create, FileAccess.Write);
+            using var writer = new CR2WWriter(fs) { LoggerService = _logger };
+            writer.WriteFile(cr2w);
+        }
+
+        /// <summary>
+        /// Writes the tile index data (TilesData buffer) for one resolution level (high or low).
+        /// For each tile, it records:
+        /// - The starting index in the data list where this tile's layer entries begin.
+        /// - For each layer present in the tile: packed atlas position (dx, dy) + scaling shifts (sx, sy).
+        /// - A bitmask indicating which layers are active in this tile.
+        /// </summary>
+        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
+        {
+            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
+            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
+
+            for (uint ty = 0; ty < heightInTiles0; ty++)
+            {
+                for (uint tx = 0; tx < widthInTiles0; tx++)
+                {
+                    var tileIdx = tx + (ty * widthInTiles0);
+                    var layersBeg = (uint)tilesDataList.Count;
+                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
+
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
+
+                    uint layersMask = 0;
+                    for (var i = 0; i < numLayers; i++)
+                    {
+                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
+                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
+                        var atlasX = position & widthInTilesGrayUp;
+                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
+                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
+                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
+
+                        uint puts = 0;
+                        puts |= atlasX;
+                        puts |= atlasY << 10;
+                        puts |= widthShift << 20;
+                        puts |= heightShift << 24;
+
+                        tilesDataList.Add(puts);
+                        layersMask |= 1u << (int)layerIdx;
+                    }
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
+                }
+            }
+        }
+
+        private void InitializeMaskLayers()
+        {
+            if (_mlmask.Layers == null) return;
+
+            for (uint i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _mlmask.Layers[i].WidthInTiles0 = (_mlmask.Layers[i].Width + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.Layers[i].HeightInTiles0 = (_mlmask.Layers[i].Height + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.Layers[i].Tiles = new List<Tile>();
+
+                for (uint y = 0; y < _mlmask.Layers[i].HeightInTiles0; y++)
+                {
+                    for (uint x = 0; x < _mlmask.Layers[i].WidthInTiles0; x++)
+                    {
+                        var tile = new Tile
+                        {
+                            AtlasInPosition = uint.MaxValue,
+                            AtlasUnCompressed = new byte[_mlmask.AtlasTileSize * _mlmask.AtlasTileSize]
+                        };
+
+                        if (i == 0)
+                        {
+                            tile.RangeMin = 255;
+                            tile.RangeMax = 255;
+                            Array.Fill(tile.AtlasUnCompressed, (byte)255);
+                        }
+                        else
+                        {
+                            tile.RangeMin = 255;
+                            tile.RangeMax = 0;
+                            for (uint yy = 0; yy < _mlmask.AtlasTileSize; yy++)
+                            {
+                                for (uint xx = 0; xx < _mlmask.AtlasTileSize; xx++)
+                                {
+                                    var v = GetPixelFromLayer(i, x, y, (int)xx - 1, (int)yy - 1);
+                                    tile.AtlasUnCompressed[xx + (yy * _mlmask.AtlasTileSize)] = v;
+                                    tile.RangeMin = Math.Min(tile.RangeMin, v);
+                                    tile.RangeMax = Math.Max(tile.RangeMax, v);
+                                }
+                            }
+                        }
+                        _mlmask.Layers[i].Tiles.Add(tile);
+                    }
+                }
+            }
+        }
+
+        private byte GetPixelFromLayer(uint layerIdx, uint tx, uint ty, int x, int y)
+        {
+            if (layerIdx == 0) return 255;
+
+            var xx = (int)(tx * _mlmask.TileSize) + x;
+            var yy = (int)(ty * _mlmask.TileSize) + y;
+            xx = Math.Clamp(xx, 0, (int)_mlmask.Layers![layerIdx].Width - 1);
+            yy = Math.Clamp(yy, 0, (int)_mlmask.Layers[layerIdx].Height - 1);
+            return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
+        }
+
+        /// <summary>
+        /// Builds all internal data structures required to write a valid .mlmask file.
+        /// Calculates global resolution bounds, classifies layers into high/low tile sets,
+        /// packs tiles into the atlas, and generates the final compressed buffers.
+        /// </summary>
+        private void Create()
+        {
+            if (_mlmask.Layers == null) return;
+
+            _mlmask.WidthHigh = 0;
+            _mlmask.HeightHigh = 0;
+            foreach (var lay in _mlmask.Layers)
+            {
+                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
+                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
+            }
+
+            // Metadata-driven: WidthLow/HeightLow are derived from actual layer image sizes
+            _mlmask.WidthLow = uint.MaxValue;
+            _mlmask.HeightLow = uint.MaxValue;
+            foreach (var lay in _mlmask.Layers)
+            {
+                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
+                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
+            }
+
+            for (var i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
+                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
+            }
+
+            uint startAtlasTileSize = (_mlmask.PreferredTileSize > 0)
+                ? _mlmask.PreferredTileSize + 2
+                : 16u;
+
+            uint tempAtlasTileSize = startAtlasTileSize;
+            while (true)
+            {
+                _mlmask.AtlasTileSize = tempAtlasTileSize;
+                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
+                tempAtlasTileSize += 16;
+
+                _mlmask.MaskTilesHigh = null;
+                _mlmask.MaskTilesLow = null;
+                _mlmask.AtlasTiles.Clear();
+                _mlmask.AtlasWidth = 0;
+                _mlmask.AtlasHeight = 0;
+                _mlmask.AtlasTilesCount = 0;
+
+                InitializeMaskLayers();
+
+                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+
+                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
+                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
+                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
+
+                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
+                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
+                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
+
+                CleanTileLayers();
+
+                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
+            }
+
+            CalculateAtlasProportionForPacking();
+            CreateAtlasBuffer();
+
+            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
+            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
+            var tilesDataList = new List<uint>();
+
+            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
+                tilesDataList.Add(0U);
+
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
+
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            foreach (var l in tilesDataList) bw.Write(l);
+            _mlmask.TilesBuffer = ms.ToArray();
+        }
+
+        /// <summary>
+        /// Distributes layers into high-resolution or low-resolution tile sets.
+        /// A layer is considered "low" if its resolution is smaller than WidthHigh.
+        /// This affects which tile grid (MaskTilesHigh or MaskTilesLow) the layer's tiles are added to.
+        /// </summary>
+        private void CleanTileLayers()
+        {
+            if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
+
+            for (uint I = 0; I < _mlmask.Layers.Length; I++)
+            {
+                if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
+                {
+                    for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
+                    {
+                        for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
+                        {
+                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
+                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+
+                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            {
+                                var layer = new TileView
+                                {
+                                    LayerIndex = I,
+                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
+                                };
+                                _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
                             }
                         }
                     }
-                    blob.Chunks.Add(chunk);
-                    mesh.weightCount = 0;
                 }
-                blob.LodChunkIndices = new CArray<CArray<CUInt16>>
+                else
                 {
-                    new()
-                };
-                if (lodLvl.Contains(2U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                if (lodLvl.Contains(4U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                if (lodLvl.Contains(8U))
-                {
-                    blob.LodChunkIndices.Add(new CArray<CUInt16>());
-                }
-                for (ushort i = 0; i < lodLvl.Length; i++)
-                {
-                    if (lodLvl[i] == 1)
+                    for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
                     {
-                        blob.LodChunkIndices[0].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 2)
-                    {
-                        blob.LodChunkIndices[1].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 4)
-                    {
-                        blob.LodChunkIndices[2].NotNull().Add(i);
-                    }
-                    if (lodLvl[i] == 8)
-                    {
-                        blob.LodChunkIndices[3].NotNull().Add(i);
+                        for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
+                        {
+                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
+                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+
+                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            {
+                                var layer = new TileView
+                                {
+                                    LayerIndex = I,
+                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
+                                };
+                                _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
+                            }
+                        }
                     }
                 }
             }
         }
 
-        #region Parameter: GarmentSupport
-
-        private void UpdateGarmentSupportParameters(List<RawMeshContainer> meshes, CMesh cMesh, bool importGarmentSupport = true, bool ignoreGarmentSupportUVParam = true)
+        private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
         {
-            for (var i = cMesh.Parameters.Count - 1; i >= 0; i--)
+            if (_mlmask.Layers == null) return 0;
+
+            var tileIndex = tx + (ty * _mlmask.Layers[layerIdx].WidthInTiles0);
+
+            if (_mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
             {
-                if (cMesh.Parameters[i] is { Chunk: meshMeshParamGarmentSupport } or { Chunk: garmentMeshParamGarment })
+                BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
+
+                var recursiveHash = FNV1A.FnvHashInitial;
+                for (uint y = 0; y < _mlmask.AtlasTileSize / 4; y++)
                 {
-                    cMesh.Parameters.RemoveAt(i);
+                    for (uint x = 0; x < _mlmask.AtlasTileSize / 4; x++)
+                    {
+                        var compressedBlock = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
+                        var color32 = new float[16];
+                        D3DX.D3DXDecodeBC4U(ref color32, compressedBlock);
+                        var color8 = new byte[16];
+                        for (uint i = 0; i < 16; i++) color8[i] = (byte)(color32[i] * 255.0f);
+                        recursiveHash = FNV1A.HashReadOnlySpan(color8, recursiveHash);
+                    }
                 }
-            }
 
-            if (!importGarmentSupport)
-            {
-                return;
-            }
-
-            var missingMorphData = new List<string>();
-            foreach (var rawMeshContainer in meshes)
-            {
-                if (rawMeshContainer.garmentMorph?.Length == 0)
+                if (!_mlmask.AtlasTiles.TryGetValue(recursiveHash, out var atlasView))
                 {
-                    missingMorphData.Add(rawMeshContainer.name!);
+                    atlasView = new TileView
+                    {
+                        AtlasInPosition = _mlmask.AtlasTilesCount++,
+                        LayerIndex = layerIdx,
+                        LayerTileIndex = tileIndex
+                    };
+                    _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
                 }
+
+                var z = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex];
+                z.AtlasInPosition = atlasView.AtlasInPosition;
+                _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
             }
-
-            if (missingMorphData.Count == meshes.Count)
-            {
-                _loggerService.Warning("Garment support is enabled, but the model doesn't contain any morph data. Please ensure all meshes have garment morph data before enabling garment support. Skipping GS Parameters!");
-                return;
-            }
-
-            // Not sure if valid or not. Parameters where removed before, so I kept it this way. Remove below if needed - Seb E. Roth
-            if (missingMorphData.Count > 0)
-            {
-                _loggerService.Warning($"Garment support is enabled, but the following submeshes do not have garment morph data: {string.Join(", ", missingMorphData)}. Please ensure all meshes have garment morph data before enabling garment support. Skipping GS Parameters!");
-                return;
-            }
-
-            var meshMeshParamGarmentSupportData = new meshMeshParamGarmentSupport
-            {
-                ChunkCapVertices = [],
-                CustomMorph = true
-            };
-            cMesh.Parameters.Add(meshMeshParamGarmentSupportData);
-
-            var garmentMeshParamGarmentData = new garmentMeshParamGarment
-            {
-                Chunks = []
-            };
-            cMesh.Parameters.Add(garmentMeshParamGarmentData);
-
-            foreach (var mesh in meshes)
-            {
-                UpdateGarmentSupportParameters(mesh, meshMeshParamGarmentSupportData, garmentMeshParamGarmentData, ignoreGarmentSupportUVParam);
-            }
+            return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
         }
 
-        private static void UpdateGarmentSupportParameters(RawMeshContainer mesh, meshMeshParamGarmentSupport garmentMeshBlobChunk, garmentMeshParamGarment garmentBlobChunk, bool ignoreGarmentSupportUVParam = true)
+        /// <summary>
+        /// Calculates the optimal atlas dimensions.
+        /// First tries to reuse the original atlas size from the .masklist (for round-trip fidelity).
+        /// If that doesn't fit, falls back to a minimum-waste power-of-2-friendly packing algorithm.
+        /// </summary>
+        private void CalculateAtlasProportionForPacking()
         {
-            ArgumentNullException.ThrowIfNull(mesh.positions, nameof(mesh));
-            ArgumentNullException.ThrowIfNull(mesh.indices, nameof(mesh));
-            ArgumentNullException.ThrowIfNull(mesh.garmentMorph, nameof(mesh));
-            ArgumentNullException.ThrowIfNull(mesh.texCoords0, nameof(mesh));
+            _mlmask.AtlasWidth = 0;
+            _mlmask.AtlasHeight = 0;
 
-            var vertBuffer = new MemoryStream();
-            var vertBw = new BinaryWriter(vertBuffer);
-
-            var indBuffer = new MemoryStream();
-            var indBw = new BinaryWriter(indBuffer);
-
-            var morphBuffer = new MemoryStream();
-            var morphBw = new BinaryWriter(morphBuffer);
-
-            var flagBuffer = new MemoryStream();
-            var flagBw = new BinaryWriter(flagBuffer);
-
-            var uvBuffer = new MemoryStream();
-            var uvBw = new BinaryWriter(uvBuffer);
-
-            var capVertices = new CArray<CUInt32>();
-
-            for (var v = 0; v < mesh.positions.Length; v++)
+            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0)
             {
-                vertBw.Write(mesh.positions[v].X);
-                vertBw.Write(mesh.positions[v].Y);
-                vertBw.Write(mesh.positions[v].Z);
-
-                morphBw.Write(mesh.garmentMorph[v].X);
-                morphBw.Write(mesh.garmentMorph[v].Y);
-                morphBw.Write(mesh.garmentMorph[v].Z);
-
-                var vertexHasValidCap = mesh.garmentSupportCap?.Length > v && mesh.garmentSupportCap[v].X >= .5f;
-                flagBw.Write(Convert.ToByte(mesh.garmentSupportWeight?.Length > v ? mesh.garmentSupportWeight[v].X * 255 : 0));
-                flagBw.Write(Convert.ToByte(vertexHasValidCap ? 1 : 0));
-                flagBw.Write((byte)0);
-                flagBw.Write((byte)0);
-                if (vertexHasValidCap)
+                var widthInTiles = _mlmask.PreferredAtlasWidth / _mlmask.AtlasTileSize;
+                if (widthInTiles > 0)
                 {
-                    capVertices.Add(Convert.ToUInt32(v));
+                    var neededRows = (_mlmask.AtlasTilesCount + widthInTiles - 1) / widthInTiles;
+                    var requiredHeight = neededRows * _mlmask.AtlasTileSize;
+
+                    if (requiredHeight <= _mlmask.PreferredAtlasHeight)
+                    {
+                        _mlmask.AtlasWidth = _mlmask.PreferredAtlasWidth;
+                        _mlmask.AtlasHeight = _mlmask.PreferredAtlasHeight;
+                        _logger.Info($"Reusing original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight}");
+                        return;
+                    }
+                    else
+                    {
+                        _logger.Info($"Original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} is insufficient for the current layer content ({_mlmask.AtlasTilesCount} unique tiles). Calculating a larger atlas...");
+                    }
+                }
+            }
+
+            uint widthTry = 16384;
+            var emptyArea = uint.MaxValue;
+
+            while (widthTry >= _mlmask.AtlasTileSize)
+            {
+                var widthInTiles0 = widthTry / _mlmask.AtlasTileSize;
+                var heightTry = (_mlmask.AtlasTilesCount + widthInTiles0 - 1) / widthInTiles0 * _mlmask.AtlasTileSize;
+
+                var widthUp = RoundUpPowerOf2(widthTry);
+                var heightUp = RoundUpPowerOf2(heightTry);
+
+                var currEmptyArea = (widthUp * heightUp) - (_mlmask.AtlasTilesCount * _mlmask.AtlasTileSize * _mlmask.AtlasTileSize);
+                if (currEmptyArea <= emptyArea)
+                {
+                    _mlmask.AtlasWidth = widthTry;
+                    _mlmask.AtlasHeight = heightTry;
+                    emptyArea = currEmptyArea;
                 }
 
-                uvBw.Write(mesh.texCoords0[v].X);
-                uvBw.Write(1 - mesh.texCoords0[v].Y);
+                if (widthTry <= heightTry) break;
+                widthTry /= 2;
             }
 
-            foreach (var i in mesh.indices)
+            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
+                throw new Exception("Atlas too large (over 16k)");
+
+            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0 &&
+                (_mlmask.AtlasWidth != _mlmask.PreferredAtlasWidth || _mlmask.AtlasHeight != _mlmask.PreferredAtlasHeight))
             {
-                indBw.Write(Convert.ToUInt16(i));
+                _logger.Info($"Atlas size automatically increased from {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} to accommodate new layer content.");
             }
-
-            garmentMeshBlobChunk.ChunkCapVertices.Add(capVertices);
-
-            garmentBlobChunk.Chunks.Add(new garmentMeshParamGarmentChunkData
+            else if (_mlmask.PreferredAtlasWidth == 0 || _mlmask.PreferredAtlasHeight == 0)
             {
-                GarmentFlags = new DataBuffer(flagBuffer.ToArray()),
-                Indices = new DataBuffer(indBuffer.ToArray()),
-                MorphOffsets = new DataBuffer(morphBuffer.ToArray()),
-                Vertices = new DataBuffer(vertBuffer.ToArray()),
-                Uv = ignoreGarmentSupportUVParam ? null : new DataBuffer(uvBuffer.ToArray()),
-                NumVertices = Convert.ToUInt32(mesh.positions.Length),
-                LodMask = 1
-            });
+                _logger.Info($"Atlas size set to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight}.");
+            }
         }
 
-        #endregion Parameter: GarmentSupport
+        private void CreateAtlasBuffer()
+        {
+            if (_mlmask.Layers == null || _mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
+                throw new Exception("Unable to generate MLmask atlas data");
+
+            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
+            var widthInBlocks0 = _mlmask.AtlasWidth / 4;
+            var heightInBlocks0 = _mlmask.AtlasHeight / 4;
+            var widthInTiles0 = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+
+            var data = new ulong[widthInBlocks0 * heightInBlocks0];
+
+            foreach (var atlasTile in _mlmask.AtlasTiles.Values)
+            {
+                var sourceLayer = _mlmask.Layers[atlasTile.LayerIndex];
+                var tileSource = sourceLayer.Tiles[(int)atlasTile.LayerTileIndex];
+
+                var position = atlasTile.AtlasInPosition;
+                var tx = position % widthInTiles0;
+                var ty = position / widthInTiles0;
+                var bx = tx * tileSizeInBlocks0;
+                var by = ty * tileSizeInBlocks0;
+
+                var destinationIdx = bx + (by * widthInBlocks0);
+                for (uint i = 0; i < tileSizeInBlocks0; i++)
+                {
+                    Array.Copy(tileSource.AtlasBlockCompressed, i * tileSizeInBlocks0, data, destinationIdx, tileSizeInBlocks0);
+                    destinationIdx += widthInBlocks0;
+                }
+            }
+
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            foreach (var d in data) bw.Write(d);
+            _mlmask.AtlasBuffer = ms.ToArray();
+        }
+
+        private void BlockCompressLocalTile(ref RawTexContainer layer, uint tileIdx)
+        {
+            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
+            var tx = tileIdx % layer.WidthInTiles0;
+            var ty = tileIdx / layer.WidthInTiles0;
+
+            var layerTile = layer.Tiles[(int)tileIdx];
+            layerTile.AtlasBlockCompressed = new ulong[tileSizeInBlocks0 * tileSizeInBlocks0];
+
+            for (uint yBlock = 0; yBlock < tileSizeInBlocks0; yBlock++)
+            {
+                for (uint xBlock = 0; xBlock < tileSizeInBlocks0; xBlock++)
+                {
+                    var referenceData = new List<float>();
+                    var toBBCValues = new float[16];
+
+                    for (uint j = 0; j < 4; j++)
+                    {
+                        for (uint i = 0; i < 4; i++)
+                        {
+                            var px = (xBlock * 4) + i;
+                            var py = (yBlock * 4) + j;
+                            var v = layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
+                            toBBCValues[i + (j * 4)] = v;
+                            referenceData.Add(v);
+                        }
+                    }
+
+                    if (tx > 0 && xBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
+                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
+
+                    if (ty > 0 && yBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
+                    else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
+
+                    ulong blockCompressed = 0;
+                    D3DX.D3DXEncodeBC4U(ref blockCompressed, toBBCValues, referenceData);
+                    layerTile.AtlasBlockCompressed[xBlock + (yBlock * tileSizeInBlocks0)] = blockCompressed;
+                }
+            }
+            layer.Tiles[(int)tileIdx] = layerTile;
+        }
+
+        private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty, uint xBlock, uint yBlock)
+        {
+            for (uint j = 0; j < 4; j++)
+            {
+                for (uint i = 0; i < 4; i++)
+                {
+                    var px = (xBlock * 4) + i;
+                    var py = (yBlock * 4) + j;
+                    var v = layer.Tiles[(int)(tx + (ty * layer.WidthInTiles0))].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
+                    referenceData.Add(v);
+                }
+            }
+        }
+
+        private static uint RoundUpPowerOf2(uint v)
+        {
+            v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16;
+            return ++v;
+        }
+
+        #endregion Core Methods
+
+        #region Structs
+
+        public struct RawTexContainer
+        {
+            public byte[] Pixels;
+            public uint Width;
+            public uint Height;
+            public List<Tile> Tiles;
+            public uint WidthShift;
+            public uint HeightShift;
+            public uint WidthInTiles0;
+            public uint HeightInTiles0;
+        }
+
+        public struct Tile
+        {
+            public byte RangeMin;
+            public byte RangeMax;
+            public byte[] AtlasUnCompressed;
+            public ulong[] AtlasBlockCompressed;
+            public uint AtlasInPosition;
+        }
+
+        public struct MaskTile
+        {
+            public List<TileView> Layers;
+        }
+
+        public struct TileView
+        {
+            public uint LayerIndex;
+            public uint AtlasInPosition;
+            public uint LayerTileIndex;
+        }
+
+        public class MlMaskContainer
+        {
+            public RawTexContainer[]? Layers;
+            public MaskTile[]? MaskTilesHigh;
+            public Dictionary<ulong, TileView> AtlasTiles = new();
+            public MaskTile[]? MaskTilesLow;
+            public uint AtlasTileSize;
+            public uint AtlasWidth;
+            public uint AtlasHeight;
+            public uint HeightHigh;
+            public uint WidthLow;
+            public uint HeightInTilesHigh;
+            public uint WidthInTilesLow;
+            public uint HeightLow;
+            public byte[]? AtlasBuffer;
+            public byte[]? TilesBuffer;
+            public uint WidthInTilesHigh;
+            public uint HeightInTilesLow;
+            public uint TileSize;
+            public uint WidthHigh;
+            public uint AtlasTilesCount;
+
+            public uint PreferredTileSize;
+            public uint PreferredAtlasWidth;
+            public uint PreferredAtlasHeight;
+        }
+
+        #endregion Structs
+
+        #region FNV1A
+
+        internal class FNV1A
+        {
+            public const ulong FnvHashInitial = 0xCBF29CE484222325;
+            public const ulong FnvHashPrime = 0x00000100000001B3;
+            public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
+            {
+                foreach (var b in source)
+                    unchecked { hash = (hash ^ b) * FnvHashPrime; }
+                return hash;
+            }
+        }
+
+        #endregion FNV1A
+
+        #region D3DX
+
+        internal class D3DX
+        {
+            [StructLayout(LayoutKind.Explicit, Size = 8)]
+            public struct BC4_UNORM
+            {
+                public float R(int offset)
+                {
+                    var index = GetIndex(offset);
+                    return DecodeFromIndex(index);
+                }
+
+                public float DecodeFromIndex(uint index)
+                {
+                    if (index == 0) return Red_0 / 255.0f;
+                    if (index == 1) return Red_1 / 255.0f;
+
+                    var fred0 = Red_0 / 255.0f;
+                    var fred1 = Red_1 / 255.0f;
+
+                    if (Red_0 > Red_1)
+                    {
+                        index--;
+                        return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
+                    }
+
+                    if (index == 6) return 0.0f;
+                    if (index == 7) return 1.0f;
+
+                    index--;
+                    return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
+                }
+
+                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
+
+                public void SetIndex(int uOffset, int uIndex)
+                {
+                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
+                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
+                }
+
+                [FieldOffset(0)] public ulong Data;
+                [FieldOffset(0)] public byte Red_0;
+                [FieldOffset(1)] public byte Red_1;
+                [FieldOffset(2)] public byte Index0;
+                [FieldOffset(3)] public byte Index1;
+                [FieldOffset(4)] public byte Index2;
+                [FieldOffset(5)] public byte Index3;
+                [FieldOffset(6)] public byte Index4;
+                [FieldOffset(7)] public byte Index5;
+            }
+
+            public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
+            {
+                var pBC4 = new BC4_UNORM();
+                FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
+                FindClosestUNORM(ref pBC4, refData);
+                resultantBlock = pBC4.Data;
+            }
+
+            private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
+            {
+                const float MIN_NORM = 0f;
+                const float MAX_NORM = 1f;
+
+                var fBlockMax = theTexelsU[0];
+                var fBlockMin = theTexelsU[0];
+                for (var i = 0; i < numTexels; ++i)
+                {
+                    if (theTexelsU[i] < fBlockMin) fBlockMin = theTexelsU[i];
+                    else if (theTexelsU[i] > fBlockMax) fBlockMax = theTexelsU[i];
+                }
+
+                var bUsing4BlockCodec = MIN_NORM == fBlockMin || MAX_NORM == fBlockMax;
+                float fStart = 0, fEnd = 0;
+
+                if (!bUsing4BlockCodec)
+                {
+                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
+                    var iStart = Convert.ToByte(fStart * 255.0f);
+                    var iEnd = Convert.ToByte(fEnd * 255.0f);
+                    endpointU_0 = iEnd;
+                    endpointU_1 = iStart;
+                }
+                else
+                {
+                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
+                    var iStart = Convert.ToByte(fStart * 255.0f);
+                    var iEnd = Convert.ToByte(fEnd * 255.0f);
+                    endpointU_1 = iEnd;
+                    endpointU_0 = iStart;
+                }
+            }
+
+            private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
+            {
+                float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
+                float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
+                float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
+                float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
+
+                var pC = 6 == cSteps ? pC6 : pC8;
+                var pD = 6 == cSteps ? pD6 : pD8;
+
+                const float maxValue = 1.0f;
+                const float minValue = 0.0f;
+
+                var fX = maxValue;
+                var fY = minValue;
+
+                if (8 == cSteps)
+                {
+                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        if (pPoints[iPoint] < fX) fX = pPoints[iPoint];
+                        if (pPoints[iPoint] > fY) fY = pPoints[iPoint];
+                    }
+                }
+                else
+                {
+                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        if (pPoints[iPoint] < fX && pPoints[iPoint] > minValue) fX = pPoints[iPoint];
+                        if (pPoints[iPoint] > fY && pPoints[iPoint] < maxValue) fY = pPoints[iPoint];
+                    }
+                    if (fX == fY) fY = maxValue;
+                }
+
+                var fSteps = Convert.ToSingle(cSteps - 1);
+
+                for (var iIteration = 0; iIteration < 8; iIteration++)
+                {
+                    if (fY - fX < 1.0f / 256.0f) break;
+
+                    var fScale = fSteps / (fY - fX);
+                    var pSteps = new float[8];
+
+                    for (var iStep = 0; iStep < cSteps; iStep++)
+                        pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
+
+                    if (6 == cSteps)
+                    {
+                        pSteps[6] = minValue;
+                        pSteps[7] = maxValue;
+                    }
+
+                    var dX = 0.0f;
+                    var dY = 0.0f;
+                    var d2X = 0.0f;
+                    var d2Y = 0.0f;
+
+                    for (uint iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        var fDot = (pPoints[(int)iPoint] - fX) * fScale;
+                        uint iStep;
+
+                        if (fDot <= 0.0f)
+                            iStep = 6 == cSteps && pPoints[(int)iPoint] <= fX * 0.5f ? (uint)6 : 0;
+                        else if (fDot >= fSteps)
+                            iStep = 6 == cSteps && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f ? 7 : cSteps - 1;
+                        else
+                            iStep = (uint)(fDot + 0.5f);
+
+                        if (iStep < cSteps)
+                        {
+                            var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
+                            dX += pC[iStep] * fDiff;
+                            d2X += pC[iStep] * pC[iStep];
+                            dY += pD[iStep] * fDiff;
+                            d2Y += pD[iStep] * pD[iStep];
+                        }
+                    }
+
+                    if (d2X > 0.0f) fX -= dX / d2X;
+                    if (d2Y > 0.0f) fY -= dY / d2Y;
+
+                    if (fX > fY) (fY, fX) = (fX, fY);
+
+                    if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f) break;
+                }
+
+                pX = fX < minValue ? minValue : fX > maxValue ? maxValue : fX;
+                pY = fY < minValue ? minValue : fY > maxValue ? maxValue : fY;
+            }
+
+            private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
+            {
+                const uint numPixelsPerBlock = 16;
+                var rGradient = new float[8];
+                for (uint i = 0; i < 8; ++i)
+                    rGradient[i] = pBC.DecodeFromIndex(i);
+
+                for (uint i = 0; i < numPixelsPerBlock; ++i)
+                {
+                    uint uBestIndex = 0;
+                    float fBestDelta = 100000;
+                    for (uint uIndex = 0; uIndex < 8; uIndex++)
+                    {
+                        var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
+                        if (fCurrentDelta < fBestDelta)
+                        {
+                            uBestIndex = uIndex;
+                            fBestDelta = fCurrentDelta;
+                        }
+                    }
+                    pBC.SetIndex((int)i, (int)uBestIndex);
+                }
+            }
+
+            public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
+            {
+                const uint numPixelsPerBlock = 16;
+                var pBC4 = new BC4_UNORM { Data = pBC };
+                for (var i = 0; i < numPixelsPerBlock; ++i)
+                    pColor[i] = pBC4.R(i);
+            }
+        }
+
+        #endregion D3DX
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -27,52 +27,43 @@ namespace WolvenKit.Modkit.RED4.MLMask
             _logger = logger;
         }
 
+        /// <summary>
+        /// Импорт .masklist → .mlmask
+        /// Поддерживает как разные разрешения слоёв, так и одинаковые.
+        /// .masklist теперь содержит только пути к файлам (без заголовка).
+        /// </summary>
         public void Import(FileInfo txtImageList, FileInfo outFile)
         {
             var lines = File.ReadAllLines(txtImageList.FullName);
             var baseDir = txtImageList.Directory.NotNull();
-
-            uint targetAtlasWidth = 0;
-            uint targetAtlasHeight = 0;
-            uint targetTileSize = 16;
 
             var filePaths = new List<string>();
 
             foreach (var line in lines)
             {
                 var trimmed = line.Trim();
-                if (string.IsNullOrWhiteSpace(trimmed))
+                if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
                     continue;
-
-                if (trimmed.StartsWith("#"))
-                {
-                    if (trimmed.Contains("AtlasWidth="))
-                        targetAtlasWidth = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("AtlasHeight="))
-                        targetAtlasHeight = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("MaskTileSize="))
-                        targetTileSize = ParseHeaderValue(trimmed);
-
-                    continue;
-                }
-
-                if (trimmed.Contains("=")) continue;
+                if (trimmed.Contains("=")) continue; // совместимость со старыми файлами
 
                 filePaths.Add(trimmed);
             }
 
-            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
-
-            if (files.Count == 0)
+            if (filePaths.Count == 0)
                 throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
 
-            _mlmask = new MlMaskContainer();
-            _mlmask.PreferredTileSize = targetTileSize;
-            _mlmask.PreferredAtlasWidth = targetAtlasWidth;
-            _mlmask.PreferredAtlasHeight = targetAtlasHeight;
+            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
+
+            _mlmask = new MlMaskContainer
+            {
+                PreferredTileSize = 16,
+                PreferredAtlasWidth = 0,
+                PreferredAtlasHeight = 0
+            };
 
             var textures = new List<RawTexContainer>();
 
+            // Добавляем белый слой 0 (если первый слой не заканчивается на _0)
             var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
             var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
 
@@ -81,34 +72,31 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 uint whiteW = 1024u;
                 uint whiteH = 1024u;
 
-                if (files.Count > 0)
+                if (files.Count > 0 && File.Exists(files[0]))
                 {
-                    var firstReal = files[0];
-                    if (File.Exists(firstReal))
+                    try
                     {
-                        try
+                        using var probe = RedImage.LoadFromFile(files[0]);
+                        if (probe != null)
                         {
-                            using var probe = RedImage.LoadFromFile(firstReal);
-                            if (probe != null)
-                            {
-                                whiteW = (uint)probe.Metadata.Width;
-                                whiteH = (uint)probe.Metadata.Height;
-                            }
+                            whiteW = (uint)probe.Metadata.Width;
+                            whiteH = (uint)probe.Metadata.Height;
                         }
-                        catch { }
                     }
+                    catch { }
                 }
 
                 var whitePixels = new byte[whiteW * whiteH];
                 Array.Fill(whitePixels, (byte)255);
                 textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
-                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH} (inferred from first provided layer metadata)");
+                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH}");
             }
 
-            for (var fileIdx = 0; fileIdx < files.Count; fileIdx++)
+            // Загружаем все слои из файлов
+            foreach (var f in files)
             {
-                var f = files[fileIdx];
-                if (!File.Exists(f)) throw new FileNotFoundException($"File not found: {f}");
+                if (!File.Exists(f))
+                    throw new FileNotFoundException($"File not found: {f}");
 
                 try
                 {
@@ -125,19 +113,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     ms.Seek(s_headerLength, SeekOrigin.Begin);
                     var pixels = br.ReadBytes((int)(imgW * imgH));
 
-                    var isBlank = IsBlankLayer(pixels);
-
-                    if (isBlank)
-                    {
-                        textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
-                        continue;
-                    }
-
                     textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
                 }
                 catch (WolvenKitException e)
                 {
-                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale)");
+                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale R8)");
                 }
             }
 
@@ -146,7 +126,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             Create();
             Write(outFile);
 
-            _logger.Info("Import complete. Keep your original .masklist file for round-trip export.");
+            _logger.Info("MLMask import completed successfully.");
         }
 
         internal static bool IsBlankLayer(byte[] pixels)
@@ -156,28 +136,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
             for (int i = 1; i < pixels.Length; i++)
                 if (pixels[i] != first) return false;
             return true;
-        }
-
-        internal static uint ParseHeaderValue(string line)
-        {
-            var parts = line.Split('=');
-            return parts.Length > 1 ? uint.Parse(parts[1].Trim()) : 0;
-        }
-
-        internal static byte[] UpscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
-        {
-            var dst = new byte[dstW * dstH];
-            var scaleX = (double)srcW / dstW;
-            var scaleY = (double)srcH / dstH;
-
-            for (uint y = 0; y < dstH; y++)
-                for (uint x = 0; x < dstW; x++)
-                {
-                    var srcX = (uint)(x * scaleX);
-                    var srcY = (uint)(y * scaleY);
-                    dst[x + y * dstW] = src[srcX + srcY * srcW];
-                }
-            return dst;
         }
 
         #region Core Methods
@@ -217,51 +175,250 @@ namespace WolvenKit.Modkit.RED4.MLMask
             writer.WriteFile(cr2w);
         }
 
-        /// <summary>
-        /// Writes the tile index data (TilesData buffer) for one resolution level (high or low).
-        /// For each tile, it records:
-        /// - The starting index in the data list where this tile's layer entries begin.
-        /// - For each layer present in the tile: packed atlas position (dx, dy) + scaling shifts (sx, sy).
-        /// - A bitmask indicating which layers are active in this tile.
-        /// </summary>
-        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
+        private void Create()
         {
-            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
-            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
+            if (_mlmask.Layers == null || _mlmask.Layers.Length == 0) return;
 
-            for (uint ty = 0; ty < heightInTiles0; ty++)
+            // High resolution
+            _mlmask.WidthHigh = 0;
+            _mlmask.HeightHigh = 0;
+            foreach (var lay in _mlmask.Layers)
             {
-                for (uint tx = 0; tx < widthInTiles0; tx++)
+                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
+                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
+            }
+
+            // Low resolution
+            _mlmask.WidthLow = _mlmask.WidthHigh;
+            _mlmask.HeightLow = _mlmask.HeightHigh;
+
+            bool hasDifferentResolutions = false;
+            foreach (var lay in _mlmask.Layers)
+            {
+                if (lay.Width < _mlmask.WidthHigh || lay.Height < _mlmask.HeightHigh)
                 {
-                    var tileIdx = tx + (ty * widthInTiles0);
-                    var layersBeg = (uint)tilesDataList.Count;
-                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
-
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
-
-                    uint layersMask = 0;
-                    for (var i = 0; i < numLayers; i++)
-                    {
-                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
-                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
-                        var atlasX = position & widthInTilesGrayUp;
-                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
-                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
-                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
-
-                        uint puts = 0;
-                        puts |= atlasX;
-                        puts |= atlasY << 10;
-                        puts |= widthShift << 20;
-                        puts |= heightShift << 24;
-
-                        tilesDataList.Add(puts);
-                        layersMask |= 1u << (int)layerIdx;
-                    }
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
+                    hasDifferentResolutions = true;
+                    _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
+                    _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
                 }
             }
+
+            if (!hasDifferentResolutions)
+            {
+                _mlmask.WidthLow = _mlmask.WidthHigh;
+                _mlmask.HeightLow = _mlmask.HeightHigh;
+            }
+
+            // Shifts
+            for (var i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
+                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
+            }
+
+            // AtlasTileSize must be divisible by 4 (we split it into 4x4 BC4 blocks for compression).
+            // Start at 16 (standard when maskTileSize=14) and increase by 4 to maintain divisibility.
+            uint tempAtlasTileSize = 16u;
+            while (true)
+            {
+                _mlmask.AtlasTileSize = tempAtlasTileSize;
+                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
+
+                _mlmask.MaskTilesHigh = null;
+                _mlmask.MaskTilesLow = null;
+                _mlmask.AtlasTiles.Clear();
+                _mlmask.AtlasWidth = 0;
+                _mlmask.AtlasHeight = 0;
+                _mlmask.AtlasTilesCount = 0;
+
+                InitializeMaskLayers();
+
+                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+
+                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
+                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
+                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
+
+                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
+                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
+                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
+
+                CleanTileLayers();
+
+                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
+
+                tempAtlasTileSize += 4;   // keep the value divisible by 4
+            }
+
+            CalculateAtlasProportionForPacking();
+            CreateAtlasBuffer();
+
+            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
+            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
+            var tilesDataList = new List<uint>();
+
+            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
+                tilesDataList.Add(0U);
+
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
+
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            foreach (var l in tilesDataList) bw.Write(l);
+            _mlmask.TilesBuffer = ms.ToArray();
+        }
+
+        private void CalculateAtlasProportionForPacking()
+        {
+            if (_mlmask.AtlasTilesCount == 0)
+                throw new Exception("No tiles to pack into atlas.");
+
+            uint tileSize = _mlmask.AtlasTileSize;
+            uint tileCount = _mlmask.AtlasTilesCount;
+
+            // The atlas size is independent of maskWidth/maskHeight.
+            // It only needs to hold all *unique* compressed tiles (after hash deduplication).
+            // Real game files often have atlas much smaller than mask resolution when content has repetition/empty areas.
+
+            uint bestWidth = 0;
+            uint bestHeight = 0;
+            ulong bestWaste = ulong.MaxValue;
+
+            // Start near square root for good aspect ratio
+            uint startWidthInTiles = Math.Max(1u, (uint)Math.Ceiling(Math.Sqrt(tileCount)));
+
+            // Try widths around the square root (good for most cases)
+            for (uint wTiles = startWidthInTiles; wTiles <= startWidthInTiles + 48 && wTiles <= 512; wTiles++)
+            {
+                if (wTiles == 0) continue;
+
+                uint hTiles = (tileCount + wTiles - 1) / wTiles; // ceil division
+                uint w = wTiles * tileSize;
+                uint h = hTiles * tileSize;
+
+                if (w > 16384 || h > 16384) continue;
+
+                ulong area = (ulong)w * h;
+                ulong usedArea = (ulong)tileCount * tileSize * tileSize;
+                ulong waste = area - usedArea;
+
+                if (waste < bestWaste || bestWidth == 0)
+                {
+                    bestWaste = waste;
+                    bestWidth = w;
+                    bestHeight = h;
+                }
+            }
+
+            // Also try a few power-of-two widths for potentially better cache/GPU behavior
+            uint[] pow2Candidates = { 256, 512, 1024, 2048, 4096 };
+            foreach (uint pw in pow2Candidates)
+            {
+                if (pw < tileSize) continue;
+                uint pwTiles = pw / tileSize;
+                uint phTiles = (tileCount + pwTiles - 1) / pwTiles;
+                uint ph = phTiles * tileSize;
+
+                if (ph > 16384) continue;
+
+                ulong pWaste = (ulong)pw * ph - (ulong)tileCount * tileSize * tileSize;
+                if (pWaste < bestWaste)
+                {
+                    bestWaste = pWaste;
+                    bestWidth = pw;
+                    bestHeight = ph;
+                }
+            }
+
+            // Final fallback: simple horizontal strip (rarely needed)
+            if (bestWidth == 0)
+            {
+                uint wTiles = Math.Min(128u, tileCount);
+                if (wTiles == 0) wTiles = 1;
+                uint hTiles = (tileCount + wTiles - 1) / wTiles;
+                bestWidth = wTiles * tileSize;
+                bestHeight = hTiles * tileSize;
+            }
+
+            _mlmask.AtlasWidth = bestWidth;
+            _mlmask.AtlasHeight = bestHeight;
+
+            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
+                throw new Exception("Atlas too large (over 16k)");
+
+            // Ensure the number of tiles horizontally is a power of 2 (required by PutTiles bit-packing).
+            uint tilesX = _mlmask.AtlasWidth / tileSize;
+            if (tilesX > 0 && (tilesX & (tilesX - 1)) != 0)
+            {
+                uint nextPow2 = 1u;
+                while (nextPow2 < tilesX) nextPow2 <<= 1;
+
+                uint newWidth = nextPow2 * tileSize;
+                uint newHeight = ((tileCount + nextPow2 - 1) / nextPow2) * tileSize;
+
+                // Try to prefer layouts where height >= width (more vertical/square, like most CDPR atlases)
+                // when it doesn't increase waste too much.
+                bool preferTaller = newHeight < newWidth;
+
+                if (preferTaller && nextPow2 > 1)
+                {
+                    uint prevPow2 = nextPow2 / 2;
+                    uint prevWidth = prevPow2 * tileSize;
+                    uint prevHeight = ((tileCount + prevPow2 - 1) / prevPow2) * tileSize;
+
+                    if (prevWidth <= 16384)
+                    {
+                        // Accept previous power of 2 if it gives height >= width or the waste increase is reasonable
+                        ulong prevWaste = (ulong)prevWidth * prevHeight - (ulong)tileCount * tileSize * tileSize;
+                        ulong currWaste = (ulong)newWidth * newHeight - (ulong)tileCount * tileSize * tileSize;
+
+                        if (prevHeight >= prevWidth || prevWaste <= currWaste * 1.6)
+                        {
+                            newWidth = prevWidth;
+                            newHeight = prevHeight;
+                        }
+                    }
+                }
+
+                if (newWidth <= 16384)
+                {
+                    _mlmask.AtlasWidth = newWidth;
+                    _mlmask.AtlasHeight = newHeight;
+                }
+            }
+
+            // Final pass: if we still have a very wide result (width > height), try one more time
+            // to use a smaller power-of-2 width if it gives a better aspect ratio with acceptable waste.
+            uint finalTilesX = _mlmask.AtlasWidth / tileSize;
+            uint finalTilesY = _mlmask.AtlasHeight / tileSize;
+
+            if (finalTilesX > finalTilesY && finalTilesX > 1)
+            {
+                uint smallerPow2 = finalTilesX / 2;
+                while (smallerPow2 > 1 && (smallerPow2 & (smallerPow2 - 1)) != 0) smallerPow2 /= 2;
+
+                if (smallerPow2 >= 1)
+                {
+                    uint tryWidth = smallerPow2 * tileSize;
+                    uint tryHeight = ((tileCount + smallerPow2 - 1) / smallerPow2) * tileSize;
+
+                    ulong tryWaste = (ulong)tryWidth * tryHeight - (ulong)tileCount * tileSize * tileSize;
+                    ulong currWaste = (ulong)_mlmask.AtlasWidth * _mlmask.AtlasHeight - (ulong)tileCount * tileSize * tileSize;
+
+                    // Accept if it makes height >= width or waste increase is small
+                    if ((tryHeight >= tryWidth || tryWaste <= currWaste * 1.5) && tryWidth <= 16384)
+                    {
+                        _mlmask.AtlasWidth = tryWidth;
+                        _mlmask.AtlasHeight = tryHeight;
+                    }
+                }
+            }
+
+            _logger.Info($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles, tileSize={tileSize})");
         }
 
         private void InitializeMaskLayers()
@@ -322,100 +479,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
             return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
         }
 
-        /// <summary>
-        /// Builds all internal data structures required to write a valid .mlmask file.
-        /// Calculates global resolution bounds, classifies layers into high/low tile sets,
-        /// packs tiles into the atlas, and generates the final compressed buffers.
-        /// </summary>
-        private void Create()
-        {
-            if (_mlmask.Layers == null) return;
-
-            _mlmask.WidthHigh = 0;
-            _mlmask.HeightHigh = 0;
-            foreach (var lay in _mlmask.Layers)
-            {
-                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
-                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
-            }
-
-            // Metadata-driven: WidthLow/HeightLow are derived from actual layer image sizes
-            _mlmask.WidthLow = uint.MaxValue;
-            _mlmask.HeightLow = uint.MaxValue;
-            foreach (var lay in _mlmask.Layers)
-            {
-                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
-                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
-            }
-
-            for (var i = 0; i < _mlmask.Layers.Length; i++)
-            {
-                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
-                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
-            }
-
-            uint startAtlasTileSize = (_mlmask.PreferredTileSize > 0)
-                ? _mlmask.PreferredTileSize + 2
-                : 16u;
-
-            uint tempAtlasTileSize = startAtlasTileSize;
-            while (true)
-            {
-                _mlmask.AtlasTileSize = tempAtlasTileSize;
-                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
-                tempAtlasTileSize += 16;
-
-                _mlmask.MaskTilesHigh = null;
-                _mlmask.MaskTilesLow = null;
-                _mlmask.AtlasTiles.Clear();
-                _mlmask.AtlasWidth = 0;
-                _mlmask.AtlasHeight = 0;
-                _mlmask.AtlasTilesCount = 0;
-
-                InitializeMaskLayers();
-
-                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-
-                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
-                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
-                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
-
-                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
-                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
-                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
-
-                CleanTileLayers();
-
-                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
-            }
-
-            CalculateAtlasProportionForPacking();
-            CreateAtlasBuffer();
-
-            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
-            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
-            var tilesDataList = new List<uint>();
-
-            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
-                tilesDataList.Add(0U);
-
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            foreach (var l in tilesDataList) bw.Write(l);
-            _mlmask.TilesBuffer = ms.ToArray();
-        }
-
-        /// <summary>
-        /// Distributes layers into high-resolution or low-resolution tile sets.
-        /// A layer is considered "low" if its resolution is smaller than WidthHigh.
-        /// This affects which tile grid (MaskTilesHigh or MaskTilesLow) the layer's tiles are added to.
-        /// </summary>
         private void CleanTileLayers()
         {
             if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
@@ -424,19 +487,30 @@ namespace WolvenKit.Modkit.RED4.MLMask
             {
                 if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
                 {
+                    // Low-res layer
                     for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
                     {
                         for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
                         {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
 
-                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            if (wTiles0 == 0 || hTiles0 == 0) continue;
+
+                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
+                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+
+                            var tx = Math.Min(txRaw, wTiles0 - 1);
+                            var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                            var tileIdxCheck = tx + (ty * wTiles0);
+                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
                             {
                                 var layer = new TileView
                                 {
                                     LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    LayerTileIndex = tx + (ty * wTiles0),
                                     AtlasInPosition = PackTileInAtlas(I, tx, ty)
                                 };
                                 _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
@@ -446,19 +520,30 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 }
                 else
                 {
+                    // High-res layer
                     for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
                     {
                         for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
                         {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
 
-                            if (_mlmask.Layers[I].Tiles[(int)(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            if (wTiles0 == 0 || hTiles0 == 0) continue;
+
+                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
+                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+
+                            var tx = Math.Min(txRaw, wTiles0 - 1);
+                            var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                            var tileIdxCheck = tx + (ty * wTiles0);
+                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
                             {
                                 var layer = new TileView
                                 {
                                     LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    LayerTileIndex = tx + (ty * wTiles0),
                                     AtlasInPosition = PackTileInAtlas(I, tx, ty)
                                 };
                                 _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
@@ -471,11 +556,23 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
         private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
         {
-            if (_mlmask.Layers == null) return 0;
+            if (_mlmask.Layers == null || layerIdx >= _mlmask.Layers.Length) return 0;
 
-            var tileIndex = tx + (ty * _mlmask.Layers[layerIdx].WidthInTiles0);
+            var layer = _mlmask.Layers[layerIdx];
+            if (layer.Tiles == null || layer.WidthInTiles0 == 0 || layer.HeightInTiles0 == 0) return 0;
 
-            if (_mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
+            // Extra safety clamp in case caller passed slightly out-of-range values
+            if (tx >= layer.WidthInTiles0) tx = layer.WidthInTiles0 - 1;
+            if (ty >= layer.HeightInTiles0) ty = layer.HeightInTiles0 - 1;
+
+            var tileIndex = tx + (ty * layer.WidthInTiles0);
+            if (tileIndex >= (uint)layer.Tiles.Count)
+            {
+                _logger?.Error($"PackTileInAtlas: calculated tileIndex {tileIndex} is out of range for layer {layerIdx} (Tiles.Count = {layer.Tiles.Count}, tx={tx}, ty={ty})");
+                return 0;
+            }
+
+            if (layer.Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
             {
                 BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
 
@@ -509,75 +606,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
             }
             return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
-        }
-
-        /// <summary>
-        /// Calculates the optimal atlas dimensions.
-        /// First tries to reuse the original atlas size from the .masklist (for round-trip fidelity).
-        /// If that doesn't fit, falls back to a minimum-waste power-of-2-friendly packing algorithm.
-        /// </summary>
-        private void CalculateAtlasProportionForPacking()
-        {
-            _mlmask.AtlasWidth = 0;
-            _mlmask.AtlasHeight = 0;
-
-            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0)
-            {
-                var widthInTiles = _mlmask.PreferredAtlasWidth / _mlmask.AtlasTileSize;
-                if (widthInTiles > 0)
-                {
-                    var neededRows = (_mlmask.AtlasTilesCount + widthInTiles - 1) / widthInTiles;
-                    var requiredHeight = neededRows * _mlmask.AtlasTileSize;
-
-                    if (requiredHeight <= _mlmask.PreferredAtlasHeight)
-                    {
-                        _mlmask.AtlasWidth = _mlmask.PreferredAtlasWidth;
-                        _mlmask.AtlasHeight = _mlmask.PreferredAtlasHeight;
-                        _logger.Info($"Reusing original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight}");
-                        return;
-                    }
-                    else
-                    {
-                        _logger.Info($"Original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} is insufficient for the current layer content ({_mlmask.AtlasTilesCount} unique tiles). Calculating a larger atlas...");
-                    }
-                }
-            }
-
-            uint widthTry = 16384;
-            var emptyArea = uint.MaxValue;
-
-            while (widthTry >= _mlmask.AtlasTileSize)
-            {
-                var widthInTiles0 = widthTry / _mlmask.AtlasTileSize;
-                var heightTry = (_mlmask.AtlasTilesCount + widthInTiles0 - 1) / widthInTiles0 * _mlmask.AtlasTileSize;
-
-                var widthUp = RoundUpPowerOf2(widthTry);
-                var heightUp = RoundUpPowerOf2(heightTry);
-
-                var currEmptyArea = (widthUp * heightUp) - (_mlmask.AtlasTilesCount * _mlmask.AtlasTileSize * _mlmask.AtlasTileSize);
-                if (currEmptyArea <= emptyArea)
-                {
-                    _mlmask.AtlasWidth = widthTry;
-                    _mlmask.AtlasHeight = heightTry;
-                    emptyArea = currEmptyArea;
-                }
-
-                if (widthTry <= heightTry) break;
-                widthTry /= 2;
-            }
-
-            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
-                throw new Exception("Atlas too large (over 16k)");
-
-            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0 &&
-                (_mlmask.AtlasWidth != _mlmask.PreferredAtlasWidth || _mlmask.AtlasHeight != _mlmask.PreferredAtlasHeight))
-            {
-                _logger.Info($"Atlas size automatically increased from {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} to accommodate new layer content.");
-            }
-            else if (_mlmask.PreferredAtlasWidth == 0 || _mlmask.PreferredAtlasHeight == 0)
-            {
-                _logger.Info($"Atlas size set to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight}.");
-            }
         }
 
         private void CreateAtlasBuffer()
@@ -661,22 +689,66 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
         private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty, uint xBlock, uint yBlock)
         {
+            // Extra defensive bounds check for neighbor tiles
+            uint w = layer.WidthInTiles0;
+            uint h = layer.HeightInTiles0;
+            if (w == 0 || h == 0) return;
+
+            if (tx >= w || ty >= h) return; // neighbor is out of layer bounds — skip
+
+            uint neighborTileIndex = tx + (ty * w);
+            if (neighborTileIndex >= (uint)layer.Tiles.Count) return;
+
             for (uint j = 0; j < 4; j++)
             {
                 for (uint i = 0; i < 4; i++)
                 {
                     var px = (xBlock * 4) + i;
                     var py = (yBlock * 4) + j;
-                    var v = layer.Tiles[(int)(tx + (ty * layer.WidthInTiles0))].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
+                    var v = layer.Tiles[(int)neighborTileIndex].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
                     referenceData.Add(v);
                 }
             }
         }
 
-        private static uint RoundUpPowerOf2(uint v)
+        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
         {
-            v--; v |= v >> 1; v |= v >> 2; v |= v >> 4; v |= v >> 8; v |= v >> 16;
-            return ++v;
+            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
+            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
+
+            for (uint ty = 0; ty < heightInTiles0; ty++)
+            {
+                for (uint tx = 0; tx < widthInTiles0; tx++)
+                {
+                    var tileIdx = tx + (ty * widthInTiles0);
+                    var layersBeg = (uint)tilesDataList.Count;
+                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
+
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
+
+                    uint layersMask = 0;
+                    for (var i = 0; i < numLayers; i++)
+                    {
+                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
+                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
+                        var atlasX = position & widthInTilesGrayUp;
+                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
+                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
+                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
+
+                        uint puts = 0;
+                        puts |= atlasX;
+                        puts |= atlasY << 10;
+                        puts |= widthShift << 20;
+                        puts |= heightShift << 24;
+
+                        tilesDataList.Add(puts);
+                        layersMask |= 1u << (int)layerIdx;
+                    }
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
+                }
+            }
         }
 
         #endregion Core Methods
@@ -751,6 +823,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
         {
             public const ulong FnvHashInitial = 0xCBF29CE484222325;
             public const ulong FnvHashPrime = 0x00000100000001B3;
+
             public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
             {
                 foreach (var b in source)
@@ -768,6 +841,24 @@ namespace WolvenKit.Modkit.RED4.MLMask
             [StructLayout(LayoutKind.Explicit, Size = 8)]
             public struct BC4_UNORM
             {
+                [FieldOffset(0)] public ulong Data;
+                [FieldOffset(0)] public byte Red_0;
+                [FieldOffset(1)] public byte Red_1;
+                [FieldOffset(2)] public byte Index0;
+                [FieldOffset(3)] public byte Index1;
+                [FieldOffset(4)] public byte Index2;
+                [FieldOffset(5)] public byte Index3;
+                [FieldOffset(6)] public byte Index4;
+                [FieldOffset(7)] public byte Index5;
+
+                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
+
+                public void SetIndex(int uOffset, int uIndex)
+                {
+                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
+                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
+                }
+
                 public float R(int offset)
                 {
                     var index = GetIndex(offset);
@@ -794,24 +885,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     index--;
                     return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
                 }
-
-                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
-
-                public void SetIndex(int uOffset, int uIndex)
-                {
-                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
-                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
-                }
-
-                [FieldOffset(0)] public ulong Data;
-                [FieldOffset(0)] public byte Red_0;
-                [FieldOffset(1)] public byte Red_1;
-                [FieldOffset(2)] public byte Index0;
-                [FieldOffset(3)] public byte Index1;
-                [FieldOffset(4)] public byte Index2;
-                [FieldOffset(5)] public byte Index3;
-                [FieldOffset(6)] public byte Index4;
-                [FieldOffset(7)] public byte Index5;
             }
 
             public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
@@ -824,9 +897,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
             {
-                const float MIN_NORM = 0f;
-                const float MAX_NORM = 1f;
-
                 var fBlockMax = theTexelsU[0];
                 var fBlockMin = theTexelsU[0];
                 for (var i = 0; i < numTexels; ++i)
@@ -835,24 +905,20 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     else if (theTexelsU[i] > fBlockMax) fBlockMax = theTexelsU[i];
                 }
 
-                var bUsing4BlockCodec = MIN_NORM == fBlockMin || MAX_NORM == fBlockMax;
+                var bUsing4BlockCodec = fBlockMin == 0f || fBlockMax == 1f;
                 float fStart = 0, fEnd = 0;
 
                 if (!bUsing4BlockCodec)
                 {
                     OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
-                    var iStart = Convert.ToByte(fStart * 255.0f);
-                    var iEnd = Convert.ToByte(fEnd * 255.0f);
-                    endpointU_0 = iEnd;
-                    endpointU_1 = iStart;
+                    endpointU_0 = (byte)(fEnd * 255.0f);
+                    endpointU_1 = (byte)(fStart * 255.0f);
                 }
                 else
                 {
                     OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
-                    var iStart = Convert.ToByte(fStart * 255.0f);
-                    var iEnd = Convert.ToByte(fEnd * 255.0f);
-                    endpointU_1 = iEnd;
-                    endpointU_0 = iStart;
+                    endpointU_1 = (byte)(fEnd * 255.0f);
+                    endpointU_0 = (byte)(fStart * 255.0f);
                 }
             }
 
@@ -863,16 +929,13 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
                 float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
 
-                var pC = 6 == cSteps ? pC6 : pC8;
-                var pD = 6 == cSteps ? pD6 : pD8;
+                var pC = (cSteps == 6) ? pC6 : pC8;
+                var pD = (cSteps == 6) ? pD6 : pD8;
 
-                const float maxValue = 1.0f;
-                const float minValue = 0.0f;
+                float fX = 1.0f;
+                float fY = 0.0f;
 
-                var fX = maxValue;
-                var fY = minValue;
-
-                if (8 == cSteps)
+                if (cSteps == 8)
                 {
                     for (var iPoint = 0; iPoint < numTexels; iPoint++)
                     {
@@ -884,10 +947,10 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 {
                     for (var iPoint = 0; iPoint < numTexels; iPoint++)
                     {
-                        if (pPoints[iPoint] < fX && pPoints[iPoint] > minValue) fX = pPoints[iPoint];
-                        if (pPoints[iPoint] > fY && pPoints[iPoint] < maxValue) fY = pPoints[iPoint];
+                        if (pPoints[iPoint] < fX && pPoints[iPoint] > 0.0f) fX = pPoints[iPoint];
+                        if (pPoints[iPoint] > fY && pPoints[iPoint] < 1.0f) fY = pPoints[iPoint];
                     }
-                    if (fX == fY) fY = maxValue;
+                    if (fX == fY) fY = 1.0f;
                 }
 
                 var fSteps = Convert.ToSingle(cSteps - 1);
@@ -902,10 +965,10 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     for (var iStep = 0; iStep < cSteps; iStep++)
                         pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
 
-                    if (6 == cSteps)
+                    if (cSteps == 6)
                     {
-                        pSteps[6] = minValue;
-                        pSteps[7] = maxValue;
+                        pSteps[6] = 0.0f;
+                        pSteps[7] = 1.0f;
                     }
 
                     var dX = 0.0f;
@@ -919,9 +982,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         uint iStep;
 
                         if (fDot <= 0.0f)
-                            iStep = 6 == cSteps && pPoints[(int)iPoint] <= fX * 0.5f ? (uint)6 : 0;
+                            iStep = (cSteps == 6 && pPoints[(int)iPoint] <= fX * 0.5f) ? 6u : 0u;
                         else if (fDot >= fSteps)
-                            iStep = 6 == cSteps && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f ? 7 : cSteps - 1;
+                            iStep = (cSteps == 6 && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f) ? 7u : cSteps - 1;
                         else
                             iStep = (uint)(fDot + 0.5f);
 
@@ -943,8 +1006,8 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f) break;
                 }
 
-                pX = fX < minValue ? minValue : fX > maxValue ? maxValue : fX;
-                pY = fY < minValue ? minValue : fY > maxValue ? maxValue : fY;
+                pX = Math.Clamp(fX, 0.0f, 1.0f);
+                pY = Math.Clamp(fY, 0.0f, 1.0f);
             }
 
             private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -53,37 +53,22 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 if (trimmed.StartsWith("#"))
                 {
                     if (trimmed.Contains("AtlasWidth="))
-                    {
                         targetAtlasWidth = ParseHeaderValue(trimmed);
-                    }
                     else if (trimmed.Contains("AtlasHeight="))
-                    {
                         targetAtlasHeight = ParseHeaderValue(trimmed);
-                    }
                     else if (trimmed.Contains("MaskWidth="))
-                    {
                         targetMaskWidth = ParseHeaderValue(trimmed);
-                    }
                     else if (trimmed.Contains("MaskHeight="))
-                    {
                         targetMaskHeight = ParseHeaderValue(trimmed);
-                    }
                     else if (trimmed.Contains("MaskTileSize="))
-                    {
                         targetTileSize = ParseHeaderValue(trimmed);
-                    }
                     else if (trimmed.Contains("LayerResolutions="))
-                    {
                         _layerResolutionsStr = trimmed.Split('=')[1].Trim();
-                    }
 
                     continue;
                 }
 
-                if (trimmed.Contains("="))
-                {
-                    continue;
-                }
+                if (trimmed.Contains("=")) continue;
 
                 filePaths.Add(trimmed);
             }
@@ -91,16 +76,19 @@ namespace WolvenKit.Modkit.RED4.MLMask
             var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
 
             if (files.Count == 0)
-            {
                 throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
-            }
 
             _mlmask = new MlMaskContainer();
+            _mlmask.PreferredTileSize = targetTileSize;
+            _mlmask.PreferredAtlasWidth = targetAtlasWidth;
+            _mlmask.PreferredAtlasHeight = targetAtlasHeight;
+
             var textures = new List<RawTexContainer>();
 
             string[]? layerResolutionsArray = null;
             uint[]? layerResW = null;
             uint[]? layerResH = null;
+
             if (!string.IsNullOrEmpty(_layerResolutionsStr))
             {
                 layerResolutionsArray = _layerResolutionsStr.Split(',');
@@ -115,11 +103,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     {
                         layerResW[i] = w;
                         layerResH[i] = h;
-                    }
-                    else
-                    {
-                        layerResW[i] = 0;
-                        layerResH[i] = 0;
                     }
                 }
             }
@@ -141,19 +124,14 @@ namespace WolvenKit.Modkit.RED4.MLMask
             for (var fileIdx = 0; fileIdx < files.Count; fileIdx++)
             {
                 var f = files[fileIdx];
-                if (!File.Exists(f))
-                {
-                    throw new FileNotFoundException($"File not found: {f}");
-                }
+                if (!File.Exists(f)) throw new FileNotFoundException($"File not found: {f}");
 
                 try
                 {
                     using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2001, $"Could not load image: {f}");
 
                     if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
-                    {
                         image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
-                    }
 
                     uint imgW = (uint)image.Metadata.Width;
                     uint imgH = (uint)image.Metadata.Height;
@@ -180,21 +158,16 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         var blankPixels = new byte[layerTargetW * layerTargetH];
                         Array.Fill(blankPixels, blankValue);
                         textures.Add(new RawTexContainer { Width = layerTargetW, Height = layerTargetH, Pixels = blankPixels });
-                        _logger.Info($"Created blank layer {Path.GetFileName(f)} at {layerTargetW}x{layerTargetH} (value: {blankValue})");
                         continue;
                     }
 
                     if (layerTargetW > 0 && layerTargetH > 0 && (imgW != layerTargetW || imgH != layerTargetH))
                     {
                         if (imgW > layerTargetW || imgH > layerTargetH)
-                        {
-                            throw new WolvenKitException(0x2003,
-                                $"Layer {f} ({imgW}x{imgH}) is larger than target size {layerTargetW}x{layerTargetH}");
-                        }
+                            throw new WolvenKitException(0x2003, $"Layer {f} is larger than target size");
 
                         var upscaled = UpscaleNearest(pixels, imgW, imgH, layerTargetW, layerTargetH);
                         textures.Add(new RawTexContainer { Width = layerTargetW, Height = layerTargetH, Pixels = upscaled });
-                        _logger.Info($"Upscaled {Path.GetFileName(f)}: {imgW}x{imgH} → {layerTargetW}x{layerTargetH}");
                     }
                     else
                     {
@@ -220,9 +193,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             if (pixels.Length == 0) return true;
             var first = pixels[0];
             for (int i = 1; i < pixels.Length; i++)
-            {
                 if (pixels[i] != first) return false;
-            }
             return true;
         }
 
@@ -389,7 +360,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             _mlmask.WidthHigh = 0;
             _mlmask.HeightHigh = 0;
-
             foreach (var lay in _mlmask.Layers)
             {
                 _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
@@ -435,7 +405,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
             }
 
-            uint tempAtlasTileSize = 16;
+            uint startAtlasTileSize = (_mlmask.PreferredTileSize > 0)
+                ? _mlmask.PreferredTileSize + 2
+                : 16u;
+
+            uint tempAtlasTileSize = startAtlasTileSize;
             while (true)
             {
                 _mlmask.AtlasTileSize = tempAtlasTileSize;
@@ -588,6 +562,26 @@ namespace WolvenKit.Modkit.RED4.MLMask
             _mlmask.AtlasWidth = 0;
             _mlmask.AtlasHeight = 0;
 
+            // Prefer original atlas size from .masklist when possible
+            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0)
+            {
+                var widthInTiles = _mlmask.PreferredAtlasWidth / _mlmask.AtlasTileSize;
+                if (widthInTiles > 0)
+                {
+                    var neededRows = (_mlmask.AtlasTilesCount + widthInTiles - 1) / widthInTiles;
+                    var requiredHeight = neededRows * _mlmask.AtlasTileSize;
+
+                    if (requiredHeight <= _mlmask.PreferredAtlasHeight)
+                    {
+                        _mlmask.AtlasWidth = _mlmask.PreferredAtlasWidth;
+                        _mlmask.AtlasHeight = _mlmask.PreferredAtlasHeight;
+                        _logger.Info($"Reusing original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight}");
+                        return;
+                    }
+                }
+            }
+
+            // Fallback: minimum waste packing
             uint widthTry = 16384;
             var emptyArea = uint.MaxValue;
 
@@ -772,6 +766,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
             public uint TileSize;
             public uint WidthHigh;
             public uint AtlasTilesCount;
+
+            // Values from original .masklist for best round-trip fidelity
+            public uint PreferredTileSize;
+            public uint PreferredAtlasWidth;
+            public uint PreferredAtlasHeight;
         }
 
         #endregion

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -202,6 +202,23 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.HeightLow = _mlmask.HeightHigh;
             }
 
+            // Protection against 3+ different resolutions (only 2 levels supported: High + Low)
+            bool hasThirdResolution = false;
+            foreach (var lay in _mlmask.Layers)
+            {
+                if (lay.Width != _mlmask.WidthHigh && lay.Width != _mlmask.WidthLow)
+                {
+                    hasThirdResolution = true;
+                    break;
+                }
+            }
+
+            if (hasThirdResolution)
+            {
+                _logger.Error("MLMask import does not support 3 or more different resolutions. Only High + Low are supported.");
+                throw new WolvenKitException(0x2003, "More than 2 different resolutions detected in masklist. Only 2 resolution levels are supported.");
+            }
+
             _logger.Info($"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
 
             for (int i = 0; i < _mlmask.Layers.Length; i++)

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -215,7 +215,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             if (hasThirdResolution)
             {
-                _logger.Error("MLMask import does not support 3 or more different resolutions. Only High + Low are supported.");
                 throw new WolvenKitException(0x2003, "More than 2 different resolutions detected in masklist. Only 2 resolution levels are supported.");
             }
 

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -20,7 +20,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
         private const uint s_headerLength = 148;
         private MlMaskContainer _mlmask;
         private readonly ILoggerService _logger;
-        private string _layerResolutionsStr = "";
 
         public MLMASK(MlMaskContainer mlMask, ILoggerService logger)
         {
@@ -33,12 +32,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
             var lines = File.ReadAllLines(txtImageList.FullName);
             var baseDir = txtImageList.Directory.NotNull();
 
-            uint targetMaskWidth = 0;
-            uint targetMaskHeight = 0;
             uint targetAtlasWidth = 0;
             uint targetAtlasHeight = 0;
             uint targetTileSize = 16;
-            _layerResolutionsStr = "";
 
             var filePaths = new List<string>();
 
@@ -46,9 +42,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             {
                 var trimmed = line.Trim();
                 if (string.IsNullOrWhiteSpace(trimmed))
-                {
                     continue;
-                }
 
                 if (trimmed.StartsWith("#"))
                 {
@@ -56,14 +50,8 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         targetAtlasWidth = ParseHeaderValue(trimmed);
                     else if (trimmed.Contains("AtlasHeight="))
                         targetAtlasHeight = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("MaskWidth="))
-                        targetMaskWidth = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("MaskHeight="))
-                        targetMaskHeight = ParseHeaderValue(trimmed);
                     else if (trimmed.Contains("MaskTileSize="))
                         targetTileSize = ParseHeaderValue(trimmed);
-                    else if (trimmed.Contains("LayerResolutions="))
-                        _layerResolutionsStr = trimmed.Split('=')[1].Trim();
 
                     continue;
                 }
@@ -85,40 +73,36 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             var textures = new List<RawTexContainer>();
 
-            string[]? layerResolutionsArray = null;
-            uint[]? layerResW = null;
-            uint[]? layerResH = null;
-
-            if (!string.IsNullOrEmpty(_layerResolutionsStr))
-            {
-                layerResolutionsArray = _layerResolutionsStr.Split(',');
-                _logger.Info($"Using per-layer resolutions from .masklist: {_layerResolutionsStr}");
-
-                layerResW = new uint[layerResolutionsArray.Length];
-                layerResH = new uint[layerResolutionsArray.Length];
-                for (var i = 0; i < layerResolutionsArray.Length; i++)
-                {
-                    var parts = layerResolutionsArray[i].Split('x');
-                    if (parts.Length == 2 && uint.TryParse(parts[0], out var w) && uint.TryParse(parts[1], out var h))
-                    {
-                        layerResW[i] = w;
-                        layerResH[i] = h;
-                    }
-                }
-            }
-
             var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
             var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
 
             if (needsLayer0)
             {
-                uint layer0W = (layerResW != null && layerResW.Length > 0 && layerResW[0] != 0) ? layerResW[0] : 1024u;
-                uint layer0H = (layerResH != null && layerResH.Length > 0 && layerResH[0] != 0) ? layerResH[0] : 1024u;
+                uint whiteW = 1024u;
+                uint whiteH = 1024u;
 
-                var whitePixels = new byte[layer0W * layer0H];
+                if (files.Count > 0)
+                {
+                    var firstReal = files[0];
+                    if (File.Exists(firstReal))
+                    {
+                        try
+                        {
+                            using var probe = RedImage.LoadFromFile(firstReal);
+                            if (probe != null)
+                            {
+                                whiteW = (uint)probe.Metadata.Width;
+                                whiteH = (uint)probe.Metadata.Height;
+                            }
+                        }
+                        catch { }
+                    }
+                }
+
+                var whitePixels = new byte[whiteW * whiteH];
                 Array.Fill(whitePixels, (byte)255);
-                textures.Add(new RawTexContainer { Width = layer0W, Height = layer0H, Pixels = whitePixels });
-                _logger.Info($"Added white layer 0 at {layer0W}x{layer0H}");
+                textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
+                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH} (inferred from first provided layer metadata)");
             }
 
             for (var fileIdx = 0; fileIdx < files.Count; fileIdx++)
@@ -136,43 +120,20 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     uint imgW = (uint)image.Metadata.Width;
                     uint imgH = (uint)image.Metadata.Height;
 
-                    uint layerTargetW = targetMaskWidth;
-                    uint layerTargetH = targetMaskHeight;
-
-                    if (layerResW != null && fileIdx < layerResW.Length && layerResW[fileIdx] != 0 && layerResH != null && layerResH[fileIdx] != 0)
-                    {
-                        layerTargetW = layerResW[fileIdx];
-                        layerTargetH = layerResH[fileIdx];
-                    }
-
                     using var ms = new MemoryStream(image.SaveToDDSMemory());
                     using var br = new BinaryReader(ms);
                     ms.Seek(s_headerLength, SeekOrigin.Begin);
                     var pixels = br.ReadBytes((int)(imgW * imgH));
 
                     var isBlank = IsBlankLayer(pixels);
-                    var blankValue = pixels.Length > 0 ? pixels[0] : (byte)0;
 
                     if (isBlank)
                     {
-                        var blankPixels = new byte[layerTargetW * layerTargetH];
-                        Array.Fill(blankPixels, blankValue);
-                        textures.Add(new RawTexContainer { Width = layerTargetW, Height = layerTargetH, Pixels = blankPixels });
+                        textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
                         continue;
                     }
 
-                    if (layerTargetW > 0 && layerTargetH > 0 && (imgW != layerTargetW || imgH != layerTargetH))
-                    {
-                        if (imgW > layerTargetW || imgH > layerTargetH)
-                            throw new WolvenKitException(0x2003, $"Layer {f} is larger than target size");
-
-                        var upscaled = UpscaleNearest(pixels, imgW, imgH, layerTargetW, layerTargetH);
-                        textures.Add(new RawTexContainer { Width = layerTargetW, Height = layerTargetH, Pixels = upscaled });
-                    }
-                    else
-                    {
-                        textures.Add(new RawTexContainer { Width = layerTargetW, Height = layerTargetH, Pixels = pixels });
-                    }
+                    textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
                 }
                 catch (WolvenKitException e)
                 {
@@ -190,7 +151,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
         internal static bool IsBlankLayer(byte[] pixels)
         {
-            if (pixels.Length == 0) return true;
+            if (pixels == null || pixels.Length == 0) return true;
             var first = pixels[0];
             for (int i = 1; i < pixels.Length; i++)
                 if (pixels[i] != first) return false;
@@ -219,7 +180,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             return dst;
         }
 
-        #region Existing Methods
+        #region Core Methods
 
         private void Write(FileInfo f)
         {
@@ -256,6 +217,13 @@ namespace WolvenKit.Modkit.RED4.MLMask
             writer.WriteFile(cr2w);
         }
 
+        /// <summary>
+        /// Writes the tile index data (TilesData buffer) for one resolution level (high or low).
+        /// For each tile, it records:
+        /// - The starting index in the data list where this tile's layer entries begin.
+        /// - For each layer present in the tile: packed atlas position (dx, dy) + scaling shifts (sx, sy).
+        /// - A bitmask indicating which layers are active in this tile.
+        /// </summary>
         private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
         {
             var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
@@ -354,6 +322,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
             return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
         }
 
+        /// <summary>
+        /// Builds all internal data structures required to write a valid .mlmask file.
+        /// Calculates global resolution bounds, classifies layers into high/low tile sets,
+        /// packs tiles into the atlas, and generates the final compressed buffers.
+        /// </summary>
         private void Create()
         {
             if (_mlmask.Layers == null) return;
@@ -366,37 +339,13 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
             }
 
-            if (!string.IsNullOrEmpty(_layerResolutionsStr))
+            // Metadata-driven: WidthLow/HeightLow are derived from actual layer image sizes
+            _mlmask.WidthLow = uint.MaxValue;
+            _mlmask.HeightLow = uint.MaxValue;
+            foreach (var lay in _mlmask.Layers)
             {
-                var resolutions = _layerResolutionsStr.Split(',');
-                uint minW = uint.MaxValue;
-                uint minH = uint.MaxValue;
-
-                foreach (var res in resolutions)
-                {
-                    var parts = res.Split('x');
-                    if (parts.Length == 2)
-                    {
-                        uint w = uint.Parse(parts[0]);
-                        uint h = uint.Parse(parts[1]);
-                        if (w < minW) minW = w;
-                        if (h < minH) minH = h;
-                    }
-                }
-
-                _mlmask.WidthLow = minW != uint.MaxValue ? minW : _mlmask.WidthHigh;
-                _mlmask.HeightLow = minH != uint.MaxValue ? minH : _mlmask.HeightHigh;
-                _logger.Info($"Preserved WidthLow={_mlmask.WidthLow}, HeightLow={_mlmask.HeightLow} from LayerResolutions");
-            }
-            else
-            {
-                _mlmask.WidthLow = uint.MaxValue;
-                _mlmask.HeightLow = uint.MaxValue;
-                foreach (var lay in _mlmask.Layers)
-                {
-                    _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
-                    _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
-                }
+                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
+                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
             }
 
             for (var i = 0; i < _mlmask.Layers.Length; i++)
@@ -462,6 +411,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
             _mlmask.TilesBuffer = ms.ToArray();
         }
 
+        /// <summary>
+        /// Distributes layers into high-resolution or low-resolution tile sets.
+        /// A layer is considered "low" if its resolution is smaller than WidthHigh.
+        /// This affects which tile grid (MaskTilesHigh or MaskTilesLow) the layer's tiles are added to.
+        /// </summary>
         private void CleanTileLayers()
         {
             if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
@@ -557,12 +511,16 @@ namespace WolvenKit.Modkit.RED4.MLMask
             return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
         }
 
+        /// <summary>
+        /// Calculates the optimal atlas dimensions.
+        /// First tries to reuse the original atlas size from the .masklist (for round-trip fidelity).
+        /// If that doesn't fit, falls back to a minimum-waste power-of-2-friendly packing algorithm.
+        /// </summary>
         private void CalculateAtlasProportionForPacking()
         {
             _mlmask.AtlasWidth = 0;
             _mlmask.AtlasHeight = 0;
 
-            // Prefer original atlas size from .masklist when possible
             if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0)
             {
                 var widthInTiles = _mlmask.PreferredAtlasWidth / _mlmask.AtlasTileSize;
@@ -578,10 +536,13 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         _logger.Info($"Reusing original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight}");
                         return;
                     }
+                    else
+                    {
+                        _logger.Info($"Original atlas size {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} is insufficient for the current layer content ({_mlmask.AtlasTilesCount} unique tiles). Calculating a larger atlas...");
+                    }
                 }
             }
 
-            // Fallback: minimum waste packing
             uint widthTry = 16384;
             var emptyArea = uint.MaxValue;
 
@@ -607,6 +568,16 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
                 throw new Exception("Atlas too large (over 16k)");
+
+            if (_mlmask.PreferredAtlasWidth > 0 && _mlmask.PreferredAtlasHeight > 0 &&
+                (_mlmask.AtlasWidth != _mlmask.PreferredAtlasWidth || _mlmask.AtlasHeight != _mlmask.PreferredAtlasHeight))
+            {
+                _logger.Info($"Atlas size automatically increased from {_mlmask.PreferredAtlasWidth}x{_mlmask.PreferredAtlasHeight} to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} to accommodate new layer content.");
+            }
+            else if (_mlmask.PreferredAtlasWidth == 0 || _mlmask.PreferredAtlasHeight == 0)
+            {
+                _logger.Info($"Atlas size set to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight}.");
+            }
         }
 
         private void CreateAtlasBuffer()
@@ -708,7 +679,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             return ++v;
         }
 
-        #endregion
+        #endregion Core Methods
 
         #region Structs
 
@@ -767,13 +738,12 @@ namespace WolvenKit.Modkit.RED4.MLMask
             public uint WidthHigh;
             public uint AtlasTilesCount;
 
-            // Values from original .masklist for best round-trip fidelity
             public uint PreferredTileSize;
             public uint PreferredAtlasWidth;
             public uint PreferredAtlasHeight;
         }
 
-        #endregion
+        #endregion Structs
 
         #region FNV1A
 
@@ -789,7 +759,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             }
         }
 
-        #endregion
+        #endregion FNV1A
 
         #region D3DX
 
@@ -1010,6 +980,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
             }
         }
 
-        #endregion
+        #endregion D3DX
     }
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -28,9 +28,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
         }
 
         /// <summary>
-        /// Импорт .masklist → .mlmask
-        /// Поддерживает как разные разрешения слоёв, так и одинаковые.
-        /// .masklist теперь содержит только пути к файлам (без заголовка).
+        /// Imports a .masklist file into a .mlmask file.
+        /// Supports both single-resolution and multi-resolution layer sets.
+        /// The .masklist now contains only layer file paths (no header).
         /// </summary>
         public void Import(FileInfo txtImageList, FileInfo outFile)
         {
@@ -43,8 +43,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
             {
                 var trimmed = line.Trim();
                 if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
+                {
                     continue;
-                if (trimmed.Contains("=")) continue; // совместимость со старыми файлами
+                }
 
                 filePaths.Add(trimmed);
             }
@@ -54,16 +55,11 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
 
-            _mlmask = new MlMaskContainer
-            {
-                PreferredTileSize = 16,
-                PreferredAtlasWidth = 0,
-                PreferredAtlasHeight = 0
-            };
+            _mlmask = new MlMaskContainer();
 
             var textures = new List<RawTexContainer>();
 
-            // Добавляем белый слой 0 (если первый слой не заканчивается на _0)
+            // Add white base layer 0 (if the first layer does not end with _0)
             var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
             var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
 
@@ -92,7 +88,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _logger.Info($"Added white layer 0 at {whiteW}x{whiteH}");
             }
 
-            // Загружаем все слои из файлов
+            // Load all layers from files
             foreach (var f in files)
             {
                 if (!File.Exists(f))
@@ -209,6 +205,13 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.HeightLow = _mlmask.HeightHigh;
             }
 
+            _logger.Info($"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
+
+            for (int i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _logger.Info($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
+            }
+
             // Shifts
             for (var i = 0; i < _mlmask.Layers.Length; i++)
             {
@@ -216,8 +219,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
             }
 
+            // Fixed tile size for this project: maskTileSize = 14 → AtlasTileSize = 16.
             // AtlasTileSize must be divisible by 4 (we split it into 4x4 BC4 blocks for compression).
-            // Start at 16 (standard when maskTileSize=14) and increase by 4 to maintain divisibility.
+            // We start at 16 and increase by 4 if needed to keep divisibility.
             uint tempAtlasTileSize = 16u;
             while (true)
             {
@@ -287,17 +291,14 @@ namespace WolvenKit.Modkit.RED4.MLMask
             uint bestWidth = 0;
             uint bestHeight = 0;
             ulong bestWaste = ulong.MaxValue;
+            double bestWasteRatio = double.MaxValue; // waste / usedArea
 
-            // Start near square root for good aspect ratio
-            uint startWidthInTiles = Math.Max(1u, (uint)Math.Ceiling(Math.Sqrt(tileCount)));
-
-            // Try widths around the square root (good for most cases)
-            for (uint wTiles = startWidthInTiles; wTiles <= startWidthInTiles + 48 && wTiles <= 512; wTiles++)
+            // Search over all reasonable power-of-2 widths (this is the constraint from PutTiles).
+            // Start from 4 tiles wide to avoid extremely narrow (1-tile) atlases.
+            for (uint wTilesPow2 = 4; wTilesPow2 <= 1024; wTilesPow2 <<= 1)
             {
-                if (wTiles == 0) continue;
-
-                uint hTiles = (tileCount + wTiles - 1) / wTiles; // ceil division
-                uint w = wTiles * tileSize;
+                uint hTiles = (tileCount + wTilesPow2 - 1) / wTilesPow2;
+                uint w = wTilesPow2 * tileSize;
                 uint h = hTiles * tileSize;
 
                 if (w > 16384 || h > 16384) continue;
@@ -305,40 +306,47 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 ulong area = (ulong)w * h;
                 ulong usedArea = (ulong)tileCount * tileSize * tileSize;
                 ulong waste = area - usedArea;
+                double wasteRatio = usedArea > 0 ? (double)waste / usedArea : 0;
 
-                if (waste < bestWaste || bestWidth == 0)
+                // Calculate aspect ratio
+                double aspect = (double)h / w;
+
+                // Hard filter: reject extremely bad aspect ratios
+                if (aspect > 4.0 || aspect < 0.25) continue;
+
+                // Prefer lower waste ratio. If ratios are close, prefer reasonable aspect ratio.
+                bool better = false;
+                if (wasteRatio < bestWasteRatio - 0.01) better = true;
+                else if (Math.Abs(wasteRatio - bestWasteRatio) <= 0.01)
+                {
+                    // Prefer aspect ratios in good range [0.5 .. 2.5]
+                    bool currGood = aspect >= 0.5 && aspect <= 2.5;
+                    bool bestGood = (bestHeight >= 0.5 * bestWidth) && (bestHeight <= 2.5 * bestWidth);
+
+                    if (currGood && !bestGood) better = true;
+                    else if (currGood == bestGood)
+                    {
+                        // Among good aspects, prefer closer to square
+                        double currDist = Math.Abs(aspect - 1.0);
+                        double bestDist = Math.Abs((double)bestHeight / bestWidth - 1.0);
+                        if (currDist < bestDist - 0.08) better = true;
+                        else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste) better = true;
+                    }
+                }
+
+                if (better || bestWidth == 0)
                 {
                     bestWaste = waste;
+                    bestWasteRatio = wasteRatio;
                     bestWidth = w;
                     bestHeight = h;
                 }
             }
 
-            // Also try a few power-of-two widths for potentially better cache/GPU behavior
-            uint[] pow2Candidates = { 256, 512, 1024, 2048, 4096 };
-            foreach (uint pw in pow2Candidates)
-            {
-                if (pw < tileSize) continue;
-                uint pwTiles = pw / tileSize;
-                uint phTiles = (tileCount + pwTiles - 1) / pwTiles;
-                uint ph = phTiles * tileSize;
-
-                if (ph > 16384) continue;
-
-                ulong pWaste = (ulong)pw * ph - (ulong)tileCount * tileSize * tileSize;
-                if (pWaste < bestWaste)
-                {
-                    bestWaste = pWaste;
-                    bestWidth = pw;
-                    bestHeight = ph;
-                }
-            }
-
-            // Final fallback: simple horizontal strip (rarely needed)
+            // Fallback (should rarely happen)
             if (bestWidth == 0)
             {
-                uint wTiles = Math.Min(128u, tileCount);
-                if (wTiles == 0) wTiles = 1;
+                uint wTiles = 64;
                 uint hTiles = (tileCount + wTiles - 1) / wTiles;
                 bestWidth = wTiles * tileSize;
                 bestHeight = hTiles * tileSize;
@@ -418,7 +426,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 }
             }
 
-            _logger.Info($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles, tileSize={tileSize})");
+            _logger.Info($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
         }
 
         private void InitializeMaskLayers()
@@ -809,10 +817,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
             public uint TileSize;
             public uint WidthHigh;
             public uint AtlasTilesCount;
-
-            public uint PreferredTileSize;
-            public uint PreferredAtlasWidth;
-            public uint PreferredAtlasHeight;
         }
 
         #endregion Structs

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -85,7 +85,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 var whitePixels = new byte[whiteW * whiteH];
                 Array.Fill(whitePixels, (byte)255);
                 textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
-                _logger.Info($"Added white layer 0 at {whiteW}x{whiteH}");
             }
 
             // Load all layers from files
@@ -121,8 +120,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             Create();
             Write(outFile);
-
-            _logger.Info("MLMask import completed successfully.");
         }
 
         internal static bool IsBlankLayer(byte[] pixels)
@@ -209,7 +206,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             for (int i = 0; i < _mlmask.Layers.Length; i++)
             {
-                _logger.Info($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
+                _logger.Debug($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
             }
 
             // Shifts
@@ -426,7 +423,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 }
             }
 
-            _logger.Info($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
+            _logger.Debug($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
         }
 
         private void InitializeMaskLayers()

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -1,4 +1,4 @@
-using System;
+// using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -233,7 +233,6 @@ public partial class ModTools
         }
 
         // Extract atlas position and scaling factors from the packed tile declaration.
-        // dx/dy = tile position in the atlas, sx/sy = bit-shift scaling for this layer.
         var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
         var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
         var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
@@ -445,22 +444,12 @@ public partial class ModTools
         {
             var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
 
+            // Simplified header - only basic info, no original atlas/mask dimensions
             var headerLines = new List<string>
             {
-                "# MLMask Export v2",
-                "# Original file header values",
-                $"# AtlasWidth={blob.Header.AtlasWidth}",
-                $"# AtlasHeight={blob.Header.AtlasHeight}",
-                $"# MaskWidth={blob.Header.MaskWidth}",
-                $"# MaskHeight={blob.Header.MaskHeight}",
-                $"# MaskWidthLow={blob.Header.MaskWidthLow}",
-                $"# MaskHeightLow={blob.Header.MaskHeightLow}",
-                $"# MaskTileSize={blob.Header.MaskTileSize}",
-                $"# NumLayers={blob.Header.NumLayers}",
-                "",
-                $"# LayerResolutions={string.Join(",", layerResolutions)}",
-                "",
-                "# Layer image files (must be in correct order)"
+                "# MLMask Export",
+                "# Layer image files (must be in correct order)",
+                ""
             };
 
             headerLines.AddRange(masks);

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -11,450 +11,471 @@ using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
-namespace WolvenKit.Modkit.RED4
+namespace WolvenKit.Modkit.RED4;
+
+public partial class ModTools
 {
-    public partial class ModTools
+    private const uint ATLAS_TILE_PADDING = 2;
+
+    // Bit layout of tileDecl (from multilayer mask tiles data)
+    private const uint TILE_PARAM_MASK = 0x3FF;   // 10 bits (0-9)
+    private const int  TILE_DX_SHIFT   = 0;       // bits 0-9  → X offset in atlas
+    private const int  TILE_DY_SHIFT   = 10;      // bits 10-19 → Y offset in atlas
+    private const int  TILE_SX_SHIFT   = 20;      // bits 20-23 → X scale/shift
+    private const int  TILE_SY_SHIFT   = 24;      // bits 24-27 → Y scale/shift
+    private const uint TILE_S_MASK     = 0xF;     // 4 bits
+
+    #region Methods
+
+    // Decode each grayscale layer to RedImage (always outputs linear R8G8B8A8_UNORM)
+    private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
     {
-        private const uint ATLAS_TILE_PADDING = 2;
+        uint atlasWidth = blob.Header.AtlasWidth;
+        uint atlasHeight = blob.Header.AtlasHeight;
+        uint maskWidth = blob.Header.MaskWidth;
+        uint maskHeight = blob.Header.MaskHeight;
+        uint maskWidthLow = blob.Header.MaskWidthLow;
+        uint maskHeightLow = blob.Header.MaskHeightLow;
+        uint maskTileSize = blob.Header.MaskTileSize;
 
-        // Bit layout of tileDecl (from multilayer mask tiles data)
-        private const uint TILE_PARAM_MASK = 0x3FF;   // 10 bits (0-9)
-        private const int  TILE_DX_SHIFT   = 0;       // bits 0-9  → X offset in atlas
-        private const int  TILE_DY_SHIFT   = 10;      // bits 10-19 → Y offset in atlas
-        private const int  TILE_SX_SHIFT   = 20;      // bits 20-23 → X scale/shift
-        private const int  TILE_SY_SHIFT   = 24;      // bits 24-27 → Y scale/shift
-        private const uint TILE_S_MASK     = 0xF;     // 4 bits
-
-        #region Methods
-
-        // Decode each grayscale layer to RedImage (always outputs linear R8G8B8A8_UNORM)
-        private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
+        var atlasRaw = new byte[atlasWidth * atlasHeight];
+        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
         {
-            uint atlasWidth = blob.Header.AtlasWidth;
-            uint atlasHeight = blob.Header.AtlasHeight;
-            uint maskWidth = blob.Header.MaskWidth;
-            uint maskHeight = blob.Header.MaskHeight;
-            uint maskWidthLow = blob.Header.MaskWidthLow;
-            uint maskHeightLow = blob.Header.MaskHeightLow;
-            uint maskTileSize = blob.Header.MaskTileSize;
+            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
+        }
 
-            var atlasRaw = new byte[atlasWidth * atlasHeight];
-            if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+        var tileBuffer = blob.TilesData.Buffer;
+        var tiles = new uint[tileBuffer.MemSize / 4];
+        using (var ms = new MemoryStream(tileBuffer.GetBytes()))
+        using (var br = new BinaryReader(ms))
+        {
+            ms.Seek(0, SeekOrigin.Begin);
+            for (var i = 0; i < tiles.Length; i++)
             {
-                throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
-            }
-
-            var tileBuffer = blob.TilesData.Buffer;
-            var tiles = new uint[tileBuffer.MemSize / 4];
-            using (var ms = new MemoryStream(tileBuffer.GetBytes()))
-            using (var br = new BinaryReader(ms))
-            {
-                ms.Seek(0, SeekOrigin.Begin);
-                for (var i = 0; i < tiles.Length; i++)
-                {
-                    tiles[i] = br.ReadUInt32();
-                }
-            }
-
-            foreach (var layer in DecodeLayerBuffers(blob))
-            {
-                var (layerBuffer, outWidth, outHeight) = layer;
-
-                var info = new DDSUtils.DDSInfo
-                {
-                    Compression = Enums.ETextureCompression.TCM_None,
-                    RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
-                    IsGamma = false,
-                    Width = outWidth,
-                    Height = outHeight,
-                    Depth = 1,
-                    MipCount = 1,
-                    SliceCount = 1,
-                    TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
-                };
-
-                // Create RedImage from grayscale buffer
-                var img = RedImage.Create(info, layerBuffer);
-
-                // Convert single-channel grayscale to RGBA (R8G8B8A8_UNORM) to avoid ambiguity when saving via WIC
-                try
-                {
-                    var targetLinear = Common.DDS.DXGI_FORMAT.DXGI_FORMAT_R8G8B8A8_UNORM;
-
-                    if (img.Metadata.Format != (DXGI_FORMAT)targetLinear)
-                    {
-                        img.Convert(targetLinear);
-                    }
-                }
-                catch
-                {
-                    // Conversion failed — yield original image to avoid losing data
-                }
-
-                yield return img;
+                tiles[i] = br.ReadUInt32();
             }
         }
 
-        // Decode and return raw grayscale buffers for each layer: (buffer, width, height)
-        private static IEnumerable<(byte[] buffer, uint width, uint height)> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
+        foreach (var layer in DecodeLayerBuffers(blob))
         {
-            uint atlasWidth = blob.Header.AtlasWidth;
-            uint atlasHeight = blob.Header.AtlasHeight;
-            uint maskWidth = blob.Header.MaskWidth;
-            uint maskHeight = blob.Header.MaskHeight;
-            uint maskWidthLow = blob.Header.MaskWidthLow;
-            uint maskHeightLow = blob.Header.MaskHeightLow;
-            uint maskTileSize = blob.Header.MaskTileSize;
-            uint maskCount = blob.Header.NumLayers;
-
-            var atlasRaw = new byte[atlasWidth * atlasHeight];
-            if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
-            {
-                throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
-            }
-
-            var tileBuffer = blob.TilesData.Buffer;
-            var tiles = new uint[tileBuffer.MemSize / 4];
-            using (var ms = new MemoryStream(tileBuffer.GetBytes()))
-            using (var br = new BinaryReader(ms))
-            {
-                ms.Seek(0, SeekOrigin.Begin);
-                for (var i = 0; i < tiles.Length; i++)
-                {
-                    tiles[i] = br.ReadUInt32();
-                }
-            }
-
-            var fullResBuffer = new byte[maskWidth * maskHeight];
-            for (var i = 0; i < maskCount; i++)
-            {
-                Array.Clear(fullResBuffer, 0, fullResBuffer.Length);
-                Decode(ref fullResBuffer, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth, atlasHeight, tiles, maskTileSize, i);
-
-                var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
-
-                byte[] layerBuffer;
-                uint outWidth;
-                uint outHeight;
-
-                if (hasHighRes || maskWidthLow == 0 || maskHeightLow == 0 || maskWidthLow == maskWidth)
-                {
-                    layerBuffer = (byte[])fullResBuffer.Clone();
-                    outWidth = maskWidth;
-                    outHeight = maskHeight;
-                }
-                else
-                {
-                    outWidth = maskWidthLow;
-                    outHeight = maskHeightLow;
-                    layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
-                }
-
-                yield return (layerBuffer, outWidth, outHeight);
-            }
-        }
-
-        private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize, int layerIndex)
-        {
-            var widthInTiles = DivCeil(maskWidth, maskTileSize);
-            var heightInTiles = DivCeil(maskHeight, maskTileSize);
-            var highResTileCount = widthInTiles * heightInTiles;
-
-            for (uint tileIdx = 0; tileIdx < highResTileCount; tileIdx++)
-            {
-                if ((tileIdx * 2) + 1 >= tiles.Length) continue;
-                var paramBits = tiles[(tileIdx * 2) + 1];
-                if ((paramBits & (1 << layerIndex)) != 0) return true;
-            }
-            return false;
-        }
-
-        private static void Decode(ref byte[] maskData, uint maskWidth, uint maskHeight, uint maskWidthLow, uint maskHeightLow, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint[] tileData, uint maskTileSize, int maskIndex)
-        {
-            var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
-            var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
-            var smallOffset = widthInTiles0 * heightInTiles0;
-            var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
-
-            // Precompute widthInTiles for both scaled and full resolutions
-            var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
-            var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
-
-            // Iterate rows first for better cache locality (row-major layout)
-            for (uint y = 0; y < maskHeight; y++)
-            {
-                for (uint x = 0; x < maskWidth; x++)
-                {
-                    DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
-                    DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
-                }
-            }
-        }
-
-        private static void DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
-        {
-            // Use precomputed widthInTiles (optimization - avoids expensive per-pixel DivCeil)
-            var xTile = x / maskTileSize / smallScale;
-            var yTile = y / maskTileSize / smallScale;
-
-            var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
-            if ((tileIndex * 2) + 1 >= tilesData.Length) return;
-
-            var paramOffset = tilesData[tileIndex * 2];
-            var paramBits = tilesData[(tileIndex * 2) + 1];
-
-            if ((uint)(paramBits & (1 << maskIndex)) == 0U) return;
-
-            var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
-
-            uint tileDecl = 0;
-            if (paramOffset + extraAdd < tilesData.Length)
-                tileDecl = tilesData[paramOffset + extraAdd];
-
-            // Extract fields from tileDecl using named constants
-            var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
-            var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
-            var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
-            var sy = (tileDecl >> TILE_SY_SHIFT) & TILE_S_MASK;
-
-            var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
-
-            var ux = ((x >> (int)sx) % maskTileSize) + 1 + (dx * atlasTileSize);
-            var uy = ((y >> (int)sy) % maskTileSize) + 1 + (dy * atlasTileSize);
-
-            var p = atlasData[ux + (uy * atlasWidth)];
-            maskData[x + (y * maskWidth)] = p;
-        }
-
-        private static uint DivCeil(uint l, uint r)
-        {
-            return (l + r - 1) / r;
-        }
-
-        private static uint CountBits(uint v)
-        {
-            return (uint)System.Numerics.BitOperations.PopCount(v);
-        }
-
-        private static byte[] DownscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
-        {
-            var dst = new byte[dstW * dstH];
-            var factorX = (double)srcW / dstW;
-            var factorY = (double)srcH / dstH;
-
-            for (uint y = 0; y < dstH; y++)
-            {
-                var rowOffset = y * dstW;
-                for (uint x = 0; x < dstW; x++)
-                {
-                    var srcX = (uint)(x * factorX);
-                    var srcY = (uint)(y * factorY);
-
-                    if (srcX >= srcW) srcX = srcW - 1;
-                    if (srcY >= srcH) srcY = srcH - 1;
-
-                    dst[rowOffset + x] = src[srcX + srcY * srcW];
-                }
-            }
-            return dst;
-        }
-
-        // Create a PNG where RGB is white and alpha = maskValue for each pixel (WK-style opacity mask over white)
-        private static byte[] CreateWkPreviewPng(byte[] gray, int width, int height)
-        {
-            // Build RGBA buffer: R=G=B=mask value (grayscale), A=255 (opaque)
-            var imgData = new byte[width * height * 4];
-            for (int i = 0; i < width * height; i++)
-            {
-                var v = gray[i];
-                var baseIdx = i * 4;
-                imgData[baseIdx + 0] = v; // R
-                imgData[baseIdx + 1] = v; // G
-                imgData[baseIdx + 2] = v; // B
-                imgData[baseIdx + 3] = 255; // A
-            }
+            var (layerBuffer, outWidth, outHeight) = layer;
 
             var info = new DDSUtils.DDSInfo
             {
                 Compression = Enums.ETextureCompression.TCM_None,
-                RawFormat = Enums.ETextureRawFormat.TRF_TrueColor,
+                RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
                 IsGamma = false,
-                Width = (uint)width,
-                Height = (uint)height,
+                Width = outWidth,
+                Height = outHeight,
                 Depth = 1,
                 MipCount = 1,
                 SliceCount = 1,
                 TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
             };
 
-            var img = RedImage.Create(info, imgData);
-            var png = img.SaveToPNGMemory();
-            img.Dispose();
-            return png;
-        }
+            var img = RedImage.Create(info, layerBuffer);
 
-        public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
-        {
-            if (mlmask.RenderResourceBlob.RenderResourceBlobPC.Chunk is not rendRenderMultilayerMaskBlobPC blob)
-                return false;
-
-            // Validate header values for atlas/tile layout
             try
             {
-                uint atlasWidth = blob.Header.AtlasWidth;
-                uint atlasHeight = blob.Header.AtlasHeight;
-                uint maskTileSize = blob.Header.MaskTileSize;
-
-                if (maskTileSize == 0)
+                var targetLinear = Common.DDS.DXGI_FORMAT.DXGI_FORMAT_R8G8B8A8_UNORM;
+                if (img.Metadata.Format != (DXGI_FORMAT)targetLinear)
                 {
-                    _loggerService.Error("Invalid MaskTileSize: 0");
-                    return false;
-                }
-
-                var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
-                if (atlasWidth % atlasTileSize != 0 || atlasHeight % atlasTileSize != 0)
-                {
-                    _loggerService.Error($"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
-                    return false;
+                    img.Convert(targetLinear);
                 }
             }
             catch
             {
-                _loggerService.Error("Failed to validate multilayer mask header.");
+                // Conversion failed — yield original image
+            }
+
+            yield return img;
+        }
+    }
+
+    // Decode and return raw grayscale buffers for each layer
+    private static IEnumerable<(byte[] buffer, uint width, uint height)> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
+    {
+        uint atlasWidth = blob.Header.AtlasWidth;
+        uint atlasHeight = blob.Header.AtlasHeight;
+        uint maskWidth = blob.Header.MaskWidth;
+        uint maskHeight = blob.Header.MaskHeight;
+        uint maskWidthLow = blob.Header.MaskWidthLow;
+        uint maskHeightLow = blob.Header.MaskHeightLow;
+        uint maskTileSize = blob.Header.MaskTileSize;
+        uint maskCount = blob.Header.NumLayers;
+
+        var atlasRaw = new byte[atlasWidth * atlasHeight];
+        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+        {
+            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
+        }
+
+        var tileBuffer = blob.TilesData.Buffer;
+        var tiles = new uint[tileBuffer.MemSize / 4];
+        using (var ms = new MemoryStream(tileBuffer.GetBytes()))
+        using (var br = new BinaryReader(ms))
+        {
+            ms.Seek(0, SeekOrigin.Begin);
+            for (var i = 0; i < tiles.Length; i++)
+            {
+                tiles[i] = br.ReadUInt32();
+            }
+        }
+
+        var fullResBuffer = new byte[maskWidth * maskHeight];
+
+        for (var i = 0; i < maskCount; i++)
+        {
+            Array.Clear(fullResBuffer, 0, fullResBuffer.Length);
+            Decode(ref fullResBuffer, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth, atlasHeight, tiles, maskTileSize, i);
+
+            var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
+
+            byte[] layerBuffer;
+            uint outWidth;
+            uint outHeight;
+
+            if (hasHighRes || maskWidthLow == 0 || maskHeightLow == 0 || maskWidthLow == maskWidth)
+            {
+                layerBuffer = (byte[])fullResBuffer.Clone();
+                outWidth = maskWidth;
+                outHeight = maskHeight;
+            }
+            else
+            {
+                outWidth = maskWidthLow;
+                outHeight = maskHeightLow;
+                layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
+            }
+
+            yield return (layerBuffer, outWidth, outHeight);
+        }
+    }
+
+    private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize, int layerIndex)
+    {
+        var widthInTiles = DivCeil(maskWidth, maskTileSize);
+        var heightInTiles = DivCeil(maskHeight, maskTileSize);
+        var highResTileCount = widthInTiles * heightInTiles;
+
+        for (uint tileIdx = 0; tileIdx < highResTileCount; tileIdx++)
+        {
+            if ((tileIdx * 2) + 1 >= tiles.Length)
+            {
+                continue;
+            }
+
+            var paramBits = tiles[(tileIdx * 2) + 1];
+
+            if ((paramBits & (1 << layerIndex)) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void Decode(ref byte[] maskData, uint maskWidth, uint maskHeight, uint maskWidthLow, uint maskHeightLow, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint[] tileData, uint maskTileSize, int maskIndex)
+    {
+        var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
+        var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
+        var smallOffset = widthInTiles0 * heightInTiles0;
+        var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
+
+        var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
+        var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
+
+        for (uint y = 0; y < maskHeight; y++)
+        {
+            for (uint x = 0; x < maskWidth; x++)
+            {
+                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
+            }
+        }
+    }
+
+    private static void DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
+    {
+        var xTile = x / maskTileSize / smallScale;
+        var yTile = y / maskTileSize / smallScale;
+
+        var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
+
+        if ((tileIndex * 2) + 1 >= tilesData.Length)
+        {
+            return;
+        }
+
+        var paramOffset = tilesData[tileIndex * 2];
+        var paramBits = tilesData[(tileIndex * 2) + 1];
+
+        if ((uint)(paramBits & (1 << maskIndex)) == 0U)
+        {
+            return;
+        }
+
+        var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
+
+        uint tileDecl = 0;
+        if (paramOffset + extraAdd < tilesData.Length)
+        {
+            tileDecl = tilesData[paramOffset + extraAdd];
+        }
+
+        var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
+        var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
+        var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
+        var sy = (tileDecl >> TILE_SY_SHIFT) & TILE_S_MASK;
+
+        var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+
+        var ux = ((x >> (int)sx) % maskTileSize) + 1 + (dx * atlasTileSize);
+        var uy = ((y >> (int)sy) % maskTileSize) + 1 + (dy * atlasTileSize);
+
+        var p = atlasData[ux + (uy * atlasWidth)];
+        maskData[x + (y * maskWidth)] = p;
+    }
+
+    private static uint DivCeil(uint l, uint r)
+    {
+        return (l + r - 1) / r;
+    }
+
+    private static uint CountBits(uint v)
+    {
+        return (uint)System.Numerics.BitOperations.PopCount(v);
+    }
+
+    private static byte[] DownscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
+    {
+        var dst = new byte[dstW * dstH];
+        var factorX = (double)srcW / dstW;
+        var factorY = (double)srcH / dstH;
+
+        for (uint y = 0; y < dstH; y++)
+        {
+            var rowOffset = y * dstW;
+            for (uint x = 0; x < dstW; x++)
+            {
+                var srcX = (uint)(x * factorX);
+                var srcY = (uint)(y * factorY);
+
+                if (srcX >= srcW)
+                {
+                    srcX = srcW - 1;
+                }
+                if (srcY >= srcH)
+                {
+                    srcY = srcH - 1;
+                }
+
+                dst[rowOffset + x] = src[srcX + srcY * srcW];
+            }
+        }
+        return dst;
+    }
+
+    private static byte[] CreateWkPreviewPng(byte[] gray, int width, int height)
+    {
+        var imgData = new byte[width * height * 4];
+        for (int i = 0; i < width * height; i++)
+        {
+            var v = gray[i];
+            var baseIdx = i * 4;
+            imgData[baseIdx + 0] = v;
+            imgData[baseIdx + 1] = v;
+            imgData[baseIdx + 2] = v;
+            imgData[baseIdx + 3] = 255;
+        }
+
+        var info = new DDSUtils.DDSInfo
+        {
+            Compression = Enums.ETextureCompression.TCM_None,
+            RawFormat = Enums.ETextureRawFormat.TRF_TrueColor,
+            IsGamma = false,
+            Width = (uint)width,
+            Height = (uint)height,
+            Depth = 1,
+            MipCount = 1,
+            SliceCount = 1,
+            TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
+        };
+
+        var img = RedImage.Create(info, imgData);
+        var png = img.SaveToPNGMemory();
+        img.Dispose();
+        return png;
+    }
+
+    public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
+    {
+        if (mlmask.RenderResourceBlob.RenderResourceBlobPC.Chunk is not rendRenderMultilayerMaskBlobPC blob)
+        {
+            return false;
+        }
+
+        try
+        {
+            uint atlasWidth = blob.Header.AtlasWidth;
+            uint atlasHeight = blob.Header.AtlasHeight;
+            uint maskTileSize = blob.Header.MaskTileSize;
+
+            if (maskTileSize == 0)
+            {
+                _loggerService.Error("Invalid MaskTileSize: 0");
                 return false;
             }
 
-            DirectoryInfo? subDir = null;
-            if (args.AsList)
+            var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+            if (atlasWidth % atlasTileSize != 0 || atlasHeight % atlasTileSize != 0)
             {
-                subDir = new DirectoryInfo(Path.ChangeExtension(outfile.FullName, null) + "_layers");
-                if (!subDir.Exists) Directory.CreateDirectory(subDir.FullName);
-            }
-
-            if ((args.AsList && subDir is null) || (!args.AsList && outfile.Directory is null))
-            {
-                _loggerService.Error("directory was null");
+                _loggerService.Error($"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
                 return false;
             }
+        }
+        catch
+        {
+            _loggerService.Error("Failed to validate multilayer mask header.");
+            return false;
+        }
 
-            var cnt = 0;
-            var masks = new List<string>();
-            var layerResolutions = new List<string>();
-
-            // Iterate raw decoded layers so we can produce WK-style preview PNGs
-            foreach (var layer in DecodeLayerBuffers(blob))
+        DirectoryInfo? subDir = null;
+        if (args.AsList)
+        {
+            subDir = new DirectoryInfo(Path.ChangeExtension(outfile.FullName, null) + "_layers");
+            if (!subDir.Exists)
             {
-                var (layerBuffer, outWidth, outHeight) = layer;
+                Directory.CreateDirectory(subDir.FullName);
+            }
+        }
 
-                var layerFileName = Path.GetFileNameWithoutExtension(outfile.FullName) + $"_{cnt++}";
-                var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName, $"{layerFileName}.{args.UncookExtension}");
+        if ((args.AsList && subDir is null) || (!args.AsList && outfile.Directory is null))
+        {
+            _loggerService.Error("directory was null");
+            return false;
+        }
 
-                if (args.UncookExtension == EUncookExtension.png)
-                {
-                    // Create WK-style preview PNG: rectangle filled with white, alpha = mask value
-                    var preview = CreateWkPreviewPng(layerBuffer, (int)outWidth, (int)outHeight);
-                    File.WriteAllBytes(newPath, preview);
+        var cnt = 0;
+        var masks = new List<string>();
+        var layerResolutions = new List<string>();
 
-                    if (args.AsList)
-                        masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
+        foreach (var layer in DecodeLayerBuffers(blob))
+        {
+            var (layerBuffer, outWidth, outHeight) = layer;
 
-                    layerResolutions.Add($"{outWidth}x{outHeight}");
-                    continue;
-                }
+            var layerFileName = Path.GetFileNameWithoutExtension(outfile.FullName) + $"_{cnt++}";
+            var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName, $"{layerFileName}.{args.UncookExtension}");
 
-                // For non-PNG formats, create RedImage and save using existing logic
-                var info = new DDSUtils.DDSInfo
-                {
-                    Compression = Enums.ETextureCompression.TCM_None,
-                    RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
-                    IsGamma = false,
-                    Width = outWidth,
-                    Height = outHeight,
-                    Depth = 1,
-                    MipCount = 1,
-                    SliceCount = 1,
-                    TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
-                };
-
-                var img = RedImage.Create(info, layerBuffer);
-
-                byte[] buffer;
-                switch (args.UncookExtension)
-                {
-                    case EUncookExtension.dds:
-                        buffer = img.SaveToDDSMemory();
-                        break;
-                    case EUncookExtension.tga:
-                        buffer = img.SaveToTGAMemory();
-                        break;
-                    case EUncookExtension.bmp:
-                        buffer = img.SaveToBMPMemory();
-                        break;
-                    case EUncookExtension.jpg:
-                        buffer = img.SaveToJPEGMemory();
-                        break;
-                    case EUncookExtension.tiff:
-                        buffer = img.SaveToTIFFMemory();
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(args.UncookExtension),
-                            $"Unsupported uncook extension: {args.UncookExtension}");
-                }
-
-                File.WriteAllBytes(newPath, buffer);
+            if (args.UncookExtension == EUncookExtension.png)
+            {
+                var preview = CreateWkPreviewPng(layerBuffer, (int)outWidth, (int)outHeight);
+                File.WriteAllBytes(newPath, preview);
 
                 if (args.AsList)
+                {
                     masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
+                }
 
-                layerResolutions.Add($"{img.Metadata.Width}x{img.Metadata.Height}");
-                img.Dispose();
+                layerResolutions.Add($"{outWidth}x{outHeight}");
+                continue;
             }
+
+            var info = new DDSUtils.DDSInfo
+            {
+                Compression = Enums.ETextureCompression.TCM_None,
+                RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
+                IsGamma = false,
+                Width = outWidth,
+                Height = outHeight,
+                Depth = 1,
+                MipCount = 1,
+                SliceCount = 1,
+                TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
+            };
+
+            var img = RedImage.Create(info, layerBuffer);
+
+            byte[] buffer;
+            switch (args.UncookExtension)
+            {
+                case EUncookExtension.dds:
+                    buffer = img.SaveToDDSMemory();
+                    break;
+                case EUncookExtension.tga:
+                    buffer = img.SaveToTGAMemory();
+                    break;
+                case EUncookExtension.bmp:
+                    buffer = img.SaveToBMPMemory();
+                    break;
+                case EUncookExtension.jpg:
+                    buffer = img.SaveToJPEGMemory();
+                    break;
+                case EUncookExtension.tiff:
+                    buffer = img.SaveToTIFFMemory();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(args.UncookExtension), $"Unsupported uncook extension: {args.UncookExtension}");
+            }
+
+            File.WriteAllBytes(newPath, buffer);
 
             if (args.AsList)
             {
-                var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
-
-                var headerLines = new List<string>
-                {
-                    "# MLMask Export v2",
-                    "# Original file header values",
-                    $"# AtlasWidth={blob.Header.AtlasWidth}",
-                    $"# AtlasHeight={blob.Header.AtlasHeight}",
-                    $"# MaskWidth={blob.Header.MaskWidth}",
-                    $"# MaskHeight={blob.Header.MaskHeight}",
-                    $"# MaskWidthLow={blob.Header.MaskWidthLow}",
-                    $"# MaskHeightLow={blob.Header.MaskHeightLow}",
-                    $"# MaskTileSize={blob.Header.MaskTileSize}",
-                    $"# NumLayers={blob.Header.NumLayers}",
-                    "",
-                    $"# LayerResolutions={string.Join(",", layerResolutions)}",
-                    "",
-                    "# Layer image files (must be in correct order)"
-                };
-
-                headerLines.AddRange(masks);
-                File.WriteAllLines(maskListPath, headerLines);
+                masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
             }
 
-            // MlmaskInspector analysis removed from standard export flow.
-
-            return true;
+            layerResolutions.Add($"{img.Metadata.Width}x{img.Metadata.Height}");
+            img.Dispose();
         }
 
-        public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
+        if (args.AsList)
         {
-            streams = new List<Stream>();
-            if (mask.RenderResourceBlob.RenderResourceBlobPC.GetValue() is not rendRenderMultilayerMaskBlobPC blob)
-                return false;
+            var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
 
-            foreach (var img in GetRedImages(blob))
+            var headerLines = new List<string>
             {
-                streams.Add(new MemoryStream(img.SaveToDDSMemory()));
-                img.Dispose();
-            }
-            return true;
+                "# MLMask Export v2",
+                "# Original file header values",
+                $"# AtlasWidth={blob.Header.AtlasWidth}",
+                $"# AtlasHeight={blob.Header.AtlasHeight}",
+                $"# MaskWidth={blob.Header.MaskWidth}",
+                $"# MaskHeight={blob.Header.MaskHeight}",
+                $"# MaskWidthLow={blob.Header.MaskWidthLow}",
+                $"# MaskHeightLow={blob.Header.MaskHeightLow}",
+                $"# MaskTileSize={blob.Header.MaskTileSize}",
+                $"# NumLayers={blob.Header.NumLayers}",
+                "",
+                $"# LayerResolutions={string.Join(",", layerResolutions)}",
+                "",
+                "# Layer image files (must be in correct order)"
+            };
+
+            headerLines.AddRange(masks);
+            File.WriteAllLines(maskListPath, headerLines);
         }
 
-        #endregion
+        return true;
     }
+
+    public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
+    {
+        streams = new List<Stream>();
+
+        if (mask.RenderResourceBlob.RenderResourceBlobPC.GetValue() is not rendRenderMultilayerMaskBlobPC blob)
+        {
+            return false;
+        }
+
+        foreach (var img in GetRedImages(blob))
+        {
+            streams.Add(new MemoryStream(img.SaveToDDSMemory()));
+            img.Dispose();
+        }
+
+        return true;
+    }
+
+    #endregion
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -92,7 +92,11 @@ public partial class ModTools
         }
     }
 
-    // Decode and return raw grayscale buffers for each layer
+    /// <summary>
+    /// Decodes each layer from the multilayer mask.
+    /// Layers are exported either at full high resolution or at the reduced low resolution,
+    /// depending on whether the layer has dedicated high-resolution tile data.
+    /// </summary>
     private static IEnumerable<(byte[] buffer, uint width, uint height)> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
     {
         uint atlasWidth = blob.Header.AtlasWidth;
@@ -152,6 +156,10 @@ public partial class ModTools
         }
     }
 
+    /// <summary>
+    /// Checks whether a specific layer has any high-resolution tile data.
+    /// This determines if the layer should be exported at full resolution or downscaled.
+    /// </summary>
     private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize, int layerIndex)
     {
         var widthInTiles = DivCeil(maskWidth, maskTileSize);
@@ -224,6 +232,8 @@ public partial class ModTools
             tileDecl = tilesData[paramOffset + extraAdd];
         }
 
+        // Extract atlas position and scaling factors from the packed tile declaration.
+        // dx/dy = tile position in the atlas, sx/sy = bit-shift scaling for this layer.
         var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
         var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
         var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
@@ -266,6 +276,7 @@ public partial class ModTools
                 {
                     srcX = srcW - 1;
                 }
+
                 if (srcY >= srcH)
                 {
                     srcY = srcH - 1;
@@ -477,5 +488,5 @@ public partial class ModTools
         return true;
     }
 
-    #endregion
+    #endregion Methods
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -1,4 +1,4 @@
-// using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
## Summary
- Export now always outputs masks in their **native per-layer resolutions**
- Import restores proper per-layer sizes during round-trip
- You can use any mlmask file as template to import your masks there

## Changes

### MlmaskTools.cs (Export)
- `GetRedImages()` now always returns layers in their original native resolution
- Added/updated `ConvertMultilayerMaskToDdsStreams()` for internal preview compatibility
- Improved `DownscaleNearest()` with boundary safety

### MlmaskImportTools.cs (Import)
- Uses per-layer resolutions when importing
- Allows 2 types of masks resolution - high res / low res (or you can import all with 1 res)
- Creates atlas with same size as before export or new one