### PR TITLE
exclude .tmp files from project-wide scans

### DIFF
--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WolvenKit.App.Extensions;
 using WolvenKit.App.Helpers;
+using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.Common;
 using WolvenKit.Core.Extensions;
 using WolvenKit.Core.Interfaces;
@@ -735,6 +736,10 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
             filePaths.AddRange(ModFiles);
             filePaths.AddRange(ResourceFiles);
         }
+
+        filePaths = filePaths
+            .Where(f => !AppViewModel.FileScanIgnoredExtensions.Contains(Path.GetExtension(f).ToLower()))
+            .ToList();
 
         progressService?.Report(0);
         var totalFiles = filePaths.Count;

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -62,7 +62,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
     private readonly ScriptFileViewModel? _fileValidationScript;
     private readonly ScriptFileViewModel? _entSpawnerImportScript;
 
-    private static readonly string[] s_ignoredExtensions = [".xbm", ".mlmask", ".bin"];
+    public static readonly string[] FileScanIgnoredExtensions = [".xbm", ".mlmask", ".bin", ".tmp"];
 
     private static readonly string[] s_packIgnoredExtensions = ["bin"];
 
@@ -109,7 +109,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
         }
 
         var filesToValidate = projArchive.Files.Values
-            .Where(f => !s_ignoredExtensions.Contains(f.Extension.ToLower()))
+            .Where(f => !FileScanIgnoredExtensions.Contains(f.Extension.ToLower()))
             // no *.ext.json
             .Where(f => !f.Extension.Contains("json") || string.IsNullOrEmpty(
                 Path.GetExtension(f.FileName.Replace(".json", ""))))

--- a/changelog/2960.yaml
+++ b/changelog/2960.yaml
@@ -1,7 +1,8 @@
 # Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
-
-- type: "changed"
-  packages: ["App"]
-  pr-number: 2960
-  author: "manavortex"
-  description: "Project-wide scans will now ignore .tmp file extension"
+changes:
+  - type: "changed"
+    packages: ["App"]
+    pr-number: 2960
+    author: "manavortex"
+    description: "Project-wide scans will now ignore .tmp file extension"
+  

--- a/changelog/2960.yaml
+++ b/changelog/2960.yaml
@@ -1,0 +1,7 @@
+# Indepth docs at https://wolvenkit.github.io/WolvenKit/contributing/keep-changelog.html
+
+- type: "changed"
+  packages: ["App"]
+  pr-number: 2960
+  author: "manavortex"
+  description: "Project-wide scans will now ignore .tmp file extension"


### PR DESCRIPTION
# exclude .tmp files from project-wide scans

Project-wide scans will now ignore .tmp files