### PR TITLE
Merge RedTypeFactory into RedTypeManager 

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -440,7 +440,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     else
                     {
                         Parent.Data = parentData is IRedRef
-                            ? RedTypeFactory.CreateAndInitRedType(parentData.RedType, Data)
+                            ? RedTypeManager.CreateAndInitRedType(parentData.RedType, Data)
                             : throw new Exception();
                     }
 
@@ -1265,7 +1265,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     [RelayCommand(CanExecute = nameof(CanAddHandle))]
     private async Task AddHandle()
     {
-        var data = RedTypeFactory.CreateAndInitRedType(PropertyType);
+        var data = RedTypeManager.CreateAndInitRedType(PropertyType);
         if (data is IRedBaseHandle handle)
         {
             var types = AppDomain.CurrentDomain.GetAssemblies()
@@ -1409,7 +1409,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                 var innerType = arr.InnerType;
                 if (innerType.IsValueType)
                 {
-                    InsertChild(-1, RedTypeFactory.CreateAndInitRedType(innerType));
+                    InsertChild(-1, RedTypeManager.CreateAndInitRedType(innerType));
                     return;
                 }
 
@@ -1452,12 +1452,12 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     }
                     else
                     {
-                        newItem = RedTypeFactory.CreateAndInitRedType(type);
+                        newItem = RedTypeManager.CreateAndInitRedType(type);
                     }
 
                     if (newItem is IRedBaseHandle handle)
                     {
-                        var pointee = RedTypeFactory.CreateAndInitRedType(handle.InnerType);
+                        var pointee = RedTypeManager.CreateAndInitRedType(handle.InnerType);
                         handle.SetValue((RedBaseClass)pointee);
                     }
 
@@ -1692,7 +1692,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             && selectedType is not null && ResolvedData is RedBaseClass rbc)
         {
             var propertyName = Interactions.Rename("");
-            var instance = RedTypeFactory.CreateAndInitRedType(selectedType);
+            var instance = RedTypeManager.CreateAndInitRedType(selectedType);
             rbc.AddDynamicProperty(propertyName, selectedType);
             rbc.SetProperty(propertyName, instance);
             //if (Data is IRedBaseHandle handle)
@@ -1729,7 +1729,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         ArgumentNullException.ThrowIfNull(ResolvedPropertyType);
         if (Data is RedDummy)
         {
-            Data = RedTypeFactory.CreateAndInitRedType(ResolvedPropertyType);
+            Data = RedTypeManager.CreateAndInitRedType(ResolvedPropertyType);
             if (Data is IRedBufferPointer ptr)
             {
                 ptr.SetValue(new RedBuffer { Data = new RedPackage { Chunks = new List<RedBaseClass>() } });
@@ -3657,7 +3657,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
 
     private void HandlePointer(Type type, string customName = "")
     {
-        var instance = RedTypeFactory.CreateAndInit(type);
+        var instance = RedTypeManager.CreateAndInit(type);
         if (instance is DynamicBaseClass dbc)
         {
             if (string.IsNullOrEmpty(customName))
@@ -3668,7 +3668,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             dbc.ClassName = customName;
         }
 
-        var data = RedTypeFactory.CreateAndInitRedType(PropertyType);
+        var data = RedTypeManager.CreateAndInitRedType(PropertyType);
         if (data is IRedBaseHandle handle)
         {
             handle.SetValue(instance);
@@ -3710,7 +3710,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         _appViewModel.CloseDialogCommand.Execute(null);
         if (sender is TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType })
         {
-            var instance = RedTypeFactory.CreateAndInitRedType(selectedType);
+            var instance = RedTypeManager.CreateAndInitRedType(selectedType);
             if (!InsertChild(-1, instance))
             {
                 _loggerService.Error("Unable to insert child");
@@ -3724,10 +3724,10 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         if (sender is TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } &&
             Data is IRedArray arr)
         {
-            var newItem = RedTypeFactory.CreateAndInitRedType(arr.InnerType);
+            var newItem = RedTypeManager.CreateAndInitRedType(arr.InnerType);
             if (newItem is IRedBaseHandle handle)
             {
-                var instance = RedTypeFactory.CreateAndInit(selectedType);
+                var instance = RedTypeManager.CreateAndInit(selectedType);
                 handle.SetValue(instance);
                 if (!InsertChild(-1, newItem))
                 {

--- a/WolvenKit.Modkit/RED4/RedTypeFactory.cs
+++ b/WolvenKit.Modkit/RED4/RedTypeFactory.cs
@@ -7,16 +7,27 @@ namespace WolvenKit.Modkit.RED4;
 
 /// <summary>
 /// Some properties are uninitialized, despite the type specifying them as non-nullable.
-/// This factory will make sure that they have valid default values. 
+/// This factory will make sure that they have valid default values.
 /// </summary>
+/// <remarks>This class is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager"/> instead.</remarks>
+[Obsolete("This class is deprecated and will be removed with the next major version. Use RedTypeManager instead.")]
 public static class RedTypeFactory
 {
+    /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInit(Type)"/> instead.</remarks>
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(Type) instead.")]
     public static RedBaseClass CreateAndInit(Type type) => Init(RedTypeManager.Create(type));
+
+    /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInit(string)"/> instead.</remarks>
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(string) instead.")]
     public static RedBaseClass CreateAndInit(string redTypeName) => Init(RedTypeManager.Create(redTypeName));
 
+    /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInitRedType(Type, params object[])"/> instead.</remarks>
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(Type, params object[]) instead.")]
     public static IRedType CreateAndInitRedType(Type type, params object[] args) =>
         Init(RedTypeManager.CreateRedType(type, args));
 
+    /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInitRedType(String, params object[])"/> instead.</remarks>
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(String, params object[]) instead.")]
     public static IRedType CreateAndInitRedType(string redTypeName, params object[] args) =>
         Init(RedTypeManager.CreateRedType(redTypeName, args));
 

--- a/WolvenKit.Modkit/RED4/RedTypeFactory.cs
+++ b/WolvenKit.Modkit/RED4/RedTypeFactory.cs
@@ -10,24 +10,24 @@ namespace WolvenKit.Modkit.RED4;
 /// This factory will make sure that they have valid default values.
 /// </summary>
 /// <remarks>This class is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager"/> instead.</remarks>
-[Obsolete("This class is deprecated and will be removed with the next major version. Use RedTypeManager instead.")]
+[Obsolete("This class is deprecated and will be removed with the next major version. Use RedTypeManager instead.", error: false)]
 public static class RedTypeFactory
 {
     /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInit(Type)"/> instead.</remarks>
-    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(Type) instead.")]
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(Type) instead.", error: false)]
     public static RedBaseClass CreateAndInit(Type type) => Init(RedTypeManager.Create(type));
 
     /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInit(string)"/> instead.</remarks>
-    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(string) instead.")]
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInit(string) instead.", error: false)]
     public static RedBaseClass CreateAndInit(string redTypeName) => Init(RedTypeManager.Create(redTypeName));
 
     /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInitRedType(Type, params object[])"/> instead.</remarks>
-    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(Type, params object[]) instead.")]
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(Type, params object[]) instead.", error: false)]
     public static IRedType CreateAndInitRedType(Type type, params object[] args) =>
         Init(RedTypeManager.CreateRedType(type, args));
 
     /// <remarks>This method is deprecated and will be removed with the next major version. Use <see cref="RedTypeManager.CreateAndInitRedType(String, params object[])"/> instead.</remarks>
-    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(String, params object[]) instead.")]
+    [Obsolete("This method is deprecated and will be removed with the next major version. Use RedTypeManager.CreateAndInitRedType(String, params object[]) instead.", error: false)]
     public static IRedType CreateAndInitRedType(string redTypeName, params object[] args) =>
         Init(RedTypeManager.CreateRedType(redTypeName, args));
 

--- a/WolvenKit.RED4/Types/Reflection/RedTypeManager.cs
+++ b/WolvenKit.RED4/Types/Reflection/RedTypeManager.cs
@@ -45,4 +45,136 @@ public class RedTypeManager
 
         return CreateRedType(type, args);
     }
+
+    public static RedBaseClass CreateAndInit(Type type) => Init(Create(type));
+    public static RedBaseClass CreateAndInit(string redTypeName) => Init(Create(redTypeName));
+
+    public static IRedType CreateAndInitRedType(Type type, params object[] args) =>
+        Init(CreateRedType(type, args));
+
+    public static IRedType CreateAndInitRedType(string redTypeName, params object[] args) =>
+        Init(CreateRedType(redTypeName, args));
+
+    // ReSharper disable NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+    private static T Init<T>(T obj) where T : IRedType
+    {
+       switch (obj)
+        {
+            case CMaterialInstance matInstance:
+                matInstance.Values ??= [];
+                break;
+            case appearanceAppearanceDefinition appDef:
+                appDef.Components ??= [];
+                break;
+            case entEntityTemplate entTemplate:
+                entTemplate.Entity ??= Init(new CHandle<entEntity>());
+                entTemplate.Components ??= [];
+                break;
+            case questShowPopup_NodeSubType subType:
+                subType.Path ??= Init(new CHandle<gameJournalPath>());
+                subType.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questOpenBriefing_NodeType openBriefingNode:
+                openBriefingNode.BriefingPath ??= Init(new CHandle<gameJournalPath>());
+                openBriefingNode.BriefingPath.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalBulkUpdate_NodeType journalBulkUpdateNodeNode:
+                journalBulkUpdateNodeNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalBulkUpdateNodeNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalChangeMappinPhase_NodeType journalChangeMappinPhaseNode:
+                journalChangeMappinPhaseNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalChangeMappinPhaseNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalContact_NodeType journalContactNodeType:
+                journalContactNodeType.Path ??= Init(new CHandle<gameJournalPath>());
+                journalContactNodeType.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalEntry_NodeType journalEntryNode:
+                journalEntryNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalEntryNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalPushPopQuestObjective_NodeType journalPushPopQuestObjectiveNode:
+                journalPushPopQuestObjectiveNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalPushPopQuestObjectiveNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalQuestEntry_NodeType journalQuestEntryNodeNode:
+                journalQuestEntryNodeNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalQuestEntryNodeNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalQuestObjectiveCounter_NodeType journalQuestObjectiveCounterNode:
+                journalQuestObjectiveCounterNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalQuestObjectiveCounterNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalQuestSetObjectiveOptional_NodeType journalQuestSetObjectiveOptionalNode:
+                journalQuestSetObjectiveOptionalNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalQuestSetObjectiveOptionalNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalSetLockQuestObjective_NodeType journalSetLockQuestObjectiveNode:
+                journalSetLockQuestObjectiveNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalSetLockQuestObjectiveNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalTrackQuest_NodeType journalTrackQuestNode:
+                journalTrackQuestNode.Path ??= Init(new CHandle<gameJournalPath>());
+                journalTrackQuestNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalEntryState_ConditionType journalEntryStateCondition:
+                journalEntryStateCondition.Path ??= Init(new CHandle<gameJournalPath>());
+                journalEntryStateCondition.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalEntryVisited_ConditionType journalEntryVisitedCondition:
+                journalEntryVisitedCondition.Path ??= Init(new CHandle<gameJournalPath>());
+                journalEntryVisitedCondition.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questJournalEntry_ConditionType journalEntryCondition:
+                journalEntryCondition.Path ??= Init(new CHandle<gameJournalPath>());
+                journalEntryCondition.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questMappinState_ConditionType mappinStateCondition:
+                mappinStateCondition.MappinPath ??= Init(new CHandle<gameJournalPath>());
+                mappinStateCondition.MappinPath.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questChangeContactList_NodeTypeParams changeContactListNodeParams:
+                changeContactListNodeParams.Contact ??= Init(new CHandle<gameJournalPath>());
+                changeContactListNodeParams.Contact.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questCallContact_NodeType callContactNode:
+                callContactNode.Addressee ??= Init(new CHandle<gameJournalPath>());
+                callContactNode.Addressee.Chunk ??= Init(new gameJournalPath());
+                callContactNode.Caller ??= Init(new CHandle<gameJournalPath>());
+                callContactNode.Caller.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questCloseMessage_NodeType closeMessageNode:
+                closeMessageNode.Msg ??= Init(new CHandle<gameJournalPath>());
+                closeMessageNode.Msg.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questOpenMessage_NodeType openMessageNode:
+                openMessageNode.Msg ??= Init(new CHandle<gameJournalPath>());
+                openMessageNode.Msg.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questSendMessage_NodeType sendMessageNode:
+                sendMessageNode.Msg ??= Init(new CHandle<gameJournalPath>());
+                sendMessageNode.Msg.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questMappinManagerNodeDefinition mappinManagerNode:
+                mappinManagerNode.Path ??= Init(new CHandle<gameJournalPath>());
+                mappinManagerNode.Path.Chunk ??= Init(new gameJournalPath());
+                break;
+            case questMappinGPSDistance questMappinGpsDistance:
+                questMappinGpsDistance.MappinPath ??= Init(new CHandle<gameJournalPath>());
+                questMappinGpsDistance.MappinPath.Chunk ??= Init(new gameJournalPath());
+                break;
+            case CHandle<RedBaseClass> baseHandle:
+                return (T)(IRedType)InitHandle(baseHandle);
+            default:
+                break;
+        }
+        return obj;
+    }
+
+    private static CHandle<T> InitHandle<T>(CHandle<T> handle) where T : RedBaseClass
+    {
+        handle.Chunk ??= CreateAndInit(typeof(T)) as T;
+        return handle;
+    }
 }

--- a/changelog/unreleased/2984.yaml
+++ b/changelog/unreleased/2984.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "deprecated"
+      packages: ["Nuget Packages"]
+      pr-number: 2984
+      author: "notaspirit"
+      description: "All functionality of ModKit.RED4.RedTypeFactory has been moved to RED4.Types.RedTypeManager."


### PR DESCRIPTION
# Merge RedTypeFactory into RedTypeManager 

**Implemented:**
- moved all methods from RedTypeFactory to RedTypeManager 
- marked  RedTypeFactory as deprecated 
- updated consumers that we control 

**Additional notes:**
This doesn't change any functionality, it simply appends all methods from RedTypeFactory to RedTypeManager. 
As ModKit depends on RED4 and there is no behavior change migration will be seamless for consumers. 

The reasoning is that they already do the same / very similar thing (create and initialize red types and classes) and thus are better to have in one place, as well as RedTypeFactory being in ModKit limiting the projects that can use it (e.g. `WolvenKit.Common` before this pr couldn't use `CreateAndInit()` but could use `Create()`). 
Specifically #2979 would benefit from the last point.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->