### PR TITLE
Masks export / import overhaul (low res and high res masks / no pixel shift/offset)

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -52,7 +52,6 @@ public class MLMASK
 
         if (files.Count == 0)
         {
-            // 0x2006 = MLMask: No layer files specified in masklist
             throw new ArgumentException("No layer files specified in masklist.", nameof(txtImageList));
         }
 

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -14,12 +14,10 @@ using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
 /// <summary>
-/// Error code ranges used in multilayer mask import:
-/// 0x2000–0x20FF : Import / masklist parsing and image loading errors
+/// MLMask import error codes (registered in LogCodeHelper):
 ///   0x2001 = Invalid color space (must be R8/grayscale)
-///   0x2002 = Reserved (power-of-2 requirement)
-///   0x2004 = No layers found in masklist
-///   0x2005 = General image loading failure
+///   0x2006 = No layer files specified in .masklist
+///   0x2007 = Failed to load layer image
 /// </summary>
 
 namespace WolvenKit.Modkit.RED4.MLMask
@@ -62,8 +60,8 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             if (files.Count == 0)
             {
-                // 0x2004 = No layers found in masklist (0x2002 is reserved for power-of-2 requirement errors)
-                throw new WolvenKitException(0x2004, "No layer files specified in masklist.");
+                // 0x2006 = MLMask: No layer files specified in masklist
+                throw new WolvenKitException(0x2006, "No layer files specified in masklist.");
             }
 
             _mlmask = new MlMaskContainer();
@@ -80,7 +78,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
                 try
                 {
-                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2005, $"Could not load image: {f}"); // 0x2005 = General image loading failure
+                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2007, $"Could not load image: {f}"); // 0x2007 = MLMask: General image loading failure
 
                     if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
                     {

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using WolvenKit.Common;
 using WolvenKit.Common.DDS;
-using WolvenKit.Common.Exceptions;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
 using WolvenKit.Core.Interfaces;
@@ -16,14 +15,9 @@ using WolvenKit.RED4.Types;
 
 namespace WolvenKit.Modkit.RED4.MLMask
 {
-    // TODO refactor all this, it's completely unsafe
-
     public class MLMASK
     {
         private const uint s_headerLength = 148;
-        //assuming DDSUtils.ConvertToDdsMemory always creates a dx10 dds,
-        //if it creates a dx9 or both we will have to check for it, headerlength = 128, if(dx10) headerlength += 20
-
         private MlMaskContainer _mlmask;
         private readonly ILoggerService _logger;
 
@@ -33,107 +27,117 @@ namespace WolvenKit.Modkit.RED4.MLMask
             _logger = logger;
         }
 
+        /// <summary>
+        /// Imports a .masklist file into a .mlmask file.
+        /// Supports both single-resolution and multi-resolution layer sets.
+        /// The .masklist now contains only layer file paths (no header).
+        /// </summary>
         public void Import(FileInfo txtImageList, FileInfo outFile)
         {
-            // relative and absolute paths
-            var paths = File.ReadAllLines(txtImageList.FullName);
+            var lines = File.ReadAllLines(txtImageList.FullName);
             var baseDir = txtImageList.Directory.NotNull();
-            var files = paths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
 
-            #region InitandVerify
+            var filePaths = new List<string>();
 
-            _mlmask = new MlMaskContainer();
-            var textures = new List<RawTexContainer>();
-
-            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
-            if (!firstLayerName.EndsWith("_0"))
+            foreach (var line in lines)
             {
-                var white = new RawTexContainer
+                var trimmed = line.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
                 {
-                    Pixels = new byte[16],
-                    Width = 4,
-                    Height = 4
-                };
-                Array.Fill<byte>(white.Pixels, 255);
-                textures.Add(white);
-            }
-
-            (uint imageDimensionX, uint imageDimensionY) = (0, 0);
-            foreach (var f in files)
-            {
-                if (!File.Exists(f))
-                {
-                    throw new FileNotFoundException($"Line{{lineIdx}}: \"{f}\" Make sure the file path is valid and exists (paths are specified line by line in ascending layer order in masklist)");
-                }
-
-                RedImage? image = null;
-                try
-                {
-                    image = RedImage.LoadFromFile(f);
-                }
-                catch (WolvenKitException e)
-                {
-                    throw new WolvenKitException(0x2001, $"{e.Message} (.mlmask images need to be in color space black and white)");
-                }
-
-                if (image == null)
-                {
-                    _logger.Error($"\"{f}\" could not be loaded!");
                     continue;
                 }
 
-                if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
-                {
-                    image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
-                }
-
-                if (image.Metadata.Width % 2 != 0 || image.Metadata.Height % 2 != 0)
-                {
-                    throw new WolvenKitException(0x2002,
-                        $"Texture {f}: width={image.Metadata.Width},height={image.Metadata.Height} must have dimensions divisible by 2");
-                }
-
-                using var ms = new MemoryStream(image.SaveToDDSMemory());
-                using var br = new BinaryReader(ms);
-                ms.Seek(s_headerLength, SeekOrigin.Begin);
-                var bytes = br.ReadBytes(image.Metadata.Width * image.Metadata.Height);
-
-                // #1865: check the the image dimensions are the same for all pngs
-                var imageWidth = (uint)image.Metadata.Width;
-                var imageHeight = (uint)image.Metadata.Height;
-
-                if (imageDimensionX == 0)
-                {
-                    imageDimensionX = imageWidth;
-                    imageDimensionY = imageHeight;
-                }
-                else if (imageDimensionX != imageWidth || imageDimensionY != imageHeight)
-                {
-                    throw new WolvenKitException(0x2003, $"Texture {f} should be of size {imageDimensionX}x{imageDimensionY}");
-                }
-
-                var tex = new RawTexContainer { Width = imageWidth, Height = imageHeight, Pixels = bytes };
-                textures.Add(tex);
+                filePaths.Add(trimmed);
             }
+
+            if (filePaths.Count == 0)
+                throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
+
+            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
+
+            _mlmask = new MlMaskContainer();
+
+            var textures = new List<RawTexContainer>();
+
+            // Add white base layer 0 (if the first layer does not end with _0)
+            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
+            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
+
+            if (needsLayer0)
+            {
+                uint whiteW = 1024u;
+                uint whiteH = 1024u;
+
+                if (files.Count > 0 && File.Exists(files[0]))
+                {
+                    try
+                    {
+                        using var probe = RedImage.LoadFromFile(files[0]);
+                        if (probe != null)
+                        {
+                            whiteW = (uint)probe.Metadata.Width;
+                            whiteH = (uint)probe.Metadata.Height;
+                        }
+                    }
+                    catch { }
+                }
+
+                var whitePixels = new byte[whiteW * whiteH];
+                Array.Fill(whitePixels, (byte)255);
+                textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
+            }
+
+            // Load all layers from files
+            foreach (var f in files)
+            {
+                if (!File.Exists(f))
+                    throw new FileNotFoundException($"File not found: {f}");
+
+                try
+                {
+                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2001, $"Could not load image: {f}");
+
+                    if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
+                        image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
+
+                    uint imgW = (uint)image.Metadata.Width;
+                    uint imgH = (uint)image.Metadata.Height;
+
+                    using var ms = new MemoryStream(image.SaveToDDSMemory());
+                    using var br = new BinaryReader(ms);
+                    ms.Seek(s_headerLength, SeekOrigin.Begin);
+                    var pixels = br.ReadBytes((int)(imgW * imgH));
+
+                    textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
+                }
+                catch (WolvenKitException e)
+                {
+                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale R8)");
+                }
+            }
+
             _mlmask.Layers = textures.ToArray();
-            #endregion
 
             Create();
             Write(outFile);
         }
 
-        #region Methods
+        internal static bool IsBlankLayer(byte[] pixels)
+        {
+            if (pixels == null || pixels.Length == 0) return true;
+            var first = pixels[0];
+            for (int i = 1; i < pixels.Length; i++)
+                if (pixels[i] != first) return false;
+            return true;
+        }
+
+        #region Core Methods
 
         private void Write(FileInfo f)
         {
             var cr2w = new CR2WFile();
-            var mask = new Multilayer_Mask
-            {
-                CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC
-            };
+            var mask = new Multilayer_Mask { CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC };
             cr2w.RootChunk = mask;
-
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
 
             var blob = new rendRenderMultilayerMaskBlobPC
             {
@@ -142,7 +146,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     Version = 3,
                     AtlasWidth = _mlmask.AtlasWidth,
                     AtlasHeight = _mlmask.AtlasHeight,
-                    NumLayers = (uint)_mlmask.Layers.Length,
+                    NumLayers = (uint)_mlmask.Layers!.Length,
                     MaskWidth = _mlmask.WidthHigh,
                     MaskHeight = _mlmask.HeightHigh,
                     MaskWidthLow = _mlmask.WidthLow,
@@ -150,72 +154,297 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     MaskTileSize = _mlmask.TileSize,
                     Flags = 2
                 },
-                AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer.NotNull()),
-                TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer.NotNull())
+                AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer!),
+                TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer!)
             };
 
             mask.RenderResourceBlob.RenderResourceBlobPC = blob;
 
-            var dir = f.Directory.NotNull();
-            if (!Directory.Exists(dir.FullName))
-            {
-                Directory.CreateDirectory(dir.FullName);
-            }
+            var dir = f.Directory ?? throw new InvalidOperationException("File directory is null");
+            if (!Directory.Exists(dir.FullName)) Directory.CreateDirectory(dir.FullName);
+
             using var fs = new FileStream(f.FullName, FileMode.Create, FileAccess.Write);
             using var writer = new CR2WWriter(fs) { LoggerService = _logger };
             writer.WriteFile(cr2w);
         }
 
-        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
+        private void Create()
         {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
+            if (_mlmask.Layers == null || _mlmask.Layers.Length == 0) return;
 
-            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
-            var widthInTilesGrayUp = Convert.ToUInt32((1 << Convert.ToInt32(widthInTilesShift0)) - 1);
-
-            for (uint ty = 0; ty < heightInTiles0; ty++)
+            // High resolution
+            _mlmask.WidthHigh = 0;
+            _mlmask.HeightHigh = 0;
+            foreach (var lay in _mlmask.Layers)
             {
-                for (uint tx = 0; tx < widthInTiles0; tx++)
+                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
+                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
+            }
+
+            // Low resolution
+            _mlmask.WidthLow = _mlmask.WidthHigh;
+            _mlmask.HeightLow = _mlmask.HeightHigh;
+
+            bool hasDifferentResolutions = false;
+            foreach (var lay in _mlmask.Layers)
+            {
+                if (lay.Width < _mlmask.WidthHigh || lay.Height < _mlmask.HeightHigh)
                 {
-                    var tileIdx = tx + (ty * widthInTiles0);
-                    var layersBeg = Convert.ToUInt32(tilesDataList.Count);
-                    var numLayers = Convert.ToUInt32(tileZ[tileIdx].Layers.Count);
-
-                    tilesDataList[Convert.ToInt32(((basisTileIdx + tileIdx) * 2) + 0)] = layersBeg;
-
-                    uint layersMask = 0;
-                    for (var I = 0; I < numLayers; I++)
-                    {
-                        var layerIdx = tileZ[tileIdx].Layers[I].LayerIndex;
-                        var position = tileZ[tileIdx].Layers[I].AtlasInPosition;
-                        var atlasX = position & widthInTilesGrayUp;
-                        var atlasY = Convert.ToUInt32(Convert.ToInt32(position) >> Convert.ToInt32(widthInTilesShift0));
-                        var widthShift = _mlmask.Layers[layerIdx].WidthShift;
-                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
-
-                        uint puts = 0;
-                        puts |= atlasX;
-                        puts |= atlasY << 10;
-                        puts |= widthShift << 20;
-                        puts |= heightShift << 24;
-
-                        tilesDataList.Add(puts);
-
-                        layersMask |= Convert.ToUInt32(1 << Convert.ToInt32(layerIdx));
-                    }
-
-                    tilesDataList[Convert.ToInt32(((basisTileIdx + tileIdx) * 2) + 1)] = layersMask;
+                    hasDifferentResolutions = true;
+                    _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
+                    _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
                 }
             }
+
+            if (!hasDifferentResolutions)
+            {
+                _mlmask.WidthLow = _mlmask.WidthHigh;
+                _mlmask.HeightLow = _mlmask.HeightHigh;
+            }
+
+            // Protection against 3+ different resolutions (only 2 levels supported: High + Low)
+            bool hasThirdResolution = false;
+            foreach (var lay in _mlmask.Layers)
+            {
+                if (lay.Width != _mlmask.WidthHigh && lay.Width != _mlmask.WidthLow)
+                {
+                    hasThirdResolution = true;
+                    break;
+                }
+            }
+
+            if (hasThirdResolution)
+            {
+                throw new WolvenKitException(0x2003, "More than 2 different resolutions detected in masklist. Only 2 resolution levels are supported.");
+            }
+
+            _logger.Info($"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
+
+            for (int i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _logger.Debug($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
+            }
+
+            // Shifts
+            for (var i = 0; i < _mlmask.Layers.Length; i++)
+            {
+                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
+                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
+            }
+
+            // Fixed tile size for this project: maskTileSize = 14 → AtlasTileSize = 16.
+            // AtlasTileSize must be divisible by 4 (we split it into 4x4 BC4 blocks for compression).
+            // We start at 16 and increase by 4 if needed to keep divisibility.
+            uint tempAtlasTileSize = 16u;
+            while (true)
+            {
+                _mlmask.AtlasTileSize = tempAtlasTileSize;
+                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
+
+                _mlmask.MaskTilesHigh = null;
+                _mlmask.MaskTilesLow = null;
+                _mlmask.AtlasTiles.Clear();
+                _mlmask.AtlasWidth = 0;
+                _mlmask.AtlasHeight = 0;
+                _mlmask.AtlasTilesCount = 0;
+
+                InitializeMaskLayers();
+
+                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+
+                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
+                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
+                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
+
+                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
+                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
+                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
+
+                CleanTileLayers();
+
+                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
+
+                tempAtlasTileSize += 4;   // keep the value divisible by 4
+            }
+
+            CalculateAtlasProportionForPacking();
+            CreateAtlasBuffer();
+
+            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
+            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
+            var tilesDataList = new List<uint>();
+
+            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
+                tilesDataList.Add(0U);
+
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
+            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
+
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            foreach (var l in tilesDataList) bw.Write(l);
+            _mlmask.TilesBuffer = ms.ToArray();
+        }
+
+        private void CalculateAtlasProportionForPacking()
+        {
+            if (_mlmask.AtlasTilesCount == 0)
+                throw new Exception("No tiles to pack into atlas.");
+
+            uint tileSize = _mlmask.AtlasTileSize;
+            uint tileCount = _mlmask.AtlasTilesCount;
+
+            // The atlas size is independent of maskWidth/maskHeight.
+            // It only needs to hold all *unique* compressed tiles (after hash deduplication).
+            // Real game files often have atlas much smaller than mask resolution when content has repetition/empty areas.
+
+            uint bestWidth = 0;
+            uint bestHeight = 0;
+            ulong bestWaste = ulong.MaxValue;
+            double bestWasteRatio = double.MaxValue; // waste / usedArea
+
+            // Search over all reasonable power-of-2 widths (this is the constraint from PutTiles).
+            // Start from 4 tiles wide to avoid extremely narrow (1-tile) atlases.
+            for (uint wTilesPow2 = 4; wTilesPow2 <= 1024; wTilesPow2 <<= 1)
+            {
+                uint hTiles = (tileCount + wTilesPow2 - 1) / wTilesPow2;
+                uint w = wTilesPow2 * tileSize;
+                uint h = hTiles * tileSize;
+
+                if (w > 16384 || h > 16384) continue;
+
+                ulong area = (ulong)w * h;
+                ulong usedArea = (ulong)tileCount * tileSize * tileSize;
+                ulong waste = area - usedArea;
+                double wasteRatio = usedArea > 0 ? (double)waste / usedArea : 0;
+
+                // Calculate aspect ratio
+                double aspect = (double)h / w;
+
+                // Hard filter: reject extremely bad aspect ratios
+                if (aspect > 4.0 || aspect < 0.25) continue;
+
+                // Prefer lower waste ratio. If ratios are close, prefer reasonable aspect ratio.
+                bool better = false;
+                if (wasteRatio < bestWasteRatio - 0.01) better = true;
+                else if (Math.Abs(wasteRatio - bestWasteRatio) <= 0.01)
+                {
+                    // Prefer aspect ratios in good range [0.5 .. 2.5]
+                    bool currGood = aspect >= 0.5 && aspect <= 2.5;
+                    bool bestGood = (bestHeight >= 0.5 * bestWidth) && (bestHeight <= 2.5 * bestWidth);
+
+                    if (currGood && !bestGood) better = true;
+                    else if (currGood == bestGood)
+                    {
+                        // Among good aspects, prefer closer to square
+                        double currDist = Math.Abs(aspect - 1.0);
+                        double bestDist = Math.Abs((double)bestHeight / bestWidth - 1.0);
+                        if (currDist < bestDist - 0.08) better = true;
+                        else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste) better = true;
+                    }
+                }
+
+                if (better || bestWidth == 0)
+                {
+                    bestWaste = waste;
+                    bestWasteRatio = wasteRatio;
+                    bestWidth = w;
+                    bestHeight = h;
+                }
+            }
+
+            // Fallback (should rarely happen)
+            if (bestWidth == 0)
+            {
+                uint wTiles = 64;
+                uint hTiles = (tileCount + wTiles - 1) / wTiles;
+                bestWidth = wTiles * tileSize;
+                bestHeight = hTiles * tileSize;
+            }
+
+            _mlmask.AtlasWidth = bestWidth;
+            _mlmask.AtlasHeight = bestHeight;
+
+            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
+                throw new Exception("Atlas too large (over 16k)");
+
+            // Ensure the number of tiles horizontally is a power of 2 (required by PutTiles bit-packing).
+            uint tilesX = _mlmask.AtlasWidth / tileSize;
+            if (tilesX > 0 && (tilesX & (tilesX - 1)) != 0)
+            {
+                uint nextPow2 = 1u;
+                while (nextPow2 < tilesX) nextPow2 <<= 1;
+
+                uint newWidth = nextPow2 * tileSize;
+                uint newHeight = ((tileCount + nextPow2 - 1) / nextPow2) * tileSize;
+
+                // Try to prefer layouts where height >= width (more vertical/square, like most CDPR atlases)
+                // when it doesn't increase waste too much.
+                bool preferTaller = newHeight < newWidth;
+
+                if (preferTaller && nextPow2 > 1)
+                {
+                    uint prevPow2 = nextPow2 / 2;
+                    uint prevWidth = prevPow2 * tileSize;
+                    uint prevHeight = ((tileCount + prevPow2 - 1) / prevPow2) * tileSize;
+
+                    if (prevWidth <= 16384)
+                    {
+                        // Accept previous power of 2 if it gives height >= width or the waste increase is reasonable
+                        ulong prevWaste = (ulong)prevWidth * prevHeight - (ulong)tileCount * tileSize * tileSize;
+                        ulong currWaste = (ulong)newWidth * newHeight - (ulong)tileCount * tileSize * tileSize;
+
+                        if (prevHeight >= prevWidth || prevWaste <= currWaste * 1.6)
+                        {
+                            newWidth = prevWidth;
+                            newHeight = prevHeight;
+                        }
+                    }
+                }
+
+                if (newWidth <= 16384)
+                {
+                    _mlmask.AtlasWidth = newWidth;
+                    _mlmask.AtlasHeight = newHeight;
+                }
+            }
+
+            // Final pass: if we still have a very wide result (width > height), try one more time
+            // to use a smaller power-of-2 width if it gives a better aspect ratio with acceptable waste.
+            uint finalTilesX = _mlmask.AtlasWidth / tileSize;
+            uint finalTilesY = _mlmask.AtlasHeight / tileSize;
+
+            if (finalTilesX > finalTilesY && finalTilesX > 1)
+            {
+                uint smallerPow2 = finalTilesX / 2;
+                while (smallerPow2 > 1 && (smallerPow2 & (smallerPow2 - 1)) != 0) smallerPow2 /= 2;
+
+                if (smallerPow2 >= 1)
+                {
+                    uint tryWidth = smallerPow2 * tileSize;
+                    uint tryHeight = ((tileCount + smallerPow2 - 1) / smallerPow2) * tileSize;
+
+                    ulong tryWaste = (ulong)tryWidth * tryHeight - (ulong)tileCount * tileSize * tileSize;
+                    ulong currWaste = (ulong)_mlmask.AtlasWidth * _mlmask.AtlasHeight - (ulong)tileCount * tileSize * tileSize;
+
+                    // Accept if it makes height >= width or waste increase is small
+                    if ((tryHeight >= tryWidth || tryWaste <= currWaste * 1.5) && tryWidth <= 16384)
+                    {
+                        _mlmask.AtlasWidth = tryWidth;
+                        _mlmask.AtlasHeight = tryHeight;
+                    }
+                }
+            }
+
+            _logger.Debug($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
         }
 
         private void InitializeMaskLayers()
         {
-            if (_mlmask.Layers is null)
-            {
-                return;
-            }
+            if (_mlmask.Layers == null) return;
 
             for (uint i = 0; i < _mlmask.Layers.Length; i++)
             {
@@ -237,25 +466,23 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         {
                             tile.RangeMin = 255;
                             tile.RangeMax = 255;
-                            Array.Fill<byte>(tile.AtlasUnCompressed, 255);
+                            Array.Fill(tile.AtlasUnCompressed, (byte)255);
                         }
                         else
                         {
                             tile.RangeMin = 255;
                             tile.RangeMax = 0;
-
                             for (uint yy = 0; yy < _mlmask.AtlasTileSize; yy++)
                             {
                                 for (uint xx = 0; xx < _mlmask.AtlasTileSize; xx++)
                                 {
-                                    var v = GetPixelFromLayer(i, x, y, Convert.ToInt32(xx) - 1, Convert.ToInt32(yy) - 1);
+                                    var v = GetPixelFromLayer(i, x, y, (int)xx - 1, (int)yy - 1);
                                     tile.AtlasUnCompressed[xx + (yy * _mlmask.AtlasTileSize)] = v;
                                     tile.RangeMin = Math.Min(tile.RangeMin, v);
                                     tile.RangeMax = Math.Max(tile.RangeMax, v);
                                 }
                             }
                         }
-
                         _mlmask.Layers[i].Tiles.Add(tile);
                     }
                 }
@@ -264,133 +491,47 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
         private byte GetPixelFromLayer(uint layerIdx, uint tx, uint ty, int x, int y)
         {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
+            if (layerIdx == 0) return 255;
 
-            if (layerIdx == 0)
-            {
-                return 255;
-            }
-
-            var xx = Convert.ToInt32(tx * _mlmask.TileSize) + x;
-            var yy = Convert.ToInt32(ty * _mlmask.TileSize) + y;
-            xx = Math.Clamp(xx, 0, Convert.ToInt32(_mlmask.Layers[layerIdx].Width - 1));
-            yy = Math.Clamp(yy, 0, Convert.ToInt32(_mlmask.Layers[layerIdx].Height - 1));
-            return _mlmask.Layers[layerIdx].Pixels[xx + (yy * Convert.ToInt32(_mlmask.Layers[layerIdx].Width))];
-        }
-
-        private void Create()
-        {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
-
-            _mlmask.WidthHigh = 0;
-            _mlmask.HeightHigh = 0;
-            _mlmask.WidthLow = uint.MaxValue;
-            _mlmask.HeightLow = uint.MaxValue;
-            foreach (var lay in _mlmask.Layers)
-            {
-                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
-                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
-
-                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
-                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
-            }
-
-            for (var i = 0; i < _mlmask.Layers.Length; i++)
-            {
-                // usage of Log2 to avoid loss of fraction
-                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
-                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
-            }
-
-            uint tempAtlasTileSize = 16;
-            while (true)
-            {
-                _mlmask.AtlasTileSize = tempAtlasTileSize;
-                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
-
-                tempAtlasTileSize += 16;
-
-                _mlmask.MaskTilesHigh = null;
-                _mlmask.MaskTilesLow = null;
-                _mlmask.AtlasTiles.Clear();
-                _mlmask.AtlasWidth = 0;
-                _mlmask.AtlasHeight = 0;
-                _mlmask.AtlasTilesCount = 0;
-
-                InitializeMaskLayers();
-
-                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-
-                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
-                for (uint i = 0; i < _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh; i++)
-                {
-                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
-                }
-
-                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
-                for (uint i = 0; i < _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow; i++)
-                {
-                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
-                }
-                CleanTileLayers();
-
-                if (_mlmask.AtlasTiles.Count <= 0x20000)
-                {
-                    break;
-                }
-            }
-
-            CalculateAtlasProportionForPacking();
-            CreateAtlasBuffer();
-
-            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
-            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
-            var tilesDataList = new List<uint>();
-
-            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
-            {
-                tilesDataList.Add(0U);
-            }
-
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
-
-            var ms = new MemoryStream();
-            var bw = new BinaryWriter(ms);
-            foreach (var l in tilesDataList)
-            {
-                bw.Write(l);
-            }
-            _mlmask.TilesBuffer = ms.ToArray();
+            var xx = (int)(tx * _mlmask.TileSize) + x;
+            var yy = (int)(ty * _mlmask.TileSize) + y;
+            xx = Math.Clamp(xx, 0, (int)_mlmask.Layers![layerIdx].Width - 1);
+            yy = Math.Clamp(yy, 0, (int)_mlmask.Layers[layerIdx].Height - 1);
+            return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
         }
 
         private void CleanTileLayers()
         {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
-            ArgumentNullException.ThrowIfNull(_mlmask.MaskTilesHigh, nameof(_mlmask.MaskTilesHigh));
-            ArgumentNullException.ThrowIfNull(_mlmask.MaskTilesLow, nameof(_mlmask.MaskTilesLow));
+            if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
 
             for (uint I = 0; I < _mlmask.Layers.Length; I++)
             {
-
                 if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
                 {
+                    // Low-res layer
                     for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
                     {
                         for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
                         {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
 
-                            if (_mlmask.Layers[I].Tiles[Convert.ToInt32(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            if (wTiles0 == 0 || hTiles0 == 0) continue;
+
+                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
+                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+
+                            var tx = Math.Min(txRaw, wTiles0 - 1);
+                            var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                            var tileIdxCheck = tx + (ty * wTiles0);
+                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
                             {
                                 var layer = new TileView
                                 {
                                     LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    LayerTileIndex = tx + (ty * wTiles0),
                                     AtlasInPosition = PackTileInAtlas(I, tx, ty)
                                 };
                                 _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
@@ -400,19 +541,30 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 }
                 else
                 {
+                    // High-res layer
                     for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
                     {
                         for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
                         {
-                            var tx = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
-                            var ty = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
 
-                            if (_mlmask.Layers[I].Tiles[Convert.ToInt32(tx + (ty * _mlmask.Layers[I].WidthInTiles0))].RangeMax > 0)
+                            if (wTiles0 == 0 || hTiles0 == 0) continue;
+
+                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
+                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+
+                            var tx = Math.Min(txRaw, wTiles0 - 1);
+                            var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                            var tileIdxCheck = tx + (ty * wTiles0);
+                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
                             {
                                 var layer = new TileView
                                 {
                                     LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * _mlmask.Layers[I].WidthInTiles0),
+                                    LayerTileIndex = tx + (ty * wTiles0),
                                     AtlasInPosition = PackTileInAtlas(I, tx, ty)
                                 };
                                 _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
@@ -425,11 +577,23 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
         private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
         {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
+            if (_mlmask.Layers == null || layerIdx >= _mlmask.Layers.Length) return 0;
 
-            var tileIndex = tx + (ty * _mlmask.Layers[layerIdx].WidthInTiles0);
+            var layer = _mlmask.Layers[layerIdx];
+            if (layer.Tiles == null || layer.WidthInTiles0 == 0 || layer.HeightInTiles0 == 0) return 0;
 
-            if (_mlmask.Layers[layerIdx].Tiles[Convert.ToInt32(tileIndex)].AtlasInPosition == uint.MaxValue)
+            // Extra safety clamp in case caller passed slightly out-of-range values
+            if (tx >= layer.WidthInTiles0) tx = layer.WidthInTiles0 - 1;
+            if (ty >= layer.HeightInTiles0) ty = layer.HeightInTiles0 - 1;
+
+            var tileIndex = tx + (ty * layer.WidthInTiles0);
+            if (tileIndex >= (uint)layer.Tiles.Count)
+            {
+                _logger?.Error($"PackTileInAtlas: calculated tileIndex {tileIndex} is out of range for layer {layerIdx} (Tiles.Count = {layer.Tiles.Count}, tx={tx}, ty={ty})");
+                return 0;
+            }
+
+            if (layer.Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
             {
                 BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
 
@@ -438,86 +602,37 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 {
                     for (uint x = 0; x < _mlmask.AtlasTileSize / 4; x++)
                     {
-                        var compressedBlock = _mlmask.Layers[layerIdx].Tiles[Convert.ToInt32(tileIndex)].AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
+                        var compressedBlock = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
                         var color32 = new float[16];
                         D3DX.D3DXDecodeBC4U(ref color32, compressedBlock);
                         var color8 = new byte[16];
-                        for (uint i = 0; i < 16; ++i)
-                        {
-                            color8[i] = Convert.ToByte(color32[i] * 255.0f);
-                        }
-
+                        for (uint i = 0; i < 16; i++) color8[i] = (byte)(color32[i] * 255.0f);
                         recursiveHash = FNV1A.HashReadOnlySpan(color8, recursiveHash);
                     }
                 }
 
                 if (!_mlmask.AtlasTiles.TryGetValue(recursiveHash, out var atlasView))
                 {
-
-                    var atlasTile = new TileView
+                    atlasView = new TileView
                     {
                         AtlasInPosition = _mlmask.AtlasTilesCount++,
                         LayerIndex = layerIdx,
                         LayerTileIndex = tileIndex
                     };
-
-                    atlasView = atlasTile;
-                    _mlmask.AtlasTiles.Add(recursiveHash, atlasTile);
+                    _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
                 }
 
-                var z = _mlmask.Layers[layerIdx].Tiles[Convert.ToInt32(tileIndex)];
+                var z = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex];
                 z.AtlasInPosition = atlasView.AtlasInPosition;
-                _mlmask.Layers[layerIdx].Tiles[Convert.ToInt32(tileIndex)] = z;
+                _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
             }
-
-            return _mlmask.Layers[layerIdx].Tiles[Convert.ToInt32(tileIndex)].AtlasInPosition;
-        }
-
-        private void CalculateAtlasProportionForPacking()
-        {
-            _mlmask.AtlasWidth = 0;
-            _mlmask.AtlasHeight = 0;
-
-            uint widthTry = 16384;
-            var emptyArea = uint.MaxValue;
-            while (widthTry >= _mlmask.AtlasTileSize)
-            {
-                var widthInTiles0 = widthTry / _mlmask.AtlasTileSize;
-                var heightTry = (_mlmask.AtlasTilesCount + widthInTiles0 - 1) / widthInTiles0 * _mlmask.AtlasTileSize;
-
-                var widthUp = RoundUpPowerOf2(widthTry);
-                var heightUp = RoundUpPowerOf2(heightTry);
-
-                var currEmptyArea = (widthUp * heightUp) - (_mlmask.AtlasTilesCount * _mlmask.AtlasTileSize * _mlmask.AtlasTileSize);
-                if (currEmptyArea <= emptyArea)
-                {
-                    _mlmask.AtlasWidth = widthTry;
-                    _mlmask.AtlasHeight = heightTry;
-                    emptyArea = currEmptyArea;
-                }
-
-                if (widthTry <= heightTry)
-                {
-                    break;
-                }
-
-                widthTry /= 2;
-            }
-
-            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
-            {
-                throw new Exception("Whoa Whoa, Way too many layers or way large mask dimensions which exceeded the max 16k DDS resolution limit for the atlas");
-            }
+            return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
         }
 
         private void CreateAtlasBuffer()
         {
-            ArgumentNullException.ThrowIfNull(_mlmask.Layers, nameof(_mlmask.Layers));
-
-            if (_mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
-            {
+            if (_mlmask.Layers == null || _mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
                 throw new Exception("Unable to generate MLmask atlas data");
-            }
 
             var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
             var widthInBlocks0 = _mlmask.AtlasWidth / 4;
@@ -529,7 +644,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             foreach (var atlasTile in _mlmask.AtlasTiles.Values)
             {
                 var sourceLayer = _mlmask.Layers[atlasTile.LayerIndex];
-                var tileSource = sourceLayer.Tiles[Convert.ToInt32(atlasTile.LayerTileIndex)];
+                var tileSource = sourceLayer.Tiles[(int)atlasTile.LayerTileIndex];
 
                 var position = atlasTile.AtlasInPosition;
                 var tx = position % widthInTiles0;
@@ -537,30 +652,27 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 var bx = tx * tileSizeInBlocks0;
                 var by = ty * tileSizeInBlocks0;
 
-                var destinationIdx = bx + (@by * widthInBlocks0);
+                var destinationIdx = bx + (by * widthInBlocks0);
                 for (uint i = 0; i < tileSizeInBlocks0; i++)
                 {
                     Array.Copy(tileSource.AtlasBlockCompressed, i * tileSizeInBlocks0, data, destinationIdx, tileSizeInBlocks0);
                     destinationIdx += widthInBlocks0;
                 }
             }
-            var ms = new MemoryStream();
-            var bw = new BinaryWriter(ms);
-            foreach (var d in data)
-            {
-                bw.Write(d);
-            }
+
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+            foreach (var d in data) bw.Write(d);
             _mlmask.AtlasBuffer = ms.ToArray();
         }
 
         private void BlockCompressLocalTile(ref RawTexContainer layer, uint tileIdx)
         {
             var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
-
             var tx = tileIdx % layer.WidthInTiles0;
             var ty = tileIdx / layer.WidthInTiles0;
 
-            var layerTile = layer.Tiles[Convert.ToInt32(tileIdx)];
+            var layerTile = layer.Tiles[(int)tileIdx];
             layerTile.AtlasBlockCompressed = new ulong[tileSizeInBlocks0 * tileSizeInBlocks0];
 
             for (uint yBlock = 0; yBlock < tileSizeInBlocks0; yBlock++)
@@ -576,82 +688,91 @@ namespace WolvenKit.Modkit.RED4.MLMask
                         {
                             var px = (xBlock * 4) + i;
                             var py = (yBlock * 4) + j;
-                            var v = Convert.ToSingle(layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)]) / 255.0f;
+                            var v = layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
                             toBBCValues[i + (j * 4)] = v;
                             referenceData.Add(v);
                         }
                     }
 
-                    if (tx > 0 && xBlock == 0)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
-                    }
-                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
-                    }
+                    if (tx > 0 && xBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
+                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
 
-                    if (ty > 0 && yBlock == 0)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
-                    }
-                    else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
-                    }
-
-                    if (tx > 0 && xBlock == 0 && ty > 0 && yBlock == 0)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx - 1, ty - 1, tileSizeInBlocks0 - 1, tileSizeInBlocks0 - 1);
-                    }
-                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1 && ty > 0 && yBlock == 0)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx + 1, ty - 1, 0, tileSizeInBlocks0 - 1);
-                    }
-                    else if (tx > 0 && xBlock == 0 && ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx - 1, ty + 1, tileSizeInBlocks0 - 1, 0);
-                    }
-                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1 && ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1)
-                    {
-                        PushBlockReferenceData(ref referenceData, layer, tx + 1, ty + 1, 0, 0);
-                    }
+                    if (ty > 0 && yBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
+                    else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
 
                     ulong blockCompressed = 0;
                     D3DX.D3DXEncodeBC4U(ref blockCompressed, toBBCValues, referenceData);
-
                     layerTile.AtlasBlockCompressed[xBlock + (yBlock * tileSizeInBlocks0)] = blockCompressed;
                 }
             }
-
-            layer.Tiles[Convert.ToInt32(tileIdx)] = layerTile;
+            layer.Tiles[(int)tileIdx] = layerTile;
         }
 
         private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty, uint xBlock, uint yBlock)
         {
+            // Extra defensive bounds check for neighbor tiles
+            uint w = layer.WidthInTiles0;
+            uint h = layer.HeightInTiles0;
+            if (w == 0 || h == 0) return;
+
+            if (tx >= w || ty >= h) return; // neighbor is out of layer bounds — skip
+
+            uint neighborTileIndex = tx + (ty * w);
+            if (neighborTileIndex >= (uint)layer.Tiles.Count) return;
+
             for (uint j = 0; j < 4; j++)
             {
                 for (uint i = 0; i < 4; i++)
                 {
                     var px = (xBlock * 4) + i;
                     var py = (yBlock * 4) + j;
-                    var v = Convert.ToSingle(layer.Tiles[Convert.ToInt32(tx + (ty * layer.WidthInTiles0))].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)]) / 255.0f;
+                    var v = layer.Tiles[(int)neighborTileIndex].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
                     referenceData.Add(v);
                 }
             }
         }
-        //https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-        private static uint RoundUpPowerOf2(uint v)
+
+        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
         {
-            v--;
-            v |= v >> 1;
-            v |= v >> 2;
-            v |= v >> 4;
-            v |= v >> 8;
-            v |= v >> 16;
-            return ++v;
+            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
+            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
+
+            for (uint ty = 0; ty < heightInTiles0; ty++)
+            {
+                for (uint tx = 0; tx < widthInTiles0; tx++)
+                {
+                    var tileIdx = tx + (ty * widthInTiles0);
+                    var layersBeg = (uint)tilesDataList.Count;
+                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
+
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
+
+                    uint layersMask = 0;
+                    for (var i = 0; i < numLayers; i++)
+                    {
+                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
+                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
+                        var atlasX = position & widthInTilesGrayUp;
+                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
+                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
+                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
+
+                        uint puts = 0;
+                        puts |= atlasX;
+                        puts |= atlasY << 10;
+                        puts |= widthShift << 20;
+                        puts |= heightShift << 24;
+
+                        tilesDataList.Add(puts);
+                        layersMask |= 1u << (int)layerIdx;
+                    }
+                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
+                }
+            }
         }
-        #endregion
+
+        #endregion Core Methods
 
         #region Structs
 
@@ -691,7 +812,6 @@ namespace WolvenKit.Modkit.RED4.MLMask
         public class MlMaskContainer
         {
             public RawTexContainer[]? Layers;
-
             public MaskTile[]? MaskTilesHigh;
             public Dictionary<ulong, TileView> AtlasTiles = new();
             public MaskTile[]? MaskTilesLow;
@@ -711,344 +831,235 @@ namespace WolvenKit.Modkit.RED4.MLMask
             public uint WidthHigh;
             public uint AtlasTilesCount;
         }
-        #endregion
-    }
 
-    #region FNV1A
+        #endregion Structs
 
-    internal class FNV1A
-    {
-        public const ulong FnvHashInitial = 0xCBF29CE484222325;
-        public const ulong FnvHashPrime = 0x00000100000001B3;
-        public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
+        #region FNV1A
+
+        internal class FNV1A
         {
-            foreach (var b in source)
-            {
-                unchecked
-                {
-                    hash = (hash ^ b) * FnvHashPrime;
-                }
-            }
+            public const ulong FnvHashInitial = 0xCBF29CE484222325;
+            public const ulong FnvHashPrime = 0x00000100000001B3;
 
-            return hash;
+            public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
+            {
+                foreach (var b in source)
+                    unchecked { hash = (hash ^ b) * FnvHashPrime; }
+                return hash;
+            }
         }
-    }
-    #endregion
 
-    #region DirectXTex
+        #endregion FNV1A
 
-    internal class D3DX
-    {
-        [StructLayout(LayoutKind.Explicit, Size = 8)]
-        public struct BC4_UNORM
+        #region D3DX
+
+        internal class D3DX
         {
-            public float R(int offset)
+            [StructLayout(LayoutKind.Explicit, Size = 8)]
+            public struct BC4_UNORM
             {
-                var index = GetIndex(offset);
-                return DecodeFromIndex(index);
-            }
+                [FieldOffset(0)] public ulong Data;
+                [FieldOffset(0)] public byte Red_0;
+                [FieldOffset(1)] public byte Red_1;
+                [FieldOffset(2)] public byte Index0;
+                [FieldOffset(3)] public byte Index1;
+                [FieldOffset(4)] public byte Index2;
+                [FieldOffset(5)] public byte Index3;
+                [FieldOffset(6)] public byte Index4;
+                [FieldOffset(7)] public byte Index5;
 
-            public float DecodeFromIndex(uint index)
-            {
-                if (index == 0)
+                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
+
+                public void SetIndex(int uOffset, int uIndex)
                 {
-                    return Red_0 / 255.0f;
+                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
+                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
                 }
 
-                if (index == 1)
+                public float R(int offset)
                 {
-                    return Red_1 / 255.0f;
+                    var index = GetIndex(offset);
+                    return DecodeFromIndex(index);
                 }
 
-                var fred0 = Red_0 / 255.0f;
-                var fred1 = Red_1 / 255.0f;
-
-                if (Red_0 > Red_1)
+                public float DecodeFromIndex(uint index)
                 {
+                    if (index == 0) return Red_0 / 255.0f;
+                    if (index == 1) return Red_1 / 255.0f;
+
+                    var fred0 = Red_0 / 255.0f;
+                    var fred1 = Red_1 / 255.0f;
+
+                    if (Red_0 > Red_1)
+                    {
+                        index--;
+                        return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
+                    }
+
+                    if (index == 6) return 0.0f;
+                    if (index == 7) return 1.0f;
+
                     index--;
-                    return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
+                    return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
                 }
-
-                if (index == 6)
-                {
-                    return 0.0f;
-                }
-
-                if (index == 7)
-                {
-                    return 1.0f;
-                }
-
-                index--;
-                return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
             }
 
-            public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
-
-            public void SetIndex(int uOffset, int uIndex)
+            public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
             {
-                Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
-                Data |= (ulong)uIndex << ((3 * uOffset) + 16);
+                var pBC4 = new BC4_UNORM();
+                FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
+                FindClosestUNORM(ref pBC4, refData);
+                resultantBlock = pBC4.Data;
             }
 
-            [FieldOffset(0)] public ulong Data;
-
-            [FieldOffset(0)] public byte Red_0;
-            [FieldOffset(1)] public byte Red_1;
-
-            [FieldOffset(2)] public byte Index0;
-            [FieldOffset(3)] public byte Index1;
-            [FieldOffset(4)] public byte Index2;
-            [FieldOffset(5)] public byte Index3;
-            [FieldOffset(6)] public byte Index4;
-            [FieldOffset(7)] public byte Index5;
-        }
-        public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
-        {
-            var pBC4 = new BC4_UNORM();
-
-            FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
-            FindClosestUNORM(ref pBC4, refData);
-            resultantBlock = pBC4.Data;
-        }
-
-        private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
-        {
-            // The boundary of codec for signed/unsigned format
-            const float MIN_NORM = 0f;
-            const float MAX_NORM = 1f;
-
-            // Find max/min of input texels
-            var fBlockMax = theTexelsU[0];
-            var fBlockMin = theTexelsU[0];
-            for (var i = 0; i < numTexels; ++i)
+            private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
             {
-                if (theTexelsU[i] < fBlockMin)
+                var fBlockMax = theTexelsU[0];
+                var fBlockMin = theTexelsU[0];
+                for (var i = 0; i < numTexels; ++i)
                 {
-                    fBlockMin = theTexelsU[i];
+                    if (theTexelsU[i] < fBlockMin) fBlockMin = theTexelsU[i];
+                    else if (theTexelsU[i] > fBlockMax) fBlockMax = theTexelsU[i];
                 }
-                else if (theTexelsU[i] > fBlockMax)
+
+                var bUsing4BlockCodec = fBlockMin == 0f || fBlockMax == 1f;
+                float fStart = 0, fEnd = 0;
+
+                if (!bUsing4BlockCodec)
                 {
-                    fBlockMax = theTexelsU[i];
+                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
+                    endpointU_0 = (byte)(fEnd * 255.0f);
+                    endpointU_1 = (byte)(fStart * 255.0f);
+                }
+                else
+                {
+                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
+                    endpointU_1 = (byte)(fEnd * 255.0f);
+                    endpointU_0 = (byte)(fStart * 255.0f);
                 }
             }
 
-            //  If there are boundary values in input texels, should use 4 interpolated color values to guarantee
-            //  the exact code of the boundary values.
-            var bUsing4BlockCodec = MIN_NORM == fBlockMin || MAX_NORM == fBlockMax;
-
-            // Using Optimize
-            float fStart = 0, fEnd = 0;
-
-            if (!bUsing4BlockCodec)
+            private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
             {
-                // 6 interpolated color values
-                OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
+                float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
+                float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
+                float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
+                float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
 
-                var iStart = Convert.ToByte(fStart * 255.0f);
-                var iEnd = Convert.ToByte(fEnd * 255.0f);
+                var pC = (cSteps == 6) ? pC6 : pC8;
+                var pD = (cSteps == 6) ? pD6 : pD8;
 
-                endpointU_0 = iEnd;
-                endpointU_1 = iStart;
+                float fX = 1.0f;
+                float fY = 0.0f;
+
+                if (cSteps == 8)
+                {
+                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        if (pPoints[iPoint] < fX) fX = pPoints[iPoint];
+                        if (pPoints[iPoint] > fY) fY = pPoints[iPoint];
+                    }
+                }
+                else
+                {
+                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        if (pPoints[iPoint] < fX && pPoints[iPoint] > 0.0f) fX = pPoints[iPoint];
+                        if (pPoints[iPoint] > fY && pPoints[iPoint] < 1.0f) fY = pPoints[iPoint];
+                    }
+                    if (fX == fY) fY = 1.0f;
+                }
+
+                var fSteps = Convert.ToSingle(cSteps - 1);
+
+                for (var iIteration = 0; iIteration < 8; iIteration++)
+                {
+                    if (fY - fX < 1.0f / 256.0f) break;
+
+                    var fScale = fSteps / (fY - fX);
+                    var pSteps = new float[8];
+
+                    for (var iStep = 0; iStep < cSteps; iStep++)
+                        pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
+
+                    if (cSteps == 6)
+                    {
+                        pSteps[6] = 0.0f;
+                        pSteps[7] = 1.0f;
+                    }
+
+                    var dX = 0.0f;
+                    var dY = 0.0f;
+                    var d2X = 0.0f;
+                    var d2Y = 0.0f;
+
+                    for (uint iPoint = 0; iPoint < numTexels; iPoint++)
+                    {
+                        var fDot = (pPoints[(int)iPoint] - fX) * fScale;
+                        uint iStep;
+
+                        if (fDot <= 0.0f)
+                            iStep = (cSteps == 6 && pPoints[(int)iPoint] <= fX * 0.5f) ? 6u : 0u;
+                        else if (fDot >= fSteps)
+                            iStep = (cSteps == 6 && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f) ? 7u : cSteps - 1;
+                        else
+                            iStep = (uint)(fDot + 0.5f);
+
+                        if (iStep < cSteps)
+                        {
+                            var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
+                            dX += pC[iStep] * fDiff;
+                            d2X += pC[iStep] * pC[iStep];
+                            dY += pD[iStep] * fDiff;
+                            d2Y += pD[iStep] * pD[iStep];
+                        }
+                    }
+
+                    if (d2X > 0.0f) fX -= dX / d2X;
+                    if (d2Y > 0.0f) fY -= dY / d2Y;
+
+                    if (fX > fY) (fY, fX) = (fX, fY);
+
+                    if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f) break;
+                }
+
+                pX = Math.Clamp(fX, 0.0f, 1.0f);
+                pY = Math.Clamp(fY, 0.0f, 1.0f);
             }
-            else
+
+            private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
             {
-                // 4 interpolated color values
-                OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
+                const uint numPixelsPerBlock = 16;
+                var rGradient = new float[8];
+                for (uint i = 0; i < 8; ++i)
+                    rGradient[i] = pBC.DecodeFromIndex(i);
 
-                var iStart = Convert.ToByte(fStart * 255.0f);
-                var iEnd = Convert.ToByte(fEnd * 255.0f);
-
-                endpointU_1 = iEnd;
-                endpointU_0 = iStart;
+                for (uint i = 0; i < numPixelsPerBlock; ++i)
+                {
+                    uint uBestIndex = 0;
+                    float fBestDelta = 100000;
+                    for (uint uIndex = 0; uIndex < 8; uIndex++)
+                    {
+                        var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
+                        if (fCurrentDelta < fBestDelta)
+                        {
+                            uBestIndex = uIndex;
+                            fBestDelta = fCurrentDelta;
+                        }
+                    }
+                    pBC.SetIndex((int)i, (int)uBestIndex);
+                }
             }
-        }
 
-        private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
-        {
-
-            float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
-            float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
-            float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
-            float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
-
-            var pC = 6 == cSteps ? pC6 : pC8;
-            var pD = 6 == cSteps ? pD6 : pD8;
-
-            const float maxValue = 1.0f;
-            const float minValue = 0.0f;
-
-            // Find Min and Max points, as starting point
-            var fX = maxValue;
-            var fY = minValue;
-
-            if (8 == cSteps)
+            public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
             {
-                for (var iPoint = 0; iPoint < numTexels; iPoint++)
-                {
-                    if (pPoints[iPoint] < fX)
-                    {
-                        fX = pPoints[iPoint];
-                    }
-
-                    if (pPoints[iPoint] > fY)
-                    {
-                        fY = pPoints[iPoint];
-                    }
-                }
+                const uint numPixelsPerBlock = 16;
+                var pBC4 = new BC4_UNORM { Data = pBC };
+                for (var i = 0; i < numPixelsPerBlock; ++i)
+                    pColor[i] = pBC4.R(i);
             }
-
-            else
-            {
-                for (var iPoint = 0; iPoint < numTexels; iPoint++)
-                {
-                    if (pPoints[iPoint] < fX && pPoints[iPoint] > minValue)
-                    {
-                        fX = pPoints[iPoint];
-                    }
-
-                    if (pPoints[iPoint] > fY && pPoints[iPoint] < maxValue)
-                    {
-                        fY = pPoints[iPoint];
-                    }
-                }
-
-                if (fX == fY)
-                {
-                    fY = maxValue;
-                }
-            }
-
-            // Use Newton's Method to find local minima of sum-of-squares error.
-            var fSteps = Convert.ToSingle(cSteps - 1);
-
-            for (var iIteration = 0; iIteration < 8; iIteration++)
-            {
-                if (fY - fX < 1.0f / 256.0f)
-                {
-                    break;
-                }
-
-                var fScale = fSteps / (fY - fX);
-
-                // Calculate new steps
-                var pSteps = new float[8];
-
-                for (var iStep = 0; iStep < cSteps; iStep++)
-                {
-                    pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
-                }
-
-                if (6 == cSteps)
-                {
-                    pSteps[6] = minValue;
-                    pSteps[7] = maxValue;
-                }
-
-                // Evaluate function, and derivatives
-                var dX = 0.0f;
-                var dY = 0.0f;
-                var d2X = 0.0f;
-                var d2Y = 0.0f;
-
-                for (uint iPoint = 0; iPoint < numTexels; iPoint++)
-                {
-                    var fDot = (pPoints[(int)iPoint] - fX) * fScale;
-
-                    uint iStep;
-
-                    if (fDot <= 0.0f)
-                    {
-                        // D3DX10 / D3DX11 didn't take into account the proper minimum value for the bRange (BC4S/BC5S) case
-                        iStep = 6 == cSteps && pPoints[(int)iPoint] <= fX * 0.5f ? (uint)6 : 0;
-                    }
-                    else if (fDot >= fSteps)
-                    {
-                        iStep = 6 == cSteps && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f ? 7 : cSteps - 1;
-                    }
-                    else
-                    {
-                        iStep = (uint)(fDot + 0.5f);
-                    }
-
-                    if (iStep < cSteps)
-                    {
-                        // D3DX had this computation backwards (pPoints[iPoint] - pSteps[iStep])
-                        // this fix improves RMS of the alpha component
-                        var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
-
-                        dX += pC[iStep] * fDiff;
-                        d2X += pC[iStep] * pC[iStep];
-
-                        dY += pD[iStep] * fDiff;
-                        d2Y += pD[iStep] * pD[iStep];
-                    }
-                }
-
-                // Move endpoints
-                if (d2X > 0.0f)
-                {
-                    fX -= dX / d2X;
-                }
-
-                if (d2Y > 0.0f)
-                {
-                    fY -= dY / d2Y;
-                }
-
-                if (fX > fY)
-                {
-                    (fY, fX) = (fX, fY);
-                }
-
-                if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f)
-                {
-                    break;
-                }
-            }
-
-            pX = fX < minValue ? minValue : fX > maxValue ? maxValue : fX;
-            pY = fY < minValue ? minValue : fY > maxValue ? maxValue : fY;
         }
 
-        private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
-        {
-            const uint numPixelsPerBlock = 16;
-            var rGradient = new float[8];
-            for (uint i = 0; i < 8; ++i)
-            {
-                rGradient[i] = pBC.DecodeFromIndex(i);
-            }
-
-            for (uint i = 0; i < numPixelsPerBlock; ++i)
-            {
-                uint uBestIndex = 0;
-                float fBestDelta = 100000;
-                for (uint uIndex = 0; uIndex < 8; uIndex++)
-                {
-                    var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
-                    if (fCurrentDelta < fBestDelta)
-                    {
-                        uBestIndex = uIndex;
-                        fBestDelta = fCurrentDelta;
-                    }
-                }
-                pBC.SetIndex((int)i, (int)uBestIndex);
-            }
-        }
-        public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
-        {
-
-            const uint numPixelsPerBlock = 16;
-            var pBC4 = new BC4_UNORM
-            {
-                Data = pBC
-            };
-            for (var i = 0; i < numPixelsPerBlock; ++i)
-            {
-                pColor[i] = pBC4.R(i);
-            }
-        }
+        #endregion D3DX
     }
-    #endregion
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -13,6 +13,15 @@ using WolvenKit.RED4.Archive.IO;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
+/// <summary>
+/// Error code ranges used in multilayer mask import:
+/// 0x2000–0x20FF : Import / masklist parsing and image loading errors
+///   0x2001 = Invalid color space (must be R8/grayscale)
+///   0x2002 = Reserved (power-of-2 requirement)
+///   0x2004 = No layers found in masklist
+///   0x2005 = General image loading failure
+/// </summary>
+
 namespace WolvenKit.Modkit.RED4.MLMask
 {
     public class MLMASK
@@ -37,7 +46,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
             var lines = File.ReadAllLines(txtImageList.FullName);
             var baseDir = txtImageList.Directory.NotNull();
 
-            var filePaths = new List<string>();
+            var files = new List<string>();
 
             foreach (var line in lines)
             {
@@ -47,58 +56,36 @@ namespace WolvenKit.Modkit.RED4.MLMask
                     continue;
                 }
 
-                filePaths.Add(trimmed);
+                // Resolve to full path immediately (single pass)
+                files.Add(Path.Combine(baseDir.FullName, trimmed));
             }
 
-            if (filePaths.Count == 0)
-                throw new WolvenKitException(0x2002, "No layer files specified in masklist.");
-
-            var files = filePaths.Select(x => Path.Combine(baseDir.FullName, x)).ToList();
+            if (files.Count == 0)
+            {
+                // 0x2004 = No layers found in masklist (0x2002 is reserved for power-of-2 requirement errors)
+                throw new WolvenKitException(0x2004, "No layer files specified in masklist.");
+            }
 
             _mlmask = new MlMaskContainer();
 
             var textures = new List<RawTexContainer>();
 
-            // Add white base layer 0 (if the first layer does not end with _0)
-            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
-            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
-
-            if (needsLayer0)
-            {
-                uint whiteW = 1024u;
-                uint whiteH = 1024u;
-
-                if (files.Count > 0 && File.Exists(files[0]))
-                {
-                    try
-                    {
-                        using var probe = RedImage.LoadFromFile(files[0]);
-                        if (probe != null)
-                        {
-                            whiteW = (uint)probe.Metadata.Width;
-                            whiteH = (uint)probe.Metadata.Height;
-                        }
-                    }
-                    catch { }
-                }
-
-                var whitePixels = new byte[whiteW * whiteH];
-                Array.Fill(whitePixels, (byte)255);
-                textures.Add(new RawTexContainer { Width = whiteW, Height = whiteH, Pixels = whitePixels });
-            }
-
-            // Load all layers from files
+            // Load all real layers first
             foreach (var f in files)
             {
                 if (!File.Exists(f))
+                {
                     throw new FileNotFoundException($"File not found: {f}");
+                }
 
                 try
                 {
-                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2001, $"Could not load image: {f}");
+                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2005, $"Could not load image: {f}"); // 0x2005 = General image loading failure
 
                     if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
+                    {
                         image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
+                    }
 
                     uint imgW = (uint)image.Metadata.Width;
                     uint imgH = (uint)image.Metadata.Height;
@@ -112,23 +99,31 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 }
                 catch (WolvenKitException e)
                 {
+                    // 0x2001 = Invalid color space (must be R8 / grayscale)
                     throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale R8)");
                 }
+            }
+
+            // Determine the low-resolution size (minimum across all loaded layers)
+            uint targetLowW = textures.Count > 0 ? textures.Min(t => t.Width) : 1024u;
+            uint targetLowH = textures.Count > 0 ? textures.Min(t => t.Height) : 1024u;
+
+            // Add white base layer 0 at the low-resolution size if needed
+            // (so it's only as big as it needs to be for the low-res path)
+            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
+            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
+
+            if (needsLayer0)
+            {
+                var whitePixels = new byte[targetLowW * targetLowH];
+                Array.Fill(whitePixels, (byte)255);
+                textures.Insert(0, new RawTexContainer { Width = targetLowW, Height = targetLowH, Pixels = whitePixels });
             }
 
             _mlmask.Layers = textures.ToArray();
 
             Create();
             Write(outFile);
-        }
-
-        internal static bool IsBlankLayer(byte[] pixels)
-        {
-            if (pixels == null || pixels.Length == 0) return true;
-            var first = pixels[0];
-            for (int i = 1; i < pixels.Length; i++)
-                if (pixels[i] != first) return false;
-            return true;
         }
 
         #region Core Methods
@@ -215,7 +210,7 @@ namespace WolvenKit.Modkit.RED4.MLMask
 
             if (hasThirdResolution)
             {
-                throw new WolvenKitException(0x2003, "More than 2 different resolutions detected in masklist. Only 2 resolution levels are supported.");
+                _logger.Info("MLMask import detected 3 or more different resolutions. Only 2 levels (High + Low) are fully supported. Results may be incorrect.");
             }
 
             _logger.Info($"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
@@ -325,25 +320,40 @@ namespace WolvenKit.Modkit.RED4.MLMask
                 double aspect = (double)h / w;
 
                 // Hard filter: reject extremely bad aspect ratios
-                if (aspect > 4.0 || aspect < 0.25) continue;
+                if (aspect > 4.0 || aspect < 0.25)
+                {
+                    continue;
+                }
 
                 // Prefer lower waste ratio. If ratios are close, prefer reasonable aspect ratio.
                 bool better = false;
-                if (wasteRatio < bestWasteRatio - 0.01) better = true;
+                if (wasteRatio < bestWasteRatio - 0.01)
+                {
+                    better = true;
+                }
                 else if (Math.Abs(wasteRatio - bestWasteRatio) <= 0.01)
                 {
                     // Prefer aspect ratios in good range [0.5 .. 2.5]
                     bool currGood = aspect >= 0.5 && aspect <= 2.5;
                     bool bestGood = (bestHeight >= 0.5 * bestWidth) && (bestHeight <= 2.5 * bestWidth);
 
-                    if (currGood && !bestGood) better = true;
+                    if (currGood && !bestGood)
+                    {
+                        better = true;
+                    }
                     else if (currGood == bestGood)
                     {
                         // Among good aspects, prefer closer to square
                         double currDist = Math.Abs(aspect - 1.0);
                         double bestDist = Math.Abs((double)bestHeight / bestWidth - 1.0);
-                        if (currDist < bestDist - 0.08) better = true;
-                        else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste) better = true;
+                        if (currDist < bestDist - 0.08)
+                        {
+                            better = true;
+                        }
+                        else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste)
+                        {
+                            better = true;
+                        }
                     }
                 }
 
@@ -369,7 +379,9 @@ namespace WolvenKit.Modkit.RED4.MLMask
             _mlmask.AtlasHeight = bestHeight;
 
             if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
+            {
                 throw new Exception("Atlas too large (over 16k)");
+            }
 
             // Ensure the number of tiles horizontally is a power of 2 (required by PutTiles bit-packing).
             uint tilesX = _mlmask.AtlasWidth / tileSize;

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -999,7 +999,9 @@ public class MLMASK
             {
                 atlasView = new TileView
                 {
-                    AtlasInPosition = _mlmask.AtlasTilesCount++, LayerIndex = layerIdx, LayerTileIndex = tileIndex
+                    AtlasInPosition = _mlmask.AtlasTilesCount++,
+                    LayerIndex = layerIdx,
+                    LayerTileIndex = tileIndex
                 };
                 _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
             }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using WolvenKit.Common;
 using WolvenKit.Common.DDS;
 using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
@@ -13,1063 +12,1242 @@ using WolvenKit.RED4.Archive.IO;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
-/// <summary>
-/// MLMask import error codes (registered in LogCodeHelper):
-///   0x2001 = Invalid color space (must be R8/grayscale)
-///   0x2006 = No layer files specified in .masklist
-///   0x2007 = Failed to load layer image
-/// </summary>
+namespace WolvenKit.Modkit.RED4.MLMask;
 
-namespace WolvenKit.Modkit.RED4.MLMask
+public class MLMASK
 {
-    public class MLMASK
+    private const uint s_headerLength = 148;
+    private readonly ILoggerService _logger;
+    private MlMaskContainer _mlmask;
+
+    public MLMASK(MlMaskContainer mlMask, ILoggerService logger)
     {
-        private const uint s_headerLength = 148;
-        private MlMaskContainer _mlmask;
-        private readonly ILoggerService _logger;
+        _mlmask = mlMask;
+        _logger = logger;
+    }
 
-        public MLMASK(MlMaskContainer mlMask, ILoggerService logger)
+    /// <summary>
+    ///     Imports a .masklist file into a .mlmask file.
+    ///     Supports both single-resolution and multi-resolution layer sets.
+    ///     The .masklist now contains only layer file paths (no header).
+    /// </summary>
+    public void Import(FileInfo txtImageList, FileInfo outFile)
+    {
+        var lines = File.ReadAllLines(txtImageList.FullName);
+        var baseDir = txtImageList.Directory.NotNull();
+
+        var files = new List<string>();
+
+        foreach (var line in lines)
         {
-            _mlmask = mlMask;
-            _logger = logger;
+            var trimmed = line.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
+            {
+                continue;
+            }
+
+            // Resolve to full path immediately (single pass)
+            files.Add(Path.Combine(baseDir.FullName, trimmed));
         }
 
-        /// <summary>
-        /// Imports a .masklist file into a .mlmask file.
-        /// Supports both single-resolution and multi-resolution layer sets.
-        /// The .masklist now contains only layer file paths (no header).
-        /// </summary>
-        public void Import(FileInfo txtImageList, FileInfo outFile)
+        if (files.Count == 0)
         {
-            var lines = File.ReadAllLines(txtImageList.FullName);
-            var baseDir = txtImageList.Directory.NotNull();
-
-            var files = new List<string>();
-
-            foreach (var line in lines)
-            {
-                var trimmed = line.Trim();
-                if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith("#"))
-                {
-                    continue;
-                }
-
-                // Resolve to full path immediately (single pass)
-                files.Add(Path.Combine(baseDir.FullName, trimmed));
-            }
-
-            if (files.Count == 0)
-            {
-                // 0x2006 = MLMask: No layer files specified in masklist
-                throw new WolvenKitException(0x2006, "No layer files specified in masklist.");
-            }
-
-            _mlmask = new MlMaskContainer();
-
-            var textures = new List<RawTexContainer>();
-
-            // Load all real layers first
-            foreach (var f in files)
-            {
-                if (!File.Exists(f))
-                {
-                    throw new FileNotFoundException($"File not found: {f}");
-                }
-
-                try
-                {
-                    using var image = RedImage.LoadFromFile(f) ?? throw new WolvenKitException(0x2007, $"Could not load image: {f}"); // 0x2007 = MLMask: General image loading failure
-
-                    if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
-                    {
-                        image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
-                    }
-
-                    uint imgW = (uint)image.Metadata.Width;
-                    uint imgH = (uint)image.Metadata.Height;
-
-                    using var ms = new MemoryStream(image.SaveToDDSMemory());
-                    using var br = new BinaryReader(ms);
-                    ms.Seek(s_headerLength, SeekOrigin.Begin);
-                    var pixels = br.ReadBytes((int)(imgW * imgH));
-
-                    textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
-                }
-                catch (WolvenKitException e)
-                {
-                    // 0x2001 = Invalid color space (must be R8 / grayscale)
-                    throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale R8)");
-                }
-            }
-
-            // Determine the low-resolution size (minimum across all loaded layers)
-            uint targetLowW = textures.Count > 0 ? textures.Min(t => t.Width) : 1024u;
-            uint targetLowH = textures.Count > 0 ? textures.Min(t => t.Height) : 1024u;
-
-            // Add white base layer 0 at the low-resolution size if needed
-            // (so it's only as big as it needs to be for the low-res path)
-            var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
-            var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
-
-            if (needsLayer0)
-            {
-                var whitePixels = new byte[targetLowW * targetLowH];
-                Array.Fill(whitePixels, (byte)255);
-                textures.Insert(0, new RawTexContainer { Width = targetLowW, Height = targetLowH, Pixels = whitePixels });
-            }
-
-            _mlmask.Layers = textures.ToArray();
-
-            Create();
-            Write(outFile);
+            // 0x2006 = MLMask: No layer files specified in masklist
+            throw new WolvenKitException(0x2006, "No layer files specified in masklist.");
         }
 
-        #region Core Methods
+        _mlmask = new MlMaskContainer();
 
-        private void Write(FileInfo f)
+        var textures = new List<RawTexContainer>();
+
+        // Load all real layers first
+        foreach (var f in files)
         {
-            var cr2w = new CR2WFile();
-            var mask = new Multilayer_Mask { CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC };
-            cr2w.RootChunk = mask;
-
-            var blob = new rendRenderMultilayerMaskBlobPC
+            if (!File.Exists(f))
             {
-                Header = new rendRenderMultilayerMaskBlobHeader
+                throw new FileNotFoundException($"File not found: {f}");
+            }
+
+            try
+            {
+                using var image = RedImage.LoadFromFile(f) ??
+                                  throw new WolvenKitException(0x2007,
+                                      $"Could not load image: {f}"); // 0x2007 = MLMask: General image loading failure
+
+                if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
                 {
-                    Version = 3,
-                    AtlasWidth = _mlmask.AtlasWidth,
-                    AtlasHeight = _mlmask.AtlasHeight,
-                    NumLayers = (uint)_mlmask.Layers!.Length,
-                    MaskWidth = _mlmask.WidthHigh,
-                    MaskHeight = _mlmask.HeightHigh,
-                    MaskWidthLow = _mlmask.WidthLow,
-                    MaskHeightLow = _mlmask.HeightLow,
-                    MaskTileSize = _mlmask.TileSize,
-                    Flags = 2
-                },
-                AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer!),
-                TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer!)
+                    image.Convert(DXGI_FORMAT.DXGI_FORMAT_R8_UNORM);
+                }
+
+                var imgW = (uint)image.Metadata.Width;
+                var imgH = (uint)image.Metadata.Height;
+
+                using var ms = new MemoryStream(image.SaveToDDSMemory());
+                using var br = new BinaryReader(ms);
+                ms.Seek(s_headerLength, SeekOrigin.Begin);
+                var pixels = br.ReadBytes((int)(imgW * imgH));
+
+                textures.Add(new RawTexContainer { Width = imgW, Height = imgH, Pixels = pixels });
+            }
+            catch (WolvenKitException e)
+            {
+                // 0x2001 = Invalid color space (must be R8 / grayscale)
+                throw new WolvenKitException(0x2001, $"{e.Message} (must be grayscale R8)");
+            }
+        }
+
+        // Determine the low-resolution size (minimum across all loaded layers)
+        var targetLowW = textures.Count > 0 ? textures.Min(t => t.Width) : 1024u;
+        var targetLowH = textures.Count > 0 ? textures.Min(t => t.Height) : 1024u;
+
+        // Add white base layer 0 at the low-resolution size if needed
+        // (so it's only as big as it needs to be for the low-res path)
+        var firstLayerName = Path.GetFileNameWithoutExtension(files[0]);
+        var needsLayer0 = !firstLayerName.EndsWith("_0") && !firstLayerName.Equals("0");
+
+        if (needsLayer0)
+        {
+            var whitePixels = new byte[targetLowW * targetLowH];
+            Array.Fill(whitePixels, (byte)255);
+            textures.Insert(0, new RawTexContainer { Width = targetLowW, Height = targetLowH, Pixels = whitePixels });
+        }
+
+        _mlmask.Layers = textures.ToArray();
+
+        Create();
+        Write(outFile);
+    }
+
+    #region FNV1A
+
+    internal class FNV1A
+    {
+        public const ulong FnvHashInitial = 0xCBF29CE484222325;
+        public const ulong FnvHashPrime = 0x00000100000001B3;
+
+        public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
+        {
+            foreach (var b in source)
+            {
+                unchecked
+                {
+                    hash = (hash ^ b) * FnvHashPrime;
+                }
+            }
+
+            return hash;
+        }
+    }
+
+    #endregion FNV1A
+
+    #region D3DX
+
+    internal class D3DX
+    {
+        public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
+        {
+            var pBC4 = new BC4_UNORM();
+            FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
+            FindClosestUNORM(ref pBC4, refData);
+            resultantBlock = pBC4.Data;
+        }
+
+        private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0,
+            ref byte endpointU_1)
+        {
+            var fBlockMax = theTexelsU[0];
+            var fBlockMin = theTexelsU[0];
+            for (var i = 0; i < numTexels; ++i)
+            {
+                if (theTexelsU[i] < fBlockMin)
+                {
+                    fBlockMin = theTexelsU[i];
+                }
+                else if (theTexelsU[i] > fBlockMax)
+                {
+                    fBlockMax = theTexelsU[i];
+                }
+            }
+
+            var bUsing4BlockCodec = fBlockMin == 0f || fBlockMax == 1f;
+            float fStart = 0, fEnd = 0;
+
+            if (!bUsing4BlockCodec)
+            {
+                OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
+                endpointU_0 = (byte)(fEnd * 255.0f);
+                endpointU_1 = (byte)(fStart * 255.0f);
+            }
+            else
+            {
+                OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
+                endpointU_1 = (byte)(fEnd * 255.0f);
+                endpointU_0 = (byte)(fStart * 255.0f);
+            }
+        }
+
+        private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
+        {
+            float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
+            float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
+            float[] pC8 =
+            {
+                7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f,
+                0.0f / 7.0f
+            };
+            float[] pD8 =
+            {
+                0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f,
+                7.0f / 7.0f
             };
 
-            mask.RenderResourceBlob.RenderResourceBlobPC = blob;
+            var pC = cSteps == 6 ? pC6 : pC8;
+            var pD = cSteps == 6 ? pD6 : pD8;
 
-            var dir = f.Directory ?? throw new InvalidOperationException("File directory is null");
-            if (!Directory.Exists(dir.FullName)) Directory.CreateDirectory(dir.FullName);
+            var fX = 1.0f;
+            var fY = 0.0f;
 
-            using var fs = new FileStream(f.FullName, FileMode.Create, FileAccess.Write);
-            using var writer = new CR2WWriter(fs) { LoggerService = _logger };
-            writer.WriteFile(cr2w);
-        }
-
-        private void Create()
-        {
-            if (_mlmask.Layers == null || _mlmask.Layers.Length == 0) return;
-
-            // High resolution
-            _mlmask.WidthHigh = 0;
-            _mlmask.HeightHigh = 0;
-            foreach (var lay in _mlmask.Layers)
+            if (cSteps == 8)
             {
-                _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
-                _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
-            }
-
-            // Low resolution
-            _mlmask.WidthLow = _mlmask.WidthHigh;
-            _mlmask.HeightLow = _mlmask.HeightHigh;
-
-            bool hasDifferentResolutions = false;
-            foreach (var lay in _mlmask.Layers)
-            {
-                if (lay.Width < _mlmask.WidthHigh || lay.Height < _mlmask.HeightHigh)
+                for (var iPoint = 0; iPoint < numTexels; iPoint++)
                 {
-                    hasDifferentResolutions = true;
-                    _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
-                    _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
+                    if (pPoints[iPoint] < fX)
+                    {
+                        fX = pPoints[iPoint];
+                    }
+
+                    if (pPoints[iPoint] > fY)
+                    {
+                        fY = pPoints[iPoint];
+                    }
+                }
+            }
+            else
+            {
+                for (var iPoint = 0; iPoint < numTexels; iPoint++)
+                {
+                    if (pPoints[iPoint] < fX && pPoints[iPoint] > 0.0f)
+                    {
+                        fX = pPoints[iPoint];
+                    }
+
+                    if (pPoints[iPoint] > fY && pPoints[iPoint] < 1.0f)
+                    {
+                        fY = pPoints[iPoint];
+                    }
+                }
+
+                if (fX == fY)
+                {
+                    fY = 1.0f;
                 }
             }
 
-            if (!hasDifferentResolutions)
-            {
-                _mlmask.WidthLow = _mlmask.WidthHigh;
-                _mlmask.HeightLow = _mlmask.HeightHigh;
-            }
+            var fSteps = Convert.ToSingle(cSteps - 1);
 
-            // Protection against 3+ different resolutions (only 2 levels supported: High + Low)
-            bool hasThirdResolution = false;
-            foreach (var lay in _mlmask.Layers)
+            for (var iIteration = 0; iIteration < 8; iIteration++)
             {
-                if (lay.Width != _mlmask.WidthHigh && lay.Width != _mlmask.WidthLow)
+                if (fY - fX < 1.0f / 256.0f)
                 {
-                    hasThirdResolution = true;
+                    break;
+                }
+
+                var fScale = fSteps / (fY - fX);
+                var pSteps = new float[8];
+
+                for (var iStep = 0; iStep < cSteps; iStep++)
+                {
+                    pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
+                }
+
+                if (cSteps == 6)
+                {
+                    pSteps[6] = 0.0f;
+                    pSteps[7] = 1.0f;
+                }
+
+                var dX = 0.0f;
+                var dY = 0.0f;
+                var d2X = 0.0f;
+                var d2Y = 0.0f;
+
+                for (uint iPoint = 0; iPoint < numTexels; iPoint++)
+                {
+                    var fDot = (pPoints[(int)iPoint] - fX) * fScale;
+                    uint iStep;
+
+                    if (fDot <= 0.0f)
+                    {
+                        iStep = cSteps == 6 && pPoints[(int)iPoint] <= fX * 0.5f ? 6u : 0u;
+                    }
+                    else if (fDot >= fSteps)
+                    {
+                        iStep = cSteps == 6 && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f ? 7u : cSteps - 1;
+                    }
+                    else
+                    {
+                        iStep = (uint)(fDot + 0.5f);
+                    }
+
+                    if (iStep < cSteps)
+                    {
+                        var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
+                        dX += pC[iStep] * fDiff;
+                        d2X += pC[iStep] * pC[iStep];
+                        dY += pD[iStep] * fDiff;
+                        d2Y += pD[iStep] * pD[iStep];
+                    }
+                }
+
+                if (d2X > 0.0f)
+                {
+                    fX -= dX / d2X;
+                }
+
+                if (d2Y > 0.0f)
+                {
+                    fY -= dY / d2Y;
+                }
+
+                if (fX > fY)
+                {
+                    (fY, fX) = (fX, fY);
+                }
+
+                if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f)
+                {
                     break;
                 }
             }
 
-            if (hasThirdResolution)
-            {
-                _logger.Info("MLMask import detected 3 or more different resolutions. Only 2 levels (High + Low) are fully supported. Results may be incorrect.");
-            }
-
-            _logger.Info($"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
-
-            for (int i = 0; i < _mlmask.Layers.Length; i++)
-            {
-                _logger.Debug($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
-            }
-
-            // Shifts
-            for (var i = 0; i < _mlmask.Layers.Length; i++)
-            {
-                _mlmask.Layers[i].WidthShift = (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
-                _mlmask.Layers[i].HeightShift = (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
-            }
-
-            // Fixed tile size for this project: maskTileSize = 14 → AtlasTileSize = 16.
-            // AtlasTileSize must be divisible by 4 (we split it into 4x4 BC4 blocks for compression).
-            // We start at 16 and increase by 4 if needed to keep divisibility.
-            uint tempAtlasTileSize = 16u;
-            while (true)
-            {
-                _mlmask.AtlasTileSize = tempAtlasTileSize;
-                _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
-
-                _mlmask.MaskTilesHigh = null;
-                _mlmask.MaskTilesLow = null;
-                _mlmask.AtlasTiles.Clear();
-                _mlmask.AtlasWidth = 0;
-                _mlmask.AtlasHeight = 0;
-                _mlmask.AtlasTilesCount = 0;
-
-                InitializeMaskLayers();
-
-                _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-
-                _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
-                for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
-                    _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
-
-                _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
-                for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
-                    _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
-
-                CleanTileLayers();
-
-                if (_mlmask.AtlasTiles.Count <= 0x20000) break;
-
-                tempAtlasTileSize += 4;   // keep the value divisible by 4
-            }
-
-            CalculateAtlasProportionForPacking();
-            CreateAtlasBuffer();
-
-            var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
-            var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
-            var tilesDataList = new List<uint>();
-
-            for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
-                tilesDataList.Add(0U);
-
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
-            PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow, _mlmask.HeightInTilesLow);
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            foreach (var l in tilesDataList) bw.Write(l);
-            _mlmask.TilesBuffer = ms.ToArray();
+            pX = Math.Clamp(fX, 0.0f, 1.0f);
+            pY = Math.Clamp(fY, 0.0f, 1.0f);
         }
 
-        private void CalculateAtlasProportionForPacking()
+        private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
         {
-            if (_mlmask.AtlasTilesCount == 0)
-                throw new Exception("No tiles to pack into atlas.");
-
-            uint tileSize = _mlmask.AtlasTileSize;
-            uint tileCount = _mlmask.AtlasTilesCount;
-
-            // The atlas size is independent of maskWidth/maskHeight.
-            // It only needs to hold all *unique* compressed tiles (after hash deduplication).
-            // Real game files often have atlas much smaller than mask resolution when content has repetition/empty areas.
-
-            uint bestWidth = 0;
-            uint bestHeight = 0;
-            ulong bestWaste = ulong.MaxValue;
-            double bestWasteRatio = double.MaxValue; // waste / usedArea
-
-            // Search over all reasonable power-of-2 widths (this is the constraint from PutTiles).
-            // Start from 4 tiles wide to avoid extremely narrow (1-tile) atlases.
-            for (uint wTilesPow2 = 4; wTilesPow2 <= 1024; wTilesPow2 <<= 1)
+            const uint numPixelsPerBlock = 16;
+            var rGradient = new float[8];
+            for (uint i = 0; i < 8; ++i)
             {
-                uint hTiles = (tileCount + wTilesPow2 - 1) / wTilesPow2;
-                uint w = wTilesPow2 * tileSize;
-                uint h = hTiles * tileSize;
+                rGradient[i] = pBC.DecodeFromIndex(i);
+            }
 
-                if (w > 16384 || h > 16384) continue;
-
-                ulong area = (ulong)w * h;
-                ulong usedArea = (ulong)tileCount * tileSize * tileSize;
-                ulong waste = area - usedArea;
-                double wasteRatio = usedArea > 0 ? (double)waste / usedArea : 0;
-
-                // Calculate aspect ratio
-                double aspect = (double)h / w;
-
-                // Hard filter: reject extremely bad aspect ratios
-                if (aspect > 4.0 || aspect < 0.25)
+            for (uint i = 0; i < numPixelsPerBlock; ++i)
+            {
+                uint uBestIndex = 0;
+                float fBestDelta = 100000;
+                for (uint uIndex = 0; uIndex < 8; uIndex++)
                 {
-                    continue;
+                    var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
+                    if (fCurrentDelta < fBestDelta)
+                    {
+                        uBestIndex = uIndex;
+                        fBestDelta = fCurrentDelta;
+                    }
                 }
 
-                // Prefer lower waste ratio. If ratios are close, prefer reasonable aspect ratio.
-                bool better = false;
-                if (wasteRatio < bestWasteRatio - 0.01)
+                pBC.SetIndex((int)i, (int)uBestIndex);
+            }
+        }
+
+        public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
+        {
+            const uint numPixelsPerBlock = 16;
+            var pBC4 = new BC4_UNORM { Data = pBC };
+            for (var i = 0; i < numPixelsPerBlock; ++i)
+            {
+                pColor[i] = pBC4.R(i);
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 8)]
+        public struct BC4_UNORM
+        {
+            [FieldOffset(0)] public ulong Data;
+            [FieldOffset(0)] public byte Red_0;
+            [FieldOffset(1)] public byte Red_1;
+            [FieldOffset(2)] public byte Index0;
+            [FieldOffset(3)] public byte Index1;
+            [FieldOffset(4)] public byte Index2;
+            [FieldOffset(5)] public byte Index3;
+            [FieldOffset(6)] public byte Index4;
+            [FieldOffset(7)] public byte Index5;
+
+            public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
+
+            public void SetIndex(int uOffset, int uIndex)
+            {
+                Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
+                Data |= (ulong)uIndex << ((3 * uOffset) + 16);
+            }
+
+            public float R(int offset)
+            {
+                var index = GetIndex(offset);
+                return DecodeFromIndex(index);
+            }
+
+            public float DecodeFromIndex(uint index)
+            {
+                if (index == 0)
+                {
+                    return Red_0 / 255.0f;
+                }
+
+                if (index == 1)
+                {
+                    return Red_1 / 255.0f;
+                }
+
+                var fred0 = Red_0 / 255.0f;
+                var fred1 = Red_1 / 255.0f;
+
+                if (Red_0 > Red_1)
+                {
+                    index--;
+                    return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
+                }
+
+                if (index == 6)
+                {
+                    return 0.0f;
+                }
+
+                if (index == 7)
+                {
+                    return 1.0f;
+                }
+
+                index--;
+                return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
+            }
+        }
+    }
+
+    #endregion D3DX
+
+    #region Core Methods
+
+    private void Write(FileInfo f)
+    {
+        var cr2w = new CR2WFile();
+        var mask = new Multilayer_Mask { CookingPlatform = Enums.ECookingPlatform.PLATFORM_PC };
+        cr2w.RootChunk = mask;
+
+        var blob = new rendRenderMultilayerMaskBlobPC
+        {
+            Header = new rendRenderMultilayerMaskBlobHeader
+            {
+                Version = 3,
+                AtlasWidth = _mlmask.AtlasWidth,
+                AtlasHeight = _mlmask.AtlasHeight,
+                NumLayers = (uint)_mlmask.Layers!.Length,
+                MaskWidth = _mlmask.WidthHigh,
+                MaskHeight = _mlmask.HeightHigh,
+                MaskWidthLow = _mlmask.WidthLow,
+                MaskHeightLow = _mlmask.HeightLow,
+                MaskTileSize = _mlmask.TileSize,
+                Flags = 2
+            },
+            AtlasData = new SerializationDeferredDataBuffer(_mlmask.AtlasBuffer!),
+            TilesData = new SerializationDeferredDataBuffer(_mlmask.TilesBuffer!)
+        };
+
+        mask.RenderResourceBlob.RenderResourceBlobPC = blob;
+
+        var dir = f.Directory ?? throw new InvalidOperationException("File directory is null");
+        if (!Directory.Exists(dir.FullName))
+        {
+            Directory.CreateDirectory(dir.FullName);
+        }
+
+        using var fs = new FileStream(f.FullName, FileMode.Create, FileAccess.Write);
+        using var writer = new CR2WWriter(fs) { LoggerService = _logger };
+        writer.WriteFile(cr2w);
+    }
+
+    private void Create()
+    {
+        if (_mlmask.Layers == null || _mlmask.Layers.Length == 0)
+        {
+            return;
+        }
+
+        // High resolution
+        _mlmask.WidthHigh = 0;
+        _mlmask.HeightHigh = 0;
+        foreach (var lay in _mlmask.Layers)
+        {
+            _mlmask.WidthHigh = Math.Max(_mlmask.WidthHigh, lay.Width);
+            _mlmask.HeightHigh = Math.Max(_mlmask.HeightHigh, lay.Height);
+        }
+
+        // Low resolution
+        _mlmask.WidthLow = _mlmask.WidthHigh;
+        _mlmask.HeightLow = _mlmask.HeightHigh;
+
+        var hasDifferentResolutions = false;
+        foreach (var lay in _mlmask.Layers)
+        {
+            if (lay.Width < _mlmask.WidthHigh || lay.Height < _mlmask.HeightHigh)
+            {
+                hasDifferentResolutions = true;
+                _mlmask.WidthLow = Math.Min(_mlmask.WidthLow, lay.Width);
+                _mlmask.HeightLow = Math.Min(_mlmask.HeightLow, lay.Height);
+            }
+        }
+
+        if (!hasDifferentResolutions)
+        {
+            _mlmask.WidthLow = _mlmask.WidthHigh;
+            _mlmask.HeightLow = _mlmask.HeightHigh;
+        }
+
+        // Protection against 3+ different resolutions (only 2 levels supported: High + Low)
+        var hasThirdResolution = false;
+        foreach (var lay in _mlmask.Layers)
+        {
+            if (lay.Width != _mlmask.WidthHigh && lay.Width != _mlmask.WidthLow)
+            {
+                hasThirdResolution = true;
+                break;
+            }
+        }
+
+        if (hasThirdResolution)
+        {
+            _logger.Info(
+                "MLMask import detected 3 or more different resolutions. Only 2 levels (High + Low) are fully supported. Results may be incorrect.");
+        }
+
+        _logger.Info(
+            $"MLMask layers: High-res {_mlmask.WidthHigh}x{_mlmask.HeightHigh}, Low-res {_mlmask.WidthLow}x{_mlmask.HeightLow}, Layers: {_mlmask.Layers.Length}");
+
+        for (var i = 0; i < _mlmask.Layers.Length; i++)
+        {
+            _logger.Debug($"  Layer {i}: {_mlmask.Layers[i].Width}x{_mlmask.Layers[i].Height}");
+        }
+
+        // Shifts
+        for (var i = 0; i < _mlmask.Layers.Length; i++)
+        {
+            _mlmask.Layers[i].WidthShift =
+                (uint)Math.Ceiling(Math.Log2(_mlmask.WidthHigh / (double)_mlmask.Layers[i].Width));
+            _mlmask.Layers[i].HeightShift =
+                (uint)Math.Ceiling(Math.Log2(_mlmask.HeightHigh / (double)_mlmask.Layers[i].Height));
+        }
+
+        // Fixed tile size for this project: maskTileSize = 14 → AtlasTileSize = 16.
+        // AtlasTileSize must be divisible by 4 (we split it into 4x4 BC4 blocks for compression).
+        // We start at 16 and increase by 4 if needed to keep divisibility.
+        var tempAtlasTileSize = 16u;
+        while (true)
+        {
+            _mlmask.AtlasTileSize = tempAtlasTileSize;
+            _mlmask.TileSize = _mlmask.AtlasTileSize - 2;
+
+            _mlmask.MaskTilesHigh = null;
+            _mlmask.MaskTilesLow = null;
+            _mlmask.AtlasTiles.Clear();
+            _mlmask.AtlasWidth = 0;
+            _mlmask.AtlasHeight = 0;
+            _mlmask.AtlasTilesCount = 0;
+
+            InitializeMaskLayers();
+
+            _mlmask.WidthInTilesHigh = (_mlmask.WidthHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+            _mlmask.HeightInTilesHigh = (_mlmask.HeightHigh + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+            _mlmask.WidthInTilesLow = (_mlmask.WidthLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+            _mlmask.HeightInTilesLow = (_mlmask.HeightLow + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+
+            _mlmask.MaskTilesHigh = new MaskTile[_mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh];
+            for (uint i = 0; i < _mlmask.MaskTilesHigh.Length; i++)
+            {
+                _mlmask.MaskTilesHigh[i].Layers = new List<TileView>();
+            }
+
+            _mlmask.MaskTilesLow = new MaskTile[_mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow];
+            for (uint i = 0; i < _mlmask.MaskTilesLow.Length; i++)
+            {
+                _mlmask.MaskTilesLow[i].Layers = new List<TileView>();
+            }
+
+            CleanTileLayers();
+
+            if (_mlmask.AtlasTiles.Count <= 0x20000)
+            {
+                break;
+            }
+
+            tempAtlasTileSize += 4; // keep the value divisible by 4
+        }
+
+        CalculateAtlasProportionForPacking();
+        CreateAtlasBuffer();
+
+        var numTilesHigh = _mlmask.WidthInTilesHigh * _mlmask.HeightInTilesHigh;
+        var numTilesLow = _mlmask.WidthInTilesLow * _mlmask.HeightInTilesLow;
+        var tilesDataList = new List<uint>();
+
+        for (uint i = 0; i < (numTilesHigh + numTilesLow) * 2; i++)
+        {
+            tilesDataList.Add(0U);
+        }
+
+        PutTiles(ref tilesDataList, _mlmask.MaskTilesHigh, 0, _mlmask.WidthInTilesHigh, _mlmask.HeightInTilesHigh);
+        PutTiles(ref tilesDataList, _mlmask.MaskTilesLow, numTilesHigh, _mlmask.WidthInTilesLow,
+            _mlmask.HeightInTilesLow);
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        foreach (var l in tilesDataList)
+        {
+            bw.Write(l);
+        }
+
+        _mlmask.TilesBuffer = ms.ToArray();
+    }
+
+    private void CalculateAtlasProportionForPacking()
+    {
+        if (_mlmask.AtlasTilesCount == 0)
+        {
+            throw new Exception("No tiles to pack into atlas.");
+        }
+
+        var tileSize = _mlmask.AtlasTileSize;
+        var tileCount = _mlmask.AtlasTilesCount;
+
+        // The atlas size is independent of maskWidth/maskHeight.
+        // It only needs to hold all *unique* compressed tiles (after hash deduplication).
+        // Real game files often have atlas much smaller than mask resolution when content has repetition/empty areas.
+
+        uint bestWidth = 0;
+        uint bestHeight = 0;
+        var bestWaste = ulong.MaxValue;
+        var bestWasteRatio = double.MaxValue; // waste / usedArea
+
+        // Search over all reasonable power-of-2 widths (this is the constraint from PutTiles).
+        // Start from 4 tiles wide to avoid extremely narrow (1-tile) atlases.
+        for (uint wTilesPow2 = 4; wTilesPow2 <= 1024; wTilesPow2 <<= 1)
+        {
+            var hTiles = (tileCount + wTilesPow2 - 1) / wTilesPow2;
+            var w = wTilesPow2 * tileSize;
+            var h = hTiles * tileSize;
+
+            if (w > 16384 || h > 16384)
+            {
+                continue;
+            }
+
+            var area = (ulong)w * h;
+            var usedArea = (ulong)tileCount * tileSize * tileSize;
+            var waste = area - usedArea;
+            var wasteRatio = usedArea > 0 ? (double)waste / usedArea : 0;
+
+            // Calculate aspect ratio
+            var aspect = (double)h / w;
+
+            // Hard filter: reject extremely bad aspect ratios
+            if (aspect > 4.0 || aspect < 0.25)
+            {
+                continue;
+            }
+
+            // Prefer lower waste ratio. If ratios are close, prefer reasonable aspect ratio.
+            var better = false;
+            if (wasteRatio < bestWasteRatio - 0.01)
+            {
+                better = true;
+            }
+            else if (Math.Abs(wasteRatio - bestWasteRatio) <= 0.01)
+            {
+                // Prefer aspect ratios in good range [0.5 .. 2.5]
+                var currGood = aspect >= 0.5 && aspect <= 2.5;
+                var bestGood = bestHeight >= 0.5 * bestWidth && bestHeight <= 2.5 * bestWidth;
+
+                if (currGood && !bestGood)
                 {
                     better = true;
                 }
-                else if (Math.Abs(wasteRatio - bestWasteRatio) <= 0.01)
+                else if (currGood == bestGood)
                 {
-                    // Prefer aspect ratios in good range [0.5 .. 2.5]
-                    bool currGood = aspect >= 0.5 && aspect <= 2.5;
-                    bool bestGood = (bestHeight >= 0.5 * bestWidth) && (bestHeight <= 2.5 * bestWidth);
-
-                    if (currGood && !bestGood)
+                    // Among good aspects, prefer closer to square
+                    var currDist = Math.Abs(aspect - 1.0);
+                    var bestDist = Math.Abs(((double)bestHeight / bestWidth) - 1.0);
+                    if (currDist < bestDist - 0.08)
                     {
                         better = true;
                     }
-                    else if (currGood == bestGood)
+                    else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste)
                     {
-                        // Among good aspects, prefer closer to square
-                        double currDist = Math.Abs(aspect - 1.0);
-                        double bestDist = Math.Abs((double)bestHeight / bestWidth - 1.0);
-                        if (currDist < bestDist - 0.08)
-                        {
-                            better = true;
-                        }
-                        else if (Math.Abs(currDist - bestDist) <= 0.08 && waste < bestWaste)
-                        {
-                            better = true;
-                        }
-                    }
-                }
-
-                if (better || bestWidth == 0)
-                {
-                    bestWaste = waste;
-                    bestWasteRatio = wasteRatio;
-                    bestWidth = w;
-                    bestHeight = h;
-                }
-            }
-
-            // Fallback (should rarely happen)
-            if (bestWidth == 0)
-            {
-                uint wTiles = 64;
-                uint hTiles = (tileCount + wTiles - 1) / wTiles;
-                bestWidth = wTiles * tileSize;
-                bestHeight = hTiles * tileSize;
-            }
-
-            _mlmask.AtlasWidth = bestWidth;
-            _mlmask.AtlasHeight = bestHeight;
-
-            if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
-            {
-                throw new Exception("Atlas too large (over 16k)");
-            }
-
-            // Ensure the number of tiles horizontally is a power of 2 (required by PutTiles bit-packing).
-            uint tilesX = _mlmask.AtlasWidth / tileSize;
-            if (tilesX > 0 && (tilesX & (tilesX - 1)) != 0)
-            {
-                uint nextPow2 = 1u;
-                while (nextPow2 < tilesX) nextPow2 <<= 1;
-
-                uint newWidth = nextPow2 * tileSize;
-                uint newHeight = ((tileCount + nextPow2 - 1) / nextPow2) * tileSize;
-
-                // Try to prefer layouts where height >= width (more vertical/square, like most CDPR atlases)
-                // when it doesn't increase waste too much.
-                bool preferTaller = newHeight < newWidth;
-
-                if (preferTaller && nextPow2 > 1)
-                {
-                    uint prevPow2 = nextPow2 / 2;
-                    uint prevWidth = prevPow2 * tileSize;
-                    uint prevHeight = ((tileCount + prevPow2 - 1) / prevPow2) * tileSize;
-
-                    if (prevWidth <= 16384)
-                    {
-                        // Accept previous power of 2 if it gives height >= width or the waste increase is reasonable
-                        ulong prevWaste = (ulong)prevWidth * prevHeight - (ulong)tileCount * tileSize * tileSize;
-                        ulong currWaste = (ulong)newWidth * newHeight - (ulong)tileCount * tileSize * tileSize;
-
-                        if (prevHeight >= prevWidth || prevWaste <= currWaste * 1.6)
-                        {
-                            newWidth = prevWidth;
-                            newHeight = prevHeight;
-                        }
-                    }
-                }
-
-                if (newWidth <= 16384)
-                {
-                    _mlmask.AtlasWidth = newWidth;
-                    _mlmask.AtlasHeight = newHeight;
-                }
-            }
-
-            // Final pass: if we still have a very wide result (width > height), try one more time
-            // to use a smaller power-of-2 width if it gives a better aspect ratio with acceptable waste.
-            uint finalTilesX = _mlmask.AtlasWidth / tileSize;
-            uint finalTilesY = _mlmask.AtlasHeight / tileSize;
-
-            if (finalTilesX > finalTilesY && finalTilesX > 1)
-            {
-                uint smallerPow2 = finalTilesX / 2;
-                while (smallerPow2 > 1 && (smallerPow2 & (smallerPow2 - 1)) != 0) smallerPow2 /= 2;
-
-                if (smallerPow2 >= 1)
-                {
-                    uint tryWidth = smallerPow2 * tileSize;
-                    uint tryHeight = ((tileCount + smallerPow2 - 1) / smallerPow2) * tileSize;
-
-                    ulong tryWaste = (ulong)tryWidth * tryHeight - (ulong)tileCount * tileSize * tileSize;
-                    ulong currWaste = (ulong)_mlmask.AtlasWidth * _mlmask.AtlasHeight - (ulong)tileCount * tileSize * tileSize;
-
-                    // Accept if it makes height >= width or waste increase is small
-                    if ((tryHeight >= tryWidth || tryWaste <= currWaste * 1.5) && tryWidth <= 16384)
-                    {
-                        _mlmask.AtlasWidth = tryWidth;
-                        _mlmask.AtlasHeight = tryHeight;
+                        better = true;
                     }
                 }
             }
 
-            _logger.Debug($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
+            if (better || bestWidth == 0)
+            {
+                bestWaste = waste;
+                bestWasteRatio = wasteRatio;
+                bestWidth = w;
+                bestHeight = h;
+            }
         }
 
-        private void InitializeMaskLayers()
+        // Fallback (should rarely happen)
+        if (bestWidth == 0)
         {
-            if (_mlmask.Layers == null) return;
+            uint wTiles = 64;
+            var hTiles = (tileCount + wTiles - 1) / wTiles;
+            bestWidth = wTiles * tileSize;
+            bestHeight = hTiles * tileSize;
+        }
 
-            for (uint i = 0; i < _mlmask.Layers.Length; i++)
+        _mlmask.AtlasWidth = bestWidth;
+        _mlmask.AtlasHeight = bestHeight;
+
+        if (_mlmask.AtlasWidth > 16384 || _mlmask.AtlasHeight > 16384)
+        {
+            throw new Exception("Atlas too large (over 16k)");
+        }
+
+        // Ensure the number of tiles horizontally is a power of 2 (required by PutTiles bit-packing).
+        var tilesX = _mlmask.AtlasWidth / tileSize;
+        if (tilesX > 0 && (tilesX & (tilesX - 1)) != 0)
+        {
+            var nextPow2 = 1u;
+            while (nextPow2 < tilesX)
             {
-                _mlmask.Layers[i].WidthInTiles0 = (_mlmask.Layers[i].Width + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.Layers[i].HeightInTiles0 = (_mlmask.Layers[i].Height + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
-                _mlmask.Layers[i].Tiles = new List<Tile>();
+                nextPow2 <<= 1;
+            }
 
-                for (uint y = 0; y < _mlmask.Layers[i].HeightInTiles0; y++)
+            var newWidth = nextPow2 * tileSize;
+            var newHeight = (tileCount + nextPow2 - 1) / nextPow2 * tileSize;
+
+            // Try to prefer layouts where height >= width (more vertical/square, like most CDPR atlases)
+            // when it doesn't increase waste too much.
+            var preferTaller = newHeight < newWidth;
+
+            if (preferTaller && nextPow2 > 1)
+            {
+                var prevPow2 = nextPow2 / 2;
+                var prevWidth = prevPow2 * tileSize;
+                var prevHeight = (tileCount + prevPow2 - 1) / prevPow2 * tileSize;
+
+                if (prevWidth <= 16384)
                 {
-                    for (uint x = 0; x < _mlmask.Layers[i].WidthInTiles0; x++)
-                    {
-                        var tile = new Tile
-                        {
-                            AtlasInPosition = uint.MaxValue,
-                            AtlasUnCompressed = new byte[_mlmask.AtlasTileSize * _mlmask.AtlasTileSize]
-                        };
+                    // Accept previous power of 2 if it gives height >= width or the waste increase is reasonable
+                    var prevWaste = ((ulong)prevWidth * prevHeight) - ((ulong)tileCount * tileSize * tileSize);
+                    var currWaste = ((ulong)newWidth * newHeight) - ((ulong)tileCount * tileSize * tileSize);
 
-                        if (i == 0)
-                        {
-                            tile.RangeMin = 255;
-                            tile.RangeMax = 255;
-                            Array.Fill(tile.AtlasUnCompressed, (byte)255);
-                        }
-                        else
-                        {
-                            tile.RangeMin = 255;
-                            tile.RangeMax = 0;
-                            for (uint yy = 0; yy < _mlmask.AtlasTileSize; yy++)
-                            {
-                                for (uint xx = 0; xx < _mlmask.AtlasTileSize; xx++)
-                                {
-                                    var v = GetPixelFromLayer(i, x, y, (int)xx - 1, (int)yy - 1);
-                                    tile.AtlasUnCompressed[xx + (yy * _mlmask.AtlasTileSize)] = v;
-                                    tile.RangeMin = Math.Min(tile.RangeMin, v);
-                                    tile.RangeMax = Math.Max(tile.RangeMax, v);
-                                }
-                            }
-                        }
-                        _mlmask.Layers[i].Tiles.Add(tile);
+                    if (prevHeight >= prevWidth || prevWaste <= currWaste * 1.6)
+                    {
+                        newWidth = prevWidth;
+                        newHeight = prevHeight;
                     }
                 }
             }
-        }
 
-        private byte GetPixelFromLayer(uint layerIdx, uint tx, uint ty, int x, int y)
-        {
-            if (layerIdx == 0) return 255;
-
-            var xx = (int)(tx * _mlmask.TileSize) + x;
-            var yy = (int)(ty * _mlmask.TileSize) + y;
-            xx = Math.Clamp(xx, 0, (int)_mlmask.Layers![layerIdx].Width - 1);
-            yy = Math.Clamp(yy, 0, (int)_mlmask.Layers[layerIdx].Height - 1);
-            return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
-        }
-
-        private void CleanTileLayers()
-        {
-            if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null) return;
-
-            for (uint I = 0; I < _mlmask.Layers.Length; I++)
+            if (newWidth <= 16384)
             {
-                if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
+                _mlmask.AtlasWidth = newWidth;
+                _mlmask.AtlasHeight = newHeight;
+            }
+        }
+
+        // Final pass: if we still have a very wide result (width > height), try one more time
+        // to use a smaller power-of-2 width if it gives a better aspect ratio with acceptable waste.
+        var finalTilesX = _mlmask.AtlasWidth / tileSize;
+        var finalTilesY = _mlmask.AtlasHeight / tileSize;
+
+        if (finalTilesX > finalTilesY && finalTilesX > 1)
+        {
+            var smallerPow2 = finalTilesX / 2;
+            while (smallerPow2 > 1 && (smallerPow2 & (smallerPow2 - 1)) != 0)
+            {
+                smallerPow2 /= 2;
+            }
+
+            if (smallerPow2 >= 1)
+            {
+                var tryWidth = smallerPow2 * tileSize;
+                var tryHeight = (tileCount + smallerPow2 - 1) / smallerPow2 * tileSize;
+
+                var tryWaste = ((ulong)tryWidth * tryHeight) - ((ulong)tileCount * tileSize * tileSize);
+                var currWaste = ((ulong)_mlmask.AtlasWidth * _mlmask.AtlasHeight) -
+                                ((ulong)tileCount * tileSize * tileSize);
+
+                // Accept if it makes height >= width or waste increase is small
+                if ((tryHeight >= tryWidth || tryWaste <= currWaste * 1.5) && tryWidth <= 16384)
                 {
-                    // Low-res layer
-                    for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
-                    {
-                        for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
-                        {
-                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
-                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
-
-                            if (wTiles0 == 0 || hTiles0 == 0) continue;
-
-                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
-                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
-
-                            var tx = Math.Min(txRaw, wTiles0 - 1);
-                            var ty = Math.Min(tyRaw, hTiles0 - 1);
-
-                            var tileIdxCheck = tx + (ty * wTiles0);
-                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
-                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
-                            {
-                                var layer = new TileView
-                                {
-                                    LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * wTiles0),
-                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
-                                };
-                                _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // High-res layer
-                    for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
-                    {
-                        for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
-                        {
-                            uint wTiles0 = _mlmask.Layers[I].WidthInTiles0;
-                            uint hTiles0 = _mlmask.Layers[I].HeightInTiles0;
-
-                            if (wTiles0 == 0 || hTiles0 == 0) continue;
-
-                            var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
-                            var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
-
-                            var tx = Math.Min(txRaw, wTiles0 - 1);
-                            var ty = Math.Min(tyRaw, hTiles0 - 1);
-
-                            var tileIdxCheck = tx + (ty * wTiles0);
-                            if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
-                                _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
-                            {
-                                var layer = new TileView
-                                {
-                                    LayerIndex = I,
-                                    LayerTileIndex = tx + (ty * wTiles0),
-                                    AtlasInPosition = PackTileInAtlas(I, tx, ty)
-                                };
-                                _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
-                            }
-                        }
-                    }
+                    _mlmask.AtlasWidth = tryWidth;
+                    _mlmask.AtlasHeight = tryHeight;
                 }
             }
         }
 
-        private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
-        {
-            if (_mlmask.Layers == null || layerIdx >= _mlmask.Layers.Length) return 0;
-
-            var layer = _mlmask.Layers[layerIdx];
-            if (layer.Tiles == null || layer.WidthInTiles0 == 0 || layer.HeightInTiles0 == 0) return 0;
-
-            // Extra safety clamp in case caller passed slightly out-of-range values
-            if (tx >= layer.WidthInTiles0) tx = layer.WidthInTiles0 - 1;
-            if (ty >= layer.HeightInTiles0) ty = layer.HeightInTiles0 - 1;
-
-            var tileIndex = tx + (ty * layer.WidthInTiles0);
-            if (tileIndex >= (uint)layer.Tiles.Count)
-            {
-                _logger?.Error($"PackTileInAtlas: calculated tileIndex {tileIndex} is out of range for layer {layerIdx} (Tiles.Count = {layer.Tiles.Count}, tx={tx}, ty={ty})");
-                return 0;
-            }
-
-            if (layer.Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
-            {
-                BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
-
-                var recursiveHash = FNV1A.FnvHashInitial;
-                for (uint y = 0; y < _mlmask.AtlasTileSize / 4; y++)
-                {
-                    for (uint x = 0; x < _mlmask.AtlasTileSize / 4; x++)
-                    {
-                        var compressedBlock = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
-                        var color32 = new float[16];
-                        D3DX.D3DXDecodeBC4U(ref color32, compressedBlock);
-                        var color8 = new byte[16];
-                        for (uint i = 0; i < 16; i++) color8[i] = (byte)(color32[i] * 255.0f);
-                        recursiveHash = FNV1A.HashReadOnlySpan(color8, recursiveHash);
-                    }
-                }
-
-                if (!_mlmask.AtlasTiles.TryGetValue(recursiveHash, out var atlasView))
-                {
-                    atlasView = new TileView
-                    {
-                        AtlasInPosition = _mlmask.AtlasTilesCount++,
-                        LayerIndex = layerIdx,
-                        LayerTileIndex = tileIndex
-                    };
-                    _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
-                }
-
-                var z = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex];
-                z.AtlasInPosition = atlasView.AtlasInPosition;
-                _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
-            }
-            return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
-        }
-
-        private void CreateAtlasBuffer()
-        {
-            if (_mlmask.Layers == null || _mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
-                throw new Exception("Unable to generate MLmask atlas data");
-
-            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
-            var widthInBlocks0 = _mlmask.AtlasWidth / 4;
-            var heightInBlocks0 = _mlmask.AtlasHeight / 4;
-            var widthInTiles0 = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-
-            var data = new ulong[widthInBlocks0 * heightInBlocks0];
-
-            foreach (var atlasTile in _mlmask.AtlasTiles.Values)
-            {
-                var sourceLayer = _mlmask.Layers[atlasTile.LayerIndex];
-                var tileSource = sourceLayer.Tiles[(int)atlasTile.LayerTileIndex];
-
-                var position = atlasTile.AtlasInPosition;
-                var tx = position % widthInTiles0;
-                var ty = position / widthInTiles0;
-                var bx = tx * tileSizeInBlocks0;
-                var by = ty * tileSizeInBlocks0;
-
-                var destinationIdx = bx + (by * widthInBlocks0);
-                for (uint i = 0; i < tileSizeInBlocks0; i++)
-                {
-                    Array.Copy(tileSource.AtlasBlockCompressed, i * tileSizeInBlocks0, data, destinationIdx, tileSizeInBlocks0);
-                    destinationIdx += widthInBlocks0;
-                }
-            }
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            foreach (var d in data) bw.Write(d);
-            _mlmask.AtlasBuffer = ms.ToArray();
-        }
-
-        private void BlockCompressLocalTile(ref RawTexContainer layer, uint tileIdx)
-        {
-            var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
-            var tx = tileIdx % layer.WidthInTiles0;
-            var ty = tileIdx / layer.WidthInTiles0;
-
-            var layerTile = layer.Tiles[(int)tileIdx];
-            layerTile.AtlasBlockCompressed = new ulong[tileSizeInBlocks0 * tileSizeInBlocks0];
-
-            for (uint yBlock = 0; yBlock < tileSizeInBlocks0; yBlock++)
-            {
-                for (uint xBlock = 0; xBlock < tileSizeInBlocks0; xBlock++)
-                {
-                    var referenceData = new List<float>();
-                    var toBBCValues = new float[16];
-
-                    for (uint j = 0; j < 4; j++)
-                    {
-                        for (uint i = 0; i < 4; i++)
-                        {
-                            var px = (xBlock * 4) + i;
-                            var py = (yBlock * 4) + j;
-                            var v = layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
-                            toBBCValues[i + (j * 4)] = v;
-                            referenceData.Add(v);
-                        }
-                    }
-
-                    if (tx > 0 && xBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
-                    else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
-
-                    if (ty > 0 && yBlock == 0) PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
-                    else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1) PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
-
-                    ulong blockCompressed = 0;
-                    D3DX.D3DXEncodeBC4U(ref blockCompressed, toBBCValues, referenceData);
-                    layerTile.AtlasBlockCompressed[xBlock + (yBlock * tileSizeInBlocks0)] = blockCompressed;
-                }
-            }
-            layer.Tiles[(int)tileIdx] = layerTile;
-        }
-
-        private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty, uint xBlock, uint yBlock)
-        {
-            // Extra defensive bounds check for neighbor tiles
-            uint w = layer.WidthInTiles0;
-            uint h = layer.HeightInTiles0;
-            if (w == 0 || h == 0) return;
-
-            if (tx >= w || ty >= h) return; // neighbor is out of layer bounds — skip
-
-            uint neighborTileIndex = tx + (ty * w);
-            if (neighborTileIndex >= (uint)layer.Tiles.Count) return;
-
-            for (uint j = 0; j < 4; j++)
-            {
-                for (uint i = 0; i < 4; i++)
-                {
-                    var px = (xBlock * 4) + i;
-                    var py = (yBlock * 4) + j;
-                    var v = layer.Tiles[(int)neighborTileIndex].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
-                    referenceData.Add(v);
-                }
-            }
-        }
-
-        private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0, uint heightInTiles0)
-        {
-            var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
-            var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
-            var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
-
-            for (uint ty = 0; ty < heightInTiles0; ty++)
-            {
-                for (uint tx = 0; tx < widthInTiles0; tx++)
-                {
-                    var tileIdx = tx + (ty * widthInTiles0);
-                    var layersBeg = (uint)tilesDataList.Count;
-                    var numLayers = (uint)tileZ[tileIdx].Layers.Count;
-
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 0)] = layersBeg;
-
-                    uint layersMask = 0;
-                    for (var i = 0; i < numLayers; i++)
-                    {
-                        var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
-                        var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
-                        var atlasX = position & widthInTilesGrayUp;
-                        var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
-                        var widthShift = _mlmask.Layers![layerIdx].WidthShift;
-                        var heightShift = _mlmask.Layers[layerIdx].HeightShift;
-
-                        uint puts = 0;
-                        puts |= atlasX;
-                        puts |= atlasY << 10;
-                        puts |= widthShift << 20;
-                        puts |= heightShift << 24;
-
-                        tilesDataList.Add(puts);
-                        layersMask |= 1u << (int)layerIdx;
-                    }
-                    tilesDataList[(int)((basisTileIdx + tileIdx) * 2 + 1)] = layersMask;
-                }
-            }
-        }
-
-        #endregion Core Methods
-
-        #region Structs
-
-        public struct RawTexContainer
-        {
-            public byte[] Pixels;
-            public uint Width;
-            public uint Height;
-            public List<Tile> Tiles;
-            public uint WidthShift;
-            public uint HeightShift;
-            public uint WidthInTiles0;
-            public uint HeightInTiles0;
-        }
-
-        public struct Tile
-        {
-            public byte RangeMin;
-            public byte RangeMax;
-            public byte[] AtlasUnCompressed;
-            public ulong[] AtlasBlockCompressed;
-            public uint AtlasInPosition;
-        }
-
-        public struct MaskTile
-        {
-            public List<TileView> Layers;
-        }
-
-        public struct TileView
-        {
-            public uint LayerIndex;
-            public uint AtlasInPosition;
-            public uint LayerTileIndex;
-        }
-
-        public class MlMaskContainer
-        {
-            public RawTexContainer[]? Layers;
-            public MaskTile[]? MaskTilesHigh;
-            public Dictionary<ulong, TileView> AtlasTiles = new();
-            public MaskTile[]? MaskTilesLow;
-            public uint AtlasTileSize;
-            public uint AtlasWidth;
-            public uint AtlasHeight;
-            public uint HeightHigh;
-            public uint WidthLow;
-            public uint HeightInTilesHigh;
-            public uint WidthInTilesLow;
-            public uint HeightLow;
-            public byte[]? AtlasBuffer;
-            public byte[]? TilesBuffer;
-            public uint WidthInTilesHigh;
-            public uint HeightInTilesLow;
-            public uint TileSize;
-            public uint WidthHigh;
-            public uint AtlasTilesCount;
-        }
-
-        #endregion Structs
-
-        #region FNV1A
-
-        internal class FNV1A
-        {
-            public const ulong FnvHashInitial = 0xCBF29CE484222325;
-            public const ulong FnvHashPrime = 0x00000100000001B3;
-
-            public static ulong HashReadOnlySpan(ReadOnlySpan<byte> source, ulong hash = FnvHashInitial)
-            {
-                foreach (var b in source)
-                    unchecked { hash = (hash ^ b) * FnvHashPrime; }
-                return hash;
-            }
-        }
-
-        #endregion FNV1A
-
-        #region D3DX
-
-        internal class D3DX
-        {
-            [StructLayout(LayoutKind.Explicit, Size = 8)]
-            public struct BC4_UNORM
-            {
-                [FieldOffset(0)] public ulong Data;
-                [FieldOffset(0)] public byte Red_0;
-                [FieldOffset(1)] public byte Red_1;
-                [FieldOffset(2)] public byte Index0;
-                [FieldOffset(3)] public byte Index1;
-                [FieldOffset(4)] public byte Index2;
-                [FieldOffset(5)] public byte Index3;
-                [FieldOffset(6)] public byte Index4;
-                [FieldOffset(7)] public byte Index5;
-
-                public uint GetIndex(int offset) => (uint)(Data >> ((3 * offset) + 16)) & 0x07;
-
-                public void SetIndex(int uOffset, int uIndex)
-                {
-                    Data &= ~((ulong)0x07 << ((3 * uOffset) + 16));
-                    Data |= (ulong)uIndex << ((3 * uOffset) + 16);
-                }
-
-                public float R(int offset)
-                {
-                    var index = GetIndex(offset);
-                    return DecodeFromIndex(index);
-                }
-
-                public float DecodeFromIndex(uint index)
-                {
-                    if (index == 0) return Red_0 / 255.0f;
-                    if (index == 1) return Red_1 / 255.0f;
-
-                    var fred0 = Red_0 / 255.0f;
-                    var fred1 = Red_1 / 255.0f;
-
-                    if (Red_0 > Red_1)
-                    {
-                        index--;
-                        return ((fred0 * ((float)7 - index)) + (fred1 * index)) / 7.0f;
-                    }
-
-                    if (index == 6) return 0.0f;
-                    if (index == 7) return 1.0f;
-
-                    index--;
-                    return ((fred0 * ((float)5 - index)) + (fred1 * index)) / 5.0f;
-                }
-            }
-
-            public static void D3DXEncodeBC4U(ref ulong resultantBlock, float[] refData, List<float> theTexelsU)
-            {
-                var pBC4 = new BC4_UNORM();
-                FindEndPointsBC4U(theTexelsU, theTexelsU.Count, ref pBC4.Red_0, ref pBC4.Red_1);
-                FindClosestUNORM(ref pBC4, refData);
-                resultantBlock = pBC4.Data;
-            }
-
-            private static void FindEndPointsBC4U(List<float> theTexelsU, int numTexels, ref byte endpointU_0, ref byte endpointU_1)
-            {
-                var fBlockMax = theTexelsU[0];
-                var fBlockMin = theTexelsU[0];
-                for (var i = 0; i < numTexels; ++i)
-                {
-                    if (theTexelsU[i] < fBlockMin) fBlockMin = theTexelsU[i];
-                    else if (theTexelsU[i] > fBlockMax) fBlockMax = theTexelsU[i];
-                }
-
-                var bUsing4BlockCodec = fBlockMin == 0f || fBlockMax == 1f;
-                float fStart = 0, fEnd = 0;
-
-                if (!bUsing4BlockCodec)
-                {
-                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 8);
-                    endpointU_0 = (byte)(fEnd * 255.0f);
-                    endpointU_1 = (byte)(fStart * 255.0f);
-                }
-                else
-                {
-                    OptimizeAlpha(ref fStart, ref fEnd, theTexelsU, numTexels, 6);
-                    endpointU_1 = (byte)(fEnd * 255.0f);
-                    endpointU_0 = (byte)(fStart * 255.0f);
-                }
-            }
-
-            private static void OptimizeAlpha(ref float pX, ref float pY, List<float> pPoints, int numTexels, uint cSteps)
-            {
-                float[] pC6 = { 5.0f / 5.0f, 4.0f / 5.0f, 3.0f / 5.0f, 2.0f / 5.0f, 1.0f / 5.0f, 0.0f / 5.0f };
-                float[] pD6 = { 0.0f / 5.0f, 1.0f / 5.0f, 2.0f / 5.0f, 3.0f / 5.0f, 4.0f / 5.0f, 5.0f / 5.0f };
-                float[] pC8 = { 7.0f / 7.0f, 6.0f / 7.0f, 5.0f / 7.0f, 4.0f / 7.0f, 3.0f / 7.0f, 2.0f / 7.0f, 1.0f / 7.0f, 0.0f / 7.0f };
-                float[] pD8 = { 0.0f / 7.0f, 1.0f / 7.0f, 2.0f / 7.0f, 3.0f / 7.0f, 4.0f / 7.0f, 5.0f / 7.0f, 6.0f / 7.0f, 7.0f / 7.0f };
-
-                var pC = (cSteps == 6) ? pC6 : pC8;
-                var pD = (cSteps == 6) ? pD6 : pD8;
-
-                float fX = 1.0f;
-                float fY = 0.0f;
-
-                if (cSteps == 8)
-                {
-                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
-                    {
-                        if (pPoints[iPoint] < fX) fX = pPoints[iPoint];
-                        if (pPoints[iPoint] > fY) fY = pPoints[iPoint];
-                    }
-                }
-                else
-                {
-                    for (var iPoint = 0; iPoint < numTexels; iPoint++)
-                    {
-                        if (pPoints[iPoint] < fX && pPoints[iPoint] > 0.0f) fX = pPoints[iPoint];
-                        if (pPoints[iPoint] > fY && pPoints[iPoint] < 1.0f) fY = pPoints[iPoint];
-                    }
-                    if (fX == fY) fY = 1.0f;
-                }
-
-                var fSteps = Convert.ToSingle(cSteps - 1);
-
-                for (var iIteration = 0; iIteration < 8; iIteration++)
-                {
-                    if (fY - fX < 1.0f / 256.0f) break;
-
-                    var fScale = fSteps / (fY - fX);
-                    var pSteps = new float[8];
-
-                    for (var iStep = 0; iStep < cSteps; iStep++)
-                        pSteps[iStep] = (pC[iStep] * fX) + (pD[iStep] * fY);
-
-                    if (cSteps == 6)
-                    {
-                        pSteps[6] = 0.0f;
-                        pSteps[7] = 1.0f;
-                    }
-
-                    var dX = 0.0f;
-                    var dY = 0.0f;
-                    var d2X = 0.0f;
-                    var d2Y = 0.0f;
-
-                    for (uint iPoint = 0; iPoint < numTexels; iPoint++)
-                    {
-                        var fDot = (pPoints[(int)iPoint] - fX) * fScale;
-                        uint iStep;
-
-                        if (fDot <= 0.0f)
-                            iStep = (cSteps == 6 && pPoints[(int)iPoint] <= fX * 0.5f) ? 6u : 0u;
-                        else if (fDot >= fSteps)
-                            iStep = (cSteps == 6 && pPoints[(int)iPoint] >= (fY + 1.0f) * 0.5f) ? 7u : cSteps - 1;
-                        else
-                            iStep = (uint)(fDot + 0.5f);
-
-                        if (iStep < cSteps)
-                        {
-                            var fDiff = pSteps[iStep] - pPoints[(int)iPoint];
-                            dX += pC[iStep] * fDiff;
-                            d2X += pC[iStep] * pC[iStep];
-                            dY += pD[iStep] * fDiff;
-                            d2Y += pD[iStep] * pD[iStep];
-                        }
-                    }
-
-                    if (d2X > 0.0f) fX -= dX / d2X;
-                    if (d2Y > 0.0f) fY -= dY / d2Y;
-
-                    if (fX > fY) (fY, fX) = (fX, fY);
-
-                    if (dX * dX < 1.0f / 64.0f && dY * dY < 1.0f / 64.0f) break;
-                }
-
-                pX = Math.Clamp(fX, 0.0f, 1.0f);
-                pY = Math.Clamp(fY, 0.0f, 1.0f);
-            }
-
-            private static void FindClosestUNORM(ref BC4_UNORM pBC, float[] theTexelsU)
-            {
-                const uint numPixelsPerBlock = 16;
-                var rGradient = new float[8];
-                for (uint i = 0; i < 8; ++i)
-                    rGradient[i] = pBC.DecodeFromIndex(i);
-
-                for (uint i = 0; i < numPixelsPerBlock; ++i)
-                {
-                    uint uBestIndex = 0;
-                    float fBestDelta = 100000;
-                    for (uint uIndex = 0; uIndex < 8; uIndex++)
-                    {
-                        var fCurrentDelta = Math.Abs(rGradient[uIndex] - theTexelsU[i]);
-                        if (fCurrentDelta < fBestDelta)
-                        {
-                            uBestIndex = uIndex;
-                            fBestDelta = fCurrentDelta;
-                        }
-                    }
-                    pBC.SetIndex((int)i, (int)uBestIndex);
-                }
-            }
-
-            public static void D3DXDecodeBC4U(ref float[] pColor, ulong pBC)
-            {
-                const uint numPixelsPerBlock = 16;
-                var pBC4 = new BC4_UNORM { Data = pBC };
-                for (var i = 0; i < numPixelsPerBlock; ++i)
-                    pColor[i] = pBC4.R(i);
-            }
-        }
-
-        #endregion D3DX
+        _logger.Debug($"Atlas packed to {_mlmask.AtlasWidth}x{_mlmask.AtlasHeight} ({tileCount} unique tiles)");
     }
+
+    private void InitializeMaskLayers()
+    {
+        if (_mlmask.Layers == null)
+        {
+            return;
+        }
+
+        for (uint i = 0; i < _mlmask.Layers.Length; i++)
+        {
+            _mlmask.Layers[i].WidthInTiles0 = (_mlmask.Layers[i].Width + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+            _mlmask.Layers[i].HeightInTiles0 = (_mlmask.Layers[i].Height + (_mlmask.TileSize - 1)) / _mlmask.TileSize;
+            _mlmask.Layers[i].Tiles = new List<Tile>();
+
+            for (uint y = 0; y < _mlmask.Layers[i].HeightInTiles0; y++)
+            {
+                for (uint x = 0; x < _mlmask.Layers[i].WidthInTiles0; x++)
+                {
+                    var tile = new Tile
+                    {
+                        AtlasInPosition = uint.MaxValue,
+                        AtlasUnCompressed = new byte[_mlmask.AtlasTileSize * _mlmask.AtlasTileSize]
+                    };
+
+                    if (i == 0)
+                    {
+                        tile.RangeMin = 255;
+                        tile.RangeMax = 255;
+                        Array.Fill(tile.AtlasUnCompressed, (byte)255);
+                    }
+                    else
+                    {
+                        tile.RangeMin = 255;
+                        tile.RangeMax = 0;
+                        for (uint yy = 0; yy < _mlmask.AtlasTileSize; yy++)
+                        {
+                            for (uint xx = 0; xx < _mlmask.AtlasTileSize; xx++)
+                            {
+                                var v = GetPixelFromLayer(i, x, y, (int)xx - 1, (int)yy - 1);
+                                tile.AtlasUnCompressed[xx + (yy * _mlmask.AtlasTileSize)] = v;
+                                tile.RangeMin = Math.Min(tile.RangeMin, v);
+                                tile.RangeMax = Math.Max(tile.RangeMax, v);
+                            }
+                        }
+                    }
+
+                    _mlmask.Layers[i].Tiles.Add(tile);
+                }
+            }
+        }
+    }
+
+    private byte GetPixelFromLayer(uint layerIdx, uint tx, uint ty, int x, int y)
+    {
+        if (layerIdx == 0)
+        {
+            return 255;
+        }
+
+        var xx = (int)(tx * _mlmask.TileSize) + x;
+        var yy = (int)(ty * _mlmask.TileSize) + y;
+        xx = Math.Clamp(xx, 0, (int)_mlmask.Layers![layerIdx].Width - 1);
+        yy = Math.Clamp(yy, 0, (int)_mlmask.Layers[layerIdx].Height - 1);
+        return _mlmask.Layers[layerIdx].Pixels[xx + (yy * (int)_mlmask.Layers[layerIdx].Width)];
+    }
+
+    private void CleanTileLayers()
+    {
+        if (_mlmask.Layers == null || _mlmask.MaskTilesHigh == null || _mlmask.MaskTilesLow == null)
+        {
+            return;
+        }
+
+        for (uint I = 0; I < _mlmask.Layers.Length; I++)
+        {
+            if (_mlmask.Layers[I].Width < _mlmask.WidthHigh)
+            {
+                // Low-res layer
+                for (uint y = 0; y < _mlmask.HeightInTilesLow; y++)
+                {
+                    for (uint x = 0; x < _mlmask.WidthInTilesLow; x++)
+                    {
+                        var wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                        var hTiles0 = _mlmask.Layers[I].HeightInTiles0;
+
+                        if (wTiles0 == 0 || hTiles0 == 0)
+                        {
+                            continue;
+                        }
+
+                        var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthLow;
+                        var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightLow;
+
+                        var tx = Math.Min(txRaw, wTiles0 - 1);
+                        var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                        var tileIdxCheck = tx + (ty * wTiles0);
+                        if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                            _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
+                        {
+                            var layer = new TileView
+                            {
+                                LayerIndex = I,
+                                LayerTileIndex = tx + (ty * wTiles0),
+                                AtlasInPosition = PackTileInAtlas(I, tx, ty)
+                            };
+                            _mlmask.MaskTilesLow[x + (y * _mlmask.WidthInTilesLow)].Layers.Add(layer);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // High-res layer
+                for (uint y = 0; y < _mlmask.HeightInTilesHigh; y++)
+                {
+                    for (uint x = 0; x < _mlmask.WidthInTilesHigh; x++)
+                    {
+                        var wTiles0 = _mlmask.Layers[I].WidthInTiles0;
+                        var hTiles0 = _mlmask.Layers[I].HeightInTiles0;
+
+                        if (wTiles0 == 0 || hTiles0 == 0)
+                        {
+                            continue;
+                        }
+
+                        var txRaw = x * _mlmask.Layers[I].Width / _mlmask.WidthHigh;
+                        var tyRaw = y * _mlmask.Layers[I].Height / _mlmask.HeightHigh;
+
+                        var tx = Math.Min(txRaw, wTiles0 - 1);
+                        var ty = Math.Min(tyRaw, hTiles0 - 1);
+
+                        var tileIdxCheck = tx + (ty * wTiles0);
+                        if (tileIdxCheck < (uint)_mlmask.Layers[I].Tiles.Count &&
+                            _mlmask.Layers[I].Tiles[(int)tileIdxCheck].RangeMax > 0)
+                        {
+                            var layer = new TileView
+                            {
+                                LayerIndex = I,
+                                LayerTileIndex = tx + (ty * wTiles0),
+                                AtlasInPosition = PackTileInAtlas(I, tx, ty)
+                            };
+                            _mlmask.MaskTilesHigh[x + (y * _mlmask.WidthInTilesHigh)].Layers.Add(layer);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private uint PackTileInAtlas(uint layerIdx, uint tx, uint ty)
+    {
+        if (_mlmask.Layers == null || layerIdx >= _mlmask.Layers.Length)
+        {
+            return 0;
+        }
+
+        var layer = _mlmask.Layers[layerIdx];
+        if (layer.Tiles == null || layer.WidthInTiles0 == 0 || layer.HeightInTiles0 == 0)
+        {
+            return 0;
+        }
+
+        // Extra safety clamp in case caller passed slightly out-of-range values
+        if (tx >= layer.WidthInTiles0)
+        {
+            tx = layer.WidthInTiles0 - 1;
+        }
+
+        if (ty >= layer.HeightInTiles0)
+        {
+            ty = layer.HeightInTiles0 - 1;
+        }
+
+        var tileIndex = tx + (ty * layer.WidthInTiles0);
+        if (tileIndex >= (uint)layer.Tiles.Count)
+        {
+            _logger?.Error(
+                $"PackTileInAtlas: calculated tileIndex {tileIndex} is out of range for layer {layerIdx} (Tiles.Count = {layer.Tiles.Count}, tx={tx}, ty={ty})");
+            return 0;
+        }
+
+        if (layer.Tiles[(int)tileIndex].AtlasInPosition == uint.MaxValue)
+        {
+            BlockCompressLocalTile(ref _mlmask.Layers[layerIdx], tileIndex);
+
+            var recursiveHash = FNV1A.FnvHashInitial;
+            for (uint y = 0; y < _mlmask.AtlasTileSize / 4; y++)
+            {
+                for (uint x = 0; x < _mlmask.AtlasTileSize / 4; x++)
+                {
+                    var compressedBlock = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex]
+                        .AtlasBlockCompressed[x + (y * _mlmask.AtlasTileSize / 4)];
+                    var color32 = new float[16];
+                    D3DX.D3DXDecodeBC4U(ref color32, compressedBlock);
+                    var color8 = new byte[16];
+                    for (uint i = 0; i < 16; i++)
+                    {
+                        color8[i] = (byte)(color32[i] * 255.0f);
+                    }
+
+                    recursiveHash = FNV1A.HashReadOnlySpan(color8, recursiveHash);
+                }
+            }
+
+            if (!_mlmask.AtlasTiles.TryGetValue(recursiveHash, out var atlasView))
+            {
+                atlasView = new TileView
+                {
+                    AtlasInPosition = _mlmask.AtlasTilesCount++, LayerIndex = layerIdx, LayerTileIndex = tileIndex
+                };
+                _mlmask.AtlasTiles.Add(recursiveHash, atlasView);
+            }
+
+            var z = _mlmask.Layers[layerIdx].Tiles[(int)tileIndex];
+            z.AtlasInPosition = atlasView.AtlasInPosition;
+            _mlmask.Layers[layerIdx].Tiles[(int)tileIndex] = z;
+        }
+
+        return _mlmask.Layers[layerIdx].Tiles[(int)tileIndex].AtlasInPosition;
+    }
+
+    private void CreateAtlasBuffer()
+    {
+        if (_mlmask.Layers == null || _mlmask.AtlasWidth <= 0 || _mlmask.AtlasHeight <= 0)
+        {
+            throw new Exception("Unable to generate MLmask atlas data");
+        }
+
+        var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
+        var widthInBlocks0 = _mlmask.AtlasWidth / 4;
+        var heightInBlocks0 = _mlmask.AtlasHeight / 4;
+        var widthInTiles0 = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+
+        var data = new ulong[widthInBlocks0 * heightInBlocks0];
+
+        foreach (var atlasTile in _mlmask.AtlasTiles.Values)
+        {
+            var sourceLayer = _mlmask.Layers[atlasTile.LayerIndex];
+            var tileSource = sourceLayer.Tiles[(int)atlasTile.LayerTileIndex];
+
+            var position = atlasTile.AtlasInPosition;
+            var tx = position % widthInTiles0;
+            var ty = position / widthInTiles0;
+            var bx = tx * tileSizeInBlocks0;
+            var by = ty * tileSizeInBlocks0;
+
+            var destinationIdx = bx + (by * widthInBlocks0);
+            for (uint i = 0; i < tileSizeInBlocks0; i++)
+            {
+                Array.Copy(tileSource.AtlasBlockCompressed, i * tileSizeInBlocks0, data, destinationIdx,
+                    tileSizeInBlocks0);
+                destinationIdx += widthInBlocks0;
+            }
+        }
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+        foreach (var d in data)
+        {
+            bw.Write(d);
+        }
+
+        _mlmask.AtlasBuffer = ms.ToArray();
+    }
+
+    private void BlockCompressLocalTile(ref RawTexContainer layer, uint tileIdx)
+    {
+        var tileSizeInBlocks0 = _mlmask.AtlasTileSize / 4;
+        var tx = tileIdx % layer.WidthInTiles0;
+        var ty = tileIdx / layer.WidthInTiles0;
+
+        var layerTile = layer.Tiles[(int)tileIdx];
+        layerTile.AtlasBlockCompressed = new ulong[tileSizeInBlocks0 * tileSizeInBlocks0];
+
+        for (uint yBlock = 0; yBlock < tileSizeInBlocks0; yBlock++)
+        {
+            for (uint xBlock = 0; xBlock < tileSizeInBlocks0; xBlock++)
+            {
+                var referenceData = new List<float>();
+                var toBBCValues = new float[16];
+
+                for (uint j = 0; j < 4; j++)
+                {
+                    for (uint i = 0; i < 4; i++)
+                    {
+                        var px = (xBlock * 4) + i;
+                        var py = (yBlock * 4) + j;
+                        var v = layerTile.AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] / 255.0f;
+                        toBBCValues[i + (j * 4)] = v;
+                        referenceData.Add(v);
+                    }
+                }
+
+                if (tx > 0 && xBlock == 0)
+                {
+                    PushBlockReferenceData(ref referenceData, layer, tx - 1, ty, tileSizeInBlocks0 - 1, yBlock);
+                }
+                else if (tx < layer.WidthInTiles0 - 1 && xBlock == tileSizeInBlocks0 - 1)
+                {
+                    PushBlockReferenceData(ref referenceData, layer, tx + 1, ty, 0, yBlock);
+                }
+
+                if (ty > 0 && yBlock == 0)
+                {
+                    PushBlockReferenceData(ref referenceData, layer, tx, ty - 1, xBlock, tileSizeInBlocks0 - 1);
+                }
+                else if (ty < layer.HeightInTiles0 - 1 && yBlock == tileSizeInBlocks0 - 1)
+                {
+                    PushBlockReferenceData(ref referenceData, layer, tx, ty + 1, xBlock, 0);
+                }
+
+                ulong blockCompressed = 0;
+                D3DX.D3DXEncodeBC4U(ref blockCompressed, toBBCValues, referenceData);
+                layerTile.AtlasBlockCompressed[xBlock + (yBlock * tileSizeInBlocks0)] = blockCompressed;
+            }
+        }
+
+        layer.Tiles[(int)tileIdx] = layerTile;
+    }
+
+    private void PushBlockReferenceData(ref List<float> referenceData, RawTexContainer layer, uint tx, uint ty,
+        uint xBlock, uint yBlock)
+    {
+        // Extra defensive bounds check for neighbor tiles
+        var w = layer.WidthInTiles0;
+        var h = layer.HeightInTiles0;
+        if (w == 0 || h == 0)
+        {
+            return;
+        }
+
+        if (tx >= w || ty >= h)
+        {
+            return; // neighbor is out of layer bounds — skip
+        }
+
+        var neighborTileIndex = tx + (ty * w);
+        if (neighborTileIndex >= (uint)layer.Tiles.Count)
+        {
+            return;
+        }
+
+        for (uint j = 0; j < 4; j++)
+        {
+            for (uint i = 0; i < 4; i++)
+            {
+                var px = (xBlock * 4) + i;
+                var py = (yBlock * 4) + j;
+                var v = layer.Tiles[(int)neighborTileIndex].AtlasUnCompressed[px + (py * _mlmask.AtlasTileSize)] /
+                        255.0f;
+                referenceData.Add(v);
+            }
+        }
+    }
+
+    private void PutTiles(ref List<uint> tilesDataList, MaskTile[] tileZ, uint basisTileIdx, uint widthInTiles0,
+        uint heightInTiles0)
+    {
+        var atlasTileSize = _mlmask.AtlasWidth / _mlmask.AtlasTileSize;
+        var widthInTilesShift0 = (uint)Math.Log2(atlasTileSize);
+        var widthInTilesGrayUp = (1u << (int)widthInTilesShift0) - 1;
+
+        for (uint ty = 0; ty < heightInTiles0; ty++)
+        {
+            for (uint tx = 0; tx < widthInTiles0; tx++)
+            {
+                var tileIdx = tx + (ty * widthInTiles0);
+                var layersBeg = (uint)tilesDataList.Count;
+                var numLayers = (uint)tileZ[tileIdx].Layers.Count;
+
+                tilesDataList[(int)(((basisTileIdx + tileIdx) * 2) + 0)] = layersBeg;
+
+                uint layersMask = 0;
+                for (var i = 0; i < numLayers; i++)
+                {
+                    var layerIdx = tileZ[tileIdx].Layers[i].LayerIndex;
+                    var position = tileZ[tileIdx].Layers[i].AtlasInPosition;
+                    var atlasX = position & widthInTilesGrayUp;
+                    var atlasY = (uint)((int)position >> (int)widthInTilesShift0);
+                    var widthShift = _mlmask.Layers![layerIdx].WidthShift;
+                    var heightShift = _mlmask.Layers[layerIdx].HeightShift;
+
+                    uint puts = 0;
+                    puts |= atlasX;
+                    puts |= atlasY << 10;
+                    puts |= widthShift << 20;
+                    puts |= heightShift << 24;
+
+                    tilesDataList.Add(puts);
+                    layersMask |= 1u << (int)layerIdx;
+                }
+
+                tilesDataList[(int)(((basisTileIdx + tileIdx) * 2) + 1)] = layersMask;
+            }
+        }
+    }
+
+    #endregion Core Methods
+
+    #region Structs
+
+    public struct RawTexContainer
+    {
+        public byte[] Pixels;
+        public uint Width;
+        public uint Height;
+        public List<Tile> Tiles;
+        public uint WidthShift;
+        public uint HeightShift;
+        public uint WidthInTiles0;
+        public uint HeightInTiles0;
+    }
+
+    public struct Tile
+    {
+        public byte RangeMin;
+        public byte RangeMax;
+        public byte[] AtlasUnCompressed;
+        public ulong[] AtlasBlockCompressed;
+        public uint AtlasInPosition;
+    }
+
+    public struct MaskTile
+    {
+        public List<TileView> Layers;
+    }
+
+    public struct TileView
+    {
+        public uint LayerIndex;
+        public uint AtlasInPosition;
+        public uint LayerTileIndex;
+    }
+
+    public class MlMaskContainer
+    {
+        public byte[]? AtlasBuffer;
+        public uint AtlasHeight;
+        public Dictionary<ulong, TileView> AtlasTiles = new();
+        public uint AtlasTilesCount;
+        public uint AtlasTileSize;
+        public uint AtlasWidth;
+        public uint HeightHigh;
+        public uint HeightInTilesHigh;
+        public uint HeightInTilesLow;
+        public uint HeightLow;
+        public RawTexContainer[]? Layers;
+        public MaskTile[]? MaskTilesHigh;
+        public MaskTile[]? MaskTilesLow;
+        public byte[]? TilesBuffer;
+        public uint TileSize;
+        public uint WidthHigh;
+        public uint WidthInTilesHigh;
+        public uint WidthInTilesLow;
+        public uint WidthLow;
+    }
+
+    #endregion Structs
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskImportTools.cs
@@ -53,7 +53,7 @@ public class MLMASK
         if (files.Count == 0)
         {
             // 0x2006 = MLMask: No layer files specified in masklist
-            throw new WolvenKitException(0x2006, "No layer files specified in masklist.");
+            throw new ArgumentException("No layer files specified in masklist.", nameof(txtImageList));
         }
 
         _mlmask = new MlMaskContainer();
@@ -70,9 +70,8 @@ public class MLMASK
 
             try
             {
-                using var image = RedImage.LoadFromFile(f) ??
-                                  throw new WolvenKitException(0x2007,
-                                      $"Could not load image: {f}"); // 0x2007 = MLMask: General image loading failure
+                using var image = RedImage.LoadFromFile(f)
+                    ?? throw new InvalidDataException($"Could not load image: {f}");
 
                 if (image.Metadata.Format != DXGI_FORMAT.DXGI_FORMAT_R8_UNORM)
                 {

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -119,7 +119,7 @@ public partial class ModTools
 
             var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
 
-            if (tileIndex * 2 + 1 >= tiles.Length)
+            if ((tileIndex * 2) + 1 >= tiles.Length)
             {
                 return false;
             }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -440,8 +440,6 @@ public partial class ModTools
         }
 
         return true;
-
-        return true;
     }
 
     public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -12,8 +12,8 @@ using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
 /// <summary>
-/// Error code ranges used in multilayer mask processing:
-/// 0x3100–0x31FF : Core decoding, BC4 unpacking and layer processing errors
+/// MLMask processing error codes (registered in LogCodeHelper):
+///   0x3003 = BC4 decode failed for multilayer mask atlas
 /// </summary>
 
 namespace WolvenKit.Modkit.RED4;
@@ -38,7 +38,7 @@ public partial class ModTools
 
     #region Methods
 
-    // Decode each grayscale layer to RedImage (always outputs linear R8G8B8A8_UNORM)
+    // Decode each grayscale layer to RedImage (outputs R8_UNORM)
     /// <summary>
     /// Decodes all layers of a multilayer mask into RedImage objects (used by ConvertMultilayerMaskToDdsStreams).
     /// </summary>
@@ -99,8 +99,8 @@ public partial class ModTools
         var atlasRaw = new byte[atlasWidth * atlasHeight];
         if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
         {
-            // 0x3101 = BC4 / multilayer mask decode error (core processing uses 0x31xx range)
-            throw new WolvenKitException(0x3101, "BC4 decode failed for multilayer mask atlas.");
+            // 0x3003 = BC4 decode error in multilayer mask
+            throw new WolvenKitException(0x3003, "BC4 decode failed for multilayer mask atlas.");
         }
 
         var tileBuffer = blob.TilesData.Buffer;
@@ -117,10 +117,36 @@ public partial class ModTools
 
         var fullResBuffer = new byte[maskWidth * maskHeight];
 
+        // Local function: decodes one layer into fullResBuffer.
+        // Made local to avoid passing many parameters (as suggested in code review).
+        void Decode(int maskIndex)
+        {
+            var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
+            var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
+            var smallOffset = widthInTiles0 * heightInTiles0;
+            var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
+
+            var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
+            var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
+
+            for (uint y = 0; y < maskHeight; y++)
+            {
+                for (uint x = 0; x < maskWidth; x++)
+                {
+                    // Decode using low-res tile map first (fallback)
+                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y, tiles, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+
+                    // Then decode using full-res tile map — this can overwrite with higher quality data
+                    // if the layer has dedicated high-resolution tiles for this pixel.
+                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y, tiles, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
+                }
+            }
+        }
+
         for (var i = 0; i < maskCount; i++)
         {
             Array.Clear(fullResBuffer, 0, fullResBuffer.Length); // Ensure pixels without tile data are black (0)
-            Decode(ref fullResBuffer, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth, atlasHeight, tiles, maskTileSize, i);
+            Decode(i);
 
             var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
 
@@ -173,31 +199,7 @@ public partial class ModTools
         return false;
     }
 
-    private static void Decode(ref byte[] maskData, uint maskWidth, uint maskHeight, uint maskWidthLow, uint maskHeightLow, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint[] tileData, uint maskTileSize, int maskIndex)
-    {
-        var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
-        var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
-        var smallOffset = widthInTiles0 * heightInTiles0;
-        var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
-
-        var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
-        var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
-
-        for (uint y = 0; y < maskHeight; y++)
-        {
-            for (uint x = 0; x < maskWidth; x++)
-            {
-                // Decode using low-res tile map first (fallback)
-                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
-                
-                // Then decode using full-res tile map — this can overwrite with higher quality data
-                // if the layer has dedicated high-resolution tiles for this pixel.
-                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
-            }
-        }
-    }
-
-    private static void DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
+    private static bool DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
     {
         var xTile = x / maskTileSize / smallScale;
         var yTile = y / maskTileSize / smallScale;
@@ -206,7 +208,7 @@ public partial class ModTools
 
         if ((tileIndex * 2) + 1 >= tilesData.Length)
         {
-            return;
+            return false;
         }
 
         var paramOffset = tilesData[tileIndex * 2];
@@ -214,7 +216,7 @@ public partial class ModTools
 
         if ((uint)(paramBits & (1 << maskIndex)) == 0U)
         {
-            return;
+            return false;
         }
 
         var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
@@ -242,6 +244,8 @@ public partial class ModTools
 
         var p = atlasData[ux + (uy * atlasWidth)];
         maskData[x + (y * maskWidth)] = p;
+
+        return true;
     }
 
     private static uint DivCeil(uint l, uint r) => (l + r - 1) / r;
@@ -309,6 +313,10 @@ public partial class ModTools
         img.Dispose();
         return png;
     }
+
+    // Note: We intentionally vertically flip PNG previews so they appear
+    // in the expected orientation in Blender / Photoshop (Y=0 at top).
+    // The in-game DDS representation remains correct for REDengine.
 
     public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
     {
@@ -435,12 +443,12 @@ public partial class ModTools
         if (args.AsList)
         {
             var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
-            // .masklist contains only the list of layer image paths (one per line), in order.
             File.WriteAllLines(maskListPath, masks);
         }
 
         return true;
     }
+    // The import side ignores lines starting with '#' or containing '='.
 
     public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
     {

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using CP77.Common.Image;
+using WolvenKit.Core.Exceptions;
 using WolvenKit.Common;
 using WolvenKit.Common.DDS;
 using WolvenKit.Common.Model.Arguments;
@@ -9,280 +11,471 @@ using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
-namespace WolvenKit.Modkit.RED4
-{
-    public partial class ModTools
-    {
-        #region Methods
+namespace WolvenKit.Modkit.RED4;
 
-        private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
+public partial class ModTools
+{
+    private const uint ATLAS_TILE_PADDING = 2;
+
+    // Bit layout of tileDecl (from multilayer mask tiles data)
+    private const uint TILE_PARAM_MASK = 0x3FF;   // 10 bits (0-9)
+    private const int  TILE_DX_SHIFT   = 0;       // bits 0-9  → X offset in atlas
+    private const int  TILE_DY_SHIFT   = 10;      // bits 10-19 → Y offset in atlas
+    private const int  TILE_SX_SHIFT   = 20;      // bits 20-23 → X scale/shift
+    private const int  TILE_SY_SHIFT   = 24;      // bits 24-27 → Y scale/shift
+    private const uint TILE_S_MASK     = 0xF;     // 4 bits
+
+    #region Methods
+
+    // Decode each grayscale layer to RedImage (always outputs linear R8G8B8A8_UNORM)
+    private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
+    {
+        uint atlasWidth = blob.Header.AtlasWidth;
+        uint atlasHeight = blob.Header.AtlasHeight;
+        uint maskWidth = blob.Header.MaskWidth;
+        uint maskHeight = blob.Header.MaskHeight;
+        uint maskWidthLow = blob.Header.MaskWidthLow;
+        uint maskHeightLow = blob.Header.MaskHeightLow;
+        uint maskTileSize = blob.Header.MaskTileSize;
+
+        var atlasRaw = new byte[atlasWidth * atlasHeight];
+        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+        {
+            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
+        }
+
+        var tileBuffer = blob.TilesData.Buffer;
+        var tiles = new uint[tileBuffer.MemSize / 4];
+        using (var ms = new MemoryStream(tileBuffer.GetBytes()))
+        using (var br = new BinaryReader(ms))
+        {
+            ms.Seek(0, SeekOrigin.Begin);
+            for (var i = 0; i < tiles.Length; i++)
+            {
+                tiles[i] = br.ReadUInt32();
+            }
+        }
+
+        foreach (var layer in DecodeLayerBuffers(blob))
+        {
+            var (layerBuffer, outWidth, outHeight) = layer;
+
+            var info = new DDSUtils.DDSInfo
+            {
+                Compression = Enums.ETextureCompression.TCM_None,
+                RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
+                IsGamma = false,
+                Width = outWidth,
+                Height = outHeight,
+                Depth = 1,
+                MipCount = 1,
+                SliceCount = 1,
+                TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
+            };
+
+            var img = RedImage.Create(info, layerBuffer);
+
+            try
+            {
+                var targetLinear = Common.DDS.DXGI_FORMAT.DXGI_FORMAT_R8_UNORM;
+                if (img.Metadata.Format != (DXGI_FORMAT)targetLinear)
+                {
+                    img.Convert(targetLinear);
+                }
+            }
+            catch
+            {
+                // Conversion failed — yield original image
+            }
+
+            yield return img;
+        }
+    }
+
+    /// <summary>
+    /// Decodes each layer from the multilayer mask.
+    /// Layers are exported either at full high resolution or at the reduced low resolution,
+    /// depending on whether the layer has dedicated high-resolution tile data.
+    /// </summary>
+    private static IEnumerable<(byte[] buffer, uint width, uint height)> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
+    {
+        uint atlasWidth = blob.Header.AtlasWidth;
+        uint atlasHeight = blob.Header.AtlasHeight;
+        uint maskWidth = blob.Header.MaskWidth;
+        uint maskHeight = blob.Header.MaskHeight;
+        uint maskWidthLow = blob.Header.MaskWidthLow;
+        uint maskHeightLow = blob.Header.MaskHeightLow;
+        uint maskTileSize = blob.Header.MaskTileSize;
+        uint maskCount = blob.Header.NumLayers;
+
+        var atlasRaw = new byte[atlasWidth * atlasHeight];
+        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+        {
+            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
+        }
+
+        var tileBuffer = blob.TilesData.Buffer;
+        var tiles = new uint[tileBuffer.MemSize / 4];
+        using (var ms = new MemoryStream(tileBuffer.GetBytes()))
+        using (var br = new BinaryReader(ms))
+        {
+            ms.Seek(0, SeekOrigin.Begin);
+            for (var i = 0; i < tiles.Length; i++)
+            {
+                tiles[i] = br.ReadUInt32();
+            }
+        }
+
+        var fullResBuffer = new byte[maskWidth * maskHeight];
+
+        for (var i = 0; i < maskCount; i++)
+        {
+            Array.Clear(fullResBuffer, 0, fullResBuffer.Length);
+            Decode(ref fullResBuffer, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth, atlasHeight, tiles, maskTileSize, i);
+
+            var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
+
+            byte[] layerBuffer;
+            uint outWidth;
+            uint outHeight;
+
+            if (hasHighRes || maskWidthLow == 0 || maskHeightLow == 0 || maskWidthLow == maskWidth)
+            {
+                layerBuffer = (byte[])fullResBuffer.Clone();
+                outWidth = maskWidth;
+                outHeight = maskHeight;
+            }
+            else
+            {
+                outWidth = maskWidthLow;
+                outHeight = maskHeightLow;
+                layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
+            }
+
+            yield return (layerBuffer, outWidth, outHeight);
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a specific layer has any high-resolution tile data.
+    /// This determines if the layer should be exported at full resolution or downscaled.
+    /// </summary>
+    private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize, int layerIndex)
+    {
+        var widthInTiles = DivCeil(maskWidth, maskTileSize);
+        var heightInTiles = DivCeil(maskHeight, maskTileSize);
+        var highResTileCount = widthInTiles * heightInTiles;
+
+        for (uint tileIdx = 0; tileIdx < highResTileCount; tileIdx++)
+        {
+            if ((tileIdx * 2) + 1 >= tiles.Length)
+            {
+                continue;
+            }
+
+            var paramBits = tiles[(tileIdx * 2) + 1];
+
+            if ((paramBits & (1 << layerIndex)) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void Decode(ref byte[] maskData, uint maskWidth, uint maskHeight, uint maskWidthLow, uint maskHeightLow, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint[] tileData, uint maskTileSize, int maskIndex)
+    {
+        var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
+        var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
+        var smallOffset = widthInTiles0 * heightInTiles0;
+        var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
+
+        var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
+        var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
+
+        for (uint y = 0; y < maskHeight; y++)
+        {
+            for (uint x = 0; x < maskWidth; x++)
+            {
+                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
+            }
+        }
+    }
+
+    private static void DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
+    {
+        var xTile = x / maskTileSize / smallScale;
+        var yTile = y / maskTileSize / smallScale;
+
+        var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
+
+        if ((tileIndex * 2) + 1 >= tilesData.Length)
+        {
+            return;
+        }
+
+        var paramOffset = tilesData[tileIndex * 2];
+        var paramBits = tilesData[(tileIndex * 2) + 1];
+
+        if ((uint)(paramBits & (1 << maskIndex)) == 0U)
+        {
+            return;
+        }
+
+        var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
+
+        uint tileDecl = 0;
+        if (paramOffset + extraAdd < tilesData.Length)
+        {
+            tileDecl = tilesData[paramOffset + extraAdd];
+        }
+
+        // Extract atlas position and scaling factors from the packed tile declaration.
+        var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
+        var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
+        var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
+        var sy = (tileDecl >> TILE_SY_SHIFT) & TILE_S_MASK;
+
+        var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+
+        var ux = ((x >> (int)sx) % maskTileSize) + 1 + (dx * atlasTileSize);
+        var uy = ((y >> (int)sy) % maskTileSize) + 1 + (dy * atlasTileSize);
+
+        var p = atlasData[ux + (uy * atlasWidth)];
+        maskData[x + (y * maskWidth)] = p;
+    }
+
+    private static uint DivCeil(uint l, uint r)
+    {
+        return (l + r - 1) / r;
+    }
+
+    private static uint CountBits(uint v)
+    {
+        return (uint)System.Numerics.BitOperations.PopCount(v);
+    }
+
+    private static byte[] DownscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
+    {
+        var dst = new byte[dstW * dstH];
+        var factorX = (double)srcW / dstW;
+        var factorY = (double)srcH / dstH;
+
+        for (uint y = 0; y < dstH; y++)
+        {
+            var rowOffset = y * dstW;
+            for (uint x = 0; x < dstW; x++)
+            {
+                var srcX = (uint)(x * factorX);
+                var srcY = (uint)(y * factorY);
+
+                if (srcX >= srcW)
+                {
+                    srcX = srcW - 1;
+                }
+
+                if (srcY >= srcH)
+                {
+                    srcY = srcH - 1;
+                }
+
+                dst[rowOffset + x] = src[srcX + srcY * srcW];
+            }
+        }
+        return dst;
+    }
+
+    private static byte[] CreateWkPreviewPng(byte[] gray, int width, int height)
+    {
+        var imgData = new byte[width * height * 4];
+        for (int i = 0; i < width * height; i++)
+        {
+            var v = gray[i];
+            var baseIdx = i * 4;
+            imgData[baseIdx + 0] = v;
+            imgData[baseIdx + 1] = v;
+            imgData[baseIdx + 2] = v;
+            imgData[baseIdx + 3] = 255;
+        }
+
+        var info = new DDSUtils.DDSInfo
+        {
+            Compression = Enums.ETextureCompression.TCM_None,
+            RawFormat = Enums.ETextureRawFormat.TRF_TrueColor,
+            IsGamma = false,
+            Width = (uint)width,
+            Height = (uint)height,
+            Depth = 1,
+            MipCount = 1,
+            SliceCount = 1,
+            TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
+        };
+
+        var img = RedImage.Create(info, imgData);
+        var png = img.SaveToPNGMemory();
+        img.Dispose();
+        return png;
+    }
+
+    public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
+    {
+        if (mlmask.RenderResourceBlob.RenderResourceBlobPC.Chunk is not rendRenderMultilayerMaskBlobPC blob)
+        {
+            return false;
+        }
+
+        try
         {
             uint atlasWidth = blob.Header.AtlasWidth;
             uint atlasHeight = blob.Header.AtlasHeight;
-
-            uint maskWidth = blob.Header.MaskWidth;
-            uint maskHeight = blob.Header.MaskHeight;
-
-            uint maskWidthLow = blob.Header.MaskWidthLow;
-            uint maskHeightLow = blob.Header.MaskHeightLow;
-
             uint maskTileSize = blob.Header.MaskTileSize;
 
-            uint maskCount = blob.Header.NumLayers;
-
-            var atlasRaw = new byte[atlasWidth * atlasHeight];
-
-            if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+            if (maskTileSize == 0)
             {
-                throw new Exception();
+                _loggerService.Error("Invalid MaskTileSize: 0");
+                return false;
             }
 
-            var tileBuffer = blob.TilesData.Buffer;
-            var tiles = new uint[tileBuffer.MemSize / 4];
-
-            using (var ms = new MemoryStream(tileBuffer.GetBytes()))
-            using (var br = new BinaryReader(ms))
+            var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+            if (atlasWidth % atlasTileSize != 0 || atlasHeight % atlasTileSize != 0)
             {
-                ms.Seek(0, SeekOrigin.Begin);
-
-                for (var i = 0; i < tiles.Length; i++)
-                {
-                    tiles[i] = br.ReadUInt32();
-                }
+                _loggerService.Error($"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
+                return false;
             }
+        }
+        catch
+        {
+            _loggerService.Error("Failed to validate multilayer mask header.");
+            return false;
+        }
 
-            var maskData = new byte[maskWidth * maskHeight];
-
-            for (var i = 0; i < maskCount; i++)
+        DirectoryInfo? subDir = null;
+        if (args.AsList)
+        {
+            subDir = new DirectoryInfo(Path.ChangeExtension(outfile.FullName, null) + "_layers");
+            if (!subDir.Exists)
             {
-                //Clear instead of allocate new is faster?
-                //Mandatory cause decode does not always write to every pixel
-                Array.Clear(maskData, 0, maskData.Length);
-
-                Decode(ref maskData, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth,
-                    atlasHeight, tiles, maskTileSize, i);
-
-                var info = new DDSUtils.DDSInfo
-                {
-                    Compression = Enums.ETextureCompression.TCM_None,
-                    RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
-                    IsGamma = false,
-                    Width = maskWidth,
-                    Height = maskHeight,
-                    Depth = 1,
-                    MipCount = 1,
-                    SliceCount = 1,
-                    TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
-                };
-
-                yield return RedImage.Create(info, maskData);
+                Directory.CreateDirectory(subDir.FullName);
             }
         }
 
-        public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
+        if ((args.AsList && subDir is null) || (!args.AsList && outfile.Directory is null))
         {
-            // read the cr2wfile
-            if (mlmask.RenderResourceBlob.RenderResourceBlobPC.Chunk is not rendRenderMultilayerMaskBlobPC blob)
+            _loggerService.Error("directory was null");
+            return false;
+        }
+
+        var cnt = 0;
+        var masks = new List<string>();
+        var layerResolutions = new List<string>();
+
+        foreach (var layer in DecodeLayerBuffers(blob))
+        {
+            var (layerBuffer, outWidth, outHeight) = layer;
+
+            var layerFileName = Path.GetFileNameWithoutExtension(outfile.FullName) + $"_{cnt++}";
+            var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName, $"{layerFileName}.{args.UncookExtension}");
+
+            if (args.UncookExtension == EUncookExtension.png)
             {
-                return false;
-            }
+                var preview = CreateWkPreviewPng(layerBuffer, (int)outWidth, (int)outHeight);
+                File.WriteAllBytes(newPath, preview);
 
-            // write texture to file
-            DirectoryInfo? subDir = null;
-            if (args.AsList)
-            {
-                subDir = new DirectoryInfo(Path.ChangeExtension(outfile.FullName, null) + "_layers");
-                if (!subDir.Exists)
-                {
-                    Directory.CreateDirectory(subDir.FullName);
-                }
-            }
-
-            if ((args.AsList && subDir is null) || (!args.AsList && outfile.Directory is null))
-            {
-                _loggerService.Error("directory was null");
-                return false;
-            }
-
-            var cnt = 0;
-            var masks = new List<string>();
-
-            foreach (var img in GetRedImages(blob))
-            {
-                var mFilename = Path.GetFileNameWithoutExtension(outfile.FullName) + $"_{cnt++}";
-                var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName, $"{mFilename}.{args.UncookExtension}");
-
-                var buffer = args.UncookExtension switch
-                {
-                    EUncookExtension.dds => img.SaveToDDSMemory(),
-                    EUncookExtension.tga => img.SaveToTGAMemory(),
-                    EUncookExtension.bmp => img.SaveToBMPMemory(),
-                    EUncookExtension.jpg => img.SaveToJPEGMemory(),
-                    EUncookExtension.png => img.SaveToPNGMemory(),
-                    EUncookExtension.tiff => img.SaveToTIFFMemory(),
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-                img.Dispose();
-
-                File.WriteAllBytes(newPath, buffer);
                 if (args.AsList)
                 {
-                    masks.Add($"{subDir!.Name}/{mFilename}.{args.UncookExtension}");
+                    masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
                 }
+
+                layerResolutions.Add($"{outWidth}x{outHeight}");
+                continue;
             }
+
+            var info = new DDSUtils.DDSInfo
+            {
+                Compression = Enums.ETextureCompression.TCM_None,
+                RawFormat = Enums.ETextureRawFormat.TRF_Grayscale,
+                IsGamma = false,
+                Width = outWidth,
+                Height = outHeight,
+                Depth = 1,
+                MipCount = 1,
+                SliceCount = 1,
+                TextureType = Enums.GpuWrapApieTextureType.TEXTYPE_2D
+            };
+
+            var img = RedImage.Create(info, layerBuffer);
+
+            byte[] buffer;
+            switch (args.UncookExtension)
+            {
+                case EUncookExtension.dds:
+                    buffer = img.SaveToDDSMemory();
+                    break;
+                case EUncookExtension.tga:
+                    buffer = img.SaveToTGAMemory();
+                    break;
+                case EUncookExtension.bmp:
+                    buffer = img.SaveToBMPMemory();
+                    break;
+                case EUncookExtension.jpg:
+                    buffer = img.SaveToJPEGMemory();
+                    break;
+                case EUncookExtension.tiff:
+                    buffer = img.SaveToTIFFMemory();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(args.UncookExtension), $"Unsupported uncook extension: {args.UncookExtension}");
+            }
+
+            File.WriteAllBytes(newPath, buffer);
 
             if (args.AsList)
             {
-                // write metadata
-                var maskList = Path.ChangeExtension(outfile.FullName, "masklist");
-                File.WriteAllLines(maskList, masks.ToArray());
+                masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
             }
 
-            return true;
+            layerResolutions.Add($"{img.Metadata.Width}x{img.Metadata.Height}");
+            img.Dispose();
         }
 
-        public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
+        if (args.AsList)
         {
-            streams = new List<Stream>();
-            if (mask.RenderResourceBlob.RenderResourceBlobPC.GetValue() is not rendRenderMultilayerMaskBlobPC blob)
-            {
-                return false;
-            }
+            var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
 
-            foreach (var img in GetRedImages(blob))
+            // Simplified header - only basic info, no original atlas/mask dimensions
+            var headerLines = new List<string>
             {
-                streams.Add(new MemoryStream(img.SaveToDDSMemory()));
-                img.Dispose();
-            }
+                "# MLMask Export",
+                "# Layer image files (must be in correct order)",
+                ""
+            };
 
-            return true;
+            headerLines.AddRange(masks);
+            File.WriteAllLines(maskListPath, headerLines);
         }
 
-        private static byte BilinearInterpolation(byte q00, byte q10, byte q01, byte q11, int x, int x1, int y, int y1)
-        {
-            const int sc = 256;
-
-            if (x1 == 0 || y1 == 0)
-            {
-                return q00;
-            }
-
-            var q00s = q00 * sc;
-            var q10s = q10 * sc;
-            var q01s = q01 * sc;
-            var q11s = q11 * sc;
-
-            var a0 = q00s;
-            var a1 = (q10s - q00s) * x / x1;
-            var a2 = (q01s - q00s) * y / y1;
-            var a3 = (q00s - q01s - q10s + q11s) * x * y / x1 / y1;
-
-            var a = a0 + a1 + a2 + a3;
-            var r = a / sc;
-            if (r > 255)
-            {
-                r = 255;
-            }
-
-            return (byte)r;
-        }
-
-        private static uint CountBits(uint v)
-        {
-            var t = v;
-            uint count = 0;
-            for (uint i = 0; i < 32; i++)
-            {
-                if ((t & 1) == 1)
-                {
-                    count++;
-                }
-                t >>= 1;
-            }
-            return count;
-        }
-
-        private static void Decode(ref byte[] maskData, uint maskWidth, uint maskHeight, uint mWidthLow, uint mHeightLow, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint[] tileData, uint maskTileSize, int maskIndex)
-        {
-            var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
-            var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
-            var smallOffset = widthInTiles0 * heightInTiles0;
-
-            // DivideByZero preventions.
-            // maskWidthLow == 0
-            // maskWidth < mWidthLow => maskWidth / mWidthLow = 0 because (int) Math
-            var smallScale =
-                mWidthLow == 0 || maskWidth < mWidthLow
-                    ? 1
-                    : maskWidth / mWidthLow;
-
-            for (uint x = 0; x < maskWidth; x++)
-            {
-                for (uint y = 0; y < maskHeight; y++)
-                {
-                    DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale);
-                    DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1);
-                }
-            }
-        }
-
-        private static void DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale)
-        {
-            var widthInTiles = DivCeil(maskWidth / smallScale, maskTileSize);
-
-            var xTile = x / maskTileSize / smallScale;
-            var yTile = y / maskTileSize / smallScale;
-
-            var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
-
-            if ((tileIndex * 2) + 1 >= tilesData.Length)
-            {
-                return;
-            }
-
-            var paramOffset = tilesData[tileIndex * 2];
-            var paramBits = tilesData[(tileIndex * 2) + 1];
-
-            if ((uint)(paramBits & (1 << maskIndex)) == 0U)
-            {
-                return;
-            }
-
-            var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
-
-            uint tileDecl = 0;
-            if (paramOffset + extraAdd < tilesData.Length)
-            {
-                tileDecl = tilesData[paramOffset + extraAdd];
-            }
-
-            var dx = tileDecl & 0x3ff;
-            var dy = (tileDecl >> 10) & 0x3ff;
-            var sx = (tileDecl >> 20) & 0xf;
-            var sy = (tileDecl >> 24) & 0xf;
-
-            var atlasTileSize = maskTileSize + 2;
-
-            var x1 = (1 << (int)sx) - 1;
-            var xi = (int)(x & x1);
-            var y1 = (1 << (int)sy) - 1;
-            var yi = (int)(y & y1);
-
-            var ux = ((x >> (int)sx) % maskTileSize) + 1 + (dx * atlasTileSize);
-            var uy = ((y >> (int)sy) % maskTileSize) + 1 + (dy * atlasTileSize);
-
-            var q00 = atlasData[ux + 0 + ((uy + 0) * atlasWidth)];
-            var q10 = atlasData[ux + 1 + ((uy + 0) * atlasWidth)];
-            var q01 = atlasData[ux + 0 + ((uy + 1) * atlasWidth)];
-            var q11 = atlasData[ux + 1 + ((uy + 1) * atlasWidth)];
-
-            var p = BilinearInterpolation(q00, q10, q01, q11, xi, x1, yi, y1);
-
-            maskData[x + (y * maskWidth)] = p;
-        }
-
-        private static uint DivCeil(uint l, uint r) => (l + r - 1) / r;
-
-        #endregion Methods
+        return true;
     }
+
+    public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
+    {
+        streams = new List<Stream>();
+
+        if (mask.RenderResourceBlob.RenderResourceBlobPC.GetValue() is not rendRenderMultilayerMaskBlobPC blob)
+        {
+            return false;
+        }
+
+        foreach (var img in GetRedImages(blob))
+        {
+            streams.Add(new MemoryStream(img.SaveToDDSMemory()));
+            img.Dispose();
+        }
+
+        return true;
+    }
+
+    #endregion Methods
 }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -281,21 +281,14 @@ public partial class ModTools
     private static byte[] CreateWkPreviewPng(byte[] grayData, int width, int height)
     {
         var imgData = new byte[width * height * 4];
-
-        // Vertically flip so that the image appears correct in Blender / image editors
-        // (REDengine often stores textures with Y=0 at the bottom)
-        for (int y = 0; y < height; y++)
+        for (int i = 0; i < width * height; i++)
         {
-            int srcY = height - 1 - y; // flip vertically
-            for (int x = 0; x < width; x++)
-            {
-                var v = grayData[srcY * width + x];
-                int dstIdx = (y * width + x) * 4;
-                imgData[dstIdx + 0] = v;
-                imgData[dstIdx + 1] = v;
-                imgData[dstIdx + 2] = v;
-                imgData[dstIdx + 3] = 255;
-            }
+            var v = grayData[i];
+            var baseIdx = i * 4;
+            imgData[baseIdx + 0] = v;
+            imgData[baseIdx + 1] = v;
+            imgData[baseIdx + 2] = v;
+            imgData[baseIdx + 3] = 255;
         }
 
         var info = new DDSUtils.DDSInfo
@@ -316,10 +309,6 @@ public partial class ModTools
         img.Dispose();
         return png;
     }
-
-    // Note: We intentionally vertically flip PNG previews so they appear
-    // in the expected orientation in Blender / Photoshop (Y=0 at top).
-    // The in-game DDS representation remains correct for REDengine.
 
     public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
     {
@@ -460,9 +449,6 @@ public partial class ModTools
 
         return true;
     }
-
-    // Note: We add a small header to .masklist for human readability.
-    // The import side ignores lines starting with '#' or containing '='.
 
     public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
     {

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -94,8 +94,7 @@ public partial class ModTools
         if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight,
                 BlockCompression.BlockCompressionType.BC4))
         {
-            // 0x3003 = BC4 decode error in multilayer mask
-            throw new WolvenKitException(0x3003, "BC4 decode failed for multilayer mask atlas.");
+            throw new InvalidDataException("BC4 decode failed for multilayer mask atlas.");
         }
 
         var tileBuffer = blob.TilesData.Buffer;

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -112,14 +112,61 @@ public partial class ModTools
 
         var fullResBuffer = new byte[maskWidth * maskHeight];
 
-        // Local function: decodes one layer into fullResBuffer.
-        // Made local to avoid passing many parameters (as suggested in code review).
+        bool DecodeSingle(uint x, uint y, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
+        {
+            var xTile = x / maskTileSize / smallScale;
+            var yTile = y / maskTileSize / smallScale;
+
+            var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
+
+            if ((tileIndex * 2) + 1 >= tiles.Length)
+            {
+                return false;
+            }
+
+            var paramOffset = tiles[tileIndex * 2];
+            var paramBits = tiles[(tileIndex * 2) + 1];
+
+            if ((uint)(paramBits & (1 << maskIndex)) == 0U)
+            {
+                return false;
+            }
+
+            var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
+
+            uint tileDecl = 0;
+            if (paramOffset + extraAdd < tiles.Length)
+            {
+                tileDecl = tiles[paramOffset + extraAdd];
+            }
+
+            // Extract atlas position and scaling factors from the packed tile declaration.
+            var dx = (tileDecl >> s_tileDxShift) & s_tileParamMask;
+            var dy = (tileDecl >> s_tileDyShift) & s_tileParamMask;
+            var sx = (tileDecl >> s_tileSxShift) & s_tileSMask;
+            var sy = (tileDecl >> s_tileSyShift) & s_tileSMask;
+
+            var atlasTileSize = maskTileSize + s_atlasTilePadding;
+
+            // Use Min to avoid reading into the right/bottom padding area of atlas tiles
+            var localX = Math.Min((x >> (int)sx) % maskTileSize, maskTileSize - 1);
+            var localY = Math.Min((y >> (int)sy) % maskTileSize, maskTileSize - 1);
+
+            var ux = localX + 1 + (dx * atlasTileSize);
+            var uy = localY + 1 + (dy * atlasTileSize);
+
+            var p = atlasRaw[ux + (uy * atlasWidth)];
+            fullResBuffer[x + (y * maskWidth)] = p;
+
+            return true;
+        }
+
         void Decode(int maskIndex)
         {
             var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
             var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
             var smallOffset = widthInTiles0 * heightInTiles0;
-            var smallScale = maskWidthLow == 0 || maskWidth < maskWidthLow ? 1u : maskWidth / maskWidthLow;
+            var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
 
             var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
             var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
@@ -128,14 +175,14 @@ public partial class ModTools
             {
                 for (uint x = 0; x < maskWidth; x++)
                 {
-                    // Decode using low-res tile map first (fallback)
-                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y,
-                        tiles, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                    // First try to decode using full-res tile map (primary)
+                    bool decoded = DecodeSingle(x, y, maskIndex, 0, 1, widthInTilesFull);
 
-                    // Then decode using full-res tile map — this can overwrite with higher quality data
-                    // if the layer has dedicated high-resolution tiles for this pixel.
-                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y,
-                        tiles, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
+                    // If full-res didn't have data for this layer/pixel, fall back to low-res tile map
+                    if (!decoded)
+                    {
+                        DecodeSingle(x, y, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                    }
                 }
             }
         }
@@ -458,7 +505,6 @@ public partial class ModTools
 
         return true;
     }
-    // The import side ignores lines starting with '#' or containing '='.
 
     public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
     {

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -111,6 +111,33 @@ public partial class ModTools
 
         var fullResBuffer = new byte[maskWidth * maskHeight];
 
+        for (var i = 0; i < maskCount; i++)
+        {
+            Array.Clear(fullResBuffer, 0, fullResBuffer.Length); // Ensure pixels without tile data are black (0)
+            Decode(i);
+
+            var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
+
+            byte[] layerBuffer;
+            uint outWidth;
+            uint outHeight;
+
+            if (hasHighRes || maskWidthLow == 0 || maskHeightLow == 0 || maskWidthLow == maskWidth)
+            {
+                layerBuffer = (byte[])fullResBuffer.Clone();
+                outWidth = maskWidth;
+                outHeight = maskHeight;
+            }
+            else
+            {
+                outWidth = maskWidthLow;
+                outHeight = maskHeightLow;
+                layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
+            }
+
+            yield return new LayerBuffer(layerBuffer, outWidth, outHeight);
+        }
+        
         bool DecodeSingle(uint x, uint y, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
         {
             var xTile = x / maskTileSize / smallScale;
@@ -197,33 +224,6 @@ public partial class ModTools
                     }
                 }
             }
-        }
-
-        for (var i = 0; i < maskCount; i++)
-        {
-            Array.Clear(fullResBuffer, 0, fullResBuffer.Length); // Ensure pixels without tile data are black (0)
-            Decode(i);
-
-            var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
-
-            byte[] layerBuffer;
-            uint outWidth;
-            uint outHeight;
-
-            if (hasHighRes || maskWidthLow == 0 || maskHeightLow == 0 || maskWidthLow == maskWidth)
-            {
-                layerBuffer = (byte[])fullResBuffer.Clone();
-                outWidth = maskWidth;
-                outHeight = maskHeight;
-            }
-            else
-            {
-                outWidth = maskWidthLow;
-                outHeight = maskHeightLow;
-                layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
-            }
-
-            yield return new LayerBuffer(layerBuffer, outWidth, outHeight);
         }
     }
 

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -1,20 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Numerics;
 using CP77.Common.Image;
-using WolvenKit.Core.Exceptions;
 using WolvenKit.Common;
 using WolvenKit.Common.DDS;
 using WolvenKit.Common.Model.Arguments;
-using WolvenKit.RED4.Archive.CR2W;
+using WolvenKit.Core.Exceptions;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
-
-/// <summary>
-/// MLMask processing error codes (registered in LogCodeHelper):
-///   0x3003 = BC4 decode failed for multilayer mask atlas
-/// </summary>
 
 namespace WolvenKit.Modkit.RED4;
 
@@ -22,25 +16,25 @@ public partial class ModTools
 {
     private const uint s_atlasTilePadding = 2;
 
+    // Bit layout of tileDecl (from multilayer mask tiles data)
+    private const uint s_tileParamMask = 0x3FF; // 10 bits (0-9)
+    private const int s_tileDxShift = 0; // bits 0-9  → X offset in atlas
+    private const int s_tileDyShift = 10; // bits 10-19 → Y offset in atlas
+    private const int s_tileSxShift = 20; // bits 20-23 → X scale/shift
+    private const int s_tileSyShift = 24; // bits 24-27 → Y scale/shift
+    private const uint s_tileSMask = 0xF; // 4 bits
+
     /// <summary>
-    /// Lightweight DTO for a decoded layer buffer + its dimensions.
-    /// Using record struct for clarity and performance (recommended over raw tuple).
+    ///     Lightweight DTO for a decoded layer buffer + its dimensions.
+    ///     Using record struct for clarity and performance (recommended over raw tuple).
     /// </summary>
     private readonly record struct LayerBuffer(byte[] Buffer, uint Width, uint Height);
-
-    // Bit layout of tileDecl (from multilayer mask tiles data)
-    private const uint s_tileParamMask = 0x3FF;   // 10 bits (0-9)
-    private const int  s_tileDxShift   = 0;       // bits 0-9  → X offset in atlas
-    private const int  s_tileDyShift   = 10;      // bits 10-19 → Y offset in atlas
-    private const int  s_tileSxShift   = 20;      // bits 20-23 → X scale/shift
-    private const int  s_tileSyShift   = 24;      // bits 24-27 → Y scale/shift
-    private const uint s_tileSMask     = 0xF;     // 4 bits
 
     #region Methods
 
     // Decode each grayscale layer to RedImage (outputs R8_UNORM)
     /// <summary>
-    /// Decodes all layers of a multilayer mask into RedImage objects (used by ConvertMultilayerMaskToDdsStreams).
+    ///     Decodes all layers of a multilayer mask into RedImage objects (used by ConvertMultilayerMaskToDdsStreams).
     /// </summary>
     private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
     {
@@ -65,8 +59,8 @@ public partial class ModTools
 
             try
             {
-                var targetLinear = Common.DDS.DXGI_FORMAT.DXGI_FORMAT_R8_UNORM;
-                if (img.Metadata.Format != (DXGI_FORMAT)targetLinear)
+                var targetLinear = DXGI_FORMAT.DXGI_FORMAT_R8_UNORM;
+                if (img.Metadata.Format != targetLinear)
                 {
                     img.Convert(targetLinear);
                 }
@@ -81,9 +75,9 @@ public partial class ModTools
     }
 
     /// <summary>
-    /// Decodes each layer from the multilayer mask.
-    /// Layers are exported either at full high resolution or at the reduced low resolution,
-    /// depending on whether the layer has dedicated high-resolution tile data.
+    ///     Decodes each layer from the multilayer mask.
+    ///     Layers are exported either at full high resolution or at the reduced low resolution,
+    ///     depending on whether the layer has dedicated high-resolution tile data.
     /// </summary>
     private static IEnumerable<LayerBuffer> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
     {
@@ -97,7 +91,8 @@ public partial class ModTools
         uint maskCount = blob.Header.NumLayers;
 
         var atlasRaw = new byte[atlasWidth * atlasHeight];
-        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
+        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight,
+                BlockCompression.BlockCompressionType.BC4))
         {
             // 0x3003 = BC4 decode error in multilayer mask
             throw new WolvenKitException(0x3003, "BC4 decode failed for multilayer mask atlas.");
@@ -124,7 +119,7 @@ public partial class ModTools
             var widthInTiles0 = DivCeil(maskWidth, maskTileSize);
             var heightInTiles0 = DivCeil(maskHeight, maskTileSize);
             var smallOffset = widthInTiles0 * heightInTiles0;
-            var smallScale = (maskWidthLow == 0 || maskWidth < maskWidthLow) ? 1u : maskWidth / maskWidthLow;
+            var smallScale = maskWidthLow == 0 || maskWidth < maskWidthLow ? 1u : maskWidth / maskWidthLow;
 
             var widthInTilesScaled = DivCeil(maskWidth / smallScale, maskTileSize);
             var widthInTilesFull = DivCeil(maskWidth, maskTileSize);
@@ -134,11 +129,13 @@ public partial class ModTools
                 for (uint x = 0; x < maskWidth; x++)
                 {
                     // Decode using low-res tile map first (fallback)
-                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y, tiles, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y,
+                        tiles, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
 
                     // Then decode using full-res tile map — this can overwrite with higher quality data
                     // if the layer has dedicated high-resolution tiles for this pixel.
-                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y, tiles, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
+                    DecodeSingle(ref fullResBuffer, maskWidth, maskHeight, atlasRaw, atlasWidth, atlasHeight, x, y,
+                        tiles, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
                 }
             }
         }
@@ -172,10 +169,11 @@ public partial class ModTools
     }
 
     /// <summary>
-    /// Checks whether a specific layer has any high-resolution tile data.
-    /// This determines if the layer should be exported at full resolution or downscaled.
+    ///     Checks whether a specific layer has any high-resolution tile data.
+    ///     This determines if the layer should be exported at full resolution or downscaled.
     /// </summary>
-    private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize, int layerIndex)
+    private static bool HasLayerHighResolutionData(uint[] tiles, uint maskWidth, uint maskHeight, uint maskTileSize,
+        int layerIndex)
     {
         var widthInTiles = DivCeil(maskWidth, maskTileSize);
         var heightInTiles = DivCeil(maskHeight, maskTileSize);
@@ -199,7 +197,9 @@ public partial class ModTools
         return false;
     }
 
-    private static bool DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData, uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex, uint tilesOffset, uint smallScale, uint widthInTiles)
+    private static bool DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData,
+        uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex,
+        uint tilesOffset, uint smallScale, uint widthInTiles)
     {
         var xTile = x / maskTileSize / smallScale;
         var yTile = y / maskTileSize / smallScale;
@@ -250,7 +250,7 @@ public partial class ModTools
 
     private static uint DivCeil(uint l, uint r) => (l + r - 1) / r;
 
-    private static uint CountBits(uint v) => (uint)System.Numerics.BitOperations.PopCount(v);
+    private static uint CountBits(uint v) => (uint)BitOperations.PopCount(v);
 
     private static byte[] DownscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
     {
@@ -276,16 +276,17 @@ public partial class ModTools
                     srcY = srcH - 1;
                 }
 
-                dst[rowOffset + x] = src[srcX + srcY * srcW];
+                dst[rowOffset + x] = src[srcX + (srcY * srcW)];
             }
         }
+
         return dst;
     }
 
     private static byte[] CreateWkPreviewPng(byte[] grayData, int width, int height)
     {
         var imgData = new byte[width * height * 4];
-        for (int i = 0; i < width * height; i++)
+        for (var i = 0; i < width * height; i++)
         {
             var v = grayData[i];
             var baseIdx = i * 4;
@@ -340,7 +341,8 @@ public partial class ModTools
             var atlasTileSize = maskTileSize + s_atlasTilePadding;
             if (atlasWidth % atlasTileSize != 0 || atlasHeight % atlasTileSize != 0)
             {
-                _loggerService.Error($"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
+                _loggerService.Error(
+                    $"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
                 return false;
             }
         }
@@ -378,7 +380,8 @@ public partial class ModTools
             var (layerBuffer, outWidth, outHeight) = layer;
 
             var layerFileName = Path.GetFileNameWithoutExtension(outfile.FullName) + $"_{cnt++}";
-            var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName, $"{layerFileName}.{args.UncookExtension}");
+            var newPath = Path.Combine(args.AsList ? subDir!.FullName : outfile.Directory!.FullName,
+                $"{layerFileName}.{args.UncookExtension}");
 
             if (args.UncookExtension == EUncookExtension.png)
             {
@@ -426,8 +429,15 @@ public partial class ModTools
                 case EUncookExtension.tiff:
                     buffer = img.SaveToTIFFMemory();
                     break;
+                case EUncookExtension.png:
+                    // PNG is handled separately above (with preview generation)
+                    goto default;
+                case EUncookExtension.cube:
+                    // .cube format is not supported for multilayer mask export
+                    goto default;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(args.UncookExtension), $"Unsupported uncook extension: {args.UncookExtension}");
+                    throw new ArgumentOutOfRangeException(nameof(args.UncookExtension),
+                        $"Unsupported uncook extension: {args.UncookExtension}");
             }
 
             File.WriteAllBytes(newPath, buffer);

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -119,7 +119,7 @@ public partial class ModTools
 
             var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
 
-            if ((tileIndex * 2) + 1 >= tiles.Length)
+            if (tileIndex * 2 + 1 >= tiles.Length)
             {
                 return false;
             }
@@ -139,8 +139,11 @@ public partial class ModTools
             {
                 tileDecl = tiles[paramOffset + extraAdd];
             }
+            else
+            {
+                return false;
+            }
 
-            // Extract atlas position and scaling factors from the packed tile declaration.
             var dx = (tileDecl >> s_tileDxShift) & s_tileParamMask;
             var dy = (tileDecl >> s_tileDyShift) & s_tileParamMask;
             var sx = (tileDecl >> s_tileSxShift) & s_tileSMask;
@@ -148,15 +151,25 @@ public partial class ModTools
 
             var atlasTileSize = maskTileSize + s_atlasTilePadding;
 
-            // Use Min to avoid reading into the right/bottom padding area of atlas tiles
             var localX = Math.Min((x >> (int)sx) % maskTileSize, maskTileSize - 1);
             var localY = Math.Min((y >> (int)sy) % maskTileSize, maskTileSize - 1);
 
             var ux = localX + 1 + (dx * atlasTileSize);
             var uy = localY + 1 + (dy * atlasTileSize);
 
-            var p = atlasRaw[ux + (uy * atlasWidth)];
-            fullResBuffer[x + (y * maskWidth)] = p;
+            var atlasIndex = ux + (uy * atlasWidth);
+            if (atlasIndex >= atlasRaw.Length)
+            {
+                return false;
+            }
+
+            var p = atlasRaw[atlasIndex];
+
+            var bufferIndex = x + (y * maskWidth);
+            if (bufferIndex < fullResBuffer.Length)
+            {
+                fullResBuffer[bufferIndex] = p;
+            }
 
             return true;
         }
@@ -244,56 +257,6 @@ public partial class ModTools
         return false;
     }
 
-    private static bool DecodeSingle(ref byte[] maskData, uint maskWidth, uint maskHeight, byte[] atlasData,
-        uint atlasWidth, uint atlasHeight, uint x, uint y, uint[] tilesData, uint maskTileSize, int maskIndex,
-        uint tilesOffset, uint smallScale, uint widthInTiles)
-    {
-        var xTile = x / maskTileSize / smallScale;
-        var yTile = y / maskTileSize / smallScale;
-
-        var tileIndex = (widthInTiles * yTile) + xTile + tilesOffset;
-
-        if ((tileIndex * 2) + 1 >= tilesData.Length)
-        {
-            return false;
-        }
-
-        var paramOffset = tilesData[tileIndex * 2];
-        var paramBits = tilesData[(tileIndex * 2) + 1];
-
-        if ((uint)(paramBits & (1 << maskIndex)) == 0U)
-        {
-            return false;
-        }
-
-        var extraAdd = CountBits((uint)(paramBits & ((1 << maskIndex) - 1)));
-
-        uint tileDecl = 0;
-        if (paramOffset + extraAdd < tilesData.Length)
-        {
-            tileDecl = tilesData[paramOffset + extraAdd];
-        }
-
-        // Extract atlas position and scaling factors from the packed tile declaration.
-        var dx = (tileDecl >> s_tileDxShift) & s_tileParamMask;
-        var dy = (tileDecl >> s_tileDyShift) & s_tileParamMask;
-        var sx = (tileDecl >> s_tileSxShift) & s_tileSMask;
-        var sy = (tileDecl >> s_tileSyShift) & s_tileSMask;
-
-        var atlasTileSize = maskTileSize + s_atlasTilePadding;
-
-        // Use Min to avoid reading into the right/bottom padding area of atlas tiles
-        var localX = Math.Min((x >> (int)sx) % maskTileSize, maskTileSize - 1);
-        var localY = Math.Min((y >> (int)sy) % maskTileSize, maskTileSize - 1);
-
-        var ux = localX + 1 + (dx * atlasTileSize);
-        var uy = localY + 1 + (dy * atlasTileSize);
-
-        var p = atlasData[ux + (uy * atlasWidth)];
-        maskData[x + (y * maskWidth)] = p;
-
-        return true;
-    }
 
     private static uint DivCeil(uint l, uint r) => (l + r - 1) / r;
 

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -435,17 +435,11 @@ public partial class ModTools
         if (args.AsList)
         {
             var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
-
-            var headerLines = new List<string>
-            {
-                "# MLMask Export",
-                "# Layer image files (must be in correct order)",
-                ""
-            };
-            headerLines.AddRange(masks);
-
-            File.WriteAllLines(maskListPath, headerLines);
+            // .masklist contains only the list of layer image paths (one per line), in order.
+            File.WriteAllLines(maskListPath, masks);
         }
+
+        return true;
 
         return true;
     }

--- a/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/MlmaskTools.cs
@@ -11,51 +11,39 @@ using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 
+/// <summary>
+/// Error code ranges used in multilayer mask processing:
+/// 0x3100–0x31FF : Core decoding, BC4 unpacking and layer processing errors
+/// </summary>
+
 namespace WolvenKit.Modkit.RED4;
 
 public partial class ModTools
 {
-    private const uint ATLAS_TILE_PADDING = 2;
+    private const uint s_atlasTilePadding = 2;
+
+    /// <summary>
+    /// Lightweight DTO for a decoded layer buffer + its dimensions.
+    /// Using record struct for clarity and performance (recommended over raw tuple).
+    /// </summary>
+    private readonly record struct LayerBuffer(byte[] Buffer, uint Width, uint Height);
 
     // Bit layout of tileDecl (from multilayer mask tiles data)
-    private const uint TILE_PARAM_MASK = 0x3FF;   // 10 bits (0-9)
-    private const int  TILE_DX_SHIFT   = 0;       // bits 0-9  → X offset in atlas
-    private const int  TILE_DY_SHIFT   = 10;      // bits 10-19 → Y offset in atlas
-    private const int  TILE_SX_SHIFT   = 20;      // bits 20-23 → X scale/shift
-    private const int  TILE_SY_SHIFT   = 24;      // bits 24-27 → Y scale/shift
-    private const uint TILE_S_MASK     = 0xF;     // 4 bits
+    private const uint s_tileParamMask = 0x3FF;   // 10 bits (0-9)
+    private const int  s_tileDxShift   = 0;       // bits 0-9  → X offset in atlas
+    private const int  s_tileDyShift   = 10;      // bits 10-19 → Y offset in atlas
+    private const int  s_tileSxShift   = 20;      // bits 20-23 → X scale/shift
+    private const int  s_tileSyShift   = 24;      // bits 24-27 → Y scale/shift
+    private const uint s_tileSMask     = 0xF;     // 4 bits
 
     #region Methods
 
     // Decode each grayscale layer to RedImage (always outputs linear R8G8B8A8_UNORM)
+    /// <summary>
+    /// Decodes all layers of a multilayer mask into RedImage objects (used by ConvertMultilayerMaskToDdsStreams).
+    /// </summary>
     private static IEnumerable<RedImage> GetRedImages(rendRenderMultilayerMaskBlobPC blob)
     {
-        uint atlasWidth = blob.Header.AtlasWidth;
-        uint atlasHeight = blob.Header.AtlasHeight;
-        uint maskWidth = blob.Header.MaskWidth;
-        uint maskHeight = blob.Header.MaskHeight;
-        uint maskWidthLow = blob.Header.MaskWidthLow;
-        uint maskHeightLow = blob.Header.MaskHeightLow;
-        uint maskTileSize = blob.Header.MaskTileSize;
-
-        var atlasRaw = new byte[atlasWidth * atlasHeight];
-        if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
-        {
-            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
-        }
-
-        var tileBuffer = blob.TilesData.Buffer;
-        var tiles = new uint[tileBuffer.MemSize / 4];
-        using (var ms = new MemoryStream(tileBuffer.GetBytes()))
-        using (var br = new BinaryReader(ms))
-        {
-            ms.Seek(0, SeekOrigin.Begin);
-            for (var i = 0; i < tiles.Length; i++)
-            {
-                tiles[i] = br.ReadUInt32();
-            }
-        }
-
         foreach (var layer in DecodeLayerBuffers(blob))
         {
             var (layerBuffer, outWidth, outHeight) = layer;
@@ -97,7 +85,7 @@ public partial class ModTools
     /// Layers are exported either at full high resolution or at the reduced low resolution,
     /// depending on whether the layer has dedicated high-resolution tile data.
     /// </summary>
-    private static IEnumerable<(byte[] buffer, uint width, uint height)> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
+    private static IEnumerable<LayerBuffer> DecodeLayerBuffers(rendRenderMultilayerMaskBlobPC blob)
     {
         uint atlasWidth = blob.Header.AtlasWidth;
         uint atlasHeight = blob.Header.AtlasHeight;
@@ -111,7 +99,8 @@ public partial class ModTools
         var atlasRaw = new byte[atlasWidth * atlasHeight];
         if (!BlockCompression.DecodeBC(blob.AtlasData.Buffer.GetBytes(), ref atlasRaw, atlasWidth, atlasHeight, BlockCompression.BlockCompressionType.BC4))
         {
-            throw new WolvenKitException(0x3001, "BC4 decode failed for multilayer mask atlas.");
+            // 0x3101 = BC4 / multilayer mask decode error (core processing uses 0x31xx range)
+            throw new WolvenKitException(0x3101, "BC4 decode failed for multilayer mask atlas.");
         }
 
         var tileBuffer = blob.TilesData.Buffer;
@@ -130,7 +119,7 @@ public partial class ModTools
 
         for (var i = 0; i < maskCount; i++)
         {
-            Array.Clear(fullResBuffer, 0, fullResBuffer.Length);
+            Array.Clear(fullResBuffer, 0, fullResBuffer.Length); // Ensure pixels without tile data are black (0)
             Decode(ref fullResBuffer, maskWidth, maskHeight, maskWidthLow, maskHeightLow, atlasRaw, atlasWidth, atlasHeight, tiles, maskTileSize, i);
 
             var hasHighRes = HasLayerHighResolutionData(tiles, maskWidth, maskHeight, maskTileSize, i);
@@ -152,7 +141,7 @@ public partial class ModTools
                 layerBuffer = DownscaleNearest(fullResBuffer, maskWidth, maskHeight, outWidth, outHeight);
             }
 
-            yield return (layerBuffer, outWidth, outHeight);
+            yield return new LayerBuffer(layerBuffer, outWidth, outHeight);
         }
     }
 
@@ -198,7 +187,11 @@ public partial class ModTools
         {
             for (uint x = 0; x < maskWidth; x++)
             {
+                // Decode using low-res tile map first (fallback)
                 DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, smallOffset, smallScale, widthInTilesScaled);
+                
+                // Then decode using full-res tile map — this can overwrite with higher quality data
+                // if the layer has dedicated high-resolution tiles for this pixel.
                 DecodeSingle(ref maskData, maskWidth, maskHeight, atlasData, atlasWidth, atlasHeight, x, y, tileData, maskTileSize, maskIndex, 0, 1, widthInTilesFull);
             }
         }
@@ -233,29 +226,27 @@ public partial class ModTools
         }
 
         // Extract atlas position and scaling factors from the packed tile declaration.
-        var dx = (tileDecl >> TILE_DX_SHIFT) & TILE_PARAM_MASK;
-        var dy = (tileDecl >> TILE_DY_SHIFT) & TILE_PARAM_MASK;
-        var sx = (tileDecl >> TILE_SX_SHIFT) & TILE_S_MASK;
-        var sy = (tileDecl >> TILE_SY_SHIFT) & TILE_S_MASK;
+        var dx = (tileDecl >> s_tileDxShift) & s_tileParamMask;
+        var dy = (tileDecl >> s_tileDyShift) & s_tileParamMask;
+        var sx = (tileDecl >> s_tileSxShift) & s_tileSMask;
+        var sy = (tileDecl >> s_tileSyShift) & s_tileSMask;
 
-        var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+        var atlasTileSize = maskTileSize + s_atlasTilePadding;
 
-        var ux = ((x >> (int)sx) % maskTileSize) + 1 + (dx * atlasTileSize);
-        var uy = ((y >> (int)sy) % maskTileSize) + 1 + (dy * atlasTileSize);
+        // Use Min to avoid reading into the right/bottom padding area of atlas tiles
+        var localX = Math.Min((x >> (int)sx) % maskTileSize, maskTileSize - 1);
+        var localY = Math.Min((y >> (int)sy) % maskTileSize, maskTileSize - 1);
+
+        var ux = localX + 1 + (dx * atlasTileSize);
+        var uy = localY + 1 + (dy * atlasTileSize);
 
         var p = atlasData[ux + (uy * atlasWidth)];
         maskData[x + (y * maskWidth)] = p;
     }
 
-    private static uint DivCeil(uint l, uint r)
-    {
-        return (l + r - 1) / r;
-    }
+    private static uint DivCeil(uint l, uint r) => (l + r - 1) / r;
 
-    private static uint CountBits(uint v)
-    {
-        return (uint)System.Numerics.BitOperations.PopCount(v);
-    }
+    private static uint CountBits(uint v) => (uint)System.Numerics.BitOperations.PopCount(v);
 
     private static byte[] DownscaleNearest(byte[] src, uint srcW, uint srcH, uint dstW, uint dstH)
     {
@@ -287,17 +278,24 @@ public partial class ModTools
         return dst;
     }
 
-    private static byte[] CreateWkPreviewPng(byte[] gray, int width, int height)
+    private static byte[] CreateWkPreviewPng(byte[] grayData, int width, int height)
     {
         var imgData = new byte[width * height * 4];
-        for (int i = 0; i < width * height; i++)
+
+        // Vertically flip so that the image appears correct in Blender / image editors
+        // (REDengine often stores textures with Y=0 at the bottom)
+        for (int y = 0; y < height; y++)
         {
-            var v = gray[i];
-            var baseIdx = i * 4;
-            imgData[baseIdx + 0] = v;
-            imgData[baseIdx + 1] = v;
-            imgData[baseIdx + 2] = v;
-            imgData[baseIdx + 3] = 255;
+            int srcY = height - 1 - y; // flip vertically
+            for (int x = 0; x < width; x++)
+            {
+                var v = grayData[srcY * width + x];
+                int dstIdx = (y * width + x) * 4;
+                imgData[dstIdx + 0] = v;
+                imgData[dstIdx + 1] = v;
+                imgData[dstIdx + 2] = v;
+                imgData[dstIdx + 3] = 255;
+            }
         }
 
         var info = new DDSUtils.DDSInfo
@@ -319,6 +317,10 @@ public partial class ModTools
         return png;
     }
 
+    // Note: We intentionally vertically flip PNG previews so they appear
+    // in the expected orientation in Blender / Photoshop (Y=0 at top).
+    // The in-game DDS representation remains correct for REDengine.
+
     public bool UncookMlmask(Multilayer_Mask mlmask, FileInfo outfile, MlmaskExportArgs args)
     {
         if (mlmask.RenderResourceBlob.RenderResourceBlobPC.Chunk is not rendRenderMultilayerMaskBlobPC blob)
@@ -338,7 +340,7 @@ public partial class ModTools
                 return false;
             }
 
-            var atlasTileSize = maskTileSize + ATLAS_TILE_PADDING;
+            var atlasTileSize = maskTileSize + s_atlasTilePadding;
             if (atlasWidth % atlasTileSize != 0 || atlasHeight % atlasTileSize != 0)
             {
                 _loggerService.Error($"Atlas dimensions {atlasWidth}x{atlasHeight} are not divisible by (MaskTileSize+2) = {atlasTileSize}.");
@@ -351,25 +353,28 @@ public partial class ModTools
             return false;
         }
 
-        DirectoryInfo? subDir = null;
-        if (args.AsList)
+        // Early argument validation
+        if (args.AsList && string.IsNullOrWhiteSpace(outfile.FullName))
         {
-            subDir = new DirectoryInfo(Path.ChangeExtension(outfile.FullName, null) + "_layers");
-            if (!subDir.Exists)
-            {
-                Directory.CreateDirectory(subDir.FullName);
-            }
-        }
-
-        if ((args.AsList && subDir is null) || (!args.AsList && outfile.Directory is null))
-        {
-            _loggerService.Error("directory was null");
+            _loggerService.Error("Output file path is required when AsList is true.");
             return false;
         }
 
+        DirectoryInfo? subDir = null;
+        if (args.AsList)
+        {
+            // Directory.CreateDirectory creates the folder only if it doesn't exist
+            // and returns the DirectoryInfo directly.
+            var layersDir = Path.ChangeExtension(outfile.FullName, null) + "_layers";
+            subDir = Directory.CreateDirectory(layersDir);
+        }
+
+        // Note: subDir is guaranteed non-null when args.AsList is true (created above).
+        // outfile.Directory can be null in rare cases (e.g. relative path with no directory).
+        // For robustness we could add an early argument check, but for now we rely on later Path.Combine calls.
+
         var cnt = 0;
         var masks = new List<string>();
-        var layerResolutions = new List<string>();
 
         foreach (var layer in DecodeLayerBuffers(blob))
         {
@@ -388,7 +393,6 @@ public partial class ModTools
                     masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
                 }
 
-                layerResolutions.Add($"{outWidth}x{outHeight}");
                 continue;
             }
 
@@ -436,7 +440,6 @@ public partial class ModTools
                 masks.Add($"{subDir!.Name}/{layerFileName}.{args.UncookExtension}");
             }
 
-            layerResolutions.Add($"{img.Metadata.Width}x{img.Metadata.Height}");
             img.Dispose();
         }
 
@@ -444,20 +447,22 @@ public partial class ModTools
         {
             var maskListPath = Path.ChangeExtension(outfile.FullName, "masklist");
 
-            // Simplified header - only basic info, no original atlas/mask dimensions
             var headerLines = new List<string>
             {
                 "# MLMask Export",
                 "# Layer image files (must be in correct order)",
                 ""
             };
-
             headerLines.AddRange(masks);
+
             File.WriteAllLines(maskListPath, headerLines);
         }
 
         return true;
     }
+
+    // Note: We add a small header to .masklist for human readability.
+    // The import side ignores lines starting with '#' or containing '='.
 
     public static bool ConvertMultilayerMaskToDdsStreams(Multilayer_Mask mask, out List<Stream> streams)
     {

--- a/WolvenKit/Helpers/LogCodeHelper.cs
+++ b/WolvenKit/Helpers/LogCodeHelper.cs
@@ -32,7 +32,6 @@ public static class LogCodeHelper
             "https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators/core-mods-explained/archivexl/archivexl-resource-patching");
         s_mapping.Add(0x3002,
             "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes##id-0x3002-resources-plugin");
-        s_mapping.Add(0x3003, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: BC4 decode error
 
         // 4: project stuff
         s_mapping.Add(0x4001, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/settings#additional-mod-directory");

--- a/WolvenKit/Helpers/LogCodeHelper.cs
+++ b/WolvenKit/Helpers/LogCodeHelper.cs
@@ -26,8 +26,6 @@ public static class LogCodeHelper
             "https://wiki.redmodding.org/cyberpunk-2077-modding/modding-guides/npcs/a-new-head-for-v#step-6-optional-disabling-the-character-creator");
         s_mapping.Add(0x2005, // mesh: bone mismatch
             "https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators-theory/3d-modelling/troubleshooting-your-mesh-edits#bones-not-found-in-import-mesh-es");
-        s_mapping.Add(0x2006, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: No layer files specified in masklist
-        s_mapping.Add(0x2007, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: General image loading failure
 
         // 3: modKit stuff
         s_mapping.Add(0x3001,

--- a/WolvenKit/Helpers/LogCodeHelper.cs
+++ b/WolvenKit/Helpers/LogCodeHelper.cs
@@ -26,12 +26,15 @@ public static class LogCodeHelper
             "https://wiki.redmodding.org/cyberpunk-2077-modding/modding-guides/npcs/a-new-head-for-v#step-6-optional-disabling-the-character-creator");
         s_mapping.Add(0x2005, // mesh: bone mismatch
             "https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators-theory/3d-modelling/troubleshooting-your-mesh-edits#bones-not-found-in-import-mesh-es");
+        s_mapping.Add(0x2006, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: No layer files specified in masklist
+        s_mapping.Add(0x2007, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: General image loading failure
 
         // 3: modKit stuff
         s_mapping.Add(0x3001,
             "https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators/core-mods-explained/archivexl/archivexl-resource-patching");
         s_mapping.Add(0x3002,
             "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes##id-0x3002-resources-plugin");
+        s_mapping.Add(0x3003, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/error-codes"); // MLMask: BC4 decode error
 
         // 4: project stuff
         s_mapping.Add(0x4001, "https://wiki.redmodding.org/wolvenkit/wolvenkit-app/settings#additional-mod-directory");

--- a/changelog/unreleased/2922.yaml
+++ b/changelog/unreleased/2922.yaml
@@ -1,6 +1,6 @@
 changes:
-    - type: "fixed | changed"
-      packages: ["App", "Nuget Packages"]
+    - type: "changed"
+      packages: ["App", "CLI", "Nuget Packages"]
       pr-number: 2922
       author: "Ametis81"
       description: "Export / Import masks at their native resolution (low and high res masks with no pixel shift / offset due to scaling)"

--- a/changelog/unreleased/2922.yaml
+++ b/changelog/unreleased/2922.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed | changed"
+      packages: ["App", "Nuget Packages"]
+      pr-number: 2922
+      author: "Ametis81"
+      description: "Export / Import masks at their native resolution (low and high res masks with no pixel shift / offset due to scaling)"


### PR DESCRIPTION
Update for exporting / importing masks at their native resolution (low and high res masks with no pixel shift / offset due to scaling) to solve the problem in https://github.com/WolvenKit/WolvenKit/issues/2432

Fixed export  - greyscale with one channel instead of RGB