### PR TITLE
Fix scene actor order

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -275,6 +275,11 @@ namespace WolvenKit.App.ViewModels.Documents
                 // Use the built-in AddActor method which handles initialization and performer symbol creation
                 _sceneData.AddActor(newActor);
 
+                foreach (var node in MainGraph.Nodes.OfType<IRefreshableDetails>())
+                {
+                    node.RefreshDetails();
+                }
+
                 // Mark document as dirty
                 Parent?.SetIsDirty(true);
 

--- a/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/scnSceneResource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace WolvenKit.RED4.Types;
@@ -11,12 +12,52 @@ public partial class scnSceneResource
     public void AddActor(scnActorDef actor)
     {
         if (actor == null) return;
-        
+
+        ShiftPlayerActorIds();
+
         // Initialize the actor with automatic ID and performer symbol
         actor.InitializeInScene(this);
         
         // Add to actors collection
         Actors.Add(actor);
+    }
+
+    private void ShiftPlayerActorIds()
+    {
+        if (PlayerActors.Count == 0)
+        {
+            return;
+        }
+
+        var actorIdMap = new Dictionary<uint, uint>();
+        var performerIdMap = new Dictionary<uint, uint>();
+
+        for (var i = 0; i < PlayerActors.Count; i++)
+        {
+            var oldActorId = (uint)PlayerActors[i].ActorId.Id;
+            var newActorId = (uint)(Actors.Count + i + 1);
+
+            actorIdMap[oldActorId] = newActorId;
+            performerIdMap[CalculatePerformerId(oldActorId)] = CalculatePerformerId(newActorId);
+        }
+
+        foreach (var result in FindType(typeof(scnActorId)))
+        {
+            var actorId = (scnActorId)result.Value;
+            if (actorIdMap.TryGetValue(actorId.Id, out var newActorId))
+            {
+                actorId.Id = newActorId;
+            }
+        }
+
+        foreach (var result in FindType(typeof(scnPerformerId)))
+        {
+            var performerId = (scnPerformerId)result.Value;
+            if (performerIdMap.TryGetValue(performerId.Id, out var newPerformerId))
+            {
+                performerId.Id = newPerformerId;
+            }
+        }
     }
     
     /// <summary>

--- a/changelog/unreleased/3008.yaml
+++ b/changelog/unreleased/3008.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3008
+      author: "misterchedda"
+      description: "Add actor button in scene editor will now recalculate all instances of the player's scnActorId and scnPerformerId automatically"


### PR DESCRIPTION
Fixes #3006 

Add actor button in scene editor will now recalculate all instances of the player's `scnActorId` and `scnPerformerId`