### PR TITLE
Group recent projects on the welcome page

### DIFF
--- a/WolvenKit.App/Models/FancyProjectObject.cs
+++ b/WolvenKit.App/Models/FancyProjectObject.cs
@@ -45,7 +45,7 @@ public partial class WelcomePageViewModel
             set => Item.IsPinned = value;
         }
 
-        // NOUVEAU : passthrough vers le modèle. Écrire ici déclenche l'auto-save + le refresh.
+        // Passthrough to the model. Writing here triggers the auto-save + refresh.
         public string? Group
         {
             get => Item.Group;

--- a/WolvenKit.App/Models/FancyProjectObject.cs
+++ b/WolvenKit.App/Models/FancyProjectObject.cs
@@ -46,7 +46,7 @@ public partial class WelcomePageViewModel
         }
 
         // Passthrough to the model. Writing here triggers the auto-save + refresh.
-        public string? Group
+        public string Group
         {
             get => Item.Group;
             set => Item.Group = value;

--- a/WolvenKit.App/Models/FancyProjectObject.cs
+++ b/WolvenKit.App/Models/FancyProjectObject.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using WolvenKit.App.Models.ProjectManagement;
@@ -41,8 +41,15 @@ public partial class WelcomePageViewModel
 
         public bool IsPinned
         {
-            get => Item.IsPinned; 
+            get => Item.IsPinned;
             set => Item.IsPinned = value;
+        }
+
+        // NOUVEAU : passthrough vers le modèle. Écrire ici déclenche l'auto-save + le refresh.
+        public string? Group
+        {
+            get => Item.Group;
+            set => Item.Group = value;
         }
 
         #endregion Properties

--- a/WolvenKit.App/Models/ProjectManagement/IRecentlyUsedItemsService.cs
+++ b/WolvenKit.App/Models/ProjectManagement/IRecentlyUsedItemsService.cs
@@ -14,4 +14,7 @@ public interface IRecentlyUsedItemsService
     void PinItem(string key);
     void UnpinItem(string key);
     void Save();
+
+    /// <summary>Existing group names (trimmed, distinct, case-insensitive, sorted).</summary>
+    IReadOnlyList<string> GetGroups();
 }

--- a/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
+++ b/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace WolvenKit.App.Models.ProjectManagement;
@@ -16,6 +16,11 @@ public partial class RecentlyUsedItemModel : ObservableObject
 
     [ObservableProperty]
     private bool _isPinned;
+
+    // NOUVEAU : groupe du projet. null ou vide = "Sans groupe".
+    // Sérialisé automatiquement dans recentItems.json (rétrocompatible : absent = null).
+    [ObservableProperty]
+    private string? _group;
 
     public RecentlyUsedItemModel(string name, DateTime dateTime, DateTime lastOpened)
     {

--- a/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
+++ b/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
@@ -20,7 +20,7 @@ public partial class RecentlyUsedItemModel : ObservableObject
     // Project group. null or empty = "Ungrouped".
     // Serialized automatically in recentItems.json (backward compatible: absent = null).
     [ObservableProperty]
-    private string? _group;
+    private string _group = "";
 
     public RecentlyUsedItemModel(string name, DateTime dateTime, DateTime lastOpened)
     {

--- a/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
+++ b/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemModel.cs
@@ -17,8 +17,8 @@ public partial class RecentlyUsedItemModel : ObservableObject
     [ObservableProperty]
     private bool _isPinned;
 
-    // NOUVEAU : groupe du projet. null ou vide = "Sans groupe".
-    // Sérialisé automatiquement dans recentItems.json (rétrocompatible : absent = null).
+    // Project group. null or empty = "Ungrouped".
+    // Serialized automatically in recentItems.json (backward compatible: absent = null).
     [ObservableProperty]
     private string? _group;
 

--- a/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemsService.cs
+++ b/WolvenKit.App/Models/ProjectManagement/RecentlyUsedItemsService.cs
@@ -16,6 +16,16 @@ public class RecentlyUsedItemsService : IRecentlyUsedItemsService
     public IObservableCache<RecentlyUsedItemModel, string> Items => _recentlyUsedItems;
     public List<RecentlyUsedItemModel> PinnedItems => _recentlyUsedItems.Items.Where(_ => _.IsPinned).ToList();
 
+    // Existing group names (trimmed, distinct, case-insensitive, sorted). Single source of truth.
+    public IReadOnlyList<string> GetGroups() =>
+        _recentlyUsedItems.Items
+            .Select(i => i.Group)
+            .Where(g => !string.IsNullOrWhiteSpace(g))
+            .Select(g => g.Trim())
+            .Distinct(StringComparer.InvariantCultureIgnoreCase)
+            .OrderBy(g => g, StringComparer.InvariantCultureIgnoreCase)
+            .ToList();
+
     public RecentlyUsedItemsService()
     {
         // load on start

--- a/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
@@ -5,7 +5,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -48,18 +47,10 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
         _projectType = ["Cyberpunk 2077"];
 
-        // Load the groups already in use so they can be offered in the dropdown.
+        // Load the existing groups (single source of truth) so they can be offered in the dropdown.
         if (_recentlyUsedItemsService is not null)
         {
-            var existingGroups = _recentlyUsedItemsService.Items.Items
-                .Select(item => item.Group)
-                .Where(g => !string.IsNullOrWhiteSpace(g))
-                .Select(g => g!.Trim())
-                .Distinct(StringComparer.InvariantCultureIgnoreCase)
-                .OrderBy(g => g, StringComparer.InvariantCultureIgnoreCase)
-                .ToList();
-
-            foreach (var g in existingGroups)
+            foreach (var g in _recentlyUsedItemsService.GetGroups())
             {
                 _availableGroups.Add(g);
             }

--- a/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
@@ -25,7 +25,7 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
     private readonly ISettingsManager _settingsManager;
 
-    // NOUVEAU : service des projets récents (pour lister les groupes existants).
+    // Recent-projects service (used to list the existing groups).
     private readonly IRecentlyUsedItemsService? _recentlyUsedItemsService;
 
     public delegate Task ReturnHandler(ProjectWizardViewModel? project);
@@ -48,7 +48,7 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
         _projectType = ["Cyberpunk 2077"];
 
-        // NOUVEAU : charge les groupes déjà utilisés pour les proposer dans la liste.
+        // Load the groups already in use so they can be offered in the dropdown.
         if (_recentlyUsedItemsService is not null)
         {
             var existingGroups = _recentlyUsedItemsService.Items.Items
@@ -111,10 +111,10 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
     [ObservableProperty] private string? _whyNotCreate;
 
-    // NOUVEAU : groupe choisi à la création (null/vide = "Sans groupe").
+    // Group chosen at creation time (null/empty = "Ungrouped").
     [ObservableProperty] private string? _selectedGroup;
 
-    // NOUVEAU : groupes existants proposés dans la liste déroulante.
+    // Existing groups offered in the dropdown.
     [ObservableProperty] private ObservableCollection<string> _availableGroups = new();
 
     #endregion Properties

--- a/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/ProjectWizardViewModel.cs
@@ -5,10 +5,12 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.ProjectManagement;
 using WolvenKit.App.Services;
 using WolvenKit.Core.Services;
 using WolvenKit.Interfaces.Extensions;
@@ -23,6 +25,9 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
     private readonly ISettingsManager _settingsManager;
 
+    // NOUVEAU : service des projets récents (pour lister les groupes existants).
+    private readonly IRecentlyUsedItemsService? _recentlyUsedItemsService;
+
     public delegate Task ReturnHandler(ProjectWizardViewModel? project);
     public ReturnHandler? FileHandler;
 
@@ -33,13 +38,32 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
 
     #region Constructors
 
-    public ProjectWizardViewModel(ISettingsManager settingsManager)
+    public ProjectWizardViewModel(ISettingsManager settingsManager,
+        IRecentlyUsedItemsService? recentlyUsedItemsService = null)
     {
         _settingsManager = settingsManager;
+        _recentlyUsedItemsService = recentlyUsedItemsService;
 
         Title = "Project Wizard";
 
         _projectType = ["Cyberpunk 2077"];
+
+        // NOUVEAU : charge les groupes déjà utilisés pour les proposer dans la liste.
+        if (_recentlyUsedItemsService is not null)
+        {
+            var existingGroups = _recentlyUsedItemsService.Items.Items
+                .Select(item => item.Group)
+                .Where(g => !string.IsNullOrWhiteSpace(g))
+                .Select(g => g!.Trim())
+                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                .OrderBy(g => g, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+
+            foreach (var g in existingGroups)
+            {
+                _availableGroups.Add(g);
+            }
+        }
 
         string? lastProjectPath;
         if (_settingsManager.LastUsedProjectPath is not null &&
@@ -86,6 +110,12 @@ public partial class ProjectWizardViewModel : DialogViewModel, INotifyDataErrorI
     [ObservableProperty] private ObservableCollection<string> _projectType;
 
     [ObservableProperty] private string? _whyNotCreate;
+
+    // NOUVEAU : groupe choisi à la création (null/vide = "Sans groupe").
+    [ObservableProperty] private string? _selectedGroup;
+
+    // NOUVEAU : groupes existants proposés dans la liste déroulante.
+    [ObservableProperty] private ObservableCollection<string> _availableGroups = new();
 
     #endregion Properties
 

--- a/WolvenKit.App/ViewModels/HomePage/Pages/ProjectGroup.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ProjectGroup.cs
@@ -6,7 +6,7 @@ namespace WolvenKit.App.ViewModels.HomePage.Pages;
 
 public partial class WelcomePageViewModel
 {
-    // NOUVEAU : représente un groupe de projets (en-tête + liste de cartes) sur la page d'accueil.
+    // Represents a project group (header + list of cards) on the welcome page.
     public partial class ProjectGroup : ObservableObject
     {
         public ProjectGroup(string name, IEnumerable<FancyProjectObject> projects)
@@ -18,7 +18,7 @@ public partial class WelcomePageViewModel
         public string Name { get; }
         public ObservableCollection<FancyProjectObject> Projects { get; }
 
-        // NOUVEAU : true = groupe déplié (cartes visibles), false = replié.
+        // true = group expanded (cards visible), false = collapsed.
         [ObservableProperty]
         private bool _isExpanded = true;
     }

--- a/WolvenKit.App/ViewModels/HomePage/Pages/ProjectGroup.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/ProjectGroup.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WolvenKit.App.ViewModels.HomePage.Pages;
+
+public partial class WelcomePageViewModel
+{
+    // NOUVEAU : représente un groupe de projets (en-tête + liste de cartes) sur la page d'accueil.
+    public partial class ProjectGroup : ObservableObject
+    {
+        public ProjectGroup(string name, IEnumerable<FancyProjectObject> projects)
+        {
+            Name = name;
+            Projects = new ObservableCollection<FancyProjectObject>(projects);
+        }
+
+        public string Name { get; }
+        public ObservableCollection<FancyProjectObject> Projects { get; }
+
+        // NOUVEAU : true = groupe déplié (cartes visibles), false = replié.
+        [ObservableProperty]
+        private bool _isExpanded = true;
+    }
+}

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -198,13 +198,13 @@ public partial class WelcomePageViewModel : PageViewModel
             return;
         }
 
-        var name = await Interactions.ShowInputBoxAsync("Move project to group", project.Group ?? "");
+        var name = await Interactions.ShowInputBoxAsync("Move project to group", project.Group);
 
         // The user typed a name -> assign it. Empty -> remove from the group.
         // (Note: this API does not clearly distinguish "Cancel" from an emptied field;
         //  to keep the group on cancel, replace the next line with:
         //  if (string.IsNullOrWhiteSpace(name)) return;)
-        project.Group = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+        project.Group = string.IsNullOrWhiteSpace(name) ? "" : name.Trim();
 
         RefreshRecentProjects();
     }
@@ -218,7 +218,7 @@ public partial class WelcomePageViewModel : PageViewModel
             return;
         }
 
-        project.Group = null;
+        project.Group = "";
         RefreshRecentProjects();
     }
 
@@ -230,7 +230,7 @@ public partial class WelcomePageViewModel : PageViewModel
             return;
         }
 
-        project.Group = string.IsNullOrWhiteSpace(group) ? null : group.Trim();
+        project.Group = string.IsNullOrWhiteSpace(group) ? "" : group.Trim();
         RefreshRecentProjects();
     }
     // Delete a group (after confirmation). Projects are NOT deleted: they simply
@@ -255,7 +255,7 @@ public partial class WelcomePageViewModel : PageViewModel
 
         foreach (var project in group.Projects.ToList())
         {
-            project.Group = null;
+            project.Group = "";
         }
 
         RefreshRecentProjects();
@@ -363,7 +363,8 @@ public partial class WelcomePageViewModel : PageViewModel
             // Group by "Group". Projects without a group go into "Ungrouped",
             // placed last; the other groups are sorted by name.
             var groups = items
-                .GroupBy(p => string.IsNullOrWhiteSpace(p.Group) ? UngroupedName : p.Group!)
+                .GroupBy(p => string.IsNullOrWhiteSpace(p.Group) ? UngroupedName : p.Group.Trim(),
+                         StringComparer.InvariantCultureIgnoreCase)
                 .OrderBy(g => g.Key == UngroupedName ? 1 : 0)
                 .ThenBy(g => g.Key, StringComparer.InvariantCultureIgnoreCase)
                 .Select(g =>
@@ -402,17 +403,9 @@ public partial class WelcomePageViewModel : PageViewModel
                 GroupedProjects.Add(g);
             }
 
-            // Build the list of existing groups (excluding "Ungrouped"), for the submenu.
-            var names = items
-                .Select(p => p.Group)
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Select(n => n!.Trim())
-                .Distinct(StringComparer.InvariantCultureIgnoreCase)
-                .OrderBy(n => n, StringComparer.InvariantCultureIgnoreCase)
-                .ToList();
-
+            // Existing groups for the submenu — single source of truth (RecentlyUsedItemsService).
             AvailableGroups.Clear();
-            foreach (var n in names)
+            foreach (var n in _recentlyUsedItemsService.GetGroups())
             {
                 AvailableGroups.Add(n);
             }

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -31,6 +31,12 @@ public partial class WelcomePageViewModel : PageViewModel
 
     private readonly ReadOnlyObservableCollection<RecentlyUsedItemModel> _recentlyUsedItems;
 
+    // NOUVEAU : nom du groupe par défaut pour les projets sans groupe.
+    public const string UngroupedName = "Ungrouped";
+
+    // NOUVEAU : noms des groupes repliés (mémorisé le temps de la session).
+    private readonly HashSet<string> _collapsedGroups = new();
+
     private Dictionary<string, int> _sortMode = new()
     {
         {"Last opened", 0},
@@ -88,6 +94,14 @@ public partial class WelcomePageViewModel : PageViewModel
 
     [ObservableProperty]
     private ObservableCollection<FancyProjectObject> _fancyProjects = new();
+
+    // NOUVEAU : projets récents regroupés par "Group", pour l'affichage en sections.
+    [ObservableProperty]
+    private ObservableCollection<ProjectGroup> _groupedProjects = new();
+
+    // NOUVEAU : noms des groupes existants (pour le sous-menu "Move to existing group").
+    [ObservableProperty]
+    private ObservableCollection<string> _availableGroups = new();
 
     [ObservableProperty]
     private List<RecentlyUsedItemModel> _pinnedItems = new();
@@ -173,6 +187,78 @@ public partial class WelcomePageViewModel : PageViewModel
     {
         //Argument.IsNotNullOrWhitespace(() => parameter);
         //_recentlyUsedItemsService.UnpinItem(parameter);
+    }
+
+    // NOUVEAU : assigne (ou modifie) le groupe d'un projet via une boîte de saisie.
+    [RelayCommand]
+    private async Task SetProjectGroup(FancyProjectObject? project)
+    {
+        if (project is null)
+        {
+            return;
+        }
+
+        var name = await Interactions.ShowInputBoxAsync("Move project to group", project.Group ?? "");
+
+        // L'utilisateur a saisi un nom -> on l'assigne. Vide -> on retire du groupe.
+        // (Note : cette API ne distingue pas clairement "Annuler" d'un champ vidé ;
+        //  si tu veux préserver le groupe sur Annulation, remplace la ligne suivante par :
+        //  if (string.IsNullOrWhiteSpace(name)) return;)
+        project.Group = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+
+        RefreshRecentProjects();
+    }
+
+    // NOUVEAU : retire un projet de son groupe (revient sous "Sans groupe").
+    [RelayCommand]
+    private void RemoveProjectGroup(FancyProjectObject? project)
+    {
+        if (project is null)
+        {
+            return;
+        }
+
+        project.Group = null;
+        RefreshRecentProjects();
+    }
+
+    // NOUVEAU : assigne un projet à un groupe existant (appelé depuis le sous-menu code-behind).
+    public void MoveProjectToGroup(FancyProjectObject? project, string group)
+    {
+        if (project is null)
+        {
+            return;
+        }
+
+        project.Group = string.IsNullOrWhiteSpace(group) ? null : group.Trim();
+        RefreshRecentProjects();
+    }
+    // NOUVEAU : supprime un groupe (après confirmation). Les projets ne sont PAS supprimés :
+    // ils repassent simplement dans "Sans groupe".
+    [RelayCommand]
+    private async Task DeleteGroup(ProjectGroup? group)
+    {
+        if (group is null || group.Name == UngroupedName)
+        {
+            return;
+        }
+
+        var result = await Interactions.ShowMessageBoxAsync(
+            $"Delete the group \"{group.Name}\"? Its {group.Projects.Count} project(s) will move back to \"{UngroupedName}\". No project is deleted from disk.",
+            "Delete group",
+            WMessageBoxButtons.YesNo);
+
+        if (result != WMessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        foreach (var project in group.Projects.ToList())
+        {
+            project.Group = null;
+        }
+
+        RefreshRecentProjects();
     }
 
     #endregion
@@ -269,8 +355,67 @@ public partial class WelcomePageViewModel : PageViewModel
         {
             _settingsManager.RecentOrder = SelectedRecentOrder;
 
+            var items = GetSortedItems(false, SelectedRecentOrder, RecentFilter);
+
             FancyProjects.Clear();
-            FancyProjects.AddRange(GetSortedItems(false, SelectedRecentOrder, RecentFilter));
+            FancyProjects.AddRange(items);
+
+            // NOUVEAU : regroupe par "Group". Les projets sans groupe vont dans
+            // "Sans groupe", placé en dernier ; les autres groupes sont triés par nom.
+            var groups = items
+                .GroupBy(p => string.IsNullOrWhiteSpace(p.Group) ? UngroupedName : p.Group!)
+                .OrderBy(g => g.Key == UngroupedName ? 1 : 0)
+                .ThenBy(g => g.Key, StringComparer.InvariantCultureIgnoreCase)
+                .Select(g =>
+                {
+                    // Restaure l'état replié/déplié mémorisé pour cette session.
+                    var group = new ProjectGroup(g.Key, g)
+                    {
+                        IsExpanded = !_collapsedGroups.Contains(g.Key)
+                    };
+
+                    // Mémorise les changements de pliage (sans toucher au disque).
+                    group.PropertyChanged += (_, e) =>
+                    {
+                        if (e.PropertyName != nameof(ProjectGroup.IsExpanded))
+                        {
+                            return;
+                        }
+
+                        if (group.IsExpanded)
+                        {
+                            _collapsedGroups.Remove(group.Name);
+                        }
+                        else
+                        {
+                            _collapsedGroups.Add(group.Name);
+                        }
+                    };
+
+                    return group;
+                })
+                .ToList();
+
+            GroupedProjects.Clear();
+            foreach (var g in groups)
+            {
+                GroupedProjects.Add(g);
+            }
+
+            // NOUVEAU : liste des groupes existants (hors "Sans groupe"), pour le sous-menu.
+            var names = items
+                .Select(p => p.Group)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n!.Trim())
+                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                .OrderBy(n => n, StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+
+            AvailableGroups.Clear();
+            foreach (var n in names)
+            {
+                AvailableGroups.Add(n);
+            }
         });
 
     private List<FancyProjectObject> GetSortedItems(bool isPinned, int order, string filter)

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -31,10 +31,10 @@ public partial class WelcomePageViewModel : PageViewModel
 
     private readonly ReadOnlyObservableCollection<RecentlyUsedItemModel> _recentlyUsedItems;
 
-    // NOUVEAU : nom du groupe par défaut pour les projets sans groupe.
+    // Default group name for projects that have no group.
     public const string UngroupedName = "Ungrouped";
 
-    // NOUVEAU : noms des groupes repliés (mémorisé le temps de la session).
+    // Names of collapsed groups (kept in memory for the current session).
     private readonly HashSet<string> _collapsedGroups = new();
 
     private Dictionary<string, int> _sortMode = new()
@@ -95,11 +95,11 @@ public partial class WelcomePageViewModel : PageViewModel
     [ObservableProperty]
     private ObservableCollection<FancyProjectObject> _fancyProjects = new();
 
-    // NOUVEAU : projets récents regroupés par "Group", pour l'affichage en sections.
+    // Recent projects grouped by "Group", for display as sections.
     [ObservableProperty]
     private ObservableCollection<ProjectGroup> _groupedProjects = new();
 
-    // NOUVEAU : noms des groupes existants (pour le sous-menu "Move to existing group").
+    // Names of existing groups (for the "Move to existing group" submenu).
     [ObservableProperty]
     private ObservableCollection<string> _availableGroups = new();
 
@@ -189,7 +189,7 @@ public partial class WelcomePageViewModel : PageViewModel
         //_recentlyUsedItemsService.UnpinItem(parameter);
     }
 
-    // NOUVEAU : assigne (ou modifie) le groupe d'un projet via une boîte de saisie.
+    // Assign (or change) a project's group via an input box.
     [RelayCommand]
     private async Task SetProjectGroup(FancyProjectObject? project)
     {
@@ -200,16 +200,16 @@ public partial class WelcomePageViewModel : PageViewModel
 
         var name = await Interactions.ShowInputBoxAsync("Move project to group", project.Group ?? "");
 
-        // L'utilisateur a saisi un nom -> on l'assigne. Vide -> on retire du groupe.
-        // (Note : cette API ne distingue pas clairement "Annuler" d'un champ vidé ;
-        //  si tu veux préserver le groupe sur Annulation, remplace la ligne suivante par :
+        // The user typed a name -> assign it. Empty -> remove from the group.
+        // (Note: this API does not clearly distinguish "Cancel" from an emptied field;
+        //  to keep the group on cancel, replace the next line with:
         //  if (string.IsNullOrWhiteSpace(name)) return;)
         project.Group = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
 
         RefreshRecentProjects();
     }
 
-    // NOUVEAU : retire un projet de son groupe (revient sous "Sans groupe").
+    // Remove a project from its group (it goes back under "Ungrouped").
     [RelayCommand]
     private void RemoveProjectGroup(FancyProjectObject? project)
     {
@@ -222,7 +222,7 @@ public partial class WelcomePageViewModel : PageViewModel
         RefreshRecentProjects();
     }
 
-    // NOUVEAU : assigne un projet à un groupe existant (appelé depuis le sous-menu code-behind).
+    // Assign a project to an existing group (called from the code-behind submenu).
     public void MoveProjectToGroup(FancyProjectObject? project, string group)
     {
         if (project is null)
@@ -233,8 +233,8 @@ public partial class WelcomePageViewModel : PageViewModel
         project.Group = string.IsNullOrWhiteSpace(group) ? null : group.Trim();
         RefreshRecentProjects();
     }
-    // NOUVEAU : supprime un groupe (après confirmation). Les projets ne sont PAS supprimés :
-    // ils repassent simplement dans "Sans groupe".
+    // Delete a group (after confirmation). Projects are NOT deleted: they simply
+    // go back under "Ungrouped".
     [RelayCommand]
     private async Task DeleteGroup(ProjectGroup? group)
     {
@@ -360,21 +360,21 @@ public partial class WelcomePageViewModel : PageViewModel
             FancyProjects.Clear();
             FancyProjects.AddRange(items);
 
-            // NOUVEAU : regroupe par "Group". Les projets sans groupe vont dans
-            // "Sans groupe", placé en dernier ; les autres groupes sont triés par nom.
+            // Group by "Group". Projects without a group go into "Ungrouped",
+            // placed last; the other groups are sorted by name.
             var groups = items
                 .GroupBy(p => string.IsNullOrWhiteSpace(p.Group) ? UngroupedName : p.Group!)
                 .OrderBy(g => g.Key == UngroupedName ? 1 : 0)
                 .ThenBy(g => g.Key, StringComparer.InvariantCultureIgnoreCase)
                 .Select(g =>
                 {
-                    // Restaure l'état replié/déplié mémorisé pour cette session.
+                    // Restore the collapsed/expanded state remembered for this session.
                     var group = new ProjectGroup(g.Key, g)
                     {
                         IsExpanded = !_collapsedGroups.Contains(g.Key)
                     };
 
-                    // Mémorise les changements de pliage (sans toucher au disque).
+                    // Remember collapse/expand changes (without persisting to disk).
                     group.PropertyChanged += (_, e) =>
                     {
                         if (e.PropertyName != nameof(ProjectGroup.IsExpanded))
@@ -402,7 +402,7 @@ public partial class WelcomePageViewModel : PageViewModel
                 GroupedProjects.Add(g);
             }
 
-            // NOUVEAU : liste des groupes existants (hors "Sans groupe"), pour le sous-menu.
+            // Build the list of existing groups (excluding "Ungrouped"), for the submenu.
             var names = items
                 .Select(p => p.Group)
                 .Where(n => !string.IsNullOrWhiteSpace(n))

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -789,7 +789,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     private async Task NewProject()
     {
         //IsOverlayShown = false;
-        await SetActiveDialog(new ProjectWizardViewModel(SettingsManager)
+        await SetActiveDialog(new ProjectWizardViewModel(SettingsManager, _recentlyUsedItemsService)
         {
             FileHandler = NewProject
         });
@@ -832,6 +832,17 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             np.CreateDefaultDirectories();
 
             await LoadProjectFromPathAsync(projectLocation);
+
+            // NOUVEAU : applique le groupe choisi dans l'assistant au projet récent.
+            if (!string.IsNullOrWhiteSpace(project.SelectedGroup))
+            {
+                var recent = _recentlyUsedItemsService.Items.Items
+                    .FirstOrDefault(i => i.Name == projectLocation);
+                if (recent is not null)
+                {
+                    recent.Group = project.SelectedGroup.Trim();
+                }
+            }
         }
         catch (Exception ex)
         {
@@ -2034,16 +2045,16 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     }
 
     private void OnAfterOverlayRendered() => DispatcherHelper.RunOnMainThread(() =>
-        {
-            IsOverlayShown = true;
-            ShouldOverlayShow = true;
-        }, DispatcherPriority.Render);
+    {
+        IsOverlayShown = true;
+        ShouldOverlayShow = true;
+    }, DispatcherPriority.Render);
 
     private void OnAfterDialogRendered() => DispatcherHelper.RunOnMainThread(() =>
-        {
-            IsDialogShown = true;
-            ShouldDialogShow = true;
-        }, DispatcherPriority.Render);
+    {
+        IsDialogShown = true;
+        ShouldDialogShow = true;
+    }, DispatcherPriority.Render);
 
     [MemberNotNull(nameof(Title))]
     public void UpdateTitle()

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -833,7 +833,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
             await LoadProjectFromPathAsync(projectLocation);
 
-            // NOUVEAU : applique le groupe choisi dans l'assistant au projet récent.
+            // Apply the group chosen in the wizard to the newly created recent project.
             if (!string.IsNullOrWhiteSpace(project.SelectedGroup))
             {
                 var recent = _recentlyUsedItemsService.Items.Items

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -2045,16 +2045,16 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     }
 
     private void OnAfterOverlayRendered() => DispatcherHelper.RunOnMainThread(() =>
-    {
-        IsOverlayShown = true;
-        ShouldOverlayShow = true;
-    }, DispatcherPriority.Render);
+        {
+            IsOverlayShown = true;
+            ShouldOverlayShow = true;
+        }, DispatcherPriority.Render);
 
     private void OnAfterDialogRendered() => DispatcherHelper.RunOnMainThread(() =>
-    {
-        IsDialogShown = true;
-        ShouldDialogShow = true;
-    }, DispatcherPriority.Render);
+        {
+            IsDialogShown = true;
+            ShouldDialogShow = true;
+        }, DispatcherPriority.Render);
 
     [MemberNotNull(nameof(Title))]
     public void UpdateTitle()

--- a/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
+++ b/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
@@ -24,6 +24,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
@@ -143,8 +144,24 @@
             hc:InfoElement.Title="Version"
             hc:InfoElement.TitlePlacement="Top" />
 
-        <Grid
+        <!-- NOUVEAU : choix du groupe (liste éditable des groupes existants, vide = Sans groupe) -->
+        <hc:ComboBox
+            x:Name="GroupComboBox"
             Grid.Row="7"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="{DynamicResource WolvenKitMarginBottom}"
+            IsEditable="True"
+            hc:InfoElement.Title="Group (optional — empty = Ungrouped)"
+            hc:InfoElement.TitlePlacement="Top"
+            hc:InfoElement.Placeholder="Type a new group name or pick an existing one"
+            ItemsSource="{Binding AvailableGroups}"
+            Text="{Binding SelectedGroup,
+                           Mode=TwoWay,
+                           UpdateSourceTrigger=PropertyChanged}" />
+
+        <Grid
+            Grid.Row="8"
             Grid.Column="0"
             Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>

--- a/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
+++ b/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
@@ -144,7 +144,7 @@
             hc:InfoElement.Title="Version"
             hc:InfoElement.TitlePlacement="Top" />
 
-        <!-- NOUVEAU : choix du groupe (liste éditable des groupes existants, vide = Sans groupe) -->
+        <!-- Group selection (editable list of existing groups; empty = Ungrouped) -->
         <hc:ComboBox
             x:Name="GroupComboBox"
             Grid.Row="7"

--- a/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
+++ b/WolvenKit/Views/Dialogs/ProjectWizardView.xaml
@@ -151,10 +151,10 @@
             Grid.Column="0"
             Grid.ColumnSpan="2"
             Margin="{DynamicResource WolvenKitMarginBottom}"
-            IsEditable="True"
             hc:InfoElement.Title="Group (optional — empty = Ungrouped)"
             hc:InfoElement.TitlePlacement="Top"
             hc:InfoElement.Placeholder="Type a new group name or pick an existing one"
+            IsEditable="True"
             ItemsSource="{Binding AvailableGroups}"
             Text="{Binding SelectedGroup,
                            Mode=TwoWay,

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -86,10 +86,36 @@
                                                 VerticalContentAlignment="Stretch"
                                                 Background="Transparent"
                                                 BorderThickness="0"
+                                                Tag="{Binding ElementName=topGrid,
+                                                              Path=DataContext}"
                                                 Command="{Binding ElementName=topGrid,
                                                                   Path=DataContext.OpenProjectCommand}"
                                                 CommandParameter="{Binding ProjectPath}"
                                                 ToolTip="{Binding Path=ProjectPath}">
+
+                                                <!-- NOUVEAU : menu clic droit pour gérer le groupe.
+                                                     Le ContextMenu vit dans un popup hors du visual tree :
+                                                     on passe par PlacementTarget.Tag (= le ViewModel racine). -->
+                                                <Button.ContextMenu>
+                                                    <ContextMenu Opened="ProjectContextMenu_Opened">
+                                                        <!-- Sous-menu rempli dynamiquement en code-behind
+                                                             avec les groupes existants (Tag sert de repère). -->
+                                                        <MenuItem
+                                                            Header="Move to existing group"
+                                                            Tag="MoveToGroupParent" />
+                                                        <MenuItem
+                                                            Header="New group…"
+                                                            Command="{Binding PlacementTarget.Tag.SetProjectGroupCommand,
+                                                                              RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                            CommandParameter="{Binding}" />
+                                                        <Separator />
+                                                        <MenuItem
+                                                            Header="Remove from group"
+                                                            Command="{Binding PlacementTarget.Tag.RemoveProjectGroupCommand,
+                                                                              RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                            CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Button.ContextMenu>
                                                 <!--Button.OpacityMask>
                                                 <VisualBrush Visual="{Binding ElementName=headerBackground}" />
                                             </Button.OpacityMask-->
@@ -555,24 +581,100 @@
                         </Grid>
                     </Grid>
 
-                    <!-- Cards -->
-                    <syncfusion:CardView
-                        Name="RecentCardView"
+                    <!-- Cards groupées (NOUVEAU) : une section par groupe.
+                         Chaque groupe = en-tête + son propre CardView. -->
+                    <ItemsControl
                         Grid.Row="1"
                         HorizontalAlignment="Left"
-                        Background="Transparent"
-                        CanSort="False"
-                        ItemContainerStyle="{StaticResource CardViewItemStyle}"
-                        ItemsSource="{Binding FancyProjects}"
-                        Orientation="Horizontal"
-                        ShowHeader="False">
-                        <syncfusion:CardView.Resources>
-                            <!-- gets rid of margin around items -->
-                            <Style TargetType="{x:Type ItemsPresenter}">
-                                <Setter Property="Margin" Value="-10" />
-                            </Style>
-                        </syncfusion:CardView.Resources>
-                    </syncfusion:CardView>
+                        ItemsSource="{Binding GroupedProjects}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,16">
+                                    <!-- En-tête du groupe : flèche (replier/déplier) + nom -->
+                                    <StackPanel
+                                        Margin="0,0,0,6"
+                                        Orientation="Horizontal">
+                                        <ToggleButton
+                                            Style="{StaticResource ToggleButtonCustom}"
+                                            VerticalAlignment="Center"
+                                            Cursor="Hand"
+                                            IsChecked="{Binding IsExpanded,
+                                                                Mode=TwoWay}"
+                                            ToolTip="Collapse / expand group">
+                                            <ToggleButton.Resources>
+                                                <Style TargetType="{x:Type iconPacks:PackIconCodicons}">
+                                                    <Setter Property="Kind" Value="ChevronDown" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger
+                                                            Binding="{Binding IsChecked,
+                                                                              RelativeSource={RelativeSource AncestorType=ToggleButton}}"
+                                                            Value="False">
+                                                            <Setter Property="Kind" Value="ChevronRight" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ToggleButton.Resources>
+                                            <iconPacks:PackIconCodicons
+                                                Width="{DynamicResource WolvenKitIconTiny}"
+                                                Foreground="#CCCCCC" />
+                                        </ToggleButton>
+
+                                        <TextBlock
+                                            Margin="6,0,0,0"
+                                            VerticalAlignment="Center"
+                                            FontSize="{DynamicResource WolvenKitFontMedium}"
+                                            FontWeight="Bold"
+                                            Foreground="#CCCCCC"
+                                            Text="{Binding Name}" />
+                                        <!-- NOUVEAU : supprimer le groupe (les projets repassent
+                                             dans "Sans groupe"). Caché pour le pseudo-groupe "Sans groupe". -->
+                                        <Button
+                                            Margin="8,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Command="{Binding DataContext.DeleteGroupCommand,
+                                                              RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            CommandParameter="{Binding}"
+                                            ToolTip="Delete group (projects move back to Ungrouped)">
+                                            <Button.Style>
+                                                <Style BasedOn="{StaticResource ButtonCustom}" TargetType="Button">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Name}" Value="Ungrouped">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                            <iconPacks:PackIconCodicons
+                                                Kind="Trash"
+                                                Width="{DynamicResource WolvenKitIconTiny}"
+                                                Foreground="{StaticResource WolvenKitRed}" />
+                                        </Button>
+
+                                    </StackPanel>
+
+                                    <!-- Projets du groupe (réutilise le même style de carte) -->
+                                    <syncfusion:CardView
+                                        MaxHeight="190"
+                                        HorizontalAlignment="Left"
+                                        Visibility="{Binding IsExpanded,
+                                                             Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        Background="Transparent"
+                                        CanSort="False"
+                                        ItemContainerStyle="{StaticResource CardViewItemStyle}"
+                                        ItemsSource="{Binding Projects}"
+                                        Orientation="Horizontal"
+                                        ShowHeader="False">
+                                        <syncfusion:CardView.Resources>
+                                            <!-- gets rid of margin around items -->
+                                            <Style TargetType="{x:Type ItemsPresenter}">
+                                                <Setter Property="Margin" Value="-10" />
+                                            </Style>
+                                        </syncfusion:CardView.Resources>
+                                    </syncfusion:CardView>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </Grid>
             </Grid>
 

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -666,7 +666,6 @@
 
                                     <!-- Group projects (reuses the same card style) -->
                                     <syncfusion:CardView
-                                        MaxHeight="190"
                                         HorizontalAlignment="Left"
                                         Background="Transparent"
                                         Visibility="{Binding IsExpanded,

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -93,13 +93,17 @@
                                                 CommandParameter="{Binding ProjectPath}"
                                                 ToolTip="{Binding Path=ProjectPath}">
 
-                                                <!-- Right-click menu to manage the group.
-                                                     The ContextMenu lives in a popup outside the visual tree,
-                                                     so we go through PlacementTarget.Tag (= the root ViewModel). -->
+                                                <!--
+                                                    Right-click menu to manage the group.
+                                                    The ContextMenu lives in a popup outside the visual tree,
+                                                    so we go through PlacementTarget.Tag (= the root ViewModel).
+                                                -->
                                                 <Button.ContextMenu>
                                                     <ContextMenu Opened="ProjectContextMenu_Opened">
-                                                        <!-- Submenu filled dynamically in code-behind
-                                                             with the existing groups (Tag is used as a marker). -->
+                                                        <!--
+                                                            Submenu filled dynamically in code-behind
+                                                            with the existing groups (Tag is used as a marker).
+                                                        -->
                                                         <MenuItem
                                                             Header="Move to existing group"
                                                             Tag="MoveToGroupParent" />
@@ -581,8 +585,10 @@
                         </Grid>
                     </Grid>
 
-                    <!-- Grouped cards: one section per group.
-                         Each group = header + its own CardView. -->
+                    <!--
+                        Grouped cards: one section per group.
+                        Each group = header + its own CardView.
+                    -->
                     <ItemsControl
                         Grid.Row="1"
                         HorizontalAlignment="Left"
@@ -595,8 +601,8 @@
                                         Margin="0,0,0,6"
                                         Orientation="Horizontal">
                                         <ToggleButton
-                                            Style="{StaticResource ToggleButtonCustom}"
                                             VerticalAlignment="Center"
+                                            Style="{StaticResource ToggleButtonCustom}"
                                             Cursor="Hand"
                                             IsChecked="{Binding IsExpanded,
                                                                 Mode=TwoWay}"
@@ -622,12 +628,14 @@
                                         <TextBlock
                                             Margin="6,0,0,0"
                                             VerticalAlignment="Center"
+                                            Foreground="#CCCCCC"
                                             FontSize="{DynamicResource WolvenKitFontMedium}"
                                             FontWeight="Bold"
-                                            Foreground="#CCCCCC"
                                             Text="{Binding Name}" />
-                                        <!-- Delete the group (its projects move back to "Ungrouped").
-                                             Hidden for the "Ungrouped" pseudo-group. -->
+                                        <!--
+                                            Delete the group (its projects move back to "Ungrouped").
+                                            Hidden for the "Ungrouped" pseudo-group.
+                                        -->
                                         <Button
                                             Margin="8,0,0,0"
                                             VerticalAlignment="Center"
@@ -636,9 +644,13 @@
                                             CommandParameter="{Binding}"
                                             ToolTip="Delete group (projects move back to Ungrouped)">
                                             <Button.Style>
-                                                <Style BasedOn="{StaticResource ButtonCustom}" TargetType="Button">
+                                                <Style
+                                                    BasedOn="{StaticResource ButtonCustom}"
+                                                    TargetType="Button">
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Name}" Value="Ungrouped">
+                                                        <DataTrigger
+                                                            Binding="{Binding Name}"
+                                                            Value="Ungrouped">
                                                             <Setter Property="Visibility" Value="Collapsed" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
@@ -656,9 +668,9 @@
                                     <syncfusion:CardView
                                         MaxHeight="190"
                                         HorizontalAlignment="Left"
+                                        Background="Transparent"
                                         Visibility="{Binding IsExpanded,
                                                              Converter={StaticResource BooleanToVisibilityConverter}}"
-                                        Background="Transparent"
                                         CanSort="False"
                                         ItemContainerStyle="{StaticResource CardViewItemStyle}"
                                         ItemsSource="{Binding Projects}"

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml
@@ -93,13 +93,13 @@
                                                 CommandParameter="{Binding ProjectPath}"
                                                 ToolTip="{Binding Path=ProjectPath}">
 
-                                                <!-- NOUVEAU : menu clic droit pour gérer le groupe.
-                                                     Le ContextMenu vit dans un popup hors du visual tree :
-                                                     on passe par PlacementTarget.Tag (= le ViewModel racine). -->
+                                                <!-- Right-click menu to manage the group.
+                                                     The ContextMenu lives in a popup outside the visual tree,
+                                                     so we go through PlacementTarget.Tag (= the root ViewModel). -->
                                                 <Button.ContextMenu>
                                                     <ContextMenu Opened="ProjectContextMenu_Opened">
-                                                        <!-- Sous-menu rempli dynamiquement en code-behind
-                                                             avec les groupes existants (Tag sert de repère). -->
+                                                        <!-- Submenu filled dynamically in code-behind
+                                                             with the existing groups (Tag is used as a marker). -->
                                                         <MenuItem
                                                             Header="Move to existing group"
                                                             Tag="MoveToGroupParent" />
@@ -581,8 +581,8 @@
                         </Grid>
                     </Grid>
 
-                    <!-- Cards groupées (NOUVEAU) : une section par groupe.
-                         Chaque groupe = en-tête + son propre CardView. -->
+                    <!-- Grouped cards: one section per group.
+                         Each group = header + its own CardView. -->
                     <ItemsControl
                         Grid.Row="1"
                         HorizontalAlignment="Left"
@@ -590,7 +590,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,16">
-                                    <!-- En-tête du groupe : flèche (replier/déplier) + nom -->
+                                    <!-- Group header: chevron (collapse/expand) + name -->
                                     <StackPanel
                                         Margin="0,0,0,6"
                                         Orientation="Horizontal">
@@ -626,8 +626,8 @@
                                             FontWeight="Bold"
                                             Foreground="#CCCCCC"
                                             Text="{Binding Name}" />
-                                        <!-- NOUVEAU : supprimer le groupe (les projets repassent
-                                             dans "Sans groupe"). Caché pour le pseudo-groupe "Sans groupe". -->
+                                        <!-- Delete the group (its projects move back to "Ungrouped").
+                                             Hidden for the "Ungrouped" pseudo-group. -->
                                         <Button
                                             Margin="8,0,0,0"
                                             VerticalAlignment="Center"
@@ -652,7 +652,7 @@
 
                                     </StackPanel>
 
-                                    <!-- Projets du groupe (réutilise le même style de carte) -->
+                                    <!-- Group projects (reuses the same card style) -->
                                     <syncfusion:CardView
                                         MaxHeight="190"
                                         HorizontalAlignment="Left"

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml.cs
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using ReactiveUI;
 using Splat;
@@ -70,6 +72,45 @@ namespace WolvenKit.Views.HomePage.Pages
 
             });
 
+        }
+
+        // NOUVEAU : remplit dynamiquement le sous-menu "Move to existing group" avec les
+        // groupes existants à l'ouverture du menu contextuel. On le fait en code-behind car
+        // les bindings de commande dans les sous-menus WPF traversent mal les popups.
+        private void ProjectContextMenu_Opened(object sender, RoutedEventArgs e)
+        {
+            if (sender is not ContextMenu contextMenu)
+            {
+                return;
+            }
+
+            if (contextMenu.PlacementTarget is not FrameworkElement element ||
+                element.DataContext is not WelcomePageViewModel.FancyProjectObject project ||
+                ViewModel is null)
+            {
+                return;
+            }
+
+            var parent = contextMenu.Items
+                .OfType<MenuItem>()
+                .FirstOrDefault(m => (m.Tag as string) == "MoveToGroupParent");
+            if (parent is null)
+            {
+                return;
+            }
+
+            parent.Items.Clear();
+
+            // Désactivé (grisé) s'il n'existe encore aucun groupe.
+            parent.IsEnabled = ViewModel.AvailableGroups.Count > 0;
+
+            foreach (var groupName in ViewModel.AvailableGroups)
+            {
+                var name = groupName; // capture locale pour la closure
+                var item = new MenuItem { Header = name };
+                item.Click += (_, _) => ViewModel.MoveProjectToGroup(project, name);
+                parent.Items.Add(item);
+            }
         }
     }
 }

--- a/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml.cs
+++ b/WolvenKit/Views/HomePage/Pages/WelcomePageView.xaml.cs
@@ -74,9 +74,9 @@ namespace WolvenKit.Views.HomePage.Pages
 
         }
 
-        // NOUVEAU : remplit dynamiquement le sous-menu "Move to existing group" avec les
-        // groupes existants à l'ouverture du menu contextuel. On le fait en code-behind car
-        // les bindings de commande dans les sous-menus WPF traversent mal les popups.
+        // Dynamically fills the "Move to existing group" submenu with the existing
+        // groups when the context menu opens. Done in code-behind because command
+        // bindings inside WPF submenus do not travel well across popups.
         private void ProjectContextMenu_Opened(object sender, RoutedEventArgs e)
         {
             if (sender is not ContextMenu contextMenu)
@@ -101,12 +101,12 @@ namespace WolvenKit.Views.HomePage.Pages
 
             parent.Items.Clear();
 
-            // Désactivé (grisé) s'il n'existe encore aucun groupe.
+            // Disabled (greyed out) when no group exists yet.
             parent.IsEnabled = ViewModel.AvailableGroups.Count > 0;
 
             foreach (var groupName in ViewModel.AvailableGroups)
             {
-                var name = groupName; // capture locale pour la closure
+                var name = groupName; // local capture for the closure
                 var item = new MenuItem { Header = name };
                 item.Click += (_, _) => ViewModel.MoveProjectToGroup(project, name);
                 parent.Items.Add(item);


### PR DESCRIPTION
# Group recent projects on the welcome page

**Implemented:**
- Project groups on the welcome page to keep the recent projects list tidy. Projects with no group stay under a default **"Ungrouped"** section, so nothing changes for existing users.
- Right-click a project to create a group, move it to an existing group, or remove it from its group.
- Collapse / expand each group.
- Delete a group (with confirmation) — its projects move back to "Ungrouped", nothing is deleted.
- Pick a group when creating a new project (optional, defaults to "Ungrouped").

**Additional notes:**
Groups are saved per project in `recentItems.json` (backward compatible, no migration). No change to the `.cpmodproj` format.

[PREVIEW](https://youtu.be/Q8iRER19ci4)


https://github.com/user-attachments/assets/3790851d-2089-4f3c-b2e2-8a53889a23af
