### PR TITLE
Downgrade WolvenKit.package target platform version to fix a build error

### DIFF
--- a/WolvenKit.Package/WolvenKit.Package.wapproj
+++ b/WolvenKit.Package/WolvenKit.Package.wapproj
@@ -19,7 +19,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>849a9683-78d3-4a05-8c76-a804dc79704a</ProjectGuid>
-    <TargetPlatformVersion>10.0.20348.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>$(NoWarn);NU1702</NoWarn>


### PR DESCRIPTION
# Downgrade WolvenKit.package target platform version to fix a build error

Last year, Microsoft posted this [changelog](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes?tabs=allfeatures#17.14.11) for Visual Studio 2022 v. 17.14.11:

> The following Windows SDK versions have been removed from the Visual Studio 2022 installer: 10.0.18362.0, **10.0.20348.0** and 10.0.22000.0. If you previously installed one of these versions of the SDK using Visual Studio it will be uninstalled when you update. If your project targets any of these SDKs you may encounter a build error such as: The Windows SDK version 10.0.22000.0 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". To resolve this, we recommend retargeting your project to 10.0.26100.0, or an earlier supported version if necessary. For a complete list of supported SDK versions please visit: https://developer.microsoft.com/windows/downloads/sdk-archive/. If you need to install an unsupported version of the SDK, you can find it here: https://developer.microsoft.com/windows/downloads/sdk-archive/index-legacy/.

The version in bold, 10.0.20348.0, is presently set as the WolvenKit.package target framework version. This causes build errors for anyone who has a fresh install of Visual Studio 2022, since the latest version it can target is 10.0.19041.0.

Therefore this PR downgrades the version to that latest supported one, 10.0.19041.0.

**Implemented:**
- n/a

**Fixed:**
- WolvenKit.package target platform version set to 10.0.19041.0, fixing a build issue for some of us.

**Additional notes:**
closes_issue_number

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->