### PR TITLE
fix: generate correct workspot output sockets

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questUseWorkspotNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questUseWorkspotNodeDefinitionWrapper.cs
@@ -1,15 +1,28 @@
-using WolvenKit.RED4.Types;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 
 public class questUseWorkspotNodeDefinitionWrapper : questAICommandNodeBaseWrapper<questUseWorkspotNodeDefinition>
 {
+    private Enums.questUseWorkspotNodeFunctions? _lastWorkspotFunction;
+    private bool _removeWorkStartedWhenDisconnected;
+
     public questUseWorkspotNodeDefinitionWrapper(questUseWorkspotNodeDefinition questAICommandNodeBase) : base(questAICommandNodeBase)
     {
+        _lastWorkspotFunction = GetWorkspotFunction(_castedData);
         PopulateWorkspotDetails();
     }
+
+    public override void RefreshFromData()
+    {
+        SynchronizeWorkStartedSocket();
+        base.RefreshFromData();
+    }
+
     public override void RefreshDetails()
     {
         PopulateWorkspotDetails();
@@ -164,6 +177,80 @@ public class questUseWorkspotNodeDefinitionWrapper : questAICommandNodeBaseWrapp
         CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
         CreateSocket("In", Enums.questSocketType.Input);
         CreateSocket("Success", Enums.questSocketType.Output);
-        //CreateSocket("Work Started", Enums.questSocketType.Output); TODO[Graph]
+        if (RequiresWorkStartedSocket(_castedData))
+        {
+            CreateSocket("Work Started", Enums.questSocketType.Output);
+        }
+    }
+
+    internal static Enums.questUseWorkspotNodeFunctions? GetWorkspotFunction(questUseWorkspotNodeDefinition node)
+    {
+        if (node.ParamsV1?.GetValue() is questUseWorkspotParamsV1 paramsV1)
+        {
+            return (Enums.questUseWorkspotNodeFunctions)paramsV1.Function;
+        }
+
+        return null;
+    }
+
+    internal static bool RequiresWorkStartedSocket(questUseWorkspotNodeDefinition node) =>
+        GetWorkspotFunction(node) == Enums.questUseWorkspotNodeFunctions.UseWorkspot;
+
+    private void SynchronizeWorkStartedSocket()
+    {
+        var function = GetWorkspotFunction(_castedData);
+        var functionChanged = function != _lastWorkspotFunction;
+        if (!functionChanged && !_removeWorkStartedWhenDisconnected)
+        {
+            return;
+        }
+
+        _lastWorkspotFunction = function;
+        var socket = _castedData.Sockets
+            .Select(x => x.Chunk)
+            .OfType<questSocketDefinition>()
+            .FirstOrDefault(x => x.Type == Enums.questSocketType.Output && x.Name.GetResolvedText() == "Work Started");
+
+        if (function == Enums.questUseWorkspotNodeFunctions.UseWorkspot)
+        {
+            _removeWorkStartedWhenDisconnected = false;
+            if (socket == null)
+            {
+                socket = CreateSocket("Work Started", Enums.questSocketType.Output);
+                Output.Add(new QuestOutputConnectorViewModel("Work Started", "Work Started", UniqueId, socket));
+                NotifySocketsChanged();
+            }
+            return;
+        }
+
+        if (socket == null)
+        {
+            _removeWorkStartedWhenDisconnected = false;
+            return;
+        }
+
+        var connector = Output
+            .OfType<QuestOutputConnectorViewModel>()
+            .FirstOrDefault(x => ReferenceEquals(x.Data, socket));
+        if (socket.Connections.Count > 0 || connector?.IsConnected == true)
+        {
+            _removeWorkStartedWhenDisconnected = true;
+            return;
+        }
+
+        _removeWorkStartedWhenDisconnected = false;
+        if (connector != null)
+        {
+            Output.Remove(connector);
+        }
+        for (var i = _castedData.Sockets.Count - 1; i >= 0; i--)
+        {
+            if (ReferenceEquals(_castedData.Sockets[i].Chunk, socket))
+            {
+                _castedData.Sockets.RemoveAt(i);
+                break;
+            }
+        }
+        NotifySocketsChanged();
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnQuestNodeWrapper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Media;
 using Splat;
 using WolvenKit.App.Extensions;
@@ -16,10 +17,13 @@ namespace WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
 public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
 {
     private readonly scnSceneResource _sceneResource;
+    private Enums.questUseWorkspotNodeFunctions? _lastUseWorkspotFunction;
+    private bool _removeWorkStartedWhenDisconnected;
     
     public scnQuestNodeWrapper(scnQuestNode scnSceneGraphNode, scnSceneResource scnSceneResource) : base(scnSceneGraphNode)
     {
         _sceneResource = scnSceneResource;
+        _lastUseWorkspotFunction = GetUseWorkspotFunction();
         if (_castedData.QuestNode != null)
         {
             //_castedData.QuestNode.PropertyChanged += QuestNodeOnPropertyChanged;
@@ -316,6 +320,8 @@ public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
     /// </summary>
     public override void RefreshFromData()
     {
+        SynchronizeUseWorkspotSockets();
+
         // Update title
         UpdateTitle();
         OnPropertyChanged(nameof(Title));
@@ -323,5 +329,111 @@ public class scnQuestNodeWrapper : BaseSceneViewModel<scnQuestNode>
         // Refresh details but DON'T regenerate sockets (this prevents duplication)
         // Sockets should only be regenerated when the socket structure actually changes
         RefreshDetails();
+    }
+
+    private Enums.questUseWorkspotNodeFunctions? GetUseWorkspotFunction()
+    {
+        if (_castedData.QuestNode?.Chunk is questUseWorkspotNodeDefinition useWorkspotNode)
+        {
+            return questUseWorkspotNodeDefinitionWrapper.GetWorkspotFunction(useWorkspotNode);
+        }
+
+        return null;
+    }
+
+    private void SynchronizeUseWorkspotSockets()
+    {
+        if (_castedData.QuestNode?.Chunk is not questUseWorkspotNodeDefinition)
+        {
+            return;
+        }
+
+        var function = GetUseWorkspotFunction();
+        var functionChanged = function != _lastUseWorkspotFunction;
+        if (!functionChanged && !_removeWorkStartedWhenDisconnected)
+        {
+            return;
+        }
+
+        _lastUseWorkspotFunction = function;
+        var shouldHaveWorkStarted = function == Enums.questUseWorkspotNodeFunctions.UseWorkspot;
+        var mappingIndex = GetOutputMappingIndex("Work Started");
+
+        if (shouldHaveWorkStarted)
+        {
+            _removeWorkStartedWhenDisconnected = false;
+            if (mappingIndex < 0)
+            {
+                AddWorkStartedSocket();
+            }
+            return;
+        }
+
+        if (mappingIndex < 0)
+        {
+            _removeWorkStartedWhenDisconnected = false;
+            return;
+        }
+
+        var socket = mappingIndex < _castedData.OutputSockets.Count
+            ? _castedData.OutputSockets[mappingIndex]
+            : null;
+        var connector = Output
+            .OfType<SceneOutputConnectorViewModel>()
+            .FirstOrDefault(x => x.Subtitle == "Work Started");
+
+        if ((socket?.Destinations.Count ?? 0) > 0 || connector?.IsConnected == true)
+        {
+            _removeWorkStartedWhenDisconnected = true;
+            return;
+        }
+
+        _removeWorkStartedWhenDisconnected = false;
+        if (connector != null)
+        {
+            Output.Remove(connector);
+        }
+        if (mappingIndex < _castedData.OutputSockets.Count)
+        {
+            _castedData.OutputSockets.RemoveAt(mappingIndex);
+        }
+        _castedData.OsockMappings.RemoveAt(mappingIndex);
+        NotifySocketsChanged();
+    }
+
+    private int GetOutputMappingIndex(string name)
+    {
+        for (var i = 0; i < _castedData.OsockMappings.Count; i++)
+        {
+            if (_castedData.OsockMappings[i].GetResolvedText() == name)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private void AddWorkStartedSocket()
+    {
+        var socket = new scnOutputSocket
+        {
+            Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 1 }
+        };
+        _castedData.OsockMappings.Add("Work Started");
+        _castedData.OutputSockets.Add(socket);
+
+        var nameAndTitle = $"({socket.Stamp.Name},{socket.Stamp.Ordinal})";
+        Output.Add(new SceneOutputConnectorViewModel(
+            nameAndTitle,
+            nameAndTitle,
+            UniqueId,
+            socket.Stamp.Name,
+            socket.Stamp.Ordinal,
+            socket)
+        {
+            Subtitle = "Work Started"
+        });
+        NotifySocketsChanged();
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.App.ViewModels.Documents;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 using WolvenKit.App.ViewModels.Shell;
@@ -272,6 +273,16 @@ public partial class RedGraph
                 sceneQuestNode.OsockMappings.Add("False");
                 sceneQuestNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 0 } });
                 sceneQuestNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 1 } });
+                break;
+            case questUseWorkspotNodeDefinition useWorkspotNode:
+                sceneQuestNode.OsockMappings.Add("Success");
+                sceneQuestNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 0 } });
+
+                if (questUseWorkspotNodeDefinitionWrapper.RequiresWorkStartedSocket(useWorkspotNode))
+                {
+                    sceneQuestNode.OsockMappings.Add("Work Started");
+                    sceneQuestNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 1 } });
+                }
                 break;
             default:
                 // Default case: single output socket

--- a/changelog/unreleased/3005.yaml
+++ b/changelog/unreleased/3005.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3005
+      author: "misterchedda"
+      description: "UseWorkspot nodes now generate function appropriate sockets in questphase and scene graphs"


### PR DESCRIPTION
Fix default sockets for UseWorkspot nodes

Initially reported by @Akiway on discord

Workspot nodes in scenes were incorrectly initialising with just a normal Output socket, when they actually need a "Success" socket instead. This is fixed (questphase actually already did this)

But the workspot nodes also sometimes have a "Work Started" socket. To understand its usage, I scanned all the base game questphase/scene files, they seem to follow this rule:

- paramsV1 -> function: UseWorkspot -> always has a "Work Started" socket
- anything else (StopWorkspot, IdleOnlyMode, JumpWorkspot) -> no "Work Started" socket (likely because "Work Started" firing makes no sense for these)

So if you set the function to UseWorkspot, wkit will automatically also create the "Work Started" socket for you. Setting it to Idle/Stop/Jump does nothing - and wkit won't delete any connections you might already have in a "Work Started" socket (I'll also add it to file validation so it atleast warns you that you might have a dead connection though)