### PR TITLE
fix: node graph details

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -563,6 +563,20 @@ internal class NodeProperties
                     counter++;
                 }
             }
+            else if (voicesetManagerCasted?.Type?.Chunk is questChangeVoicesetState_NodeType changeVoicesetState)
+            {
+                var param = changeVoicesetState.Params.FirstOrDefault();
+                if (param != null)
+                {
+                    details["Entity"] = ParseGameEntityReference(param.PuppetRef);
+                    details["Player"] = param.IsPlayer ? "True" : "False";
+                    details["Voiceset Lines"] = param.EnableVoicesetLines ? "Enabled" : "Disabled";
+                    details["Voiceset Grunts"] = param.EnableVoicesetGrunts ? "Enabled" : "Disabled";
+                    details["Blocked Inputs"] = param.InputsToBlock.Count == 0
+                        ? "None"
+                        : string.Join(", ", param.InputsToBlock.Select(input => input.Input.GetResolvedText()));
+                }
+            }
         }
         else if (node is questInteractiveObjectManagerNodeDefinition interactiveObjectManagerCasted)
         {
@@ -843,10 +857,70 @@ internal class NodeProperties
         {
             details["Entity Reference"] = ParseGameEntityReference(movePuppetManagerCasted?.EntityReference);
             details["Move Type"] = movePuppetManagerCasted?.MoveType.ToString()!;
+            details["Parameters"] = GetNameFromClass(movePuppetManagerCasted?.NodeParams?.Chunk);
 
             if (movePuppetManagerCasted?.NodeParams?.Chunk is questMoveOnSplineParams splineParams)
             {
                 details["Spline Node Ref"] = splineParams?.SplineNodeRef.GetResolvedText()!;
+            }
+            else if (movePuppetManagerCasted?.NodeParams?.Chunk is questMovePuppetNodeParams moveParams)
+            {
+                details["Movement"] = moveParams.MoveType.ToEnumString();
+
+                if (moveParams.MoveOnSplineParams?.Chunk is questMoveOnSplineParams nestedSplineParams)
+                {
+                    details["Spline Node Ref"] = nestedSplineParams.SplineNodeRef.GetResolvedText()!;
+                }
+                else if (moveParams.MoveToParams?.Chunk is questMoveToParams moveToParams)
+                {
+                    details["Movement Type"] = moveToParams.MovementType.ToEnumString();
+                    details["Movement Target"] = GetNameFromUniversalRef(moveToParams.MovementTargetRef?.Chunk);
+                    details["Facing Target"] = GetNameFromUniversalRef(moveToParams.FacingTargetRef?.Chunk);
+                }
+            }
+        }
+        else if (node is questCombatNodeDefinition combatNode)
+        {
+            details["Entity"] = ParseGameEntityReference(combatNode.EntityReference);
+            details["Command"] = combatNode.Function.GetResolvedText()?.Replace("questCombatNodeParams_", "") ?? "";
+            details["Parameters"] = GetNameFromClass(combatNode.Params?.Chunk);
+
+            switch (combatNode.Params?.Chunk)
+            {
+                case questCombatNodeParams_ShootAt shootAt:
+                    AddCombatTargetDetails(details, shootAt.TargetOverrideNode, shootAt.TargetOverridePuppet);
+                    details["Duration"] = shootAt.Duration.ToString();
+                    details["Once"] = shootAt.Once ? "True" : "False";
+                    break;
+                case questCombatNodeParams_ThrowGrenade throwGrenade:
+                    AddCombatTargetDetails(details, throwGrenade.TargetOverrideNode, throwGrenade.TargetOverridePuppet);
+                    details["Duration"] = throwGrenade.Duration.ToString();
+                    details["Once"] = throwGrenade.Once ? "True" : "False";
+                    break;
+                case questCombatNodeParams_CombatTarget combatTarget:
+                    AddCombatTargetDetails(details, combatTarget.TargetNode, combatTarget.TargetPuppet);
+                    details["Duration"] = combatTarget.Duration.ToString();
+                    break;
+                case questCombatNodeParams_LookAtTarget lookAtTarget:
+                    AddCombatTargetDetails(details, lookAtTarget.TargetNode, lookAtTarget.TargetPuppet);
+                    details["Duration"] = lookAtTarget.Duration.ToString();
+                    break;
+                case questCombatNodeParams_RestrictMovementToArea restrictMovement:
+                    details["Area"] = restrictMovement.Area.GetResolvedText() ?? "";
+                    break;
+                case questCombatNodeParams_SwitchWeapon switchWeapon:
+                    details["Mode"] = switchWeapon.Mode.ToEnumString();
+                    break;
+                case questCombatNodeParams_PrimaryWeapon primaryWeapon:
+                    details["Unequip"] = primaryWeapon.UnEquip ? "True" : "False";
+                    break;
+                case questCombatNodeParams_SecondaryWeapon secondaryWeapon:
+                    details["Unequip"] = secondaryWeapon.UnEquip ? "True" : "False";
+                    break;
+                case questCombatNodeParams_UseCover useCover:
+                    details["Cover"] = useCover.Cover.GetResolvedText() ?? "";
+                    details["One Time Selection"] = useCover.OneTimeSelection ? "True" : "False";
+                    break;
             }
         }
         else if (node is questPhoneManagerNodeDefinition phoneManagerCasted)
@@ -1557,6 +1631,24 @@ internal class NodeProperties
         }
 
         return "";
+    }
+
+    private static void AddCombatTargetDetails(
+        Dictionary<string, string> details,
+        NodeRef targetNode,
+        gameEntityReference targetPuppet)
+    {
+        var nodeRef = targetNode.GetResolvedText();
+        if (!string.IsNullOrEmpty(nodeRef))
+        {
+            details["Target Node"] = nodeRef;
+        }
+
+        var puppetRef = ParseGameEntityReference(targetPuppet);
+        if (puppetRef != "-")
+        {
+            details["Target Puppet"] = puppetRef;
+        }
     }
 
     public static string ParseGameEntityReference(gameEntityReference? entRef)

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questCombatNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questCombatNodeDefinitionWrapper.cs
@@ -6,6 +6,7 @@ public class questCombatNodeDefinitionWrapper : questConfigurableAICommandNodeWr
 {
     public questCombatNodeDefinitionWrapper(questCombatNodeDefinition questConfigurableAICommandNode) : base(questConfigurableAICommandNode)
     {
+        RefreshDetails();
     }
 
     internal override void CreateDefaultSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questMovePuppetNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questMovePuppetNodeDefinitionWrapper.cs
@@ -6,6 +6,7 @@ public class questMovePuppetNodeDefinitionWrapper : questConfigurableAICommandNo
 {
     public questMovePuppetNodeDefinitionWrapper(questMovePuppetNodeDefinition questConfigurableAICommandNode) : base(questConfigurableAICommandNode)
     {
+        RefreshDetails();
     }
 
     internal override void CreateDefaultSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questOutputNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questOutputNodeDefinitionWrapper.cs
@@ -13,8 +13,8 @@ public class questOutputNodeDefinitionWrapper : questIONodeDefinitionWrapper<que
 
     protected override void PopulateDetailsInto(Dictionary<string, string> details)
     {
-        details.Add("Type", _castedData.Type.ToEnumString());
         base.PopulateDetailsInto(details);
+        details["Type"] = _castedData.Type.ToEnumString();
     }
 
     internal override void GenerateSockets()

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questVoicesetManagerNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questVoicesetManagerNodeDefinitionWrapper.cs
@@ -7,7 +7,7 @@ public class questVoicesetManagerNodeDefinitionWrapper : questDisableableNodeDef
 {
     public questVoicesetManagerNodeDefinitionWrapper(questVoicesetManagerNodeDefinition questDisableableNodeDefinition) : base(questDisableableNodeDefinition)
     {
-        Details.AddRange(NodeProperties.GetPropertiesFor(questDisableableNodeDefinition));
+        RefreshDetails();
     }
 
     internal override void CreateDefaultSockets()

--- a/changelog/unreleased/3009.yaml
+++ b/changelog/unreleased/3009.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3009
+      author: "misterchedda"
+      description: "More node graph details for Combat, MovePuppet, VoicesetManager. Output node also correctly shows its type now"


### PR DESCRIPTION
more node graph details for Combat, MovePuppet, VoicesetManager. Output node also correctly shows its type now

<img width="439" height="200" alt="image" src="https://github.com/user-attachments/assets/e9a63b61-e103-48ce-be73-4b71cb4959a3" />
<img width="259" height="173" alt="image" src="https://github.com/user-attachments/assets/e8dc00f1-8da6-44dc-9f84-7708f8543a1b" />
<img width="513" height="202" alt="image" src="https://github.com/user-attachments/assets/c4cf83b9-cb33-4f9a-9f97-699e782c69f1" />
