### PR TITLE
fix: add some missing node details for pausecondition and more

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -146,6 +146,12 @@ internal class NodeProperties
                 details["Required Entry Type"] = journalBulkUpdateCasted?.RequiredEntryType.ToString()!;
                 details["Send Notification"] = journalBulkUpdateCasted?.SendNotification == true ? "True" : "False";
             }
+            if (journalNodeCasted?.Type?.Chunk is questJournalChangeMappinPhase_NodeType journalChangeMappinCasted)
+            {
+                details.AddRange(ParseJournalPath(journalChangeMappinCasted?.Path?.Chunk));
+                details["Phase"] = journalChangeMappinCasted?.Phase.ToEnumString()!;
+                details["Notify UI"] = journalChangeMappinCasted?.NotifyUI == true ? "True" : "False";
+            }
         }
         else if (node is questUseWorkspotNodeDefinition useWorkspotNodeCasted)
         {
@@ -702,6 +708,53 @@ internal class NodeProperties
                     counter++;
                 }
             }
+            if (itemManagerCasted?.Type?.Chunk is questInjectLoot_NodeType injectLootNodeCasted)
+            {
+                var paramsArr = injectLootNodeCasted.Params;
+
+                int counter = 1;
+                foreach (var param in paramsArr)
+                {
+                    var paramChunk = param?.Chunk;
+                    details["#" + counter + " Object Ref"] = GetNameFromUniversalRef(paramChunk?.ObjectRef?.Chunk);
+
+                    var operations = GetInjectLootOperations(paramChunk);
+                    if (operations.Count > 0)
+                    {
+                        var firstOperation = operations[0];
+                        details["#" + counter + " Operation"] = firstOperation.OperationType.ToEnumString();
+                        details["#" + counter + " Item"] = firstOperation.ItemTDBID.GetResolvedText()!;
+                        details["#" + counter + " Quantity"] = firstOperation.Quantity.ToString()!;
+
+                        if (operations.Count > 1)
+                        {
+                            details["#" + counter + " Operations Count"] = operations.Count.ToString();
+                        }
+                    }
+
+                    counter++;
+                }
+            }
+        }
+        else if (node is questRewardManagerNodeDefinition rewardManagerCasted)
+        {
+            details["Manager"] = GetNameFromClass(rewardManagerCasted?.Type?.Chunk);
+
+            if (rewardManagerCasted?.Type?.Chunk is questGiveReward_NodeType giveRewardNodeCasted)
+            {
+                int counter = 1;
+                foreach (var reward in giveRewardNodeCasted.Rewards)
+                {
+                    var rewardName = reward.GetResolvedText();
+                    if (string.IsNullOrEmpty(rewardName))
+                    {
+                        continue;
+                    }
+
+                    details["#" + counter + " Reward"] = rewardName;
+                    counter++;
+                }
+            }
         }
         else if (node is questCrowdManagerNodeDefinition crowdManagerCasted)
         {
@@ -887,6 +940,21 @@ internal class NodeProperties
 
         // Return true if we found curated properties (more than just the initial "Type")
         return details.Count > initialCount;
+    }
+
+    private static List<questInjectLoot_NodeTypeParams_OperationData> GetInjectLootOperations(questInjectLoot_NodeTypeParams? param)
+    {
+        var operations = new List<questInjectLoot_NodeTypeParams_OperationData>();
+
+        if (param == null)
+        {
+            return operations;
+        }
+
+        operations.AddRange(param.Operations);
+        operations.AddRange(param.LootOperations.Select(x => x?.Chunk).OfType<questInjectLoot_NodeTypeParams_OperationData>());
+
+        return operations;
     }
 
     private static Dictionary<string, string> GetSmartAutoDiscoveredProperties(questNodeDefinition? node)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConditionHelper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/Internal/QuestConditionHelper.cs
@@ -98,6 +98,8 @@ public class QuestConditionHelper
                 // Fallback to type name if we can't format it semantically
                 details["Condition"] = conditionTypeName;
             }
+
+            AddSpecificConditionDetails(condition, details);
         }
 
         return details;
@@ -110,6 +112,7 @@ public class QuestConditionHelper
             questTriggerCondition trigger => FormatTriggerCondition(trigger),
             questFactsDBCondition facts => FormatFactsCondition(facts),
             questObjectCondition obj => FormatObjectCondition(obj),
+            questNodeLoadingCondition nodeLoading => FormatNodeLoadingCondition(nodeLoading),
             questTimeCondition time => FormatTimeCondition(time),
             questCharacterCondition character => FormatCharacterCondition(character),
             questDistanceCondition distance => FormatDistanceCondition(distance),
@@ -162,6 +165,11 @@ public class QuestConditionHelper
             var controllerClass = device.DeviceControllerClass.GetResolvedText();
             return $"{objectRef} ({controllerClass}) {function}";
         }
+        else if (obj.Type?.Chunk is questInteraction_ConditionType interaction)
+        {
+            var objectRef = interaction.ObjectRef.GetResolvedText();
+            return $"{objectRef} {interaction.EventType.ToEnumString()}";
+        }
         else if (obj.Type?.Chunk is questInventory_ConditionType inventory)
         {
             var target = inventory.IsPlayer ? "Player" : ParseGameEntityReference(inventory.ObjectRef);
@@ -172,6 +180,33 @@ public class QuestConditionHelper
             return $"{target} {op} {inventory.Quantity} {item}";
         }
         return "Object condition";
+    }
+
+    private static string FormatNodeLoadingCondition(questNodeLoadingCondition nodeLoading)
+    {
+        var objectRef = nodeLoading.ObjectRef.GetResolvedText();
+        if (string.IsNullOrEmpty(objectRef))
+        {
+            return "Node loading condition";
+        }
+
+        return nodeLoading.Inverted == true ? $"Node not loading {objectRef}" : $"Node loading {objectRef}";
+    }
+
+    private static void AddSpecificConditionDetails(questIBaseCondition condition, Dictionary<string, string> details)
+    {
+        if (condition is questObjectCondition obj && obj.Type?.Chunk is questInteraction_ConditionType interaction)
+        {
+            details["Event Type"] = interaction.EventType.ToEnumString();
+        }
+        else if (condition is questNodeLoadingCondition nodeLoading)
+        {
+            details["Inverted"] = nodeLoading.Inverted == true ? "True" : "False";
+        }
+        else if (condition is questSystemCondition system && system.Type?.Chunk is questSaveLock_ConditionType saveLock)
+        {
+            details["Inverted"] = saveLock.Inverted == true ? "True" : "False";
+        }
     }
 
     private static string FormatTimeCondition(questTimeCondition time)

--- a/changelog/unreleased/2978.yaml
+++ b/changelog/unreleased/2978.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 2978
+      author: "misterchedda"
+      description: "Added missing quest graph node details for item, reward, and some condition and journal nodes."


### PR DESCRIPTION
Add some missing node details for quest nodes

specifically:
- NodeLoading, object interaction, and save lock conditions
- More details exposed for ItemManager InjectLoot, RewardManager, and JournalChangeMappinPhase

