### PR TITLE
Allow individual changelog file per pr

### DIFF
--- a/.github/workflows/stage-changelog.yml
+++ b/.github/workflows/stage-changelog.yml
@@ -16,15 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Ensure Changes exist
-        shell: bash
-        run: |
-          git checkout main
-          if cmp -s 'changelog/!template.yaml' 'changelog/!unreleased.yaml'; then
-            echo "No changes in changelog, aborting."
-            exit 1
-          fi
-
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -34,6 +25,19 @@ jobs:
         run: |
           git push origin --delete changelog-staging || true
           git checkout -b changelog-staging
+
+      - name: Precompile Changelog
+        run: |
+          pip install pyyaml
+          python "tools/precompile_changelog.py" "changelog/unreleased" "changelog/!unreleased.yaml"
+
+      - name: Ensure Changes exist
+        shell: bash
+        run: |
+          if cmp -s 'changelog/!template.yaml' 'changelog/!unreleased.yaml'; then
+            echo "No changes in changelog, aborting."
+            exit 1
+          fi
 
       - name: Get app version
         uses: naminodarie/get-net-sdk-project-versions-action@v2
@@ -48,7 +52,6 @@ jobs:
       - name: Generate changelog
         run: |
           mkdir compiled-changelog
-          pip install pyyaml
           echo ${{env.VERSION_APP}}
           python "tools/compile_changelog.py" --release ${{env.VERSION_APP}} --input "changelog/!unreleased.yaml" --out-md "changelog/generated/CHANGELOG.md" --out-bb "changelog/generated/CHANGELOG.txt" --changelog "CHANGELOG.md"
 

--- a/docs/contributing/keep-changelog.md
+++ b/docs/contributing/keep-changelog.md
@@ -1,17 +1,18 @@
 # Keep a Changelog
 
-Our changelog rules generally follow [keepachangelog.com](https://keepachangelog.com/en/1.1.0/).
+Our changelog rules generally  follow [keepachangelog.com](https://keepachangelog.com/en/1.1.0/).
 
-This project keeps the changelog in `.yaml` files within the `changelog` directory. The `!unreleased.yaml` file contains changes that are merged into main but have not been part of a stable release yet.
-::: info
-This is the file that is modified as part of the pull request process.
-:::
+This project keeps the unreleased changes in yaml format under `changelog/unreleased` where each file represents an individual pull request. The file name is the pull request number.
 ::: warning
-`CHANGELOG.md` as well as `{VERSION}.yaml` files are auto generated as part of the release process and should not be manually modified.
+
+All other files in the `changelog` directory should not be manually modified as they are generated.
+While `changelog/unreleased.yaml` will consider changes added to it directly, it should be avoided due to the high risk of merge conflicts.
+
 :::
 
-Each changelog entry should be added to the `changes:` array in the `!unreleased.yaml` file where each entry has the follwing structure:
+To add a new changelog entry make a copy of the `changelog/!template.yaml` file under `changelog/unreleased/{PR_NUMBER}.yaml` and add as many entries as needed to the `changes:` array.
 
+Each changes entry follows the following format:
 ```yaml
 # This can be either `security`, `deprecated`, `removed`, `added`, `fixed`, or `changed`.
 # Pick one.
@@ -27,7 +28,3 @@ Each changelog entry should be added to the `changes:` array in the `!unreleased
     # User facing change description
     description: ""
 ```
-::: info
-A Pull request can have multiple changelog entries.
-:::
-

--- a/tools/precompile_changelog.py
+++ b/tools/precompile_changelog.py
@@ -1,0 +1,136 @@
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ChangelogDumper(yaml.SafeDumper):
+    pass
+
+
+def represent_list(dumper: yaml.Dumper, data: list[Any]) -> yaml.SequenceNode:
+    use_flow_style = all(isinstance(item, str) for item in data)
+    return dumper.represent_sequence(
+        "tag:yaml.org,2002:seq",
+        data,
+        flow_style=use_flow_style,
+    )
+
+
+ChangelogDumper.add_representer(list, represent_list)
+
+
+def read_yaml_file(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+
+    if data is None:
+        return {}
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected YAML object in {path}, got {type(data).__name__}")
+
+    return data
+
+
+def write_yaml_file(path: Path, data: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as file:
+        yaml.dump(
+            data,
+            file,
+            Dumper=ChangelogDumper,
+            sort_keys=False,
+            allow_unicode=True,
+            default_flow_style=False,
+        )
+
+
+def normalize_changes(value: Any, source: Path) -> list[Any]:
+    if value is None:
+        return []
+
+    if not isinstance(value, list):
+        raise ValueError(f"Expected 'changes' to be a list in {source}")
+
+    return value
+
+
+def collect_unreleased_changes(unreleased_dir: Path) -> tuple[list[Any], list[Path]]:
+    if not unreleased_dir.exists():
+        return [], []
+
+    if not unreleased_dir.is_dir():
+        raise NotADirectoryError(f"{unreleased_dir} is not a directory")
+
+    changes: list[Any] = []
+    files_to_delete: list[Path] = []
+
+    for path in sorted(unreleased_dir.iterdir()):
+        if not path.is_file():
+            continue
+
+        if path.suffix.lower() not in {".yaml", ".yml"}:
+            continue
+
+        data = read_yaml_file(path)
+        changes.extend(normalize_changes(data.get("changes"), path))
+        files_to_delete.append(path)
+
+    return changes, files_to_delete
+
+
+def append_changes_to_unreleased_file(unreleased_file: Path, changes: list[Any]) -> None:
+    if unreleased_file.exists():
+        data = read_yaml_file(unreleased_file)
+    else:
+        data = {}
+
+    existing_changes = normalize_changes(data.get("changes"), unreleased_file)
+    existing_changes.extend(changes)
+
+    data["changes"] = existing_changes
+    write_yaml_file(unreleased_file, data)
+
+
+def delete_files(paths: list[Path]) -> None:
+    for path in paths:
+        path.unlink()
+
+
+def parse_args() -> tuple[Path, Path]:
+    parser = ArgumentParser(
+        description=(
+            "Append changes from YAML files in an unreleased changelog directory "
+            "to an unreleased changelog YAML file."
+        )
+    )
+    parser.add_argument(
+        "unreleased_dir",
+        type=Path,
+        help="Directory containing unreleased changelog YAML files.",
+    )
+    parser.add_argument(
+        "unreleased_file",
+        type=Path,
+        help="YAML file whose 'changes' list should be appended to.",
+    )
+
+    args = parser.parse_args()
+    return args.unreleased_dir, args.unreleased_file
+
+
+def main() -> None:
+    unreleased_dir, unreleased_file = parse_args()
+
+    changes, files_to_delete = collect_unreleased_changes(unreleased_dir)
+
+    if not changes:
+        return
+
+    append_changes_to_unreleased_file(unreleased_file, changes)
+    delete_files(files_to_delete)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Allow individual changelog file per pr

This implements a new precompile step to the changelog generation action which will gather changes from all yaml files in the  `changelog/unreleased` directory.
Manually added changes to `changelog/unreleased.yaml` are still preserved but it is no longer the intended way to do it. 
The docs have been adjusted to reflect that change.

This addresses the issue of merge conflicts when every contributor was expected to append to the same file. 
The workflow downstream of the precompilation step remains unchanged.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->