### PR TITLE
Adjust release actions to no longer push to main 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,28 +52,20 @@ jobs:
         id: get_version
         with:
           proj-path: ${{env.PROJ}}
+
       - name: change version
         shell: bash
         run: echo "VERSION_APP=${{steps.get_version.outputs.assembly-version}}" >> $GITHUB_ENV
 
+      - name: Create Release Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{env.VERSION_APP}} -m "Release ${{env.VERSION_APP}}"
+          git push origin --tag ${{env.VERSION_APP}}
+
       ##########################################
       # CHANGELOG
-
-      - name: Ensure changelog is staged
-        shell: pwsh
-        run: |
-          $branchExists = git ls-remote --exit-code --heads origin changelog-staging
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Changelog branch exists"
-          } else {
-            Write-Host "Changelog branch does not exist, please run stage changelog first"
-            exit 1
-          }
-      
-      - name: Checkout changelog branch
-        run: |
-          git fetch origin changelog-staging
-          git checkout changelog-staging
 
       - name: Read MD Version Changelog
         id: md_changelog
@@ -81,7 +73,7 @@ jobs:
         run: |
           {
             echo 'content<<EOF'
-            cat compiled-changelog/CHANGELOG.md
+            cat changelog/generated/CHANGELOG.md
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
@@ -91,58 +83,9 @@ jobs:
         run: |
           {
             echo 'content<<EOF'
-            cat compiled-changelog/CHANGELOG.txt
+            cat changelog/generated/CHANGELOG.txt
             echo EOF
           } >> "$GITHUB_OUTPUT"
-
-      - name: Read History Changelog
-        id: history_changelog
-        shell: bash
-        run: |
-          {
-            echo 'content<<EOF'
-            cat CHANGELOG.md
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Clean up Branches
-        run: |
-          git checkout main
-          git branch -D changelog-staging
-
-      - name: Write Changelog
-        shell: pwsh
-        env:
-          CHANGELOG: ${{ steps.history_changelog.outputs.content }}
-        run: Set-Content -Path "CHANGELOG.md" -Value $env:CHANGELOG
-
-      - name: Name Unreleased
-        shell: pwsh
-        run: |
-          cd changelog
-          Rename-Item -Path "!unreleased.yaml" -NewName "${{env.VERSION_APP}}.yaml"
-
-      - name: Add Templated Unreleased
-        shell: pwsh
-        run: |
-          cd changelog
-          Copy-Item -Path "!template.yaml" -Destination "!unreleased.yaml"
-
-      - name: Commit
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git add changelog\*.yaml
-          git commit -m "Update changelog for version ${{env.VERSION_APP}}" || echo "No changes to commit"
-
-      - name: Create Release Tag
-        run: git tag -a ${{env.VERSION_APP}} -m "Release ${{env.VERSION_APP}}"
-
-      - name: Push changes
-        run: |
-          git push origin --delete changelog-staging
-          git push origin main --tags
 
       - name: Populate Release Template
         shell: pwsh

--- a/.github/workflows/stage-changelog.yml
+++ b/.github/workflows/stage-changelog.yml
@@ -4,15 +4,26 @@ on:
 
 env:
   PROJ: ./WolvenKit/WolvenKit.csproj
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   stage-changelog:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Ensure Changes exist
+        shell: bash
+        run: |
+          git checkout main
+          if cmp -s 'changelog/!template.yaml' 'changelog/!unreleased.yaml'; then
+            echo "No changes in changelog, aborting."
+            exit 1
+          fi
 
       - name: Configure git
         run: |
@@ -39,12 +50,29 @@ jobs:
           mkdir compiled-changelog
           pip install pyyaml
           echo ${{env.VERSION_APP}}
-          python "tools/compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog/!unreleased.yaml" --out-md "compiled-changelog/CHANGELOG.md" --out-bb "compiled-changelog/CHANGELOG.txt" --changelog "CHANGELOG.md"
+          python "tools/compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog/!unreleased.yaml" --out-md "changelog/generated/CHANGELOG.md" --out-bb "changelog/generated/CHANGELOG.txt" --changelog "CHANGELOG.md"
+
+      - name: Name Unreleased
+        shell: bash
+        run: |
+          mv 'changelog/!unreleased.yaml' "changelog/${VERSION_APP}.yaml"
+
+      - name: Add Templated Unreleased
+        shell: bash
+        run: |
+          cp 'changelog/!template.yaml' 'changelog/!unreleased.yaml'
 
       - name: Commit and Push
         run: |
           git add CHANGELOG.md
-          git add compiled-changelog/CHANGELOG.md
-          git add compiled-changelog/CHANGELOG.txt
-          git commit -m "Stage changelog for version ${{env.VERSION_APP}}" || echo "No changes to commit"
+          git add changelog/
+          git commit -m "Generate changelog for version ${{env.VERSION_APP}} and update source yaml files" || echo "No changes to commit"
           git push origin changelog-staging
+
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --base main \
+            --head "changelog-staging" \
+            --title "Generate changelog for ${{env.VERSION_APP}}" \
+            --body "Generates user facing changelog entries and updates source yaml files. beep boop."

--- a/docs/maintaining/release-process.md
+++ b/docs/maintaining/release-process.md
@@ -1,23 +1,23 @@
 # Release Process
 
-Stable releases are done by (or with the permission of) the project lead and are scheduled to be around the first of every month.
+Stable releases are done by (or with the permission of) the project lead and are expected to be performed the first of every month.
 
 Nightly releases get automatically build and released daily when changes on the `dev` branch are present.
 
 ## Verify Version
-Ensure the version upgrade conforms to semver in terms of minor and patch, avoid major releases for now.
+Ensure the version upgrade conforms to semver in terms of minor and patch. Major releases should be planned ahead of time to bundle breaking changes and leave enough time for users to move off of deprecated features.
+
 If the version needs to be changed run the `bump version` action.
 
-## Staging the Changelog
-Before running the main `release` workflow `stage changelog` must be run to generate the changelog from the yaml source.
-Once the action is finished the changelog can be viewed in the `changelog-staging` branch, where the `CHANGELOG.md`, `compiled-changelog/CHANGELOG.md`, and `compiled-changelog/CHANGELOG.txt` are saved.
-At this stage the changelog should be verified and can be manually edited if needed.
+## Generate the Changelog
+Before running the `release` workflow the `state changelog` action must be run to generate a pull request containing the user facing changelog based on the yaml source.
+This pull request needs to be validated and merged into the main branch before the release workflow can be run.
 ::: info
-Edits to the intermediate generated files should only include formatting changes.
+Edits to the generated files should only include formatting changes.
 For content changes edit `changelog/!unreleased.yaml` on the main branch and run `stage changelog` again.
 :::
 
-## Releasing
+## Release
 To release for all platforms (Nuget Packages, GitHub, NexusMods), manually trigger the release workflow. It will create a new tag, read the changelog from the previous step, build all assets and release them.
 
 ## Post Release


### PR DESCRIPTION
# Adjust release actions to no longer push to main 

**Implemented:**
- the stage changelog action now generates a pull request targeting the main branch which contains all the changes needed as part of the release (appended main changelog, separate changelog files for this specific release in markdown and bbcode as well as bumping the yaml changelog version) 
- the release action now simply reads those files and does not make any changes to the upstream
- Adjusted the docs to reflect new workflow

This avoids the issue of providing the action with permissions to push to a protected branch as well as providing a more transparent and boundary setting process.