### PR TITLE
Fix: quest scene graph perf quick fixes

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -47,8 +47,7 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
             details.Add("Phase Resource", Path.GetFileName(_castedData.PhaseResource.DepotPath.GetResolvedText())!);
         }
         
-        // Add node count for the phase
-        var nodeCount = GetPhaseNodeCount();
+        var nodeCount = GetInlinePhaseNodeCount();
         if (nodeCount > 0)
         {
             details.Add("Total Nodes", nodeCount.ToString());
@@ -143,33 +142,15 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
     internal override void CreateDefaultSockets() => CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
 
     /// <summary>
-    /// Get the total count of nodes in this phase graph
+    /// Get the node count from an inline phase graph without loading an external resource
     /// </summary>
-    private int GetPhaseNodeCount()
+    private int GetInlinePhaseNodeCount()
     {
-        // Check embedded graph first
         if (_castedData.PhaseGraph?.Chunk != null)
         {
             return _castedData.PhaseGraph.Chunk.Nodes?.Count ?? 0;
         }
-        
-        // Check external phase resource
-        if (_castedData.PhaseResource.DepotPath != ResourcePath.Empty)
-        {
-            try
-            {
-                var cr2w = _archiveManager.GetCR2WFile(_castedData.PhaseResource.DepotPath);
-                if (cr2w is { RootChunk: questQuestPhaseResource res } && res.Graph?.Chunk != null)
-                {
-                    return res.Graph.Chunk.Nodes?.Count ?? 0;
-                }
-            }
-            catch (Exception)
-            {
-                // Silently fail if we can't load the resource
-            }
-        }
-        
+
         return 0;
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -144,13 +144,5 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
     /// <summary>
     /// Get the node count from an inline phase graph without loading an external resource
     /// </summary>
-    private int GetInlinePhaseNodeCount()
-    {
-        if (_castedData.PhaseGraph?.Chunk != null)
-        {
-            return _castedData.PhaseGraph.Chunk.Nodes?.Count ?? 0;
-        }
-
-        return 0;
-    }
+    private int GetInlinePhaseNodeCount() => _castedData.PhaseGraph?.Chunk?.Nodes?.Count ?? 0;
 }

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -83,12 +83,14 @@ public partial class GraphEditorView : UserControl
         set
         {
             var previousNode = _selectedNode;
-            if (SetField(ref _selectedNode, value))
+            if (!SetField(ref _selectedNode, value))
             {
-                if (value is not null || ReferenceEquals(NodeSelectionService.Instance.SelectedNode, previousNode))
-                {
-                    NodeSelectionService.Instance.SelectedNode = value;
-                }
+                return;
+            }
+
+            if (value is not null || ReferenceEquals(NodeSelectionService.Instance.SelectedNode, previousNode))
+            {
+                NodeSelectionService.Instance.SelectedNode = value;
             }
         }
     }

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -82,10 +82,13 @@ public partial class GraphEditorView : UserControl
         get => _selectedNode;
         set
         {
+            var previousNode = _selectedNode;
             if (SetField(ref _selectedNode, value))
             {
-                // Update the global selection service
-                NodeSelectionService.Instance.SelectedNode = value;
+                if (value is not null || ReferenceEquals(NodeSelectionService.Instance.SelectedNode, previousNode))
+                {
+                    NodeSelectionService.Instance.SelectedNode = value;
+                }
             }
         }
     }
@@ -127,6 +130,22 @@ public partial class GraphEditorView : UserControl
         }
 
         Source.GraphStateSave();
+    }
+
+    internal void PrepareForClose()
+    {
+        var graph = Source;
+
+        SelectedNode = null;
+        SelectedNodes.Clear();
+
+        if (graph?.Editor == Editor)
+        {
+            graph.GraphStateSave();
+            graph.Editor = null;
+        }
+
+        SetCurrentValue(SourceProperty, null);
     }
 
     private void ArrangeNodes()

--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Xml;
 using ReactiveUI;
 using Splat;
@@ -24,6 +25,7 @@ using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Core.Interfaces;
 using WolvenKit.Functionality.Layout;
+using WolvenKit.Views.GraphEditor;
 using DockState = WolvenKit.App.Models.Docking.DockState;
 
 namespace WolvenKit.Views.Shell
@@ -690,6 +692,12 @@ namespace WolvenKit.Views.Shell
                     var control = (from ContentControl element in PART_DockingManager.Children
                                    where element.Content == item
                                    select element).FirstOrDefault();
+
+                    if (control is not null)
+                    {
+                        DetachGraphEditorsForClose(control);
+                    }
+
                     PART_DockingManager.Children.Remove(control);
 
                     // set active document to null
@@ -745,6 +753,42 @@ namespace WolvenKit.Views.Shell
                 DockingManager.SetCanSerialize(control, element.CanSerialize);
 
                 PART_DockingManager.Children.Add(control);
+            }
+        }
+
+        private static void DetachGraphEditorsForClose(DependencyObject root)
+        {
+            foreach (var graphEditor in FindVisualChildren<GraphEditorView>(root))
+            {
+                graphEditor.PrepareForClose();
+            }
+        }
+
+        private static IEnumerable<T> FindVisualChildren<T>(DependencyObject root) where T : DependencyObject
+        {
+            int childCount;
+            try
+            {
+                childCount = VisualTreeHelper.GetChildrenCount(root);
+            }
+            catch (InvalidOperationException)
+            {
+                yield break;
+            }
+
+            for (var i = 0; i < childCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                if (child is T typedChild)
+                {
+                    yield return typedChild;
+                    continue;
+                }
+
+                foreach (var descendant in FindVisualChildren<T>(child))
+                {
+                    yield return descendant;
+                }
             }
         }
 

--- a/changelog/unreleased/3002.yaml
+++ b/changelog/unreleased/3002.yaml
@@ -1,0 +1,11 @@
+changes:
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3002
+      author: "misterchedda"
+      description: "Improved quest phase graph loading performance by avoiding eager loading of external phase resources"
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3002
+      author: "misterchedda"
+      description: "Improved quest and scene graph document closing performance"


### PR DESCRIPTION
cherry picked a couple of self contained smaller performance related fixes from #2911 that are quick wins:

> Avoid loading external phase resources just for the phase node count

> Detach graph editors before document close teardown

(I'll keep #2911 as WIP for now, it'll eventually be a bigger graph virtualization refactor)
