### PR TITLE
Fix: better section timeline duration editing

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineEventTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineEventTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Models.Timeline;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Scene.Timeline;
+
+[TestClass]
+[DoNotParallelize]
+public class TimelineEventTests
+{
+    [TestMethod]
+    public void TimingChangesUpdateTheUnderlyingEvent()
+    {
+        var changeCount = 0;
+        var sceneEvent = CreateSceneEvent(100, 200);
+        var timelineEvent = new TimelineEvent(sceneEvent, () => changeCount++);
+
+        timelineEvent.StartTime = 300;
+        timelineEvent.Duration = 400;
+
+        Assert.AreEqual(300U, (uint)sceneEvent.StartTime);
+        Assert.AreEqual(400U, (uint)sceneEvent.Duration);
+        Assert.AreEqual(700U, timelineEvent.EndTime);
+        Assert.AreEqual(2, changeCount);
+    }
+
+    [TestMethod]
+    public void AdjacentEventsDoNotOverlap()
+    {
+        var first = CreateTimelineEvent(100, 100);
+        var adjacent = CreateTimelineEvent(200, 50);
+        var overlapping = CreateTimelineEvent(199, 50);
+
+        Assert.IsFalse(first.OverlapsWith(adjacent));
+        Assert.IsTrue(first.OverlapsWith(overlapping));
+    }
+
+    [TestMethod]
+    public void SocketEventExposesItsIndexAndCategory()
+    {
+        var sceneEvent = CreateSceneEvent(100, 0);
+        var timelineEvent = new TimelineEvent(sceneEvent, () => { }, eventIndex: 3);
+
+        Assert.AreEqual("Other", timelineEvent.Category);
+        Assert.AreEqual("#3 Socket", timelineEvent.TitleLine);
+        Assert.AreEqual("(2, 1)", timelineEvent.DetailsLine);
+    }
+
+    private static TimelineEvent CreateTimelineEvent(uint startTime, uint duration) =>
+        new(CreateSceneEvent(startTime, duration), () => { });
+
+    private static scneventsSocket CreateSceneEvent(uint startTime, uint duration) =>
+        new()
+        {
+            StartTime = startTime,
+            Duration = duration,
+            OsockStamp = new scnOutputSocketStamp { Name = 2, Ordinal = 1 }
+        };
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineServiceTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineServiceTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Scene.Timeline;
+
+[TestClass]
+[DoNotParallelize]
+public class TimelineServiceTests
+{
+    [TestMethod]
+    public void LoadingSectionPreservesPositiveDurationBuffer()
+    {
+        using var fixture = new TimelineFixture(10_000, CreateEvent(7_000, 1_000));
+
+        Assert.AreEqual(10_000U, fixture.Service.SectionDuration);
+        Assert.AreEqual(10_000U, fixture.Service.TimelineDuration);
+        Assert.AreEqual(8_000U, fixture.Service.LatestEventEndTime);
+        Assert.IsFalse(fixture.Service.IsSectionDurationTooShort);
+        Assert.AreEqual(10_000U, GetStoredDuration(fixture.Node));
+    }
+
+    [TestMethod]
+    public void LoadingOverrunReportsItWithoutChangingStoredDuration()
+    {
+        using var fixture = new TimelineFixture(7_500, CreateEvent(7_000, 1_000));
+
+        Assert.AreEqual(7_500U, fixture.Service.SectionDuration);
+        Assert.AreEqual(8_000U, fixture.Service.TimelineDuration);
+        Assert.AreEqual(8_000U, fixture.Service.LatestEventEndTime);
+        Assert.IsTrue(fixture.Service.IsSectionDurationTooShort);
+        Assert.AreEqual(7_500U, GetStoredDuration(fixture.Node));
+    }
+
+    [DataTestMethod]
+    [DataRow(7_500U, 8_000U)]
+    [DataRow(10_000U, 10_000U)]
+    public void ExtendToEventsOnlyChangesAnOverrun(uint sectionDuration, uint expectedDuration)
+    {
+        using var fixture = new TimelineFixture(sectionDuration, CreateEvent(7_000, 1_000));
+
+        fixture.Service.ExtendSectionDurationToEvents();
+
+        Assert.AreEqual(expectedDuration, fixture.Service.SectionDuration);
+        Assert.AreEqual(expectedDuration, GetStoredDuration(fixture.Node));
+        Assert.IsFalse(fixture.Service.IsSectionDurationTooShort);
+    }
+
+    [TestMethod]
+    public void PreviewDoesNotChangeStoredDurationUntilCommitted()
+    {
+        using var fixture = new TimelineFixture(10_000, CreateEvent(7_000, 1_000));
+
+        fixture.Service.PreviewSectionDuration(9_000);
+
+        Assert.AreEqual(9_000U, fixture.Service.SectionDuration);
+        Assert.AreEqual(10_000U, GetStoredDuration(fixture.Node));
+
+        fixture.Service.SetSectionDuration(fixture.Service.SectionDuration);
+
+        Assert.AreEqual(9_000U, GetStoredDuration(fixture.Node));
+    }
+
+    [DataTestMethod]
+    [DataRow(7_000U, 8_000U)]
+    [DataRow(9_000U, 9_000U)]
+    public void SetSectionDurationCannotEndBeforeTheLatestEvent(uint requestedDuration, uint expectedDuration)
+    {
+        using var fixture = new TimelineFixture(10_000, CreateEvent(7_000, 1_000));
+
+        fixture.Service.SetSectionDuration(requestedDuration);
+
+        Assert.AreEqual(expectedDuration, fixture.Service.SectionDuration);
+        Assert.AreEqual(expectedDuration, GetStoredDuration(fixture.Node));
+    }
+
+    [TestMethod]
+    public void SectionWithoutEventsCanBeReducedFreely()
+    {
+        using var fixture = new TimelineFixture(10_000);
+
+        fixture.Service.SetSectionDuration(1_000);
+
+        Assert.AreEqual(1_000U, fixture.Service.SectionDuration);
+        Assert.AreEqual(1_000U, GetStoredDuration(fixture.Node));
+    }
+
+    [TestMethod]
+    public void EventTimingChangeUpdatesDurationStateAndUnderlyingEvent()
+    {
+        var sceneEvent = CreateEvent(500, 500);
+        using var fixture = new TimelineFixture(1_500, sceneEvent);
+        var timelineEvent = fixture.Service.Tracks.Single().Events.Single();
+
+        timelineEvent.StartTime = 1_200;
+
+        Assert.AreEqual(1_200U, (uint)sceneEvent.StartTime);
+        Assert.AreEqual(1_700U, fixture.Service.LatestEventEndTime);
+        Assert.AreEqual(1_700U, fixture.Service.TimelineDuration);
+        Assert.IsTrue(fixture.Service.IsSectionDurationTooShort);
+        Assert.AreEqual(1_500U, GetStoredDuration(fixture.Node));
+    }
+
+    [TestMethod]
+    public void TimingChangeReordersUnderlyingEvents()
+    {
+        var first = CreateEvent(100, 50);
+        var second = CreateEvent(300, 50);
+        using var fixture = new TimelineFixture(1_000, first, second);
+        var firstTimelineEvent = fixture.Service.Tracks.Single().Events[0];
+
+        firstTimelineEvent.StartTime = 400;
+
+        Assert.AreSame(second, fixture.Node.Events[0].GetValue());
+        Assert.AreSame(first, fixture.Node.Events[1].GetValue());
+    }
+
+    [TestMethod]
+    public void TracksUseCategoryOrderAndSortEventsByStartTime()
+    {
+        var laterSocket = CreateEvent(300, 0);
+        var audio = new scnAudioEvent { StartTime = 200, Duration = 50 };
+        var earlierSocket = CreateEvent(100, 0);
+        using var fixture = new TimelineFixture(1_000, laterSocket, audio, earlierSocket);
+
+        CollectionAssert.AreEqual(
+            new[] { "Audio", "Other" },
+            fixture.Service.Tracks.Select(track => track.Category).ToArray());
+        CollectionAssert.AreEqual(
+            new uint[] { 100, 300 },
+            fixture.Service.Tracks[1].Events.Select(timelineEvent => timelineEvent.StartTime).ToArray());
+    }
+
+    [TestMethod]
+    public void ExternalPropertyUpdatesRefreshDurationAndEventTiming()
+    {
+        var sceneEvent = CreateEvent(500, 500);
+        using var fixture = new TimelineFixture(1_500, sceneEvent);
+
+        fixture.Node.SectionDuration.Stu = 2_000;
+        NodePropertyUpdateService.NotifyPropertyUpdated(fixture.Node);
+
+        Assert.AreEqual(2_000U, fixture.Service.SectionDuration);
+
+        sceneEvent.StartTime = 2_000;
+        NodePropertyUpdateService.NotifyPropertyUpdated(sceneEvent);
+
+        Assert.AreEqual(2_500U, fixture.Service.LatestEventEndTime);
+        Assert.IsTrue(fixture.Service.IsSectionDurationTooShort);
+    }
+
+    [TestMethod]
+    public void SnappedSectionDurationSnapsBeforeApplyingEventEndFloor()
+    {
+        using var fixture = new TimelineFixture(2_000, CreateEvent(1_000, 50));
+        fixture.Service.SnapInterval = 100;
+
+        Assert.AreEqual(1_050U, fixture.Service.GetSnappedSectionDuration(1_020));
+        Assert.AreEqual(1_200U, fixture.Service.GetSnappedSectionDuration(1_180));
+
+        fixture.Service.IsSnapEnabled = false;
+
+        Assert.AreEqual(1_075U, fixture.Service.GetSnappedSectionDuration(1_075));
+    }
+
+    [TestMethod]
+    public void ClearTimelineResetsLoadedState()
+    {
+        using var fixture = new TimelineFixture(1_500, CreateEvent(500, 500));
+
+        fixture.Service.ClearTimeline();
+
+        Assert.IsFalse(fixture.Service.HasSectionNode);
+        Assert.AreEqual(0, fixture.Service.Tracks.Count);
+        Assert.AreEqual(0U, fixture.Service.SectionDuration);
+        Assert.AreEqual(0U, fixture.Service.TimelineDuration);
+        Assert.AreEqual(0U, fixture.Service.LatestEventEndTime);
+        Assert.IsFalse(fixture.Service.IsSectionDurationTooShort);
+    }
+
+    [TestMethod]
+    public void ZoomOperationsRespectBoundsAndFitDuration()
+    {
+        using var service = new TimelineService();
+
+        service.ZoomLevel = service.MaxZoomLevel;
+        service.ZoomIn();
+        Assert.AreEqual(service.MaxZoomLevel, service.ZoomLevel);
+
+        service.ZoomLevel = service.MinZoomLevel;
+        service.ZoomOut();
+        Assert.AreEqual(service.MinZoomLevel, service.ZoomLevel);
+
+        service.TimelineDuration = 1_000;
+        service.ZoomToFit(100);
+        Assert.AreEqual(0.9, service.ZoomLevel, 0.00001);
+    }
+
+    private static uint GetStoredDuration(scnSectionNode node) => node.SectionDuration.Stu;
+
+    private static scneventsSocket CreateEvent(uint startTime, uint duration) =>
+        new() { StartTime = startTime, Duration = duration };
+
+    private sealed class TimelineFixture : IDisposable
+    {
+        public TimelineFixture(uint sectionDuration, params scnSceneEvent[] events)
+        {
+            Node = new scnSectionNode
+            {
+                NodeId = new scnNodeId { Id = 42 },
+                SectionDuration = new scnSceneTime { Stu = sectionDuration }
+            };
+
+            foreach (var sceneEvent in events)
+            {
+                Node.Events.Add(new CHandle<scnSceneEvent>(sceneEvent));
+            }
+
+            Wrapper = new scnSectionNodeWrapper(Node, new scnSceneResource());
+            Service = new TimelineService();
+            Service.LoadSectionNode(Wrapper);
+        }
+
+        public scnSectionNode Node { get; }
+        public scnSectionNodeWrapper Wrapper { get; }
+        public TimelineService Service { get; }
+
+        public void Dispose()
+        {
+            Service.Dispose();
+            Wrapper.Dispose();
+        }
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineTrackTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/TimelineTrackTests.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Models.Timeline;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Scene.Timeline;
+
+[TestClass]
+[DoNotParallelize]
+public class TimelineTrackTests
+{
+    [TestMethod]
+    public void NonOverlappingAndAdjacentEventsShareARow()
+    {
+        var track = CreateTrack(
+            CreateEvent(0, 100),
+            CreateEvent(100, 100),
+            CreateEvent(250, 50));
+
+        track.AssignEventRows();
+
+        foreach (var timelineEvent in track.Events)
+        {
+            Assert.AreEqual(0, timelineEvent.Row);
+        }
+        Assert.AreEqual(1, track.RowCount);
+    }
+
+    [TestMethod]
+    public void OverlappingEventsUseSeparateRows()
+    {
+        var track = CreateTrack(
+            CreateEvent(0, 200),
+            CreateEvent(100, 200),
+            CreateEvent(200, 100));
+
+        track.AssignEventRows();
+
+        CollectionAssert.AreEqual(new[] { 0, 1, 0 }, track.Events.Select(timelineEvent => timelineEvent.Row).ToArray());
+        Assert.AreEqual(2, track.RowCount);
+    }
+
+    [TestMethod]
+    public void PreferredRowIsUsedWhenAvailable()
+    {
+        var preferred = CreateEvent(0, 200, preferredRow: 2);
+        var conflicting = CreateEvent(100, 50, preferredRow: 2);
+        var track = CreateTrack(preferred, conflicting);
+
+        track.AssignEventRows();
+
+        Assert.AreEqual(2, preferred.Row);
+        Assert.AreEqual(0, conflicting.Row);
+        Assert.AreEqual(3, track.RowCount);
+    }
+
+    [TestMethod]
+    public void ZeroDurationEventsAtTheSameTimeUseSeparateRows()
+    {
+        var track = CreateTrack(
+            CreateEvent(100, 0),
+            CreateEvent(100, 0));
+
+        track.AssignEventRows();
+
+        CollectionAssert.AreEqual(new[] { 0, 1 }, track.Events.Select(timelineEvent => timelineEvent.Row).ToArray());
+        Assert.AreEqual(2, track.RowCount);
+    }
+
+    private static TimelineTrack CreateTrack(params TimelineEvent[] events)
+    {
+        var track = new TimelineTrack("Other");
+        foreach (var timelineEvent in events)
+        {
+            track.Events.Add(timelineEvent);
+        }
+
+        return track;
+    }
+
+    private static TimelineEvent CreateEvent(uint startTime, uint duration, int preferredRow = -1) =>
+        new(new scneventsSocket { StartTime = startTime, Duration = duration }, () => { })
+        {
+            PreferredRow = preferredRow
+        };
+}

--- a/WolvenKit.App/Services/TimelineService.cs
+++ b/WolvenKit.App/Services/TimelineService.cs
@@ -40,7 +40,10 @@ public partial class TimelineService : ObservableObject, IDisposable
     private uint _timelineDuration;
 
     [ObservableProperty]
-    private bool _isSectionDurationOutOfSync;
+    private uint _latestEventEndTime;
+
+    [ObservableProperty]
+    private bool _isSectionDurationTooShort;
 
     [ObservableProperty]
     private uint _snapInterval = 100;
@@ -99,7 +102,8 @@ public partial class TimelineService : ObservableObject, IDisposable
         Tracks.Clear();
         SectionDuration = 0;
         TimelineDuration = 0;
-        IsSectionDurationOutOfSync = false;
+        LatestEventEndTime = 0;
+        IsSectionDurationTooShort = false;
     }
 
     private void RebuildTracks()
@@ -266,9 +270,9 @@ public partial class TimelineService : ObservableObject, IDisposable
 
     private void RefreshTimelineDuration()
     {
-        var eventEndTime = GetMaxEventEndTime();
-        TimelineDuration = Math.Max(SectionDuration, eventEndTime);
-        IsSectionDurationOutOfSync = SectionDuration != eventEndTime;
+        LatestEventEndTime = GetMaxEventEndTime();
+        TimelineDuration = Math.Max(SectionDuration, LatestEventEndTime);
+        IsSectionDurationTooShort = LatestEventEndTime > SectionDuration;
     }
 
     private uint GetMaxEventEndTime()
@@ -302,22 +306,36 @@ public partial class TimelineService : ObservableObject, IDisposable
             .Any(evt => evt.StartTime != evt.Event.StartTime || evt.Duration != evt.Event.Duration);
     }
 
-    public void FitSectionDurationToEvents()
+    public void ExtendSectionDurationToEvents()
+    {
+        if (LatestEventEndTime > SectionDuration)
+        {
+            SetSectionDuration(LatestEventEndTime);
+        }
+    }
+
+    public void PreviewSectionDuration(uint duration)
+    {
+        SectionDuration = duration;
+        TimelineDuration = Math.Max(duration, LatestEventEndTime);
+        IsSectionDurationTooShort = LatestEventEndTime > duration;
+    }
+
+    public void SetSectionDuration(uint duration)
     {
         if (_sectionNode == null)
         {
             return;
         }
 
-        var newDuration = GetMaxEventEndTime();
+        var newDuration = Math.Max(duration, LatestEventEndTime);
         if ((_sectionNode.SectionDuration?.Stu ?? 0) == newDuration)
         {
+            PreviewSectionDuration(newDuration);
             return;
         }
 
-        SectionDuration = newDuration;
-        TimelineDuration = newDuration;
-        IsSectionDurationOutOfSync = false;
+        PreviewSectionDuration(newDuration);
         _sectionNode.SectionDuration = new scnSceneTime { Stu = newDuration };
 
         MarkDocumentDirty();
@@ -338,6 +356,9 @@ public partial class TimelineService : ObservableObject, IDisposable
 
         return (uint)(Math.Round((double)value / SnapInterval) * SnapInterval);
     }
+
+    public uint GetSnappedSectionDuration(uint duration) =>
+        Math.Max(SnapValue(duration), LatestEventEndTime);
 
     public void ZoomIn()
     {

--- a/WolvenKit.App/Services/TimelineService.cs
+++ b/WolvenKit.App/Services/TimelineService.cs
@@ -37,6 +37,12 @@ public partial class TimelineService : ObservableObject, IDisposable
     private uint _sectionDuration;
 
     [ObservableProperty]
+    private uint _timelineDuration;
+
+    [ObservableProperty]
+    private bool _isSectionDurationOutOfSync;
+
+    [ObservableProperty]
     private uint _snapInterval = 100;
 
     [ObservableProperty]
@@ -92,6 +98,8 @@ public partial class TimelineService : ObservableObject, IDisposable
         HasSectionNode = false;
         Tracks.Clear();
         SectionDuration = 0;
+        TimelineDuration = 0;
+        IsSectionDurationOutOfSync = false;
     }
 
     private void RebuildTracks()
@@ -147,7 +155,8 @@ public partial class TimelineService : ObservableObject, IDisposable
             Tracks.Add(track);
         }
 
-        RecalculateSectionDuration();
+        SectionDuration = _sectionNode.SectionDuration?.Stu ?? 0;
+        RefreshTimelineDuration();
         _lastKnownEventCount = _sectionNode.Events?.Count ?? 0;
         
         OnPropertyChanged(nameof(Tracks));
@@ -174,7 +183,7 @@ public partial class TimelineService : ObservableObject, IDisposable
             OnPropertyChanged(nameof(Tracks));
         }
         
-        RecalculateSectionDuration();
+        RefreshTimelineDuration();
         
         if (!IsDragging)
         {
@@ -255,20 +264,27 @@ public partial class TimelineService : ObservableObject, IDisposable
         NodePropertyUpdateService.RequestPropertyPanelRefresh();
     }
 
-    private void RecalculateSectionDuration()
+    private void RefreshTimelineDuration()
+    {
+        var eventEndTime = GetMaxEventEndTime();
+        TimelineDuration = Math.Max(SectionDuration, eventEndTime);
+        IsSectionDurationOutOfSync = SectionDuration != eventEndTime;
+    }
+
+    private uint GetMaxEventEndTime()
     {
         if (_sectionNode == null)
         {
-            return;
+            return 0;
         }
 
         uint maxEndTime = 0;
 
-        foreach (var track in Tracks)
+        foreach (var eventHandle in _sectionNode.Events)
         {
-            foreach (var evt in track.Events)
+            if (eventHandle.GetValue() is scnSceneEvent sceneEvent)
             {
-                var endTime = evt.EndTime;
+                var endTime = sceneEvent.StartTime + sceneEvent.Duration;
                 if (endTime > maxEndTime)
                 {
                     maxEndTime = endTime;
@@ -276,11 +292,36 @@ public partial class TimelineService : ObservableObject, IDisposable
             }
         }
 
-        var currentDuration = _sectionNode.SectionDuration?.Stu ?? 0;
-        var newDuration = Math.Max(maxEndTime, currentDuration);
+        return maxEndTime;
+    }
+
+    private bool HaveEventTimingsChanged()
+    {
+        return Tracks
+            .SelectMany(track => track.Events)
+            .Any(evt => evt.StartTime != evt.Event.StartTime || evt.Duration != evt.Event.Duration);
+    }
+
+    public void FitSectionDurationToEvents()
+    {
+        if (_sectionNode == null)
+        {
+            return;
+        }
+
+        var newDuration = GetMaxEventEndTime();
+        if ((_sectionNode.SectionDuration?.Stu ?? 0) == newDuration)
+        {
+            return;
+        }
 
         SectionDuration = newDuration;
+        TimelineDuration = newDuration;
+        IsSectionDurationOutOfSync = false;
         _sectionNode.SectionDuration = new scnSceneTime { Stu = newDuration };
+
+        MarkDocumentDirty();
+        NotifyPropertyUpdate();
     }
 
     private void MarkDocumentDirty()
@@ -310,9 +351,9 @@ public partial class TimelineService : ObservableObject, IDisposable
 
     public void ZoomToFit(double viewportWidth)
     {
-        if (SectionDuration > 0 && viewportWidth > 0)
+        if (TimelineDuration > 0 && viewportWidth > 0)
         {
-            var targetPixelsPerMs = viewportWidth / SectionDuration * 0.9;
+            var targetPixelsPerMs = viewportWidth / TimelineDuration * 0.9;
             ZoomLevel = targetPixelsPerMs / 0.1;
             ZoomLevel = Math.Clamp(ZoomLevel, MinZoomLevel, MaxZoomLevel);
         }
@@ -331,17 +372,24 @@ public partial class TimelineService : ObservableObject, IDisposable
             isOurNode = otherSection.NodeId?.Id == _sectionNode.NodeId?.Id;
         }
         
-        if (!isOurNode)
+        var isOurEvent = e.NodeData is scnSceneEvent updatedEvent &&
+                         _sectionNode.Events.Any(handle => ReferenceEquals(handle.GetValue(), updatedEvent));
+
+        if (!isOurNode && !isOurEvent)
         {
             return;
         }
             
         var currentEventCount = _sectionNode.Events?.Count ?? 0;
-        if (currentEventCount != _lastKnownEventCount)
+        if (currentEventCount != _lastKnownEventCount || HaveEventTimingsChanged())
         {
             _lastKnownEventCount = currentEventCount;
             RebuildTracks();
+            return;
         }
+
+        SectionDuration = _sectionNode.SectionDuration?.Stu ?? 0;
+        RefreshTimelineDuration();
     }
 
     public void Dispose()

--- a/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
+++ b/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
@@ -28,6 +28,8 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
     public bool HasSectionNode => _service.HasSectionNode;
     public string SectionName => _service.SectionName;
     public uint SectionDuration => _service.SectionDuration;
+    public uint TimelineDuration => _service.TimelineDuration;
+    public bool IsSectionDurationOutOfSync => _service.IsSectionDurationOutOfSync;
     public uint SnapInterval { get => _service.SnapInterval; set => _service.SnapInterval = value; }
     public bool IsSnapEnabled { get => _service.IsSnapEnabled; set => _service.IsSnapEnabled = value; }
     public bool IsDragging { get => _service.IsDragging; set => _service.IsDragging = value; }
@@ -43,7 +45,7 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
     public double MinPixelsPerMs => _service.MinZoomLevel * BasePixelsPerMs;
     public double MaxPixelsPerMs => _service.MaxZoomLevel * BasePixelsPerMs;
 
-    public double TimelineWidth => Math.Max(ViewportWidth, SectionDuration * PixelsPerMs);
+    public double TimelineWidth => Math.Max(ViewportWidth, TimelineDuration * PixelsPerMs);
     public double GetRowHeight() => BaseRowHeight;
     public double GetTrackHeight(TimelineTrack track) => track.HeightMultiplier * BaseRowHeight;
     public double TotalTrackHeight => Tracks.Sum(t => GetTrackHeight(t));
@@ -58,7 +60,13 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
                 break;
             case nameof(TimelineService.SectionDuration):
                 OnPropertyChanged(nameof(SectionDuration));
+                break;
+            case nameof(TimelineService.TimelineDuration):
+                OnPropertyChanged(nameof(TimelineDuration));
                 OnPropertyChanged(nameof(TimelineWidth));
+                break;
+            case nameof(TimelineService.IsSectionDurationOutOfSync):
+                OnPropertyChanged(nameof(IsSectionDurationOutOfSync));
                 break;
             case nameof(TimelineService.Tracks):
                 OnPropertyChanged(nameof(Tracks));
@@ -98,6 +106,9 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
 
     [RelayCommand]
     private void ZoomToFit() => _service.ZoomToFit(ViewportWidth);
+
+    [RelayCommand]
+    private void FitSectionDurationToEvents() => _service.FitSectionDurationToEvents();
 
     public void Dispose() => _service.Dispose();
 }

--- a/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
+++ b/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
@@ -29,7 +29,8 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
     public string SectionName => _service.SectionName;
     public uint SectionDuration => _service.SectionDuration;
     public uint TimelineDuration => _service.TimelineDuration;
-    public bool IsSectionDurationOutOfSync => _service.IsSectionDurationOutOfSync;
+    public uint LatestEventEndTime => _service.LatestEventEndTime;
+    public bool IsSectionDurationTooShort => _service.IsSectionDurationTooShort;
     public uint SnapInterval { get => _service.SnapInterval; set => _service.SnapInterval = value; }
     public bool IsSnapEnabled { get => _service.IsSnapEnabled; set => _service.IsSnapEnabled = value; }
     public bool IsDragging { get => _service.IsDragging; set => _service.IsDragging = value; }
@@ -65,8 +66,11 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
                 OnPropertyChanged(nameof(TimelineDuration));
                 OnPropertyChanged(nameof(TimelineWidth));
                 break;
-            case nameof(TimelineService.IsSectionDurationOutOfSync):
-                OnPropertyChanged(nameof(IsSectionDurationOutOfSync));
+            case nameof(TimelineService.LatestEventEndTime):
+                OnPropertyChanged(nameof(LatestEventEndTime));
+                break;
+            case nameof(TimelineService.IsSectionDurationTooShort):
+                OnPropertyChanged(nameof(IsSectionDurationTooShort));
                 break;
             case nameof(TimelineService.Tracks):
                 OnPropertyChanged(nameof(Tracks));
@@ -88,7 +92,13 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
 
     public void RefreshAfterDrag() => _service.RefreshAfterDrag();
 
+    public void PreviewSectionDuration(uint duration) => _service.PreviewSectionDuration(duration);
+
+    public void SetSectionDuration(uint duration) => _service.SetSectionDuration(duration);
+
     public uint SnapValue(uint value) => _service.SnapValue(value);
+
+    public uint GetSnappedSectionDuration(uint duration) => _service.GetSnappedSectionDuration(duration);
 
     public uint PixelsToTime(double pixels)
     {
@@ -108,7 +118,7 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
     private void ZoomToFit() => _service.ZoomToFit(ViewportWidth);
 
     [RelayCommand]
-    private void FitSectionDurationToEvents() => _service.FitSectionDurationToEvents();
+    private void ExtendSectionDurationToEvents() => _service.ExtendSectionDurationToEvents();
 
     public void Dispose() => _service.Dispose();
 }

--- a/WolvenKit/Views/Timeline/SectionTimelineView.xaml
+++ b/WolvenKit/Views/Timeline/SectionTimelineView.xaml
@@ -130,26 +130,13 @@
                     <Button
                         Margin="8,0,0,0"
                         Padding="8,3"
-                        Command="{Binding FitSectionDurationToEventsCommand}"
-                        IsEnabled="{Binding IsSectionDurationOutOfSync}"
-                        ToolTipService.ShowOnDisabled="True">
-                        <Button.Style>
-                            <Style
-                                BasedOn="{StaticResource {x:Type Button}}"
-                                TargetType="Button">
-                                <Setter Property="ToolTip" Value="Section duration already matches the event end" />
-                                <Style.Triggers>
-                                    <DataTrigger
-                                        Binding="{Binding IsSectionDurationOutOfSync}"
-                                        Value="True">
-                                        <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
-                                        <Setter Property="BorderBrush" Value="{StaticResource WolvenKitRed}" />
-                                        <Setter Property="Foreground" Value="White" />
-                                        <Setter Property="ToolTip" Value="Set section duration to the end of the last event" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Button.Style>
+                        Background="{StaticResource WolvenKitRed}"
+                        BorderBrush="{StaticResource WolvenKitRed}"
+                        Command="{Binding ExtendSectionDurationToEventsCommand}"
+                        Foreground="White"
+                        ToolTip="Extend section duration to the end of the last event"
+                        Visibility="{Binding IsSectionDurationTooShort,
+                                             Converter={StaticResource BoolToVis}}">
                         <StackPanel Orientation="Horizontal">
                             <iconPacks:PackIconMaterial
                                 Kind="ArrowExpandHorizontal"
@@ -159,7 +146,7 @@
                                 VerticalAlignment="Center" />
                             <TextBlock
                                 VerticalAlignment="Center"
-                                Text="Set to event end" />
+                                Text="Extend to event end" />
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/WolvenKit/Views/Timeline/SectionTimelineView.xaml
+++ b/WolvenKit/Views/Timeline/SectionTimelineView.xaml
@@ -127,6 +127,41 @@
                             </MultiBinding>
                         </TextBlock.Text>
                     </TextBlock>
+                    <Button
+                        Margin="8,0,0,0"
+                        Padding="8,3"
+                        Command="{Binding FitSectionDurationToEventsCommand}"
+                        IsEnabled="{Binding IsSectionDurationOutOfSync}"
+                        ToolTipService.ShowOnDisabled="True">
+                        <Button.Style>
+                            <Style
+                                BasedOn="{StaticResource {x:Type Button}}"
+                                TargetType="Button">
+                                <Setter Property="ToolTip" Value="Section duration already matches the event end" />
+                                <Style.Triggers>
+                                    <DataTrigger
+                                        Binding="{Binding IsSectionDurationOutOfSync}"
+                                        Value="True">
+                                        <Setter Property="Background" Value="{StaticResource WolvenKitRed}" />
+                                        <Setter Property="BorderBrush" Value="{StaticResource WolvenKitRed}" />
+                                        <Setter Property="Foreground" Value="White" />
+                                        <Setter Property="ToolTip" Value="Set section duration to the end of the last event" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                        <StackPanel Orientation="Horizontal">
+                            <iconPacks:PackIconMaterial
+                                Kind="ArrowExpandHorizontal"
+                                Width="14"
+                                Height="14"
+                                Margin="0,0,4,0"
+                                VerticalAlignment="Center" />
+                            <TextBlock
+                                VerticalAlignment="Center"
+                                Text="Set to event end" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Grid>
         </Border>

--- a/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
+++ b/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
@@ -34,6 +34,17 @@ public partial class SectionTimelineView : UserControl
     private TimelineEvent? _selectedEvent;
     private Border? _selectedBorder;
     private Border? _activeResizeGrip;
+    private Border? _sectionEndHandle;
+    private Line? _rulerSectionEndLine;
+    private Line? _rulerSectionEndCap;
+    private Line? _timelineSectionEndLine;
+    private Rectangle? _overrunRegion;
+    private bool _isRenderPending;
+    private bool _isDraggingSectionEnd;
+    private bool _isSectionEndHovered;
+    private bool _sectionEndDragHasChanged;
+    private Point _sectionEndDragStartPoint;
+    private uint _sectionEndDragStartDuration;
     private const double DragThreshold = 5.0;
 
     public SectionTimelineView()
@@ -53,6 +64,13 @@ public partial class SectionTimelineView : UserControl
     
     private void OnGlobalMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
+        if (_isDraggingSectionEnd)
+        {
+            FinishSectionEndDrag();
+            e.Handled = true;
+            return;
+        }
+
         if (_isResizing)
         {
             _draggedEvent = null;
@@ -82,13 +100,16 @@ public partial class SectionTimelineView : UserControl
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         UpdateViewportWidth();
-        RenderTimeline();
+        QueueRenderTimeline();
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
     {
         UpdateViewportWidth();
-        RenderTimeline();
+        if (!_isDraggingSectionEnd)
+        {
+            QueueRenderTimeline();
+        }
     }
 
     private void UpdateViewportWidth()
@@ -101,7 +122,7 @@ public partial class SectionTimelineView : UserControl
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (_draggedEvent != null || _isResizing)
+        if (_draggedEvent != null || _isResizing || _isDraggingSectionEnd)
         {
             return;
         }
@@ -112,8 +133,26 @@ public partial class SectionTimelineView : UserControl
             or nameof(SectionTimelineViewModel.TimelineDuration)
             or nameof(SectionTimelineViewModel.Tracks))
         {
-            Dispatcher.BeginInvoke(new Action(RenderTimeline));
+            QueueRenderTimeline();
         }
+    }
+
+    private void QueueRenderTimeline()
+    {
+        if (_isRenderPending)
+        {
+            return;
+        }
+
+        _isRenderPending = true;
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            _isRenderPending = false;
+            if (!_isDraggingSectionEnd)
+            {
+                RenderTimeline();
+            }
+        }));
     }
 
     private void RenderTimeline()
@@ -138,11 +177,14 @@ public partial class SectionTimelineView : UserControl
         }
 
         TimeRulerCanvas.Children.Clear();
+        _rulerSectionEndLine = null;
+        _rulerSectionEndCap = null;
+        _sectionEndHandle = null;
 
         var duration = _viewModel.TimelineDuration;
         var pixelsPerMs = _viewModel.PixelsPerMs;
         
-        if (duration == 0 || pixelsPerMs == 0)
+        if (pixelsPerMs == 0)
         {
             return;
         }
@@ -177,6 +219,8 @@ public partial class SectionTimelineView : UserControl
             Canvas.SetTop(label, 2);
             TimeRulerCanvas.Children.Add(label);
         }
+
+        RenderRulerSectionEndMarker();
     }
 
     private static uint GetTickInterval(double pixelsPerMs)
@@ -210,11 +254,14 @@ public partial class SectionTimelineView : UserControl
 
         TimelineCanvas.Children.Clear();
         _eventElements.Clear();
+        _timelineSectionEndLine = null;
+        _overrunRegion = null;
 
         var pixelsPerMs = _viewModel.PixelsPerMs;
         double yOffset = 0;
 
         RenderGridLines();
+        RenderOverrunRegion();
 
         foreach (var track in _viewModel.Tracks)
         {
@@ -244,7 +291,273 @@ public partial class SectionTimelineView : UserControl
             yOffset += trackHeight;
         }
 
+        RenderTimelineSectionEndMarker(yOffset);
+
         TimelineCanvas.SetCurrentValue(HeightProperty, yOffset);
+    }
+
+    private void RenderOverrunRegion()
+    {
+        if (_viewModel == null || !_viewModel.IsSectionDurationTooShort)
+        {
+            return;
+        }
+
+        var sectionEndX = _viewModel.TimeToPixels(_viewModel.SectionDuration);
+        _overrunRegion = new Rectangle
+        {
+            Width = Math.Max(0, _viewModel.TimelineWidth - sectionEndX),
+            Height = _viewModel.TotalTrackHeight,
+            Fill = new SolidColorBrush(Color.FromArgb(38, 223, 41, 53)),
+            IsHitTestVisible = false
+        };
+
+        Canvas.SetLeft(_overrunRegion, sectionEndX);
+        Canvas.SetTop(_overrunRegion, 0);
+        TimelineCanvas.Children.Add(_overrunRegion);
+    }
+
+    private void RenderRulerSectionEndMarker()
+    {
+        if (_viewModel == null)
+        {
+            return;
+        }
+
+        var sectionEndX = _viewModel.TimeToPixels(_viewModel.SectionDuration);
+        var markerBrush = GetSectionEndMarkerBrush();
+        _rulerSectionEndLine = new Line
+        {
+            X1 = sectionEndX,
+            X2 = sectionEndX,
+            Y1 = 0,
+            Y2 = 24,
+            Stroke = markerBrush,
+            StrokeThickness = _viewModel.IsSectionDurationTooShort ? 2 : 1,
+            IsHitTestVisible = false
+        };
+
+        _rulerSectionEndCap = new Line
+        {
+            X1 = sectionEndX - 8,
+            X2 = sectionEndX,
+            Y1 = 2,
+            Y2 = 2,
+            Stroke = markerBrush,
+            StrokeThickness = 2,
+            IsHitTestVisible = false
+        };
+
+        _sectionEndHandle = new Border
+        {
+            Width = 16,
+            Height = 24,
+            Background = Brushes.Transparent,
+            Cursor = Cursors.SizeWE,
+            ToolTip = $"Section end: {_viewModel.SectionDuration}ms. Drag to adjust."
+        };
+        _sectionEndHandle.MouseLeftButtonDown += SectionEndHandle_MouseLeftButtonDown;
+        _sectionEndHandle.MouseMove += SectionEndHandle_MouseMove;
+        _sectionEndHandle.MouseEnter += SectionEndHandle_MouseEnter;
+        _sectionEndHandle.MouseLeave += SectionEndHandle_MouseLeave;
+
+        Canvas.SetLeft(_sectionEndHandle, Math.Max(0, sectionEndX - 12));
+        Canvas.SetTop(_sectionEndHandle, 0);
+        Panel.SetZIndex(_rulerSectionEndLine, 10);
+        Panel.SetZIndex(_rulerSectionEndCap, 10);
+        Panel.SetZIndex(_sectionEndHandle, 11);
+        TimeRulerCanvas.Children.Add(_rulerSectionEndLine);
+        TimeRulerCanvas.Children.Add(_rulerSectionEndCap);
+        TimeRulerCanvas.Children.Add(_sectionEndHandle);
+    }
+
+    private void RenderTimelineSectionEndMarker(double height)
+    {
+        if (_viewModel == null || height <= 0)
+        {
+            return;
+        }
+
+        var sectionEndX = _viewModel.TimeToPixels(_viewModel.SectionDuration);
+        _timelineSectionEndLine = new Line
+        {
+            X1 = sectionEndX,
+            X2 = sectionEndX,
+            Y1 = 0,
+            Y2 = height,
+            Stroke = GetSectionEndMarkerBrush(),
+            StrokeThickness = _viewModel.IsSectionDurationTooShort ? 2 : 1,
+            IsHitTestVisible = false
+        };
+
+        Panel.SetZIndex(_timelineSectionEndLine, 10);
+        TimelineCanvas.Children.Add(_timelineSectionEndLine);
+    }
+
+    private Brush GetSectionEndMarkerBrush()
+    {
+        if ((_isDraggingSectionEnd || _isSectionEndHovered) &&
+            TryFindResource("WolvenKitYellow") is Brush highlightBrush)
+        {
+            return highlightBrush;
+        }
+
+        return new SolidColorBrush(_viewModel?.IsSectionDurationTooShort == true
+            ? Color.FromRgb(223, 41, 53)
+            : Color.FromRgb(120, 120, 120));
+    }
+
+    private void SectionEndHandle_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_viewModel == null || sender is not Border handle || _viewModel.PixelsPerMs <= 0)
+        {
+            return;
+        }
+
+        _isDraggingSectionEnd = true;
+        _sectionEndDragHasChanged = false;
+        _sectionEndDragStartPoint = e.GetPosition(TimeRulerCanvas);
+        _sectionEndDragStartDuration = _viewModel.SectionDuration;
+        _viewModel.IsDragging = true;
+        handle.CaptureMouse();
+        UpdateSectionEndMarkerBrushes();
+        e.Handled = true;
+    }
+
+    private void SectionEndHandle_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isDraggingSectionEnd || _viewModel == null || _viewModel.PixelsPerMs <= 0)
+        {
+            return;
+        }
+
+        var currentPoint = e.GetPosition(TimeRulerCanvas);
+        var deltaMs = (currentPoint.X - _sectionEndDragStartPoint.X) / _viewModel.PixelsPerMs;
+        var rawDuration = Math.Clamp(_sectionEndDragStartDuration + deltaMs, 0, uint.MaxValue);
+        var newDuration = _viewModel.GetSnappedSectionDuration((uint)Math.Round(rawDuration));
+
+        if (newDuration == _viewModel.SectionDuration)
+        {
+            return;
+        }
+
+        _sectionEndDragHasChanged = true;
+        _viewModel.PreviewSectionDuration(newDuration);
+        UpdateSectionEndMarkerVisuals();
+        e.Handled = true;
+    }
+
+    private void SectionEndHandle_MouseEnter(object sender, MouseEventArgs e)
+    {
+        _isSectionEndHovered = true;
+        UpdateSectionEndMarkerBrushes();
+    }
+
+    private void SectionEndHandle_MouseLeave(object sender, MouseEventArgs e)
+    {
+        _isSectionEndHovered = false;
+        UpdateSectionEndMarkerBrushes();
+    }
+
+    private void FinishSectionEndDrag()
+    {
+        if (!_isDraggingSectionEnd || _viewModel == null)
+        {
+            return;
+        }
+
+        _isDraggingSectionEnd = false;
+        _sectionEndHandle?.ReleaseMouseCapture();
+        _viewModel.IsDragging = false;
+
+        if (_sectionEndDragHasChanged)
+        {
+            _viewModel.SetSectionDuration(_viewModel.SectionDuration);
+        }
+
+        _sectionEndDragHasChanged = false;
+        QueueRenderTimeline();
+    }
+
+    private void UpdateSectionEndMarkerVisuals()
+    {
+        if (_viewModel == null)
+        {
+            return;
+        }
+
+        var sectionEndX = _viewModel.TimeToPixels(_viewModel.SectionDuration);
+
+        if (_rulerSectionEndLine != null)
+        {
+            _rulerSectionEndLine.SetCurrentValue(Line.X1Property, sectionEndX);
+            _rulerSectionEndLine.SetCurrentValue(Line.X2Property, sectionEndX);
+        }
+
+        if (_rulerSectionEndCap != null)
+        {
+            _rulerSectionEndCap.SetCurrentValue(Line.X1Property, sectionEndX - 8);
+            _rulerSectionEndCap.SetCurrentValue(Line.X2Property, sectionEndX);
+        }
+
+        if (_timelineSectionEndLine != null)
+        {
+            _timelineSectionEndLine.SetCurrentValue(Line.X1Property, sectionEndX);
+            _timelineSectionEndLine.SetCurrentValue(Line.X2Property, sectionEndX);
+        }
+
+        if (_sectionEndHandle != null)
+        {
+            Canvas.SetLeft(_sectionEndHandle, Math.Max(0, sectionEndX - 12));
+            _sectionEndHandle.SetCurrentValue(ToolTipProperty, GetSectionEndToolTip());
+        }
+
+        if (_overrunRegion != null)
+        {
+            _overrunRegion.SetCurrentValue(VisibilityProperty,
+                _viewModel.IsSectionDurationTooShort ? Visibility.Visible : Visibility.Collapsed);
+            Canvas.SetLeft(_overrunRegion, sectionEndX);
+            _overrunRegion.SetCurrentValue(WidthProperty, Math.Max(0, _viewModel.TimelineWidth - sectionEndX));
+        }
+
+        UpdateSectionEndMarkerBrushes();
+    }
+
+    private void UpdateSectionEndMarkerBrushes()
+    {
+        var brush = GetSectionEndMarkerBrush();
+        var isEmphasized = _isDraggingSectionEnd || _isSectionEndHovered ||
+                           _viewModel?.IsSectionDurationTooShort == true;
+        var thickness = isEmphasized ? 2.0 : 1.0;
+
+        if (_rulerSectionEndLine != null)
+        {
+            _rulerSectionEndLine.SetCurrentValue(Shape.StrokeProperty, brush);
+            _rulerSectionEndLine.SetCurrentValue(Shape.StrokeThicknessProperty, thickness);
+        }
+
+        if (_rulerSectionEndCap != null)
+        {
+            _rulerSectionEndCap.SetCurrentValue(Shape.StrokeProperty, brush);
+        }
+
+        if (_timelineSectionEndLine != null)
+        {
+            _timelineSectionEndLine.SetCurrentValue(Shape.StrokeProperty, brush);
+            _timelineSectionEndLine.SetCurrentValue(Shape.StrokeThicknessProperty, thickness);
+        }
+    }
+
+    private string GetSectionEndToolTip()
+    {
+        if (_viewModel == null)
+        {
+            return "Section end";
+        }
+
+        return _viewModel.LatestEventEndTime > 0
+            ? $"Section end: {_viewModel.SectionDuration}ms. Drag to adjust (minimum {_viewModel.LatestEventEndTime}ms)."
+            : $"Section end: {_viewModel.SectionDuration}ms. Drag to adjust.";
     }
 
     private void RenderGridLines()
@@ -281,6 +594,9 @@ public partial class SectionTimelineView : UserControl
         var x = evt.StartTime * pixelsPerMs;
         var width = Math.Max(80, evt.Duration * pixelsPerMs);
         var eventColor = TimelineColorHelper.GetColorForEventType(evt.EventType);
+        var titleLine = evt.TitleLine;
+        var detailsLine = evt.DetailsLine;
+        var displayLabel = $"{titleLine} {detailsLine}".Trim();
 
         var border = new Border
         {
@@ -290,7 +606,7 @@ public partial class SectionTimelineView : UserControl
             MinWidth = 80,
             Cursor = Cursors.SizeAll,
             Tag = evt,
-            ToolTip = $"{evt.DisplayLabel}\nStart: {evt.StartTime}ms\nDuration: {evt.Duration}ms"
+            ToolTip = $"{displayLabel}\nStart: {evt.StartTime}ms\nDuration: {evt.Duration}ms"
         };
 
         var stackPanel = new StackPanel
@@ -301,7 +617,7 @@ public partial class SectionTimelineView : UserControl
 
         var titleLabel = new TextBlock
         {
-            Text = evt.TitleLine,
+            Text = titleLine,
             Foreground = Brushes.White,
             FontWeight = FontWeights.SemiBold,
             TextTrimming = TextTrimming.CharacterEllipsis
@@ -310,14 +626,14 @@ public partial class SectionTimelineView : UserControl
 
         var detailsLabel = new TextBlock
         {
-            Text = evt.DetailsLine,
+            Text = detailsLine,
             Foreground = new SolidColorBrush(Color.FromArgb(200, 255, 255, 255)),
             TextTrimming = TextTrimming.CharacterEllipsis
         };
         detailsLabel.SetResourceReference(TextBlock.FontSizeProperty, "WolvenKitFontAltTitle");
 
         stackPanel.Children.Add(titleLabel);
-        if (!string.IsNullOrEmpty(evt.DetailsLine))
+        if (!string.IsNullOrEmpty(detailsLine))
         {
             stackPanel.Children.Add(detailsLabel);
         }

--- a/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
+++ b/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
@@ -109,6 +109,7 @@ public partial class SectionTimelineView : UserControl
         if (e.PropertyName is nameof(SectionTimelineViewModel.HasSectionNode) 
             or nameof(SectionTimelineViewModel.PixelsPerMs)
             or nameof(SectionTimelineViewModel.SectionDuration)
+            or nameof(SectionTimelineViewModel.TimelineDuration)
             or nameof(SectionTimelineViewModel.Tracks))
         {
             Dispatcher.BeginInvoke(new Action(RenderTimeline));
@@ -138,7 +139,7 @@ public partial class SectionTimelineView : UserControl
 
         TimeRulerCanvas.Children.Clear();
 
-        var duration = _viewModel.SectionDuration;
+        var duration = _viewModel.TimelineDuration;
         var pixelsPerMs = _viewModel.PixelsPerMs;
         
         if (duration == 0 || pixelsPerMs == 0)
@@ -252,7 +253,7 @@ public partial class SectionTimelineView : UserControl
             return;
 
         var pixelsPerMs = _viewModel.PixelsPerMs;
-        var duration = _viewModel.SectionDuration;
+        var duration = _viewModel.TimelineDuration;
         var totalHeight = _viewModel.TotalTrackHeight;
         
         uint gridInterval = GetTickInterval(pixelsPerMs);

--- a/changelog/unreleased/3011.yaml
+++ b/changelog/unreleased/3011.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3011
+      author: "misterchedda"
+      description: "Scene section durations are no longer adjusted automatically when selecting sections or moving timeline events, and can now be changed explicitly using the timeline marker or Extend to event end action"


### PR DESCRIPTION
A section duration will no longer get adjusted automatically and silently on selection. Although #2809 prevented section durations from shrinking, opening the section timeline could still automatically extend the duration when an event ended beyond it

Changing section duration now requires express user intent:

- A new draggable timeline stu marker at the end of the section timeline. Dragging this sets the section duration directly (respects snap and clamped so you can't drag it below the last event end ie you can't create an invalid section with it)

<img width="344" height="116" alt="image" src="https://github.com/user-attachments/assets/5f1dc4de-5886-4d15-9aee-123dab6a5b63" />


- A new button "Extend to event end" that extends the section duration to the end of the last event. This button is only visible when the last event end > section duration, so it doubles as an "your section is invalid" indicator. Also the timeline clearly visibly shows when an event is placed outside the section duration (marker + out-of-bounds region turn red).
<img width="433" height="288" alt="Screenshot 2026-07-13 173547" src="https://github.com/user-attachments/assets/9e2b7d8e-aa5f-4cc7-9bc6-b741f4d89c74" />
<img width="377" height="151" alt="Screenshot 2026-07-13 174620" src="https://github.com/user-attachments/assets/e65463e0-6625-4992-b01d-2ed06123832a" />

As a consequence - more importantly: dragging an event past the section end no longer auto extends the section duration either (this was part of the same implicit mutation behavior). The timeline shows the event in the red out of bounds region and users will need to press "Extend to event end" to fix it or drag the new timeline stu marker to explicitly mark a section's end