### PR TITLE
Add usage focused docs for templating relevant components

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,6 +60,13 @@ export default defineConfig({
                 collapsed: false,
                 items: [
                     {
+                        text: 'WolvenKit.App',
+                        collapsed: true,
+                        items: [
+                            { text: 'Red Type Template Dropdown', link: '/code-documentation/Subprojects/WolvenKit.App/RedTypeTemplateDropdown' },
+                        ]
+                    },
+                    {
                         text: 'WolvenKit.Common',
                         collapsed: true,
                         items: [
@@ -67,7 +74,14 @@ export default defineConfig({
                         ]
                     }
                 ]
-            }
+            },
+            {
+                text: 'WolvenKit UI/UX Design',
+                collapsed: true,
+                items: [
+                    { text: 'Exposing Templates to the User', link: '/code-documentation/WolvenKitUIUXDesign/ExposingTemplatesToTheUser' },
+                ]
+            },
         ]
       }
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,19 @@ export default defineConfig({
         collapsed: false,
         items: [
           { text: 'Homepage', link: '/code-documentation/home' },
+            {
+                text: 'Subprojects',
+                collapsed: false,
+                items: [
+                    {
+                        text: 'WolvenKit.Common',
+                        collapsed: true,
+                        items: [
+                            { text: 'Red Type Template Service', link: '/code-documentation/Subprojects/WolvenKit.Common/RedTypeTemplateService' },
+                        ]
+                    }
+                ]
+            }
         ]
       }
     ],

--- a/docs/code-documentation/Subprojects/WolvenKit.App/RedTypeTemplateDropdown.md
+++ b/docs/code-documentation/Subprojects/WolvenKit.App/RedTypeTemplateDropdown.md
@@ -1,0 +1,22 @@
+# Red Type Template Dropdown
+
+The `RedTypeTemplateDropdown` faciliates the user chooing an available template for the given type.
+
+## Usage
+
+In the xaml add a `RedTypeTemplateDropdown` and bind it to an `RedTypeTemplateDropdownViewModel` instance.
+
+```xaml
+<controls:RedTypeTemplateDropdown
+                    ViewModel="{Binding RedTypeTemplateDropdownViewModel}"/>
+```
+
+All code interactions are done through the ViewModel.
+
+The type of the templates in the dropdown is directly tied to the `RequestedType` property, changing it will update the drop down options live. <br>
+The selected template is represented by the `SelectedRedTypeTemplate` property which is a `RedTypeTemplateSelectionOption` and a type of `RedTypeTemplateDescriptor` with an additional property for the source which can be `System`, `User`, or `Raw` where `Raw` represents no template at all.
+::: warning
+If directly passed to the `RedTypeTemplateService` the additional source property will be ignored. <br>
+Instead use `CreateTypeInstanceFromSelectionOption` which is an extension method that correctly handles the added source property. <br>
+Additional methods can be added to `RedTypeTemplateServiceHelper`.
+:::

--- a/docs/code-documentation/Subprojects/WolvenKit.Common/RedTypeTemplateService.md
+++ b/docs/code-documentation/Subprojects/WolvenKit.Common/RedTypeTemplateService.md
@@ -53,5 +53,12 @@ All methods are thread safe.
 Most methods have several overloads, e.g. accepting the type as a generic as well as a parameter, or a `RedTypeTemplateDescriptor`. <br>
 Many parameters are optional, for example when reading, the name defaults to "default" and source to Auto, when writing only the destination is defaulted to User.
 
+## Design
+
+Templates when stored are plain json files containing a serialized `RedTypeTemplate` where the name and type are primarily encoded in it's filename which follows the `NAME.TYPE.json` pattern. <br>
+When templates are loaded a descriptor is created for each template that contains it's name, type and backing filepath. It is only deserialized during the `LoadTemplates` method to validate that it does not contain malformed data as this is a good place to communicate any issues with the user. <br>
+In addition catching most malformed templates early means there is less of a chance for unexpected template resolution when reading templates where a template is indexed but cannot be read.
+
+Template files are ultimately read at the time of reading the template using either `ReadTemplate` or `CreateTypeInstance`. This lowers the memory footprint of the service as it only needs to keep track of the descriptors rather than the entire payload.
 
 

--- a/docs/code-documentation/Subprojects/WolvenKit.Common/RedTypeTemplateService.md
+++ b/docs/code-documentation/Subprojects/WolvenKit.Common/RedTypeTemplateService.md
@@ -1,0 +1,57 @@
+# Red Type Template Service
+
+The Red Type Template Service is the core of the templatating system in WolvenKit. It handles the management of templates, including reading and validating files on the disk as well as read and write access from the program.
+
+## Usage
+
+**Instanciation**
+
+To instanciate the service only the ILoggerService is required, alongside the path to the user and system template folders.
+Templates are indexed on class creation and a rescan can be triggered via the `LoadTemplates` method at any time.
+
+:::info
+Note that only files in the root of the template folders are indexed. This is to allow the OS to handle the enforcing of unique file names.
+:::
+
+**Reading**
+
+To read a specific indexed template, use the `ReadTemplate` method. This will return a `RedTemplate` object which contains the metadata (author, version and description) as well as the templated data.
+If no template is found, `null` is returned.
+
+If instead you want to create a guaranteed instance of a class from information about a template, use the `CreateTypeInstance` method. <br>
+This methods will always return an instance of the type. In case the requested template does not exist it will try to read the "default" template of the same type and source, if it is not available a new instance of the type will be created using `RedTypeManager.CreateAndInitRedType`.
+
+**Writing**
+
+Creation of a new template is handled by the `WriteTemplate` method. It expects a `RedTemplate` object as input where the `Data` property is not null and contains a templatable type, alongside a template name and destination.
+
+:::warning
+`WriteTemplate` always overwrite existing templates, to check whether a template already exists use the `TemplateExists` method.
+:::
+
+:::info
+Checking whether a type is templatable is done using the `IsTypeTemplatable` method. <br>
+Templatable types are types which are assignable to `IRedType`, are non abstract and non primitive and don't inherit from `IRedPrimitive`.
+:::
+
+Templates can be deleted using the `DeleteTemplate` method.
+
+:::warning
+For usage within the WolvenKit project modifying the system templates is not allowed, though not enforced by code.
+This is due to system templates being pulled from the `WolvenKit/Wolvenkit-Resources` repository
+:::
+
+**Miscellaneous**
+
+A template descriptor containing the file path and name can be aquired from the `GetTemplateDescriptor` method or by directly querying the `SystemTemplates` and `UserTemplates` lists. <br>
+In situations where the template is chosen in a different place than it is resolved this can be useful in combination with `IsOnlyNoneOrDefaultAvailable` to auto select a template and avoid unnecessary user interaction.
+
+The implementation of `ParseType` in this class is lazily cached and as such quicker than indexing the domain assembly and their types every time.
+
+All methods are thread safe.
+
+Most methods have several overloads, e.g. accepting the type as a generic as well as a parameter, or a `RedTypeTemplateDescriptor`. <br>
+Many parameters are optional, for example when reading, the name defaults to "default" and source to Auto, when writing only the destination is defaulted to User.
+
+
+

--- a/docs/code-documentation/WolvenKitUIUXDesign/ExposingTemplatesToTheUser.md
+++ b/docs/code-documentation/WolvenKitUIUXDesign/ExposingTemplatesToTheUser.md
@@ -1,0 +1,11 @@
+# Exposing Templates to the User
+
+The user needs to be able to specify a template whenever a user interaction creates a new `IRedType` instance (e.g. New File Dialog, the yellow + button in the tree view, etc.).
+::: info
+If no templates are available or the only template is "default" for the type created, the choice may be skipped and the default option auto selected.
+:::
+
+When presenting the user with options for templates, the "default" template should be preselected if available.
+
+To make this easier [a dropdown component](../Subprojects/WolvenKit.App/RedTypeTemplateDropdown) is available which accepts a requested type and exposes the selected `RedTypeTemplateSelectionOption`.
+


### PR DESCRIPTION
# Add usage focused docs for templating relevant components

Adds docs for using the `RedTypeTemplateSerivce`, a brief section on it's design choices, as well as guidelines on how templates should be presented to the end user and usage docs of the `RedTypeTemplateDropdown`.