### PR TITLE
remove dynamic path updates in auto-refactor

### DIFF
--- a/WolvenKit.App/Helpers/ProjectResourceTools.cs
+++ b/WolvenKit.App/Helpers/ProjectResourceTools.cs
@@ -772,6 +772,7 @@ public partial class ProjectResourceTools
 
                     var wasModified = false;
                     Dictionary<string, string> foundReplacements = new();
+                    List<string> dynamicPaths = new();
 
                     foreach (var (oldAbsPath, newAbsPath) in pathReplacements)
                     {
@@ -783,14 +784,17 @@ public partial class ProjectResourceTools
                             continue;
                         }
 
-                        cr2W = ReplacePathInFile(cr2W, oldPathStr, newPathStr, out var b);
+                        cr2W = ReplacePathInFile(cr2W, oldPathStr, newPathStr, out var b, out var hasDynamicPath);
                         if (!b)
                         {
                             continue;
                         }
-
                         wasModified = true;
                         foundReplacements.Add(oldPathStr, newPathStr);
+                        if (hasDynamicPath)
+                        {
+                            dynamicPaths.Add(oldPathStr);
+                        }
                     }
 
                     if (!wasModified)
@@ -798,8 +802,15 @@ public partial class ProjectResourceTools
                         return Task.CompletedTask;
                     }
 
+                    var relativePath = activeProject.GetRelativePath(absoluteFilePath);
                     _loggerService.Debug(
-                        $"Replaced the following paths in \"{activeProject.GetRelativePath(absoluteFilePath)}\"\n\t: {string.Join(",\n\t", foundReplacements.Select(kvp => $"{kvp.Key} -> {kvp.Value}"))}");
+                        $"Replaced the following paths in \"{relativePath}\"\n\t: {string.Join(",\n\t", foundReplacements.Select(kvp => $"{kvp.Key} -> {kvp.Value}"))}");
+
+                    if (dynamicPaths.Count > 0)
+                    {
+                        _loggerService.Warning(
+                            $"You have to update dynamic paths in \"{relativePath}\" by hand:\n\t {string.Join(",\n\t", dynamicPaths)}");
+                    }
 
                     _crwWTools.WriteCr2W(cr2W, absoluteFilePath);
                 }
@@ -816,9 +827,11 @@ public partial class ProjectResourceTools
         }
     }
 
-    private CR2WFile ReplacePathInFile(CR2WFile cr2W, string oldPathStr, string newPathStr, out bool wasModified)
+    private CR2WFile ReplacePathInFile(CR2WFile cr2W, string oldPathStr, string newPathStr, out bool wasModified,
+        out bool dynamicPathsNeedRenaming)
     {
         wasModified = false;
+        dynamicPathsNeedRenaming = false;
 
         if (oldPathStr == newPathStr || _projectManager.ActiveProject is not { } activeProject)
         {
@@ -834,7 +847,7 @@ public partial class ProjectResourceTools
 
 
         if ((cr2W.RootChunk is not (JsonResource or C2dArray)) &&
-            ReplaceInIRedRefs())
+            ReplaceInIRedRefs(ref dynamicPathsNeedRenaming))
         {
             wasModified = true;
         }
@@ -890,7 +903,7 @@ public partial class ProjectResourceTools
             return ret;
         }
 
-        bool ReplaceInIRedRefs()
+        bool ReplaceInIRedRefs(ref bool dynamicPathsNeedRenaming)
         {
             var refs = cr2W.FindType(typeof(IRedRef));
             var ret = false;
@@ -906,8 +919,7 @@ public partial class ProjectResourceTools
                 if (depotPath.StartsWith(ArchiveXlHelper.ArchiveXLSubstitutionPrefix) && ArchiveXlHelper
                         .ResolveDynamicPaths(depotPath, activeProject).Contains(oldPathStr))
                 {
-                    // handle dynamic substitution
-                    newPathStr = ArchiveXlHelper.ReplaceInDynamicPath(depotPath, newPathStr);
+                    dynamicPathsNeedRenaming = true;
                 }
                 else if (depotPath != oldPathStr)
                 {
@@ -1335,7 +1347,7 @@ public partial class ProjectResourceTools
         HashSet<string> miFiles = [];
         foreach (var kvp in pathReplacements)
         {
-            ReplacePathInFile(cr2W, kvp.Key, kvp.Value, out var _);
+            ReplacePathInFile(cr2W, kvp.Key, kvp.Value, out var _, out var _);
             if (kvp.Value.EndsWith(".mi"))
             {
                 miFiles.Add(kvp.Value);
@@ -1347,7 +1359,7 @@ public partial class ProjectResourceTools
         {
             foreach (var kvp in pathReplacements)
             {
-                ReplacePathInFile(miCr2W, kvp.Key, kvp.Value, out var _);
+                ReplacePathInFile(miCr2W, kvp.Key, kvp.Value, out var _, out var _);
             }
         }
 

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -12,3 +12,10 @@ changes:
       pr-number: 2917
       author: "manavortex"
       description: "Fixed 'create item codes from yaml'"
+
+changes:
+    - type: "removed"
+      packages: ["App"]
+      pr-number: 2924
+      author: "manavortex"
+      description: "WKit will no longer try to update dynamic paths (breaking them in the process), and instead warn about them."


### PR DESCRIPTION
# Remove dynamic path updates in auto-refactor

**Fixed:**
- WKit will no longer try to update dynamic paths (breaking them in the process), and instead warn about them
