### PR TITLE
feat: add comment boxes

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/GraphCommentState.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/GraphCommentState.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace WolvenKit.App.ViewModels.GraphEditor;
+
+internal sealed class GraphCommentState
+{
+    public List<GraphCommentStateEntry>? Comments { get; set; } = [];
+}
+
+internal sealed class GraphCommentStateEntry
+{
+    public string? Id { get; set; }
+    public string? Text { get; set; }
+    public string? AccentColor { get; set; }
+    public double? X { get; set; }
+    public double? Y { get; set; }
+    public double? Width { get; set; }
+    public double? Height { get; set; }
+}

--- a/WolvenKit.App/ViewModels/GraphEditor/GraphCommentViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/GraphCommentViewModel.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace WolvenKit.App.ViewModels.GraphEditor;
+
+public partial class GraphCommentViewModel : ObservableObject
+{
+    private const double MinWidth = 180;
+    private const double MinHeight = 120;
+    private const double MaxWidth = 4000;
+    private const double MaxHeight = 2600;
+    public const string DefaultAccentColor = "#FFAAAAAA";
+    public const double DefaultWidth = 360;
+    public const double DefaultHeight = 220;
+
+    public string Id { get; init; } = Guid.NewGuid().ToString("N");
+
+    public int ZIndex => -1000;
+
+    public double MaximumWidth => MaxWidth;
+
+    public double MaximumHeight => MaxHeight;
+
+    [ObservableProperty]
+    private string _text = "Comment";
+
+    [ObservableProperty]
+    private bool _isEditing;
+
+    [ObservableProperty]
+    private string _accentColor = DefaultAccentColor;
+
+    [ObservableProperty]
+    private Point _location;
+
+    private double _width = DefaultWidth;
+    public double Width
+    {
+        get => _width;
+        set => SetProperty(ref _width, ClampDimension(value, MinWidth, MaxWidth));
+    }
+
+    private double _height = DefaultHeight;
+    public double Height
+    {
+        get => _height;
+        set => SetProperty(ref _height, ClampDimension(value, MinHeight, MaxHeight));
+    }
+
+    public Size Size
+    {
+        get => new(Width, Height);
+        set { }
+    }
+
+    public Brush BorderBrush => CreateBrush(AccentColor, 0xFF);
+
+    public Brush HeaderBrush => CreateBrush(AccentColor, 0xDD);
+
+    public Brush BackgroundBrush => CreateBrush(AccentColor, 0x22);
+
+    public void ResetSize()
+    {
+        Width = DefaultWidth;
+        Height = DefaultHeight;
+    }
+
+    private static double ClampDimension(double value, double min, double max)
+    {
+        if (double.IsNaN(value))
+        {
+            return min;
+        }
+
+        if (double.IsInfinity(value))
+        {
+            return max;
+        }
+
+        return Math.Clamp(value, min, max);
+    }
+
+    partial void OnAccentColorChanged(string value)
+    {
+        OnPropertyChanged(nameof(BorderBrush));
+        OnPropertyChanged(nameof(HeaderBrush));
+        OnPropertyChanged(nameof(BackgroundBrush));
+    }
+
+    private static Brush CreateBrush(string colorValue, byte alpha)
+    {
+        var color = ParseColor(colorValue);
+        color.A = alpha;
+
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+
+    private static Color ParseColor(string colorValue)
+    {
+        try
+        {
+            if (ColorConverter.ConvertFromString(colorValue) is Color color)
+            {
+                return color;
+            }
+        }
+        catch (FormatException)
+        {
+        }
+
+        return Colors.Gold;
+    }
+}

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Input;
@@ -43,13 +45,16 @@ public partial class RedGraph : IDisposable
     public RedGraphType GraphType { get; } = RedGraphType.Invalid;
 
     public string Title { get; }
+    public ObservableCollection<object> CanvasItems { get; } = new();
     public ObservableCollection<NodeViewModel> Nodes { get; } = new();
     public ObservableCollection<ConnectionViewModel> Connections { get; } = new();
+    public ObservableCollection<GraphCommentViewModel> Comments { get; } = new();
     public PendingConnectionViewModel PendingConnection { get; }
 
     public ICommand ConnectCommand { get; }
     public ICommand DisconnectCommand { get; }
     public ICommand ItemsDragCompletedCommand { get; }
+    public ICommand RemoveCommentCommand { get; }
 
     public Nodify.NodifyEditor? Editor { get; set; }
 
@@ -86,8 +91,12 @@ public partial class RedGraph : IDisposable
         ConnectCommand = new RelayCommand(Connect);
         DisconnectCommand = new RelayCommand<BaseConnectorViewModel>(Disconnect);
         ItemsDragCompletedCommand = new RelayCommand(ItemsDragCompleted);
+        RemoveCommentCommand = new RelayCommand<GraphCommentViewModel>(RemoveComment);
 
         _loggerService = Locator.Current.GetService<ILoggerService>();
+
+        Comments.CollectionChanged += CommentsOnCollectionChanged;
+        Nodes.CollectionChanged += NodesOnCollectionChanged;
     }
 
     public void Connect()
@@ -293,19 +302,22 @@ public partial class RedGraph : IDisposable
 
     public void CenterOnSelectedNodes(IList<object> nodes)
     {
-        if (nodes.Count > 0 && Editor != null)
+        if (Editor == null)
         {
-            if (nodes[0] is not NodeViewModel nvm)
-            {
-                throw new Exception();
-            }
-
-            Editor.ViewportZoom = 1;
-            Editor.ViewportLocation = new System.Windows.Point(
-                nvm.Location.X - (Editor.ViewportSize.Width / 2) + (nvm.Size.Width / 2),
-                nvm.Location.Y - (Editor.ViewportSize.Height / 2) + (nvm.Size.Height / 2)
-            );
+            return;
         }
+
+        var nvm = nodes.OfType<NodeViewModel>().FirstOrDefault();
+        if (nvm == null)
+        {
+            return;
+        }
+
+        Editor.ViewportZoom = 1;
+        Editor.ViewportLocation = new System.Windows.Point(
+            nvm.Location.X - (Editor.ViewportSize.Width / 2) + (nvm.Size.Width / 2),
+            nvm.Location.Y - (Editor.ViewportSize.Height / 2) + (nvm.Size.Height / 2)
+        );
     }
 
     public void RecalculateSockets(IGraphProvider nodeViewModel)
@@ -373,17 +385,120 @@ public partial class RedGraph : IDisposable
         return new System.Windows.Rect(minX, minY, maxX - minX, maxY - minY);
     }
 
+    public GraphCommentViewModel AddComment(System.Windows.Point location, IEnumerable<object>? selectedItems = null)
+    {
+        const double padding = 60;
+        const double headerPadding = 90;
+
+        var selectedNodes = selectedItems?
+            .OfType<NodeViewModel>()
+            .ToList() ?? [];
+
+        GraphCommentViewModel comment;
+        if (selectedNodes.Count > 0)
+        {
+            var minX = selectedNodes.Min(node => node.Location.X);
+            var minY = selectedNodes.Min(node => node.Location.Y);
+            var maxX = selectedNodes.Max(node => node.Location.X + Math.Max(node.Size.Width, 260));
+            var maxY = selectedNodes.Max(node => node.Location.Y + Math.Max(node.Size.Height, 120));
+
+            comment = new GraphCommentViewModel
+            {
+                Location = new System.Windows.Point(minX - padding, minY - headerPadding),
+                Width = maxX - minX + (padding * 2),
+                Height = maxY - minY + headerPadding + padding
+            };
+        }
+        else
+        {
+            comment = new GraphCommentViewModel
+            {
+                Location = location
+            };
+        }
+
+        AddComment(comment);
+        GraphCommentStateSave();
+
+        return comment;
+    }
+
+    private void AddComment(GraphCommentViewModel comment)
+    {
+        comment.PropertyChanged += CommentOnPropertyChanged;
+        Comments.Add(comment);
+    }
+
+    private void RemoveComment(GraphCommentViewModel? comment)
+    {
+        if (comment == null)
+        {
+            return;
+        }
+
+        comment.PropertyChanged -= CommentOnPropertyChanged;
+        Comments.Remove(comment);
+        GraphCommentStateSave();
+    }
+
+    private void ClearComments()
+    {
+        if (Comments.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var comment in Comments)
+        {
+            comment.PropertyChanged -= CommentOnPropertyChanged;
+        }
+
+        Comments.Clear();
+    }
+
+    private void CommentsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildCanvasItems();
+
+    private void NodesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildCanvasItems();
+
+    private void RebuildCanvasItems()
+    {
+        CanvasItems.Clear();
+
+        foreach (var comment in Comments)
+        {
+            CanvasItems.Add(comment);
+        }
+
+        foreach (var node in Nodes)
+        {
+            CanvasItems.Add(node);
+        }
+    }
+
+    private void CommentOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(GraphCommentViewModel.Text))
+        {
+            GraphCommentStateSave();
+        }
+        else if (e.PropertyName == nameof(GraphCommentViewModel.AccentColor))
+        {
+            GraphCommentStateSave();
+        }
+    }
+
     public void GraphStateLoad()
     {
         var loaded = false;
+        _allowGraphSave = false;
 
         if (DocumentViewModel != null)
         {
             var proj = DocumentViewModel.GetActiveProject();
             if (proj != null)
             {
-                var statePath = Path.Combine(proj.ProjectDirectory, "GraphEditorStates", DocumentViewModel.RelativePath + StateParents + ".json");
-                if (File.Exists(statePath))
+                var statePath = GetGraphEditorStatePath(".json");
+                if (statePath != null && File.Exists(statePath))
                 {
                     var jsonData = JObject.Parse(File.ReadAllText(statePath));
                     var nodesArray = jsonData.SelectTokens("Nodes.[*]");
@@ -447,12 +562,15 @@ public partial class RedGraph : IDisposable
             node.IsInitialLoad = false;
         }
 
+        ClearComments();
+        GraphCommentStateLoad();
         _allowGraphSave = true;
     }
 
     private void ItemsDragCompleted()
     {
         GraphStateSave();
+        GraphCommentStateSave();
     }
 
     public void GraphStateSave()
@@ -462,13 +580,13 @@ public partial class RedGraph : IDisposable
             var proj = DocumentViewModel.GetActiveProject();
             if (proj != null)
             {
-                var statePath = Path.Combine(proj.ProjectDirectory, "GraphEditorStates", DocumentViewModel.RelativePath + StateParents + ".json");
-                var parentFolder = Path.GetDirectoryName(statePath);
-
-                if (parentFolder != null && !Directory.Exists(parentFolder))
+                var statePath = GetGraphEditorStatePath(".json");
+                if (statePath == null)
                 {
-                    Directory.CreateDirectory(parentFolder);
+                    return;
                 }
+
+                EnsureGraphEditorStateFolder(statePath);
 
                 if (File.Exists(statePath))
                 {
@@ -515,6 +633,119 @@ public partial class RedGraph : IDisposable
         }
     }
 
+    private void GraphCommentStateLoad()
+    {
+        if (DocumentViewModel == null)
+        {
+            return;
+        }
+
+        var statePath = GetGraphEditorStatePath(".comments.json");
+        if (statePath == null)
+        {
+            return;
+        }
+
+        if (!File.Exists(statePath))
+        {
+            return;
+        }
+
+        var jsonData = JObject.Parse(File.ReadAllText(statePath));
+        var commentsArray = jsonData.SelectTokens("Comments.[*]");
+        foreach (var commentToken in commentsArray)
+        {
+            var id = commentToken.SelectToken("Id")?.ToObject<string>();
+            var text = commentToken.SelectToken("Text")?.ToObject<string>();
+            var x = commentToken.SelectToken("X")?.ToObject<double>();
+            var y = commentToken.SelectToken("Y")?.ToObject<double>();
+            var width = commentToken.SelectToken("Width")?.ToObject<double>();
+            var height = commentToken.SelectToken("Height")?.ToObject<double>();
+            var accentColor = commentToken.SelectToken("AccentColor")?.ToObject<string>();
+
+            if (x is null || y is null || width is null || height is null)
+            {
+                continue;
+            }
+
+            AddComment(new GraphCommentViewModel
+            {
+                Id = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("N") : id,
+                Text = string.IsNullOrWhiteSpace(text) ? "Comment" : text,
+                AccentColor = string.IsNullOrWhiteSpace(accentColor) ? GraphCommentViewModel.DefaultAccentColor : accentColor,
+                Location = new System.Windows.Point(x.Value, y.Value),
+                Width = width.Value,
+                Height = height.Value
+            });
+        }
+    }
+
+    public void GraphCommentStateSave()
+    {
+        if (DocumentViewModel == null || !_allowGraphSave)
+        {
+            return;
+        }
+
+        var statePath = GetGraphEditorStatePath(".comments.json");
+        if (statePath == null)
+        {
+            return;
+        }
+
+        if (Comments.Count == 0)
+        {
+            if (File.Exists(statePath))
+            {
+                File.Delete(statePath);
+            }
+
+            return;
+        }
+
+        EnsureGraphEditorStateFolder(statePath);
+
+        var jComments = new JArray();
+        foreach (var comment in Comments)
+        {
+            jComments.Add(new JObject(
+                new JProperty("Id", comment.Id),
+                new JProperty("Text", comment.Text),
+                new JProperty("AccentColor", comment.AccentColor),
+                new JProperty("X", comment.Location.X),
+                new JProperty("Y", comment.Location.Y),
+                new JProperty("Width", comment.Width),
+                new JProperty("Height", comment.Height)
+            ));
+        }
+
+        var jRoot = new JObject
+        {
+            new JProperty("Comments", jComments)
+        };
+
+        File.WriteAllText(statePath, JsonConvert.SerializeObject(jRoot));
+    }
+
+    private string? GetGraphEditorStatePath(string extension)
+    {
+        var proj = DocumentViewModel?.GetActiveProject();
+
+        return proj == null
+            ? null
+            : Path.Combine(proj.ProjectDirectory, "GraphEditorStates", DocumentViewModel!.RelativePath + StateParents + extension);
+    }
+
+    private static void EnsureGraphEditorStateFolder(string statePath)
+    {
+        var parentFolder = Path.GetDirectoryName(statePath);
+
+        if (parentFolder != null && !Directory.Exists(parentFolder))
+        {
+            Directory.CreateDirectory(parentFolder);
+        }
+    }
+
     private void NotifyNodesUpdated(params uint[] nodeIds)
     {
         foreach (var nodeId in nodeIds)
@@ -549,6 +780,8 @@ public partial class RedGraph : IDisposable
                 {
                     node.Dispose();
                 }
+
+                ClearComments();
             }
 
             _disposedValue = true;

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -651,31 +651,27 @@ public partial class RedGraph : IDisposable
             return;
         }
 
-        var jsonData = JObject.Parse(File.ReadAllText(statePath));
-        var commentsArray = jsonData.SelectTokens("Comments.[*]");
-        foreach (var commentToken in commentsArray)
+        var state = JsonConvert.DeserializeObject<GraphCommentState>(File.ReadAllText(statePath));
+        if (state == null)
         {
-            var id = commentToken.SelectToken("Id")?.ToObject<string>();
-            var text = commentToken.SelectToken("Text")?.ToObject<string>();
-            var x = commentToken.SelectToken("X")?.ToObject<double>();
-            var y = commentToken.SelectToken("Y")?.ToObject<double>();
-            var width = commentToken.SelectToken("Width")?.ToObject<double>();
-            var height = commentToken.SelectToken("Height")?.ToObject<double>();
-            var accentColor = commentToken.SelectToken("AccentColor")?.ToObject<string>();
+            return;
+        }
 
-            if (x is null || y is null || width is null || height is null)
+        foreach (var comment in state.Comments ?? [])
+        {
+            if (comment.X is null || comment.Y is null || comment.Width is null || comment.Height is null)
             {
                 continue;
             }
 
             AddComment(new GraphCommentViewModel
             {
-                Id = string.IsNullOrWhiteSpace(id) ? Guid.NewGuid().ToString("N") : id,
-                Text = string.IsNullOrWhiteSpace(text) ? "Comment" : text,
-                AccentColor = string.IsNullOrWhiteSpace(accentColor) ? GraphCommentViewModel.DefaultAccentColor : accentColor,
-                Location = new System.Windows.Point(x.Value, y.Value),
-                Width = width.Value,
-                Height = height.Value
+                Id = string.IsNullOrWhiteSpace(comment.Id) ? Guid.NewGuid().ToString("N") : comment.Id,
+                Text = string.IsNullOrWhiteSpace(comment.Text) ? "Comment" : comment.Text,
+                AccentColor = string.IsNullOrWhiteSpace(comment.AccentColor) ? GraphCommentViewModel.DefaultAccentColor : comment.AccentColor,
+                Location = new System.Windows.Point(comment.X.Value, comment.Y.Value),
+                Width = comment.Width.Value,
+                Height = comment.Height.Value
             });
         }
     }
@@ -705,26 +701,21 @@ public partial class RedGraph : IDisposable
 
         EnsureGraphEditorStateFolder(statePath);
 
-        var jComments = new JArray();
-        foreach (var comment in Comments)
+        var state = new GraphCommentState
         {
-            jComments.Add(new JObject(
-                new JProperty("Id", comment.Id),
-                new JProperty("Text", comment.Text),
-                new JProperty("AccentColor", comment.AccentColor),
-                new JProperty("X", comment.Location.X),
-                new JProperty("Y", comment.Location.Y),
-                new JProperty("Width", comment.Width),
-                new JProperty("Height", comment.Height)
-            ));
-        }
-
-        var jRoot = new JObject
-        {
-            new JProperty("Comments", jComments)
+            Comments = Comments.Select(comment => new GraphCommentStateEntry
+            {
+                Id = comment.Id,
+                Text = comment.Text,
+                AccentColor = comment.AccentColor,
+                X = comment.Location.X,
+                Y = comment.Location.Y,
+                Width = comment.Width,
+                Height = comment.Height
+            }).ToList()
         };
 
-        File.WriteAllText(statePath, JsonConvert.SerializeObject(jRoot));
+        File.WriteAllText(statePath, JsonConvert.SerializeObject(state));
     }
 
     private string? GetGraphEditorStatePath(string extension)

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -1037,12 +1037,41 @@ namespace WolvenKit.Views.Documents
             // Get the currently displayed graph (could be main graph or a subgraph)
             var currentGraph = QuestPhaseGraphEditor.Source;
 
+            // Shortcut: C to add a comment at the cursor or around selected nodes
+            if (e.Key == Key.C && Keyboard.Modifiers == ModifierKeys.None)
+            {
+                if (IsTextEditingControlFocused())
+                {
+                    return;
+                }
+
+                if (QuestPhaseGraphEditor.AddCommentFromCurrentCursor())
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+
             // Shortcut: Delete key to soft delete, Shift+Delete for hard delete
             if (e.Key == Key.Delete)
             {
                 // Don't handle delete key if user is editing text
                 if (IsTextEditingControlFocused())
                     return;
+
+                var selectedComments = QuestPhaseGraphEditor?.Editor?.SelectedItems?
+                    .OfType<GraphCommentViewModel>()
+                    .ToList();
+
+                if (selectedComments is { Count: > 0 })
+                {
+                    foreach (var comment in selectedComments)
+                    {
+                        currentGraph.RemoveCommentCommand.Execute(comment);
+                    }
+
+                    e.Handled = true;
+                }
 
                 // Use SelectedNodes from underlying GraphEditor
                 var selectedNodes = QuestPhaseGraphEditor?.Editor?.SelectedItems?

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -525,12 +525,41 @@ namespace WolvenKit.Views.Documents
             if (viewModel?.MainGraph == null)
                 return;
 
+            // Shortcut: C to add a comment at the cursor or around selected nodes
+            if (e.Key == Key.C && Keyboard.Modifiers == ModifierKeys.None)
+            {
+                if (IsEditingContextActive())
+                {
+                    return;
+                }
+
+                if (SceneGraphEditor.AddCommentFromCurrentCursor())
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+
             // Shortcut: Delete key to soft delete, Shift+Delete for hard delete
             if (e.Key == Key.Delete)
             {
                 // Don't handle delete key if user is editing text
                 if (IsEditingContextActive())
                     return;
+
+                var selectedComments = SceneGraphEditor?.Editor?.SelectedItems?
+                    .OfType<GraphCommentViewModel>()
+                    .ToList();
+
+                if (selectedComments is { Count: > 0 })
+                {
+                    foreach (var comment in selectedComments)
+                    {
+                        viewModel.MainGraph.RemoveCommentCommand.Execute(comment);
+                    }
+
+                    e.Handled = true;
+                }
 
                 // Use SelectedNodes from underlying GraphEditor
                 var selectedNodes = SceneGraphEditor?.Editor?.SelectedItems?

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -122,11 +122,11 @@
             DisplayConnectionsOnTop="True"
             EnableRealtimeSelection="True"
             ItemsSource="{Binding ElementName=uc,
-                                  Path=Source.Nodes}"
+                                  Path=Source.CanvasItems}"
             PendingConnection="{Binding ElementName=uc,
                                         Path=Source.PendingConnection}"
             SelectedItem="{Binding ElementName=uc,
-                                   Path=SelectedNode,
+                                   Path=SelectedItem,
                                    Mode=TwoWay}"
             SelectedItems="{Binding ElementName=uc,
                                     Path=SelectedNodes,
@@ -610,6 +610,87 @@
                     </nodify:Node>
                 </DataTemplate>
 
+                <DataTemplate DataType="{x:Type nodes:GraphCommentViewModel}">
+                    <nodify:GroupingNode
+                        Width="{Binding Width}"
+                        Height="{Binding Height}"
+                        MaxWidth="{Binding MaximumWidth}"
+                        MaxHeight="{Binding MaximumHeight}"
+                        MinWidth="180"
+                        MinHeight="120"
+                        Background="{Binding BackgroundBrush}"
+                        BorderBrush="{Binding BorderBrush}"
+                        BorderThickness="3"
+                        CanResize="True"
+                        ContextMenuOpening="Comment_ContextMenuOpening"
+                        Header="{Binding}"
+                        HeaderBrush="{Binding HeaderBrush}"
+                        MovementMode="Group"
+                        ResizeCompleted="Comment_OnResizeCompleted">
+                        <nodify:GroupingNode.ContextMenu>
+                            <ContextMenu />
+                        </nodify:GroupingNode.ContextMenu>
+                        <nodify:GroupingNode.HeaderTemplate>
+                            <DataTemplate DataType="{x:Type nodes:GraphCommentViewModel}">
+                                <Grid Cursor="SizeAll">
+                                    <TextBlock
+                                        Padding="4,1,4,1"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        FontSize="{DynamicResource WolvenKitFontTitle}"
+                                        FontWeight="SemiBold"
+                                        MouseLeftButtonDown="CommentText_OnMouseLeftButtonDown"
+                                        Text="{Binding Text}"
+                                        TextWrapping="Wrap">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+
+                                    <TextBox
+                                        x:Name="CommentEditTextBox"
+                                        MinWidth="120"
+                                        Padding="4,1,4,1"
+                                        VerticalContentAlignment="Center"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        CaretBrush="White"
+                                        Cursor="IBeam"
+                                        Foreground="White"
+                                        FontSize="{DynamicResource WolvenKitFontTitle}"
+                                        FontWeight="SemiBold"
+                                        TextWrapping="Wrap"
+                                        IsVisibleChanged="CommentEditTextBox_OnIsVisibleChanged"
+                                        LostKeyboardFocus="CommentEditTextBox_OnLostKeyboardFocus"
+                                        PreviewKeyDown="CommentEditTextBox_OnPreviewKeyDown"
+                                        Text="{Binding Text,
+                                                       Mode=TwoWay,
+                                                       UpdateSourceTrigger=PropertyChanged,
+                                                       Delay=500}">
+                                        <TextBox.Style>
+                                            <Style TargetType="TextBox">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsEditing}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBox.Style>
+                                    </TextBox>
+                                </Grid>
+                            </DataTemplate>
+                        </nodify:GroupingNode.HeaderTemplate>
+                    </nodify:GroupingNode>
+                </DataTemplate>
+
 
             </nodify:NodifyEditor.Resources>
 
@@ -676,6 +757,7 @@
                     <Setter Property="BorderBrush" Value="Transparent" />
                     <Setter Property="BorderThickness" Value="0" />
                     <Setter Property="Location" Value="{Binding Location}" />
+                    <Setter Property="Panel.ZIndex" Value="{Binding ZIndex, FallbackValue=0}" />
                     <Style.Triggers>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter Property="BorderBrush" Value="{StaticResource WolvenKitYellow}" />

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -8,8 +8,10 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Shapes;
 using System.Windows.Threading;
 using Nodify;
 using ReactiveUI;
@@ -33,6 +35,18 @@ namespace WolvenKit.Views.GraphEditor;
 /// </summary>
 public partial class GraphEditorView : UserControl
 {
+    private static readonly (string Name, string Color)[] s_commentColorPresets =
+    [
+        ("Yellow", "#FFFFD400"),
+        ("Green", "#FF5BB85B"),
+        ("Blue", "#FF3FA7FF"),
+        ("Purple", "#FFB77AFF"),
+        ("Pink", "#FFFF80C8"),
+        ("Red", "#FFFF5C5C"),
+        ("Gray", "#FFAAAAAA"),
+        ("Orange", "#FFFF9F1C")
+    ];
+
     public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
         nameof(Source), typeof(RedGraph), typeof(GraphEditorView), new PropertyMetadata(null, OnSourceChanged));
 
@@ -73,6 +87,20 @@ public partial class GraphEditorView : UserControl
     {
         add => AddHandler(NodeDoubleClickEvent, value);
         remove => RemoveHandler(NodeDoubleClickEvent, value);
+    }
+
+    private object _selectedItem;
+
+    public object SelectedItem
+    {
+        get => _selectedItem;
+        set
+        {
+            if (SetField(ref _selectedItem, value))
+            {
+                SelectedNode = value as NodeViewModel;
+            }
+        }
     }
 
     private NodeViewModel _selectedNode;
@@ -361,6 +389,15 @@ public partial class GraphEditorView : UserControl
             nodifyEditor.ContextMenu.Items.Add(addMenu);
         }
 
+        if (Source.GraphType is RedGraphType.Quest or RedGraphType.Scene)
+        {
+            var hasNodeSelection = SelectedNodes.OfType<NodeViewModel>().Any();
+            nodifyEditor.ContextMenu.Items.Add(CreateMenuItem(
+                hasNodeSelection ? "Add Comment Around Selection" : "Add Comment",
+                "CommentTextOutline",
+                () => Source.AddComment(mousePosition, SelectedNodes)));
+        }
+
         nodifyEditor.ContextMenu.Items.Add(CreateMenuItem("Arrange Items", "ViewDashboard", ArrangeNodes));
 
         nodifyEditor.ContextMenu.Items.Add(CreateMenuItem("Hide/unhide sockets", "Eye", ToggleAllSockets));
@@ -446,12 +483,13 @@ public partial class GraphEditorView : UserControl
             return;
         }
 
-        if (SelectedNodes.Count > 1)
+        var selectedGraphNodes = SelectedNodes.OfType<NodeViewModel>().Cast<object>().ToList();
+        if (selectedGraphNodes.Count > 1)
         {
-            node.ContextMenu.Items.Add(CreateMenuItem("Destroy Nodes", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNodes(SelectedNodes)));
+            node.ContextMenu.Items.Add(CreateMenuItem("Destroy Nodes", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNodes(selectedGraphNodes)));
             if (Source.GraphType == RedGraphType.Quest)
             {
-                node.ContextMenu.Items.Add(CreateMenuItem("Convert to Phase", "FolderOutline", "WolvenKitRed", () => Source.CreatePhaseFromSelection(SelectedNodes)));
+                node.ContextMenu.Items.Add(CreateMenuItem("Convert to Phase", "FolderOutline", "WolvenKitRed", () => Source.CreatePhaseFromSelection(selectedGraphNodes)));
             }
             node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
 
@@ -658,6 +696,166 @@ public partial class GraphEditorView : UserControl
         node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
 
         e.Handled = true;
+    }
+
+    private void Comment_OnResizeCompleted(object sender, Nodify.Events.ResizeEventArgs e)
+    {
+        if (sender is not GroupingNode { DataContext: GraphCommentViewModel comment })
+        {
+            return;
+        }
+
+        comment.Width = e.NewSize.Width;
+        comment.Height = e.NewSize.Height;
+        Source?.GraphCommentStateSave();
+    }
+
+    private void CommentText_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ClickCount < 2)
+        {
+            return;
+        }
+
+        if (sender is not FrameworkElement { DataContext: GraphCommentViewModel comment })
+        {
+            return;
+        }
+
+        comment.IsEditing = true;
+        e.Handled = true;
+    }
+
+    private void CommentEditTextBox_OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (sender is not TextBox { IsVisible: true } textBox)
+        {
+            return;
+        }
+
+        textBox.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            textBox.Focus();
+            textBox.SelectAll();
+        }), DispatcherPriority.Input);
+    }
+
+    private void CommentEditTextBox_OnLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        EndCommentTextEdit(sender);
+    }
+
+    private void CommentEditTextBox_OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key is not (Key.Enter or Key.Escape))
+        {
+            return;
+        }
+
+        EndCommentTextEdit(sender);
+        Keyboard.ClearFocus();
+        e.Handled = true;
+    }
+
+    private static void EndCommentTextEdit(object sender)
+    {
+        if (sender is not TextBox { DataContext: GraphCommentViewModel comment } textBox)
+        {
+            return;
+        }
+
+        textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+        comment.IsEditing = false;
+    }
+
+    private void Comment_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+    {
+        if (sender is not GroupingNode { DataContext: GraphCommentViewModel comment } groupingNode || Source == null)
+        {
+            return;
+        }
+
+        groupingNode.ContextMenu ??= new ContextMenu();
+        groupingNode.ContextMenu.Items.Clear();
+        groupingNode.ContextMenu.Items.Add(CreateCommentColorMenu(comment));
+        groupingNode.ContextMenu.Items.Add(CreateMenuItem(
+            "Reset Comment Size",
+            "Resize",
+            "WolvenKitYellow",
+            () =>
+            {
+                comment.ResetSize();
+                Source.GraphCommentStateSave();
+            }));
+        groupingNode.ContextMenu.Items.Add(new Separator());
+        groupingNode.ContextMenu.Items.Add(CreateMenuItem(
+            "Delete Comment",
+            "Delete",
+            "WolvenKitRed",
+            () => Source.RemoveCommentCommand.Execute(comment)));
+        groupingNode.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
+
+        e.Handled = true;
+    }
+
+    private MenuItem CreateCommentColorMenu(GraphCommentViewModel comment)
+    {
+        var item = new MenuItem
+        {
+            Header = "Change Color",
+            Padding = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
+            Icon = new IconBox
+            {
+                IconPack = IconPackType.Material,
+                Kind = "Palette",
+                Foreground = (Brush)Application.Current.Resources["WolvenKitYellow"]!,
+                Margin = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
+                Size = (double)Application.Current.Resources["WolvenKitIconMicro"]!
+            }
+        };
+
+        foreach (var (name, color) in s_commentColorPresets)
+        {
+            var colorItem = new MenuItem
+            {
+                Header = name,
+                IsCheckable = true,
+                IsChecked = string.Equals(comment.AccentColor, color, StringComparison.OrdinalIgnoreCase),
+                Padding = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
+                Icon = new Rectangle
+                {
+                    Width = 12,
+                    Height = 12,
+                    Fill = CreateCommentSwatchBrush(color),
+                    Stroke = Brushes.White,
+                    StrokeThickness = 0.5,
+                    Margin = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!
+                }
+            };
+
+            colorItem.Click += (_, _) => comment.AccentColor = color;
+            item.Items.Add(colorItem);
+        }
+
+        return item;
+    }
+
+    private static Brush CreateCommentSwatchBrush(string colorValue)
+    {
+        try
+        {
+            if (ColorConverter.ConvertFromString(colorValue) is Color color)
+            {
+                var brush = new SolidColorBrush(color);
+                brush.Freeze();
+                return brush;
+            }
+        }
+        catch (FormatException)
+        {
+        }
+
+        return Brushes.Gold;
     }
 
 

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -698,6 +698,17 @@ public partial class GraphEditorView : UserControl
         e.Handled = true;
     }
 
+    public bool AddCommentFromCurrentCursor()
+    {
+        if (Source?.GraphType is not (RedGraphType.Quest or RedGraphType.Scene))
+        {
+            return false;
+        }
+
+        Source.AddComment(GetMousePositionInGraph(Editor), SelectedNodes);
+        return true;
+    }
+
     private void Comment_OnResizeCompleted(object sender, Nodify.Events.ResizeEventArgs e)
     {
         if (sender is not GroupingNode { DataContext: GraphCommentViewModel comment })

--- a/changelog/unreleased/2997.yaml
+++ b/changelog/unreleased/2997.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 2997
+      author: "misterchedda"
+      description: "Added comment boxes to quest and scene editors"


### PR DESCRIPTION
<img width="1160" height="328" alt="Screenshot 2026-07-08 165142" src="https://github.com/user-attachments/assets/306fc06a-dd19-4ca3-8221-2b595413005a" />

Adds editor only comment boxes to quest and scene editors

- right-click on empty canvas to create comment
- comments can be moved, resized, renamed with double-click. Also recolored, reset, and deleted
- also: select multiple nodes and right-click on canvas to create comment enclosing the selected nodes
- comment state is persisted in a new `*.comments.json` file (living beside the existing graph layout json)
- shortcuts: "C" on canvas to add comment and "Delete" deletes it

<img width="581" height="517" alt="Screenshot 2026-07-08 165722" src="https://github.com/user-attachments/assets/f71e08c8-c91c-485e-a803-420395d122a6" />

 