### PR TITLE
Catch for undefined foreground textbox text colour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ Libs/Irrlicht.dll
 WolvenKit.IrrlichtLime/Release-x86
 msbuild.binlog
 !texconv.pdb
+/.history

--- a/WolvenKit/Themes/App.Styles.xaml
+++ b/WolvenKit/Themes/App.Styles.xaml
@@ -321,7 +321,7 @@
         <Setter Property="Foreground" Value="White" />
     </Style>
     <Style
-      BasedOn="{StaticResource WolvenkitTexStBoxStyle}"
+      BasedOn="{StaticResource WolvenkitTextBoxStyle}"
       TargetType="{x:Type TextBox}"/>
 
     <!-- Also counts for syncfusion:SfTextBoxExt -->

--- a/WolvenKit/Themes/App.Styles.xaml
+++ b/WolvenKit/Themes/App.Styles.xaml
@@ -320,6 +320,9 @@
         <Setter Property="BorderBrush" Value="{StaticResource ContentBackgroundAlt3}" />
         <Setter Property="Foreground" Value="White" />
     </Style>
+    <Style
+      BasedOn="{StaticResource WolvenkitTexStBoxStyle}"
+      TargetType="{x:Type TextBox}"/>
 
     <!-- Also counts for syncfusion:SfTextBoxExt -->
     <Style


### PR DESCRIPTION
# Catch for undefined foreground textbox text colour


**Fixed:**
- some textbox colours not correctly defining foreground text colour, added catch for uncalled variants


