### PR TITLE
Async File Addition to Mod, & Batched Logging

### DIFF
--- a/WolvenKit.App/Controllers/IGameController.cs
+++ b/WolvenKit.App/Controllers/IGameController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WolvenKit.App.Models;
 using WolvenKit.Common;
@@ -7,6 +8,12 @@ namespace WolvenKit.App.Controllers;
 
 public interface IGameController
 {
+    /// <summary>
+    /// Adds files to the mod's directory, creating necessary folders, using current scope.
+    /// </summary>
+    /// <param name="files"></param>
+    public Task AddToModAsync(IList<IGameFile> files);
+
     /// <summary>
     /// Finds a file in the currently active scope and adds it to the mod
     /// </summary>
@@ -23,7 +30,7 @@ public interface IGameController
     public bool AddToMod(ulong hash, ArchiveManagerScope searchScope);
 
     /// <summary>
-    /// Adds file to the mod's directory, creating the necessary folders. 
+    /// Adds file to the mod's directory, creating the necessary folders.
     /// </summary>
     /// <param name="file">the file in question</param>
     /// <param name="searchScope">Search scope. Defaults to ArchiveManagerScope.Basegame</param>

--- a/WolvenKit.App/Controllers/MockGameController.cs
+++ b/WolvenKit.App/Controllers/MockGameController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WolvenKit.App.Models;
 using WolvenKit.Common;
@@ -22,6 +23,8 @@ public class MockGameController : IGameController
     public bool AddToMod(ulong hash, ArchiveManagerScope searchScope) => throw new NotImplementedException();
 
     public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope) => throw new NotImplementedException();
+    public Task AddToModAsync(IList<IGameFile> files) => throw new NotImplementedException();
+
     public bool AddToMod(ulong hash) => throw new NotImplementedException();
     public async Task HandleStartup() => await Task.CompletedTask;
     public Task<bool> LaunchProjectAsync(LaunchProfile profile) => throw new NotImplementedException();

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -1012,6 +1012,25 @@ public class RED4Controller : ObservableObject, IGameController
         return true;
     }
 
+    public async Task AddToModAsync(IList<IGameFile> files)
+    {
+        var progress = 0;
+
+        _progressService.IsIndeterminate = false;
+        _progressService.Report(0.1);
+
+        await Parallel.ForEachAsync(files, async (file, token) =>
+        {
+            AddToMod(file);
+            Interlocked.Increment(ref progress);
+            _progressService.Report(progress / (float)files.Count);
+        });
+
+        _progressService.Completed();
+        _projectEvents.PublishFilesImported(new FilesImportedMessage([.. files],[]));
+    }
+
+
     /// <Inheritdoc />
     public bool AddToMod(ulong hash)
     {

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -1017,17 +1018,45 @@ public class RED4Controller : ObservableObject, IGameController
         var progress = 0;
 
         _progressService.IsIndeterminate = false;
-        _progressService.Report(0.1);
+        _progressService.Report(0);
 
-        await Parallel.ForEachAsync(files, async (file, token) =>
+        var total = files.Count;
+
+        if (total > 0)
         {
-            AddToMod(file);
-            Interlocked.Increment(ref progress);
-            _progressService.Report(progress / (float)files.Count);
-        });
+            // Limit concurrency for disk I/O (extraction + writes). Unbounded parallelism
+            // often saturates the disk and ends up slower + spams the UI thread.
+            var dop = Math.Min(8, Math.Max(1, Environment.ProcessorCount / 2));
+
+            await Parallel.ForEachAsync(
+                files,
+                new ParallelOptions { MaxDegreeOfParallelism = dop },
+                (file, token) =>
+                {
+                    token.ThrowIfCancellationRequested();
+                    AddToMod(file);
+                    var current = Interlocked.Increment(ref progress);
+                    var reportInterval = Math.Max(1, total / 50);
+
+                    if (current % reportInterval == 0 || current == total)
+                    {
+                        _progressService.Report(current / (float)total);
+                    }
+
+                    return ValueTask.CompletedTask;
+                });
+
+            var report = "";
+
+            foreach (var file in files)
+            {
+                report += $"Added game file to project: {file.Name}\r\n";
+            }
+
+            _loggerService.Info(report);
+        }
 
         _progressService.Completed();
-        _projectEvents.PublishFilesImported(new FilesImportedMessage([.. files],[]));
     }
 
 
@@ -1090,7 +1119,6 @@ public class RED4Controller : ObservableObject, IGameController
             {
                 using FileStream fs = new(diskPathInfo.FullName, FileMode.Create);
                 file.Extract(fs);
-                _loggerService.Info($"Added game file to project: {file.Name}");
             }
             catch (Exception ex)
             {

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -579,24 +579,12 @@ public partial class AssetBrowserViewModel : ToolViewModel
         }
     }
 
-    private async void InternalAddFiles(IList<IGameFile> files)
+    private async Task InternalAddFiles(IList<IGameFile> files)
     {
-        var progress = 0;
-
-        _progressService.IsIndeterminate = false;
-        _progressService.Report(0.1);
-
-        await Parallel.ForEachAsync(files, async (file, token) =>
-        {
-            await Task.Run(() => { _gameController.GetController().AddToMod(file); }, token);
-
-            Interlocked.Increment(ref progress);
-            _progressService.Report(progress / (float)files.Count);
-        });
-
-        _progressService.Completed();
-
+        _appViewModel.GetToolViewModel<ProjectExplorerViewModel>()?.SuspendFileWatcher();
+        await _gameController.GetController().AddToModAsync(files);
         _loggerService.Success($"Added {files.Count} files to the project.");
+        _appViewModel.GetToolViewModel<ProjectExplorerViewModel>()?.ResumeFileWatcher();
     }
 
     /// <summary>

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -564,7 +564,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
             finalFilesToAdd = filesToAdd.Values.ToList();
         }
 
-        InternalAddFiles(finalFilesToAdd);
+        await InternalAddFiles(finalFilesToAdd);
     }
 
     private void GetFilesRecursive(RedFileSystemModel directory, Dictionary<ulong, IGameFile> files)

--- a/changelog/!unreleased.yaml
+++ b/changelog/!unreleased.yaml
@@ -32,3 +32,8 @@ changes:
       pr-number: 2934
       author: "manavortex"
       description: "When generating a radio, the folder in resources will now be created"
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 2941
+      author: "gistya"
+      description: "Improved performance when adding thousands of game files to a mod"


### PR DESCRIPTION
# Async File Addition to Mod, & Batched Logging

This is the second smaller PR broken out of the large "performance." The goal is to limit risk of regression while addressing the "lowest hanging fruit" of serious performance issues. 

This PR fixes an application hang that would occur when adding a large number of files (3000+). The existing code ran with unlimited parallelism to export files, which is hard on the disk, also spamming the progress manager and logger that both ask for synchronous context on the UI thread. The result would be a total gridlock of the main thread, with the application becoming unresponsive for long periods of time. 

With this change, you can do a large import of files with no hang, and it's super fast. 

**Fixed:**
- app freeze up and slowness on import of large number of files to mod
