### PR TITLE
add test coverage for GraphEditor

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
@@ -1,0 +1,202 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WolvenKit.App.Factories;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
+using WolvenKit.RED4.Types;
+using WolvenKit.UnitTests.App.GraphEditor.Shared;
+using Point = System.Windows.Point;
+
+namespace WolvenKit.UnitTests.App.GraphEditor;
+
+[TestClass]
+[DoNotParallelize]
+public class GraphDocumentIntegrationTests
+{
+    [TestMethod]
+    public void QuestGraphMutationsMarkDocumentDirty()
+    {
+        using var fixture = new GraphDocumentTestFixture("mod\\test.questphase");
+        var start = new questStartNodeDefinition { Id = 1 };
+        GraphTestHelpers.AddQuestSocket(start, "Out", Enums.questSocketType.Output);
+        var end = new questEndNodeDefinition { Id = 2 };
+        GraphTestHelpers.AddQuestSocket(end, "In", Enums.questSocketType.Input);
+        var graphData = GraphTestHelpers.CreateQuestGraph(start, end);
+        using var graph = RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+        AttachDocument(graph, fixture.Document);
+
+        graph.CreateQuestNode(typeof(questFactsDBManagerNodeDefinition), new Point());
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.PendingConnection.Source = graph.Nodes.OfType<questStartNodeDefinitionWrapper>().Single().Output.Single();
+        graph.PendingConnection.Target = graph.Nodes.OfType<questEndNodeDefinitionWrapper>().Single().Input.Single();
+        graph.Connect();
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.RemoveQuestConnectionPublic(graph.Connections.Cast<QuestConnectionViewModel>().Single());
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.RemoveNode(graph.Nodes.OfType<questFactsDBManagerNodeDefinitionWrapper>().Single());
+        Assert.IsTrue(fixture.Document.IsDirty);
+    }
+
+    [TestMethod]
+    public void SceneGraphMutationsMarkDocumentDirty()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        GraphTestHelpers.AddSceneOutput(start);
+        var end = new scnEndNode { NodeId = new scnNodeId { Id = 2 } };
+        var resource = GraphTestHelpers.CreateSceneResource(start, end);
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+
+        graph.CreateSceneNode(typeof(scnAndNode), new Point());
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.PendingConnection.Source = graph.Nodes.OfType<scnStartNodeWrapper>().Single().Output.Single();
+        graph.PendingConnection.Target = graph.Nodes.OfType<scnEndNodeWrapper>().Single().Input.Single();
+        graph.Connect();
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.RemoveSceneConnectionPublic(graph.Connections.Cast<SceneConnectionViewModel>().Single());
+        Assert.IsTrue(fixture.Document.IsDirty);
+
+        fixture.Document.SetIsDirty(false);
+        graph.RemoveNode(graph.Nodes.OfType<scnAndNodeWrapper>().Single());
+        Assert.IsTrue(fixture.Document.IsDirty);
+    }
+
+    [TestMethod]
+    public void SceneGraphGenerationAndRefreshDoNotMarkDocumentDirty()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        GraphTestHelpers.AddSceneOutput(start);
+        var resource = GraphTestHelpers.CreateSceneResource(start);
+
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+
+        Assert.IsFalse(fixture.Document.IsDirty);
+
+        graph.Nodes.Single().RefreshFromData();
+
+        Assert.IsFalse(fixture.Document.IsDirty);
+    }
+
+    [TestMethod]
+    public void GraphStateRoundTripRestoresNodeAndCommentMetadata()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        fixture.EnableStateLoading();
+        var node = new scnAndNode { NodeId = new scnNodeId { Id = 1 } };
+        GraphTestHelpers.AddSceneOutput(node);
+        var resource = GraphTestHelpers.CreateSceneResource(node);
+
+        using (var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document))
+        {
+            graph.GraphStateLoad();
+            graph.Nodes.Single().Location = new Point(120, 340);
+            graph.Nodes.Single().ShowUnusedSockets = false;
+            var comment = graph.AddComment(new Point(20, 40));
+            comment.Text = "Stateful comment";
+            comment.AccentColor = "#FFFF8800";
+            comment.Width = 640;
+            comment.Height = 360;
+            graph.GraphStateSave();
+            graph.GraphCommentStateSave();
+        }
+
+        fixture.Document.SetIsDirty(false);
+        using var restored = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+        restored.GraphStateLoad();
+
+        Assert.AreEqual(new Point(120, 340), restored.Nodes.Single().Location);
+        Assert.IsFalse(restored.Nodes.Single().ShowUnusedSockets);
+        var restoredComment = restored.Comments.Single();
+        Assert.AreEqual("Stateful comment", restoredComment.Text);
+        Assert.AreEqual("#FFFF8800", restoredComment.AccentColor);
+        Assert.AreEqual(new Point(20, 40), restoredComment.Location);
+        Assert.AreEqual(640, restoredComment.Width);
+        Assert.AreEqual(360, restoredComment.Height);
+        Assert.IsFalse(fixture.Document.IsDirty);
+    }
+
+    [TestMethod]
+    public void StateParentsKeepNestedGraphStateSeparate()
+    {
+        using var fixture = new GraphDocumentTestFixture("mod\\test.questphase");
+        fixture.EnableStateLoading();
+        fixture.EnableStateLoading(".phase_7");
+
+        SaveGraphLocation(fixture, "", new Point(10, 20));
+        SaveGraphLocation(fixture, ".phase_7", new Point(70, 80));
+
+        Assert.AreEqual(new Point(10, 20), LoadGraphLocation(fixture, ""));
+        Assert.AreEqual(new Point(70, 80), LoadGraphLocation(fixture, ".phase_7"));
+    }
+
+    [TestMethod]
+    public void DisposingGraphUnsubscribesFromNodePropertyUpdates()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        GraphTestHelpers.AddSceneOutput(start);
+        var resource = GraphTestHelpers.CreateSceneResource(start);
+        var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+        var wrapper = graph.Nodes.Single();
+        var notifications = 0;
+        wrapper.PropertyChanged += (_, _) => notifications++;
+
+        NodePropertyUpdateService.NotifyPropertyUpdated(wrapper.Data);
+        Assert.IsTrue(notifications > 0);
+
+        graph.Dispose();
+        notifications = 0;
+        NodePropertyUpdateService.NotifyPropertyUpdated(wrapper.Data);
+
+        Assert.AreEqual(0, notifications);
+    }
+
+    private static void AttachDocument(RedGraph graph, WolvenKit.App.ViewModels.Documents.RedDocumentViewModel document)
+    {
+        graph.DocumentViewModel = document;
+        foreach (var node in graph.Nodes)
+        {
+            node.DocumentViewModel = document;
+        }
+    }
+
+    private static void SaveGraphLocation(GraphDocumentTestFixture fixture, string stateParents, Point location)
+    {
+        var node = new questStartNodeDefinition { Id = 1 };
+        var graphData = GraphTestHelpers.CreateQuestGraph(node);
+        using var graph = RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+        AttachDocument(graph, fixture.Document);
+        graph.StateParents = stateParents;
+        graph.GraphStateLoad();
+        graph.Nodes.Single().Location = location;
+        graph.GraphStateSave();
+    }
+
+    private static Point LoadGraphLocation(GraphDocumentTestFixture fixture, string stateParents)
+    {
+        var node = new questStartNodeDefinition { Id = 1 };
+        var graphData = GraphTestHelpers.CreateQuestGraph(node);
+        using var graph = RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+        AttachDocument(graph, fixture.Document);
+        graph.StateParents = stateParents;
+        graph.GraphStateLoad();
+        return graph.Nodes.Single().Location;
+    }
+
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Quest/QuestGraphTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Quest/QuestGraphTests.cs
@@ -149,6 +149,51 @@ public class QuestGraphTests
     }
 
     [TestMethod]
+    public void RefreshDetailsReflectsChangesToQuestNodeData()
+    {
+        var graphData = GraphTestHelpers.CreateQuestGraph();
+        using var graph = GenerateGraph(graphData);
+        graph.CreateQuestNode(typeof(questFactsDBManagerNodeDefinition), new Point());
+        var wrapper = graph.Nodes.OfType<questFactsDBManagerNodeDefinitionWrapper>().Single();
+        var node = (questFactsDBManagerNodeDefinition)wrapper.Data;
+        var nodeType = (questSetVar_NodeType)node.Type.GetValue()!;
+        nodeType.FactName = "first_fact";
+        nodeType.Value = 1;
+        wrapper.RefreshDetails();
+
+        Assert.AreEqual("first_fact", wrapper.Details["Fact Name"]);
+        Assert.AreEqual("1", wrapper.Details["Value"]);
+
+        nodeType.FactName = "updated_fact";
+        nodeType.Value = 2;
+        wrapper.RefreshDetails();
+
+        Assert.AreEqual("updated_fact", wrapper.Details["Fact Name"]);
+        Assert.AreEqual("2", wrapper.Details["Value"]);
+        Assert.IsFalse(wrapper.Details.ContainsValue("first_fact"));
+    }
+
+    [TestMethod]
+    public void GenerateGraphSkipsConnectionToSocketOutsideGraph()
+    {
+        var start = new questStartNodeDefinition { Id = 1 };
+        var output = GraphTestHelpers.AddQuestSocket(start, "Out", Enums.questSocketType.Output);
+        var orphanInput = new questSocketDefinition
+        {
+            Name = "In",
+            Type = Enums.questSocketType.Input
+        };
+        GraphTestHelpers.ConnectQuestSockets(output, orphanInput);
+        var graphData = GraphTestHelpers.CreateQuestGraph(start);
+
+        using var graph = GenerateGraph(graphData);
+
+        Assert.AreEqual(1, graph.Nodes.Count);
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(1, output.Connections.Count);
+    }
+
+    [TestMethod]
     public void LoadingExistingSocketsDoesNotDuplicateThem()
     {
         var node = new questStartNodeDefinition { Id = 1 };

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Quest/QuestGraphTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Quest/QuestGraphTests.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WolvenKit.App.Factories;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.RED4.Types;
+using WolvenKit.UnitTests.App.GraphEditor.Shared;
+using Point = System.Windows.Point;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Quest;
+
+[TestClass]
+[DoNotParallelize]
+public class QuestGraphTests
+{
+    [TestMethod]
+    public void GenerateGraphCreatesExpectedWrappersAndConnection()
+    {
+        var start = new questStartNodeDefinition { Id = 1 };
+        GraphTestHelpers.AddQuestSocket(start, "CutDestination", Enums.questSocketType.CutDestination);
+        var output = GraphTestHelpers.AddQuestSocket(start, "Out", Enums.questSocketType.Output);
+
+        var end = new questEndNodeDefinition { Id = 2 };
+        GraphTestHelpers.AddQuestSocket(end, "CutDestination", Enums.questSocketType.CutDestination);
+        var input = GraphTestHelpers.AddQuestSocket(end, "In", Enums.questSocketType.Input);
+        var connectionData = GraphTestHelpers.ConnectQuestSockets(output, input);
+        var graphData = GraphTestHelpers.CreateQuestGraph(start, end);
+
+        using var graph = GenerateGraph(graphData);
+
+        Assert.AreEqual(RedGraphType.Quest, graph.GraphType);
+        Assert.AreEqual(2, graph.Nodes.Count);
+        Assert.AreEqual(2, graph.CanvasItems.Count);
+        Assert.IsInstanceOfType(graph.Nodes[0], typeof(questStartNodeDefinitionWrapper));
+        Assert.IsInstanceOfType(graph.Nodes[1], typeof(questEndNodeDefinitionWrapper));
+
+        var connection = graph.Connections.Cast<QuestConnectionViewModel>().Single();
+        Assert.AreSame(connectionData, connection.ConnectionDefinition);
+        Assert.AreSame(output, ((QuestOutputConnectorViewModel)connection.Source).Data);
+        Assert.AreSame(input, ((QuestInputConnectorViewModel)connection.Target).Data);
+        Assert.IsTrue(connection.Source.IsConnected);
+        Assert.IsTrue(connection.Target.IsConnected);
+    }
+
+    [TestMethod]
+    public void ConnectAndDisconnectSynchronizesBackingSockets()
+    {
+        var graphData = GraphTestHelpers.CreateQuestGraph();
+        using var graph = GenerateGraph(graphData);
+        graph.CreateQuestNode(typeof(questStartNodeDefinition), new Point());
+        graph.CreateQuestNode(typeof(questEndNodeDefinition), new Point());
+
+        var source = graph.Nodes
+            .OfType<questStartNodeDefinitionWrapper>()
+            .Single()
+            .Output
+            .Cast<QuestOutputConnectorViewModel>()
+            .Single();
+        var target = graph.Nodes
+            .OfType<questEndNodeDefinitionWrapper>()
+            .Single()
+            .Input
+            .Cast<QuestInputConnectorViewModel>()
+            .Single(connector => connector.Name == "In");
+
+        graph.PendingConnection.Source = source;
+        graph.PendingConnection.Target = target;
+        graph.Connect();
+
+        var connection = graph.Connections.Cast<QuestConnectionViewModel>().Single();
+        Assert.AreEqual(1, source.Data.Connections.Count);
+        Assert.AreEqual(1, target.Data.Connections.Count);
+        Assert.AreSame(source.Data, connection.ConnectionDefinition.Source.GetValue());
+        Assert.AreSame(target.Data, connection.ConnectionDefinition.Destination.GetValue());
+
+        graph.RemoveQuestConnectionPublic(connection);
+
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(0, source.Data.Connections.Count);
+        Assert.AreEqual(0, target.Data.Connections.Count);
+        Assert.IsFalse(source.IsConnected);
+        Assert.IsFalse(target.IsConnected);
+    }
+
+    [TestMethod]
+    public void RemoveNodeRemovesBackingNodeAndIncidentConnections()
+    {
+        var graphData = GraphTestHelpers.CreateQuestGraph();
+        using var graph = GenerateGraph(graphData);
+        graph.CreateQuestNode(typeof(questStartNodeDefinition), new Point());
+        graph.CreateQuestNode(typeof(questEndNodeDefinition), new Point());
+
+        var sourceNode = graph.Nodes.OfType<questStartNodeDefinitionWrapper>().Single();
+        var targetNode = graph.Nodes.OfType<questEndNodeDefinitionWrapper>().Single();
+        graph.PendingConnection.Source = sourceNode.Output.Single();
+        graph.PendingConnection.Target = targetNode.Input.Single(connector => connector.Name == "In");
+        graph.Connect();
+
+        graph.RemoveNode(targetNode);
+
+        Assert.AreEqual(1, graph.Nodes.Count);
+        Assert.AreEqual(1, graph.CanvasItems.Count);
+        Assert.AreEqual(1, graphData.Nodes.Count);
+        Assert.AreSame(sourceNode.Data, graphData.Nodes[0].GetValue());
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(0, ((QuestOutputConnectorViewModel)sourceNode.Output.Single()).Data.Connections.Count);
+    }
+
+    [TestMethod]
+    public void CreateNodeUsesNextIdAndCreatesDefaultSockets()
+    {
+        var existing = new questStartNodeDefinition { Id = 7 };
+        var graphData = GraphTestHelpers.CreateQuestGraph(existing);
+        using var graph = GenerateGraph(graphData);
+
+        graph.CreateQuestNode(typeof(questStartNodeDefinition), new Point(10, 20));
+        graph.CreateQuestNode(typeof(questEndNodeDefinition), new Point(30, 40));
+
+        var start = graph.Nodes.OfType<questStartNodeDefinitionWrapper>().Single(node => node.UniqueId == 8);
+        var end = graph.Nodes.OfType<questEndNodeDefinitionWrapper>().Single();
+
+        Assert.AreEqual(8U, start.UniqueId);
+        Assert.AreEqual(9U, end.UniqueId);
+        CollectionAssert.AreEqual(new[] { "CutDestination" }, start.Input.Select(connector => connector.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "Out" }, start.Output.Select(connector => connector.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "CutDestination", "In" }, end.Input.Select(connector => connector.Name).ToArray());
+        Assert.AreEqual(0, end.Output.Count);
+        Assert.AreEqual(3, graphData.Nodes.Count);
+        Assert.AreEqual(new Point(10, 20), start.Location);
+    }
+
+    [TestMethod]
+    public void CreateFactsDbNodeInitializesItsOnlySupportedType()
+    {
+        var graphData = GraphTestHelpers.CreateQuestGraph();
+        using var graph = GenerateGraph(graphData);
+
+        graph.CreateQuestNode(typeof(questFactsDBManagerNodeDefinition), new Point());
+
+        var wrapper = graph.Nodes.OfType<questFactsDBManagerNodeDefinitionWrapper>().Single();
+        var node = (questFactsDBManagerNodeDefinition)wrapper.Data;
+        Assert.IsInstanceOfType(node.Type.GetValue(), typeof(questSetVar_NodeType));
+        CollectionAssert.AreEqual(
+            new[] { "CutDestination", "In" },
+            wrapper.Input.Select(connector => connector.Name).ToArray());
+        CollectionAssert.AreEqual(new[] { "Out" }, wrapper.Output.Select(connector => connector.Name).ToArray());
+    }
+
+    [TestMethod]
+    public void LoadingExistingSocketsDoesNotDuplicateThem()
+    {
+        var node = new questStartNodeDefinition { Id = 1 };
+        GraphTestHelpers.AddQuestSocket(node, "CutDestination", Enums.questSocketType.CutDestination);
+        GraphTestHelpers.AddQuestSocket(node, "Out", Enums.questSocketType.Output);
+        var graphData = GraphTestHelpers.CreateQuestGraph(node);
+
+        using var graph = GenerateGraph(graphData);
+
+        Assert.AreEqual(2, node.Sockets.Count);
+        Assert.AreEqual(1, graph.Nodes.Single().Input.Count);
+        Assert.AreEqual(1, graph.Nodes.Single().Output.Count);
+    }
+
+    private static RedGraph GenerateGraph(questGraphDefinition graphData) =>
+        RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/SceneGraphTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/SceneGraphTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
+using WolvenKit.RED4.Types;
+using WolvenKit.UnitTests.App.GraphEditor.Shared;
+using Point = System.Windows.Point;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Scene;
+
+[TestClass]
+[DoNotParallelize]
+public class SceneGraphTests
+{
+    [TestMethod]
+    public void GenerateGraphCreatesExpectedWrappersAndConnection()
+    {
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        var output = GraphTestHelpers.AddSceneOutput(start);
+        var end = new scnEndNode { NodeId = new scnNodeId { Id = 2 } };
+        var destination = GraphTestHelpers.ConnectSceneSocket(output, end.NodeId.Id);
+        var resource = GraphTestHelpers.CreateSceneResource(start, end);
+
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+
+        Assert.AreEqual(RedGraphType.Scene, graph.GraphType);
+        Assert.AreEqual(2, graph.Nodes.Count);
+        Assert.AreEqual(2, graph.CanvasItems.Count);
+        Assert.IsInstanceOfType(graph.Nodes[0], typeof(scnStartNodeWrapper));
+        Assert.IsInstanceOfType(graph.Nodes[1], typeof(scnEndNodeWrapper));
+
+        var connection = graph.Connections.Cast<SceneConnectionViewModel>().Single();
+        Assert.AreSame(output, ((SceneOutputConnectorViewModel)connection.Source).Data);
+        Assert.AreEqual((uint)destination.NodeId.Id, connection.Target.OwnerId);
+        Assert.AreEqual((ushort)destination.IsockStamp.Name, ((SceneInputConnectorViewModel)connection.Target).NameId);
+        Assert.AreEqual((ushort)destination.IsockStamp.Ordinal, ((SceneInputConnectorViewModel)connection.Target).Ordinal);
+        Assert.IsTrue(connection.Source.IsConnected);
+        Assert.IsTrue(connection.Target.IsConnected);
+    }
+
+    [TestMethod]
+    public void ConnectAndDisconnectSynchronizesBackingSocket()
+    {
+        var resource = GraphTestHelpers.CreateSceneResource();
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        graph.CreateSceneNode(typeof(scnStartNode), new Point());
+        graph.CreateSceneNode(typeof(scnEndNode), new Point());
+
+        var source = graph.Nodes
+            .OfType<scnStartNodeWrapper>()
+            .Single()
+            .Output
+            .Cast<SceneOutputConnectorViewModel>()
+            .Single();
+        var target = graph.Nodes
+            .OfType<scnEndNodeWrapper>()
+            .Single()
+            .Input
+            .Cast<SceneInputConnectorViewModel>()
+            .Single();
+
+        graph.PendingConnection.Source = source;
+        graph.PendingConnection.Target = target;
+        graph.Connect();
+
+        var connection = graph.Connections.Cast<SceneConnectionViewModel>().Single();
+        var destination = source.Data!.Destinations.Single();
+        Assert.AreEqual(target.OwnerId, (uint)destination.NodeId.Id);
+        Assert.AreEqual(target.NameId, (ushort)destination.IsockStamp.Name);
+        Assert.AreEqual(target.Ordinal, (ushort)destination.IsockStamp.Ordinal);
+
+        graph.RemoveSceneConnectionPublic(connection);
+
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(0, source.Data.Destinations.Count);
+        Assert.IsFalse(source.IsConnected);
+        Assert.IsFalse(target.IsConnected);
+    }
+
+    [TestMethod]
+    public void RemoveNodeRemovesBackingNodeAndIncidentConnections()
+    {
+        var resource = GraphTestHelpers.CreateSceneResource();
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        graph.CreateSceneNode(typeof(scnStartNode), new Point());
+        graph.CreateSceneNode(typeof(scnEndNode), new Point());
+
+        var sourceNode = graph.Nodes.OfType<scnStartNodeWrapper>().Single();
+        var targetNode = graph.Nodes.OfType<scnEndNodeWrapper>().Single();
+        graph.PendingConnection.Source = sourceNode.Output.Single();
+        graph.PendingConnection.Target = targetNode.Input.Single();
+        graph.Connect();
+
+        graph.RemoveNode(targetNode);
+
+        Assert.AreEqual(1, graph.Nodes.Count);
+        Assert.AreEqual(1, graph.CanvasItems.Count);
+        Assert.AreEqual(1, resource.SceneGraph.Chunk!.Graph.Count);
+        Assert.AreSame(sourceNode.Data, resource.SceneGraph.Chunk.Graph[0].GetValue());
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(0, ((SceneOutputConnectorViewModel)sourceNode.Output.Single()).Data!.Destinations.Count);
+    }
+
+    [TestMethod]
+    public void CreateNodeUsesNextIdAndCreatesStandardSockets()
+    {
+        var existing = new scnAndNode { NodeId = new scnNodeId { Id = 7 } };
+        var resource = GraphTestHelpers.CreateSceneResource(existing);
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+
+        var id = graph.CreateSceneNode(typeof(scnAndNode), new Point(10, 20));
+
+        var wrapper = graph.Nodes.OfType<scnAndNodeWrapper>().Single(node => node.UniqueId == id);
+        Assert.AreEqual(8U, id);
+        CollectionAssert.AreEqual(new[] { "In", "Cancel" }, wrapper.Input.Select(connector => connector.Name).ToArray());
+        Assert.AreEqual(1, wrapper.Output.Count);
+        var output = (SceneOutputConnectorViewModel)wrapper.Output.Single();
+        Assert.AreEqual((ushort)0, output.NameId);
+        Assert.AreEqual((ushort)0, output.Ordinal);
+        Assert.AreEqual(2, resource.SceneGraph.Chunk!.Graph.Count);
+        Assert.AreEqual(new Point(10, 20), wrapper.Location);
+    }
+
+    [TestMethod]
+    public void CreateEmbeddedQuestNodeKeepsSceneAndQuestIdsAndSocketsInSync()
+    {
+        var resource = GraphTestHelpers.CreateSceneResource();
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+
+        var id = graph.CreateSceneNode(typeof(questConditionNodeDefinition), new Point());
+
+        var wrapper = graph.Nodes.OfType<scnQuestNodeWrapper>().Single();
+        var sceneNode = (scnQuestNode)wrapper.Data;
+        Assert.AreEqual(id, (uint)sceneNode.NodeId.Id);
+        Assert.AreEqual((ushort)id, (ushort)sceneNode.QuestNode.Chunk!.Id);
+        Assert.IsInstanceOfType(sceneNode.QuestNode.GetValue(), typeof(questConditionNodeDefinition));
+        CollectionAssert.AreEqual(
+            new[] { "CutDestination", "In" },
+            wrapper.Input.Select(connector => connector.Name).ToArray());
+        CollectionAssert.AreEqual(
+            new[] { "True", "False" },
+            wrapper.Output.Select(connector => connector.Subtitle).ToArray());
+        Assert.AreEqual(2, sceneNode.OutputSockets.Count);
+    }
+
+    [TestMethod]
+    public void AddAndRemoveDynamicInputKeepsCancelAndBackingCountInSync()
+    {
+        var node = new scnAndNode
+        {
+            NodeId = new scnNodeId { Id = 1 },
+            NumInSockets = 2
+        };
+        GraphTestHelpers.AddSceneOutput(node);
+        var resource = GraphTestHelpers.CreateSceneResource(node);
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        var wrapper = graph.Nodes.OfType<scnAndNodeWrapper>().Single();
+
+        var connector = (SceneInputConnectorViewModel)wrapper.AddInput();
+
+        Assert.AreEqual((ushort)0, connector.NameId);
+        Assert.AreEqual((ushort)1, connector.Ordinal);
+        Assert.AreEqual(3U, (uint)node.NumInSockets);
+        Assert.AreEqual(3, wrapper.Input.Count);
+
+        wrapper.RemoveInput();
+
+        CollectionAssert.AreEqual(new[] { "In", "Cancel" }, wrapper.Input.Select(input => input.Name).ToArray());
+        Assert.AreEqual(2U, (uint)node.NumInSockets);
+    }
+
+    [TestMethod]
+    public void AddAndRemoveDynamicXorInputKeepsCancelSocket()
+    {
+        AssertDynamicInputRemovalKeepsCancel(new scnXorNode(), typeof(scnXorNodeWrapper));
+    }
+
+    [TestMethod]
+    public void AddAndRemoveDynamicHubInputKeepsCancelSocket()
+    {
+        AssertDynamicInputRemovalKeepsCancel(new scnHubNode(), typeof(scnHubNodeWrapper));
+    }
+
+    private static void AssertDynamicInputRemovalKeepsCancel(scnSceneGraphNode node, Type wrapperType)
+    {
+        node.NodeId = new scnNodeId { Id = 1 };
+        GraphTestHelpers.AddSceneOutput(node);
+        var resource = GraphTestHelpers.CreateSceneResource(node);
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        var wrapper = (BaseSceneViewModel)graph.Nodes.Single(candidate => candidate.GetType() == wrapperType);
+        var dynamicInput = (IDynamicInputNode)wrapper;
+
+        var connector = (SceneInputConnectorViewModel)dynamicInput.AddInput();
+
+        Assert.AreEqual((ushort)0, connector.NameId);
+        Assert.AreEqual((ushort)1, connector.Ordinal);
+
+        dynamicInput.RemoveInput();
+
+        CollectionAssert.AreEqual(new[] { "In", "Cancel" }, wrapper.Input.Select(input => input.Name).ToArray());
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/SceneGraphTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/SceneGraphTests.cs
@@ -146,6 +146,73 @@ public class SceneGraphTests
     }
 
     [TestMethod]
+    public void RefreshDetailsReflectsChangesToEmbeddedQuestNodeData()
+    {
+        var resource = GraphTestHelpers.CreateSceneResource();
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        graph.CreateSceneNode(typeof(questFactsDBManagerNodeDefinition), new Point());
+        var wrapper = graph.Nodes.OfType<scnQuestNodeWrapper>().Single();
+        var sceneNode = (scnQuestNode)wrapper.Data;
+        var factsNode = (questFactsDBManagerNodeDefinition)sceneNode.QuestNode.GetValue()!;
+        var nodeType = (questSetVar_NodeType)factsNode.Type.GetValue()!;
+        nodeType.FactName = "first_fact";
+        nodeType.Value = 1;
+        wrapper.RefreshDetails();
+
+        Assert.AreEqual("first_fact", wrapper.Details["Fact Name"]);
+        Assert.AreEqual("1", wrapper.Details["Value"]);
+
+        nodeType.FactName = "updated_fact";
+        nodeType.Value = 2;
+        wrapper.RefreshDetails();
+
+        Assert.AreEqual("updated_fact", wrapper.Details["Fact Name"]);
+        Assert.AreEqual("2", wrapper.Details["Value"]);
+        Assert.IsFalse(wrapper.Details.ContainsValue("first_fact"));
+    }
+
+    [TestMethod]
+    public void RefreshFromDataPreservesSceneConnectorsAndConnection()
+    {
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        var output = GraphTestHelpers.AddSceneOutput(start);
+        var end = new scnEndNode { NodeId = new scnNodeId { Id = 2 } };
+        GraphTestHelpers.ConnectSceneSocket(output, end.NodeId.Id);
+        var resource = GraphTestHelpers.CreateSceneResource(start, end);
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+        var startWrapper = graph.Nodes.OfType<scnStartNodeWrapper>().Single();
+        var endWrapper = graph.Nodes.OfType<scnEndNodeWrapper>().Single();
+        var source = startWrapper.Output.Single();
+        var target = endWrapper.Input.Single();
+        var connection = graph.Connections.Single();
+
+        startWrapper.RefreshFromData();
+        endWrapper.RefreshFromData();
+
+        Assert.AreSame(source, startWrapper.Output.Single());
+        Assert.AreSame(target, endWrapper.Input.Single());
+        Assert.AreSame(source, connection.Source);
+        Assert.AreSame(target, connection.Target);
+        Assert.IsTrue(source.IsConnected);
+        Assert.IsTrue(target.IsConnected);
+    }
+
+    [TestMethod]
+    public void GenerateGraphSkipsDestinationForNodeOutsideGraph()
+    {
+        var start = new scnStartNode { NodeId = new scnNodeId { Id = 1 } };
+        var output = GraphTestHelpers.AddSceneOutput(start);
+        GraphTestHelpers.ConnectSceneSocket(output, 999);
+        var resource = GraphTestHelpers.CreateSceneResource(start);
+
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource);
+
+        Assert.AreEqual(1, graph.Nodes.Count);
+        Assert.AreEqual(0, graph.Connections.Count);
+        Assert.AreEqual(1, output.Destinations.Count);
+    }
+
+    [TestMethod]
     public void AddAndRemoveDynamicInputKeepsCancelAndBackingCountInSync()
     {
         var node = new scnAndNode

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphDocumentTestFixture.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphDocumentTestFixture.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Documents;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Shared;
+
+internal sealed class GraphDocumentTestFixture : IDisposable
+{
+    private const string EmptyState = """
+        {"EditorX":0,"EditorY":0,"EditorZ":0,"Nodes":[]}
+        """;
+
+    public GraphDocumentTestFixture(string relativePath = "mod\\test.scene")
+    {
+        ProjectDirectory = Path.Combine(Path.GetTempPath(), "WolvenKit.GraphTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(ProjectDirectory);
+
+        var project = new Cp77Project(
+            Path.Combine(ProjectDirectory, "GraphTests.cpmodproj"),
+            "GraphTests",
+            "GraphTests");
+        var projectManager = new Mock<IProjectManager>();
+        projectManager.SetupGet(manager => manager.ActiveProject).Returns(project);
+
+        // The production constructor builds the complete tab UI; graph lifecycle tests only need this state.
+        Document = (RedDocumentViewModel)RuntimeHelpers.GetUninitializedObject(typeof(RedDocumentViewModel));
+        SetPrivateField(Document, "_projectManager", projectManager.Object);
+        SetPrivateField(Document, "_path", relativePath);
+        Document.ContentId = relativePath;
+        Document.FilePath = relativePath;
+        Document.TabItemViewModels = new ObservableCollection<RedDocumentTabViewModel>();
+        Document.SetIsDirty(false);
+    }
+
+    public RedDocumentViewModel Document { get; }
+
+    public string ProjectDirectory { get; }
+
+    public string GetStatePath(string stateParents = "", string extension = ".json") =>
+        Path.Combine(ProjectDirectory, "GraphEditorStates", Document.RelativePath + stateParents + extension);
+
+    public void EnableStateLoading(string stateParents = "")
+    {
+        var statePath = GetStatePath(stateParents);
+        Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+        File.WriteAllText(statePath, EmptyState);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(ProjectDirectory))
+        {
+            Directory.Delete(ProjectDirectory, true);
+        }
+    }
+
+    private static void SetPrivateField<T>(T target, string fieldName, object value)
+    {
+        var field = typeof(T).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic) ??
+                    throw new InvalidOperationException($"Could not find field {fieldName} on {typeof(T).Name}.");
+        field.SetValue(target, value);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphTestHelpers.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphTestHelpers.cs
@@ -1,0 +1,95 @@
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Shared;
+
+internal static class GraphTestHelpers
+{
+    public static questGraphDefinition CreateQuestGraph(params graphGraphNodeDefinition[] nodes)
+    {
+        var graph = new questGraphDefinition();
+        foreach (var node in nodes)
+        {
+            graph.Nodes.Add(new CHandle<graphGraphNodeDefinition>(node));
+        }
+
+        return graph;
+    }
+
+    public static questSocketDefinition AddQuestSocket(
+        graphGraphNodeDefinition node,
+        string name,
+        Enums.questSocketType type)
+    {
+        var socket = new questSocketDefinition { Name = name, Type = type };
+        node.Sockets.Add(new CHandle<graphGraphSocketDefinition>(socket));
+        return socket;
+    }
+
+    public static graphGraphConnectionDefinition ConnectQuestSockets(
+        questSocketDefinition source,
+        questSocketDefinition destination)
+    {
+        var connection = new graphGraphConnectionDefinition
+        {
+            Source = new CWeakHandle<graphGraphSocketDefinition>(source),
+            Destination = new CWeakHandle<graphGraphSocketDefinition>(destination)
+        };
+
+        source.Connections.Add(new CHandle<graphGraphConnectionDefinition>(connection));
+        destination.Connections.Add(new CHandle<graphGraphConnectionDefinition>(connection));
+        return connection;
+    }
+
+    public static scnSceneResource CreateSceneResource(params scnSceneGraphNode[] nodes)
+    {
+        var sceneGraph = new scnSceneGraph();
+        var resource = new scnSceneResource
+        {
+            SceneGraph = new CHandle<scnSceneGraph>(sceneGraph)
+        };
+
+        foreach (var node in nodes)
+        {
+            sceneGraph.Graph.Add(new CHandle<scnSceneGraphNode>(node));
+
+            if (node is scnStartNode)
+            {
+                resource.EntryPoints.Add(new scnEntryPoint { NodeId = new scnNodeId { Id = node.NodeId.Id } });
+            }
+            else if (node is scnEndNode)
+            {
+                resource.ExitPoints.Add(new scnExitPoint { NodeId = new scnNodeId { Id = node.NodeId.Id } });
+            }
+        }
+
+        return resource;
+    }
+
+    public static scnOutputSocket AddSceneOutput(
+        scnSceneGraphNode node,
+        ushort name = 0,
+        ushort ordinal = 0)
+    {
+        var socket = new scnOutputSocket
+        {
+            Stamp = new scnOutputSocketStamp { Name = name, Ordinal = ordinal }
+        };
+        node.OutputSockets.Add(socket);
+        return socket;
+    }
+
+    public static scnInputSocketId ConnectSceneSocket(
+        scnOutputSocket source,
+        uint targetNodeId,
+        ushort inputName = 0,
+        ushort inputOrdinal = 0)
+    {
+        var destination = new scnInputSocketId
+        {
+            NodeId = new scnNodeId { Id = targetNodeId },
+            IsockStamp = new scnInputSocketStamp { Name = inputName, Ordinal = inputOrdinal }
+        };
+        source.Destinations.Add(destination);
+        return destination;
+    }
+}

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnAndNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnAndNodeWrapper.cs
@@ -131,12 +131,17 @@ public class scnAndNodeWrapper : BaseSceneViewModel<scnAndNode>, IDynamicInputNo
 
     public void RemoveInput()
     {
-        // Only remove if we have more than the base socket count
-        if (Input.Count > InputSocketNames.Count)
+        var removableSocket = Input
+            .OfType<SceneInputConnectorViewModel>()
+            .Where(input => input.NameId == 0 && input.Ordinal > 0)
+            .OrderByDescending(input => input.Ordinal)
+            .FirstOrDefault();
+
+        if (removableSocket != null)
         {
-            Input.Remove(Input[^1]);
+            Input.Remove(removableSocket);
             _castedData.NumInSockets--;
-            
+
             // Notify UI and mark document dirty
             NotifySocketsChanged();
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnAndNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnAndNodeWrapper.cs
@@ -137,13 +137,15 @@ public class scnAndNodeWrapper : BaseSceneViewModel<scnAndNode>, IDynamicInputNo
             .OrderByDescending(input => input.Ordinal)
             .FirstOrDefault();
 
-        if (removableSocket != null)
+        if (removableSocket == null)
         {
-            Input.Remove(removableSocket);
-            _castedData.NumInSockets--;
-
-            // Notify UI and mark document dirty
-            NotifySocketsChanged();
+            return;
         }
+
+        Input.Remove(removableSocket);
+        _castedData.NumInSockets--;
+
+        // Notify UI and mark document dirty
+        NotifySocketsChanged();
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnHubNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnHubNodeWrapper.cs
@@ -118,13 +118,18 @@ public class scnHubNodeWrapper : BaseSceneViewModel<scnHubNode>, IDynamicInputNo
         };
     }
 
-    public void RemoveInput() 
+    public void RemoveInput()
     {
-        // Only remove if we have more than the base socket count
-        if (Input.Count > InputSocketNames.Count)
+        var removableSocket = Input
+            .OfType<SceneInputConnectorViewModel>()
+            .Where(input => input.NameId == 0 && input.Ordinal > 0)
+            .OrderByDescending(input => input.Ordinal)
+            .FirstOrDefault();
+
+        if (removableSocket != null)
         {
-            Input.Remove(Input[^1]);
-            
+            Input.Remove(removableSocket);
+
             // Notify UI and mark document dirty
             NotifySocketsChanged();
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnHubNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnHubNodeWrapper.cs
@@ -126,12 +126,14 @@ public class scnHubNodeWrapper : BaseSceneViewModel<scnHubNode>, IDynamicInputNo
             .OrderByDescending(input => input.Ordinal)
             .FirstOrDefault();
 
-        if (removableSocket != null)
+        if (removableSocket == null)
         {
-            Input.Remove(removableSocket);
-
-            // Notify UI and mark document dirty
-            NotifySocketsChanged();
+            return;
         }
+
+        Input.Remove(removableSocket);
+
+        // Notify UI and mark document dirty
+        NotifySocketsChanged();
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnXorNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnXorNodeWrapper.cs
@@ -126,12 +126,14 @@ public class scnXorNodeWrapper : BaseSceneViewModel<scnXorNode>, IDynamicInputNo
             .OrderByDescending(input => input.Ordinal)
             .FirstOrDefault();
 
-        if (removableSocket != null)
+        if (removableSocket == null)
         {
-            Input.Remove(removableSocket);
-
-            // Notify UI and mark document dirty
-            NotifySocketsChanged();
+            return;
         }
+
+        Input.Remove(removableSocket);
+
+        // Notify UI and mark document dirty
+        NotifySocketsChanged();
     }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnXorNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnXorNodeWrapper.cs
@@ -118,13 +118,18 @@ public class scnXorNodeWrapper : BaseSceneViewModel<scnXorNode>, IDynamicInputNo
         };
     }
 
-    public void RemoveInput() 
+    public void RemoveInput()
     {
-        // Only remove if we have more than the base socket count
-        if (Input.Count > InputSocketNames.Count)
+        var removableSocket = Input
+            .OfType<SceneInputConnectorViewModel>()
+            .Where(input => input.NameId == 0 && input.Ordinal > 0)
+            .OrderByDescending(input => input.Ordinal)
+            .FirstOrDefault();
+
+        if (removableSocket != null)
         {
-            Input.Remove(Input[^1]);
-            
+            Input.Remove(removableSocket);
+
             // Notify UI and mark document dirty
             NotifySocketsChanged();
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -119,6 +119,8 @@ public partial class RedGraph
         }
 
         Nodes.Add(wrappedInstance);
+
+        DocumentViewModel?.SetIsDirty(true);
     }
 
     private graphGraphNodeDefinition InternalCreateQuestNode(Type type)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -491,6 +491,10 @@ public partial class RedGraph : IDisposable
     {
         var loaded = false;
         _allowGraphSave = false;
+        foreach (var node in Nodes)
+        {
+            node.IsInitialLoad = true;
+        }
 
         if (DocumentViewModel != null)
         {


### PR DESCRIPTION
adds some foundational unit test coverage for GraphEditor

- Graph generation, node mutation, and connection sync
- Default and dynamic socket behavior
- Node detail refresh
- Dangling connection handling
- Document dirty state
- Graph layout, socket visibility, and comment persistence
- Nested graph state isolation and subscription cleanup

The tests also identified three bugs, i snuck in the fixes in this pr: 
- Creating a quest node did not mark the document dirty
- Loading saved socket visibility could mark a scene dirty on open
- Dynamic input removal could remove the fixed Cancel socket (this method wasnt used by the UI yet so no user impact)