### PR TITLE
General fixes

### DIFF
--- a/WolvenKit.Common/Services/HashService.cs
+++ b/WolvenKit.Common/Services/HashService.cs
@@ -221,7 +221,7 @@ namespace WolvenKit.Common.Services
                 collection.Add(nextLine);
             }
 
-            var lookupTable = new LookupTable(collection, _maxDoP, ResourcePath.CalculateHash);
+            var lookupTable = new LookupTable(collection, _maxDoP, (s) => ResourcePath.CalculateHash(s, false));
 
             ResourcePathPool.SetNative(lookupTable);
         }

--- a/WolvenKit.Common/Services/HashService.cs
+++ b/WolvenKit.Common/Services/HashService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
+using WolvenKit.Common.FNV1A;
 using WolvenKit.Common.Model;
 using WolvenKit.Core.Compression;
 using WolvenKit.Core.Exceptions;
@@ -240,7 +241,7 @@ namespace WolvenKit.Common.Services
                 collection.Add(nextLine);
             }
 
-            var lookupTable = new LookupTable(collection, _maxDoP, ResourcePath.CalculateHash);
+            var lookupTable = new LookupTable(collection, _maxDoP, NodeRef.CalculateHash);
 
             NodeRefPool.SetNative(lookupTable);
         }

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -643,8 +643,6 @@ namespace WolvenKit.RED4.CR2W.Archive
 
         public IGameFile? GetGameFile(ResourcePath path, bool includeMods = true, bool includeProject = true)
         {
-            var filePath = path.GetResolvedText() ?? "";
-
             // check if the file is in the project archive
             if (includeProject && ProjectArchive != null && ProjectArchive.Files.TryGetValue(path, out var projectFile))
             {
@@ -652,15 +650,13 @@ namespace WolvenKit.RED4.CR2W.Archive
                 return projectFile;
             }
 
-            var fileHash = ResourcePath.CalculateHash(filePath);
-
             // check if the file is in a mod archive
             if (includeMods)
             {
                 var modFile = GetModArchives()
                     .Select(x => x.Files)
-                    .Where(x => x.ContainsKey(path) || x.ContainsKey(fileHash))
-                    .Select(x => x[path] ?? x[fileHash])
+                    .Where(x => x.ContainsKey(path))
+                    .Select(x => x[path])
                     .FirstOrDefault();
 
                 if (modFile != null)
@@ -673,8 +669,8 @@ namespace WolvenKit.RED4.CR2W.Archive
             // check if the file is in a base archive
             var baseFile = GetGameArchives()
                 .Select(x => x.Files)
-                .Where(x => x.ContainsKey(path) || x.ContainsKey(fileHash))
-                .Select(x => x[path] ?? x[fileHash])
+                .Where(x => x.ContainsKey(path))
+                .Select(x => x[path])
                 .FirstOrDefault();
 
 

--- a/WolvenKit.RED4/Types/Primitives/Simples/NodeRef.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/NodeRef.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using WolvenKit.Common.FNV1A;
 using WolvenKit.RED4.Types.Pools;
 
 namespace WolvenKit.RED4.Types;
@@ -89,6 +90,9 @@ public readonly struct NodeRef : IRedString, IRedPrimitive<NodeRef>, IEquatable<
 
         return true;
     }
+
+    public static ulong CalculateHash(string nodeRef) =>
+        FNV1A64HashAlgorithm.HashStringWithoutAliases(nodeRef);
 
     public string? GetString() => this;
     public override string ToString() => TryGetResolvedText(out var text) ? text : _hash.ToString();

--- a/WolvenKit.RED4/Types/Primitives/Simples/ResourcePath.cs
+++ b/WolvenKit.RED4/Types/Primitives/Simples/ResourcePath.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using WolvenKit.Common.FNV1A;
@@ -137,8 +137,8 @@ public readonly struct ResourcePath : IRedString, IRedPrimitive<string>, IEquata
         return strResult.ToString().ToLowerInvariant();
     }
 
-    public static ulong CalculateHash(string resourcePath) =>
-        FNV1A64HashAlgorithm.HashString(SanitizePath(resourcePath));
+    public static ulong CalculateHash(string resourcePath, bool sanitize = true) =>
+        FNV1A64HashAlgorithm.HashString(sanitize ? SanitizePath(resourcePath) : resourcePath);
 
     public string? GetString() => this;
     public override string? ToString() => GetResolvedText();


### PR DESCRIPTION
# General fixes

**Fixed:**
- Native NodeRef list using wrong hashing function (Rendering the native list useless)
- Potential error while getting gamefiles by `ResourcePath` (`ResourcePath` is already a hash. Trying to resolving that and hashing it again either results in the same hash or in the hash of "")

**Refactored:**
- Don't sanitize base filepaths on load (already happens when the list is created, saves some time)