### PR TITLE
fix "add dependency" only affecting the first path

### DIFF
--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -758,7 +758,9 @@ namespace WolvenKit.Views.Documents
                 childNode.ForceLoadPropertiesRecursive();
                 foreach (var (oldPath, newPath) in pathReplacements)
                 {
-                    if (await childNode.SearchAndReplaceAsync(oldPath, newPath, true, false) == 0)
+                    // result of await can't be in if statement check, or logic is flaky
+                    var replaced = await childNode.SearchAndReplaceAsync(oldPath, newPath, true, false);
+                    if (replaced <= 0)
                     {
                         continue;
                     }


### PR DESCRIPTION
# "Add dependencies" fix (again)

**Fixed:**
- "Add dependencies" in a mesh or mi file will now search&replace in all properties instead of just the first