### PR TITLE
feat: add graph action palette

### DIFF
--- a/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
+++ b/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
@@ -54,7 +54,7 @@ public partial class RedTypeTemplateDropdownViewModel : ObservableObject
         SelectedRedTypeTemplate = ((List<RedTypeTemplateSelectionOption>)CurrentRedTypeTemplates.Source).First();
 
         RequestedType = typeof(object);
-        _ = Refresh();
+        RefreshFromRegistry();
     }
 
     partial void OnRequestedTypeChanged(Type value)
@@ -89,8 +89,9 @@ public partial class RedTypeTemplateDropdownViewModel : ObservableObject
     {
         TemplatesByType.Clear();
 
-        IndexTemplates(_redTypeTemplateService.UserTemplates, RedTypeTemplateSelectionOptionSource.User);
-        IndexTemplates(_redTypeTemplateService.SystemTemplates, RedTypeTemplateSelectionOptionSource.System);
+        var templates = _redTypeTemplateService.GetTemplateRegistrySnapshot();
+        IndexTemplates(templates.User, RedTypeTemplateSelectionOptionSource.User);
+        IndexTemplates(templates.System, RedTypeTemplateSelectionOptionSource.System);
 
         foreach (var kvp in TemplatesByType)
         {

--- a/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
+++ b/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
@@ -66,17 +66,21 @@ public partial class RedTypeTemplateDropdownViewModel : ObservableObject
         ApplyTemplateCustomSort(CurrentRedTypeTemplates);
     }
 
+    public void RefreshFromRegistry()
+    {
+        IndexRedTypeTemplates();
+        CurrentRedTypeTemplates.Source = TemplatesByType.TryGetValue(RequestedType, out var list) ? list : _defaultList;
+        SelectedRedTypeTemplate = GetInitialTemplateForSelectedFile();
+        CurrentRedTypeTemplates.View.Refresh();
+        ApplyTemplateCustomSort(CurrentRedTypeTemplates);
+    }
+
     [RelayCommand]
     private async Task Refresh()
     {
         await Task.Run(() => RedTypeTemplateServiceHelper.UpdateSystemTemplatesFromRemote(_loggerService));
         _redTypeTemplateService.LoadTemplates();
-
-        IndexRedTypeTemplates();
-        CurrentRedTypeTemplates.Source = TemplatesByType.TryGetValue(RequestedType, out var list) ? list : _defaultList;
-        SelectedRedTypeTemplate = GetInitialTemplateForSelectedFile();
-        CurrentRedTypeTemplates?.View.Refresh();
-        ApplyTemplateCustomSort(CurrentRedTypeTemplates);
+        RefreshFromRegistry();
 
         PostRefresh?.Invoke(this, EventArgs.Empty);
     }

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/NodeProperties.cs
@@ -274,9 +274,19 @@ internal class NodeProperties
         }
         else if (node is questEventManagerNodeDefinition eventManagerNodeCasted)
         {
-            details["Component Name"] = eventManagerNodeCasted?.ComponentName.ToString()!;
+            var componentName = eventManagerNodeCasted.ComponentName.GetResolvedText();
+            if (!string.IsNullOrEmpty(componentName) && componentName != "None")
+            {
+                details["Component Name"] = componentName;
+            }
+
             details["Event"] = eventManagerNodeCasted?.Event?.Chunk?.GetType()?.Name!;
 
+            if (eventManagerNodeCasted?.Event?.Chunk is QuestExecuteTransition executeTransition)
+            {
+                var transition = executeTransition.Transition;
+                details["Transition"] = $"{transition.GetType().Name} to {transition.TransitionTo.ToEnumString()} ({transition.TransitionMode.ToEnumString()})";
+            }
             if (eventManagerNodeCasted?.Event?.Chunk is DisableBraindanceActions disableBDActionsCasted)
             {
                 details.AddRange(ParseBDMask(disableBDActionsCasted.ActionMask));
@@ -292,10 +302,38 @@ internal class NodeProperties
                 details["- Name"] = gameActionEventCasted?.Name.GetResolvedText()!;
                 details["- Time To Live"] = gameActionEventCasted?.TimeToLive.ToString()!;
             }
+            if (eventManagerNodeCasted?.Event?.Chunk is SetWantedLevel setWantedLevel)
+            {
+                details["Wanted Level"] = setWantedLevel.WantedLevel.ToEnumString();
+
+                var options = new List<string>();
+                if (setWantedLevel.ForceGreyStars)
+                {
+                    options.Add("Force Grey Stars");
+                }
+                if (setWantedLevel.ResetGreyStars)
+                {
+                    options.Add("Reset Grey Stars");
+                }
+                if (setWantedLevel.ForcePlayerPositionAsLastCrimePoint)
+                {
+                    options.Add("Player Position as Last Crime Point");
+                }
+                if (setWantedLevel.ForceIgnoreSecurityAreas)
+                {
+                    options.Add("Ignore Security Areas");
+                }
+
+                details["Wanted Options"] = options.Count == 0 ? "None" : string.Join(", ", options);
+            }
 
             details["Is Object Player"] = eventManagerNodeCasted?.IsObjectPlayer == true ? "True" : "False";
             details["Manager Name"] = eventManagerNodeCasted?.ManagerName.ToString()!;
-            details["Object Ref"] = ParseGameEntityReference(eventManagerNodeCasted?.ObjectRef);
+            var objectRef = ParseGameEntityReference(eventManagerNodeCasted?.ObjectRef);
+            if (objectRef != "-")
+            {
+                details["Object Ref"] = objectRef;
+            }
         }
         else if (node is questEnvironmentManagerNodeDefinition envManagerNodeCasted)
         {
@@ -607,6 +645,18 @@ internal class NodeProperties
                     details["#" + counter + " Slot Name"] = param?.Chunk?.SlotName.ToString()!;
 
                     counter++;
+                }
+            }
+            else if (interactiveObjectManagerCasted?.Type?.Chunk is questElevator_ManageNPCAttachment_NodeType elevatorManager)
+            {
+                var useNumberedLabels = elevatorManager.Params.Count > 1;
+                for (var i = 0; i < elevatorManager.Params.Count; i++)
+                {
+                    var param = elevatorManager.Params[i];
+                    var prefix = useNumberedLabels ? $"#{i + 1} " : "";
+                    details[$"{prefix}Action"] = param.Action.ToEnumString();
+                    details[$"{prefix}Elevator Ref"] = param.ElevatorRef.GetResolvedText()!;
+                    details[$"{prefix}NPC Ref"] = ParseGameEntityReference(param.NpcRef);
                 }
             }
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -108,7 +108,7 @@ public partial class RedGraph
         return s_questNodeTypes;
     }
 
-    public void CreateQuestNode(Type type, System.Windows.Point point, RedTypeTemplateSelectionOption? templateDesc = null)
+    public uint CreateQuestNode(Type type, System.Windows.Point point, RedTypeTemplateSelectionOption? templateDesc = null)
     {
         var instance = InternalCreateQuestNode(type, templateDesc);
         var wrappedInstance = WrapQuestNode(instance, true);
@@ -123,6 +123,8 @@ public partial class RedGraph
         Nodes.Add(wrappedInstance);
 
         DocumentViewModel?.SetIsDirty(true);
+
+        return wrappedInstance.UniqueId;
     }
 
     private graphGraphNodeDefinition InternalCreateQuestNode(Type type, RedTypeTemplateSelectionOption? templateDesc = null)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -152,7 +152,8 @@ public partial class RedGraph
             if (nodeDefinition is questFactsDBManagerNodeDefinition factsDBNode)
             {
                 // Initialize the Type property with questSetVar_NodeType (the only implementation)
-                factsDBNode.Type = new CHandle<questIFactsDBManagerNodeType>(new questSetVar_NodeType());
+                factsDBNode.Type ??= new CHandle<questIFactsDBManagerNodeType>();
+                factsDBNode.Type.Chunk ??= new questSetVar_NodeType();
             }
 
             if (nodeDefinition is questInputNodeDefinition inputNode)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -144,6 +144,17 @@ public partial class RedGraph
             throw new Exception();
         }
 
+        if (templateDesc != null)
+        {
+            foreach (var socket in questNode.Sockets)
+            {
+                if (socket.Chunk is questSocketDefinition socketDefinition)
+                {
+                    socketDefinition.Connections.Clear();
+                }
+            }
+        }
+
         if (instance is questNodeDefinition nodeDefinition)
         {
             nodeDefinition.Id = ++_currentQuestNodeId;
@@ -438,7 +449,7 @@ public partial class RedGraph
             nodeWrapper = tmp;
         }
 
-        if (isNew)
+        if (isNew && node.Sockets.Count == 0)
         {
             nodeWrapper.CreateDefaultSockets();
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -247,7 +247,8 @@ public partial class RedGraph
         if (questNode is questFactsDBManagerNodeDefinition factsDBNode)
         {
             // Initialize the Type property with questSetVar_NodeType (the only implementation)
-            factsDBNode.Type = new CHandle<questIFactsDBManagerNodeType>(new questSetVar_NodeType());
+            factsDBNode.Type ??= new CHandle<questIFactsDBManagerNodeType>();
+            factsDBNode.Type.Chunk ??= new questSetVar_NodeType();
         }
 
         // Create the wrapper scene node and get its ID

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -108,8 +108,19 @@ public partial class RedGraph
             throw new Exception($"Failed to create scene node of type {type.Name}");
         }
 
+        if (templateDesc != null)
+        {
+            foreach (var outputSocket in sceneNode.OutputSockets)
+            {
+                outputSocket.Destinations.Clear();
+            }
+        }
+
         sceneNode.NodeId = new scnNodeId { Id = ++_currentSceneNodeId };
-        sceneNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 0 } });
+        if (sceneNode.OutputSockets.Count == 0)
+        {
+            sceneNode.OutputSockets.Add(new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 0 } });
+        }
 
         if (sceneNode is scnChoiceNode choiceNode)
         {
@@ -241,6 +252,17 @@ public partial class RedGraph
         if (questInstance is not questNodeDefinition questNode)
         {
             throw new Exception($"Failed to create quest node of type {questNodeType.Name}");
+        }
+
+        if (templateDesc != null)
+        {
+            foreach (var socket in questNode.Sockets)
+            {
+                if (socket.Chunk is questSocketDefinition socketDefinition)
+                {
+                    socketDefinition.Connections.Clear();
+                }
+            }
         }
 
         // Special initialization for certain quest node types

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -37,14 +37,7 @@ public partial class RedGraph
     /// <summary>
     /// Get quest node types that can be embedded in scene graphs via scnQuestNode
     /// </summary>
-    public List<Type> GetQuestNodeTypesForScene()
-    {
-        // Get all quest node types that inherit from questNodeDefinition
-        return AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(x => x.GetTypes())
-            .Where(x => typeof(questNodeDefinition).IsAssignableFrom(x) && !x.IsAbstract)
-            .ToList();
-    }
+    public List<Type> GetQuestNodeTypesForScene() => GetQuestNodeTypes();
 
     public uint CreateSceneNode(Type type, System.Windows.Point point, RedTypeTemplateSelectionOption? templateDesc = null)
     {

--- a/WolvenKit.Common/Services/RedTypeTemplateService.cs
+++ b/WolvenKit.Common/Services/RedTypeTemplateService.cs
@@ -58,6 +58,15 @@ public class RedTypeTemplateService
         }
     }
 
+    public (IReadOnlyList<RedTypeTemplateDescriptor> User, IReadOnlyList<RedTypeTemplateDescriptor> System)
+        GetTemplateRegistrySnapshot()
+    {
+        lock (_lock)
+        {
+            return (UserTemplates.ToList(), SystemTemplates.ToList());
+        }
+    }
+
     private void LoadTemplatesFromDirectory(string dir, List<RedTypeTemplateDescriptor> templates)
     {
         foreach (var f in new DirectoryInfo(dir).EnumerateFiles("*", SearchOption.TopDirectoryOnly))

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -1164,7 +1164,7 @@ namespace WolvenKit.Views.Documents
             // Shortcut: Ctrl+N to open new node dialog
             if (e.Key == Key.N && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
             {
-                _ = QuestPhaseGraphEditor?.OpenNodeSelectorAtViewportCenter();
+                QuestPhaseGraphEditor?.OpenActionPaletteAtViewportCenter();
                 e.Handled = true;
             }
 

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -64,8 +64,6 @@ namespace WolvenKit.Views.Documents
         private bool _disposed = false;
         private IDocumentViewModel? _currentDocument; // Track current document for disposal detection
 
-        private ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>()!;
-
         // Node selection persistence across document switches
         private static readonly Dictionary<string, (uint nodeId, int graphLevel)> s_documentNodeSelections = new();
 
@@ -1166,7 +1164,7 @@ namespace WolvenKit.Views.Documents
             // Shortcut: Ctrl+N to open new node dialog
             if (e.Key == Key.N && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
             {
-                OpenNewNodeDialog(currentGraph);
+                _ = QuestPhaseGraphEditor?.OpenNodeSelectorAtViewportCenter();
                 e.Handled = true;
             }
 
@@ -1219,73 +1217,6 @@ namespace WolvenKit.Views.Documents
                     e.Handled = true;
                 }
             }
-        }
-
-        /// <summary>
-        /// Open the new node type selector dialog
-        /// </summary>
-        private async void OpenNewNodeDialog(RedGraph? graph)
-        {
-            if (graph?.GraphType != RedGraphType.Quest)
-            {
-                return;
-            }
-
-            try
-            {
-                if (Locator.Current.GetService<AppViewModel>() is not { } appViewModel)
-                {
-                    return;
-                }
-
-                // Get quest node types
-                var questNodeTypes = graph.GetQuestNodeTypes();
-
-                var questTypes = questNodeTypes
-                    .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Quest", x))
-                    .OrderBy(x => x.Name)
-                    .ToList();
-
-                // Create and show the type selector dialog
-                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, _loggerService, questTypes)
-                {
-                    DialogHandler = model =>
-                    {
-                        appViewModel.CloseDialogCommand.Execute(null);
-                        if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } tsdvm)
-                        {
-                            return;
-                        }
-
-                        // Create new node at current viewport center
-                        var viewportCenter = GetViewportCenter();
-                        graph.CreateQuestNode(selectedType, viewportCenter, tsdvm.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
-                    }
-                });
-            }
-            catch (Exception)
-            {
-                // Silently handle any dialog creation errors
-            }
-        }
-
-        /// <summary>
-        /// Get the center point of the current viewport for placing new nodes
-        /// </summary>
-        private System.Windows.Point GetViewportCenter()
-        {
-            if (QuestPhaseGraphEditor?.Editor == null)
-            {
-                return new System.Windows.Point(0, 0);
-            }
-
-            var viewport = QuestPhaseGraphEditor.Editor.ViewportLocation;
-            var size = QuestPhaseGraphEditor.Editor.ViewportSize;
-
-            return new System.Windows.Point(
-                viewport.X + size.Width / 2,
-                viewport.Y + size.Height / 2
-            );
         }
 
         /// <summary>

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -643,7 +643,7 @@ namespace WolvenKit.Views.Documents
             // Shortcut: Ctrl+N to open new node dialog
             if (e.Key == Key.N && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
             {
-                _ = SceneGraphEditor?.OpenNodeSelectorAtViewportCenter();
+                SceneGraphEditor?.OpenActionPaletteAtViewportCenter();
                 e.Handled = true;
             }
 

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -44,8 +44,6 @@ namespace WolvenKit.Views.Documents
         private static IDocumentViewModel? s_lastActiveDocument;
         private static bool s_selectionManagerInitialized = false;
 
-        private readonly ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>()!;
-
         private bool _disposed = false;
 
         public SceneGraphView()
@@ -645,7 +643,7 @@ namespace WolvenKit.Views.Documents
             // Shortcut: Ctrl+N to open new node dialog
             if (e.Key == Key.N && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
             {
-                OpenNewNodeDialog(viewModel.MainGraph);
+                _ = SceneGraphEditor?.OpenNodeSelectorAtViewportCenter();
                 e.Handled = true;
             }
 
@@ -699,89 +697,6 @@ namespace WolvenKit.Views.Documents
                     e.Handled = true;
                 }
             }
-        }
-
-        /// <summary>
-        /// Open the new node type selector dialog
-        /// </summary>
-        private async void OpenNewNodeDialog(RedGraph graph)
-        {
-            if (graph?.GraphType != RedGraphType.Scene) return;
-
-            try
-            {
-                var appViewModel = Locator.Current.GetService<AppViewModel>();
-                if (appViewModel == null) return;
-
-                // Get scene node types
-                var sceneNodeTypes = graph.GetSceneNodeTypes();
-
-                // Separate DynamicSceneGraph from regular scene types (move to end)
-                var regularSceneTypes = sceneNodeTypes.Where(x => x.Name != "DynamicSceneGraphNode").ToList();
-                var dynamicSceneTypes = sceneNodeTypes.Where(x => x.Name == "DynamicSceneGraphNode").ToList();
-
-                var sceneTypes = regularSceneTypes
-                    .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Scene", x))
-                    .OrderBy(x => x.Name)
-                    .ToList();
-
-                // Get quest node types that can be embedded in scene graphs
-                var questNodeTypes = graph.GetQuestNodeTypesForScene();
-                var questTypes = questNodeTypes
-                    .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Quest", x))
-                    .OrderBy(x => x.Name)
-                    .ToList();
-
-                // Combine both types
-                var allTypes = new List<TypeEntry>();
-                allTypes.AddRange(sceneTypes);
-                allTypes.AddRange(questTypes);
-
-                // Add DynamicSceneGraph at the end
-                allTypes.AddRange(dynamicSceneTypes
-                    .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Scene", x)));
-
-                // Create and show the type selector dialog
-                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, _loggerService, allTypes)
-                {
-                    DialogHandler = model =>
-                    {
-                        appViewModel.CloseDialogCommand.Execute(null);
-                        if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } tsdvm)
-                        {
-                            return;
-                        }
-
-                        // Create new node at current viewport center
-                        var viewportCenter = GetViewportCenter();
-                        var nodeId = graph.CreateSceneNode(selectedType, viewportCenter, tsdvm.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
-                        SelectNodeById(nodeId);
-                    }
-                });
-            }
-            catch (Exception)
-            {
-                // Silently handle any dialog creation errors
-            }
-        }
-
-
-
-        /// <summary>
-        /// Get the center point of the current viewport for placing new nodes
-        /// </summary>
-        private Point GetViewportCenter()
-        {
-            if (SceneGraphEditor?.Editor == null)
-                return new Point(0, 0);
-
-            var viewport = SceneGraphEditor.Editor.ViewportLocation;
-            var size = SceneGraphEditor.Editor.ViewportSize;
-
-            return new Point(
-                viewport.X + size.Width / 2,
-                viewport.Y + size.Height / 2
-            );
         }
 
         /// <summary>

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
@@ -141,14 +141,8 @@
     </UserControl.Resources>
 
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-
         <Border
             x:Name="MainPanel"
-            Grid.Column="{Binding MainPanelColumn, ElementName=Root}"
             Width="380"
             Height="520"
             VerticalAlignment="Top"
@@ -308,44 +302,48 @@
             </Grid>
         </Border>
 
-        <Border
-            x:Name="VariantPanel"
-            Grid.Column="{Binding VariantPanelColumn, ElementName=Root}"
-            Width="230"
-            MaxHeight="420"
-            Margin="{Binding VariantPanelMargin, ElementName=Root}"
-            VerticalAlignment="Top"
-            Background="{DynamicResource ContentBackgroundAlt3}"
-            BorderBrush="{DynamicResource BorderAlt}"
-            BorderThickness="1"
-            CornerRadius="4"
-            Visibility="{Binding IsVariantPanelVisible, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <Grid Margin="8">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
+        <Popup
+            x:Name="VariantPopup"
+            AllowsTransparency="True"
+            Placement="Custom"
+            PlacementTarget="{Binding ElementName=MainPanel}"
+            StaysOpen="True">
+            <Border
+                x:Name="VariantPanel"
+                Width="230"
+                MaxHeight="420"
+                Background="{DynamicResource ContentBackgroundAlt3}"
+                BorderBrush="{DynamicResource BorderAlt}"
+                BorderThickness="1"
+                CornerRadius="4">
+                <Grid Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
 
-                <TextBlock
-                    Margin="4,1,4,7"
-                    FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                    FontWeight="SemiBold"
-                    Text="{Binding VariantHeading, ElementName=Root}"
-                    TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Margin="4,1,4,7"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        FontWeight="SemiBold"
+                        Text="{Binding VariantHeading, ElementName=Root}"
+                        TextTrimming="CharacterEllipsis" />
 
-                <ListBox
-                    x:Name="VariantList"
-                    Grid.Row="1"
-                    Background="Transparent"
-                    BorderThickness="0"
-                    ItemContainerStyle="{StaticResource PaletteListItemStyle}"
-                    ItemTemplate="{StaticResource VariantItemTemplate}"
-                    ItemsSource="{Binding VariantItems, ElementName=Root}"
-                    PreviewMouseLeftButtonUp="VariantList_OnPreviewMouseLeftButtonUp"
-                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                    ScrollViewer.VerticalScrollBarVisibility="Auto"
-                    SelectionMode="Single" />
-            </Grid>
-        </Border>
+                    <ListBox
+                        x:Name="VariantList"
+                        Grid.Row="1"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        ItemContainerStyle="{StaticResource PaletteListItemStyle}"
+                        ItemTemplate="{StaticResource VariantItemTemplate}"
+                        ItemsSource="{Binding VariantItems, ElementName=Root}"
+                        PreviewKeyDown="OnPreviewKeyDown"
+                        PreviewMouseLeftButtonUp="VariantList_OnPreviewMouseLeftButtonUp"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                        ScrollViewer.VerticalScrollBarVisibility="Auto"
+                        SelectionMode="Single" />
+                </Grid>
+            </Border>
+        </Popup>
     </Grid>
 </UserControl>

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
@@ -1,0 +1,319 @@
+<UserControl
+    x:Class="WolvenKit.Views.GraphEditor.GraphActionPalette"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:templates="clr-namespace:WolvenKit.Views.Templates"
+    x:Name="Root"
+    MaxHeight="520"
+    PreviewKeyDown="OnPreviewKeyDown"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <CollectionViewSource x:Key="GroupedActions" Source="{Binding VisibleItems, ElementName=Root}">
+            <CollectionViewSource.GroupDescriptions>
+                <PropertyGroupDescription PropertyName="Category" />
+            </CollectionViewSource.GroupDescriptions>
+        </CollectionViewSource>
+
+        <DataTemplate x:Key="GlyphIconTemplate">
+            <TextBlock
+                Width="20"
+                Height="20"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                FontSize="16"
+                TextAlignment="Center"
+                Text="{Binding Glyph}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="MaterialIconTemplate">
+            <iconPacks:PackIconMaterial
+                Width="16"
+                Height="16"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource WolvenKitYellow}"
+                Kind="{Binding IconKind}" />
+        </DataTemplate>
+
+        <Style x:Key="PaletteListItemStyle" TargetType="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Margin" Value="0,1" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="IsSelected" Value="True" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <DataTemplate x:Key="PaletteItemTemplate">
+            <Grid Margin="6,5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="32" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <ContentControl Content="{Binding}">
+                    <ContentControl.Style>
+                        <Style TargetType="ContentControl">
+                            <Setter Property="ContentTemplate" Value="{StaticResource GlyphIconTemplate}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasMaterialIcon}" Value="True">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource MaterialIconTemplate}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ContentControl.Style>
+                </ContentControl>
+
+                <StackPanel Grid.Column="1">
+                    <TextBlock
+                        Text="{Binding Title}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Foreground="{DynamicResource BorderAlt2}"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        Text="{Binding Subtitle}"
+                        TextTrimming="CharacterEllipsis">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Subtitle}" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </StackPanel>
+
+                <Button
+                    Grid.Column="2"
+                    Width="28"
+                    Height="28"
+                    Margin="8,0,0,0"
+                    Padding="0"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    MouseEnter="TemplateVariantsButton_OnMouseEnter"
+                    PreviewMouseLeftButtonUp="TemplateVariantsButton_OnPreviewMouseLeftButtonUp"
+                    Tag="{Binding}"
+                    ToolTip="Choose template"
+                    Visibility="{Binding HasVariants, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <templates:IconBox
+                        Width="16"
+                        Height="16"
+                        Margin="0"
+                        Foreground="{DynamicResource BorderAlt2}"
+                        IconPack="Material"
+                        Kind="ChevronRight"
+                        Size="{DynamicResource WolvenKitIconMicro}" />
+                </Button>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="VariantItemTemplate">
+            <Grid Margin="7,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="28" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <ContentControl Content="{Binding}">
+                    <ContentControl.Style>
+                        <Style TargetType="ContentControl">
+                            <Setter Property="ContentTemplate" Value="{StaticResource GlyphIconTemplate}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasMaterialIcon}" Value="True">
+                                    <Setter Property="ContentTemplate" Value="{StaticResource MaterialIconTemplate}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ContentControl.Style>
+                </ContentControl>
+
+                <StackPanel Grid.Column="1">
+                    <TextBlock
+                        Text="{Binding Title}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Foreground="{DynamicResource BorderAlt2}"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        Text="{Binding Subtitle}"
+                        TextTrimming="CharacterEllipsis" />
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <Border
+            x:Name="MainPanel"
+            Width="440"
+            Background="{DynamicResource ContentBackgroundAlt3}"
+            BorderBrush="{DynamicResource BorderAlt}"
+            BorderThickness="1"
+            CornerRadius="4">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock
+                    Margin="4,1,4,7"
+                    FontSize="{DynamicResource WolvenKitFontBody}"
+                    FontWeight="SemiBold"
+                    Text="{Binding Heading, ElementName=Root}" />
+
+                <Border
+                    Grid.Row="1"
+                    Margin="0,0,0,6"
+                    Background="{DynamicResource ContentBackgroundAlt2}"
+                    BorderBrush="{DynamicResource WolvenKitYellow}"
+                    BorderThickness="1"
+                    CornerRadius="3">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="40" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <iconPacks:PackIconMaterial
+                            Width="16"
+                            Height="16"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource WolvenKitYellow}"
+                            Kind="Magnify" />
+
+                        <TextBox
+                            x:Name="SearchBox"
+                            Grid.Column="1"
+                            Padding="2,7"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            FontSize="{DynamicResource WolvenKitFontBody}"
+                            Text="{Binding SearchText, ElementName=Root, UpdateSourceTrigger=PropertyChanged}" />
+
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="4,0,0,0"
+                            VerticalAlignment="Center"
+                            IsHitTestVisible="False"
+                            Foreground="{DynamicResource BorderAlt2}"
+                            Text="Search actions">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Text, ElementName=SearchBox}" Value="">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Grid>
+                </Border>
+
+                <ListBox
+                    x:Name="ActionList"
+                    Grid.Row="2"
+                    MaxHeight="420"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    ItemContainerStyle="{StaticResource PaletteListItemStyle}"
+                    ItemTemplate="{StaticResource PaletteItemTemplate}"
+                    ItemsSource="{Binding Source={StaticResource GroupedActions}}"
+                    PreviewMouseLeftButtonUp="ActionList_OnPreviewMouseLeftButtonUp"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                    SelectionMode="Single"
+                    VirtualizingPanel.IsVirtualizing="True"
+                    VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+                    <ListBox.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.ContainerStyle>
+                                <Style TargetType="GroupItem">
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="GroupItem">
+                                                <StackPanel>
+                                                    <ContentPresenter Content="{TemplateBinding Content}" />
+                                                    <ItemsPresenter />
+                                                </StackPanel>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </GroupStyle.ContainerStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <TextBlock
+                                        Margin="7,8,5,3"
+                                        Foreground="{DynamicResource BorderAlt2}"
+                                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                        FontWeight="SemiBold"
+                                        Text="{Binding Name}" />
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ListBox.GroupStyle>
+                </ListBox>
+            </Grid>
+        </Border>
+
+        <Border
+            x:Name="VariantPanel"
+            Grid.Column="1"
+            Width="270"
+            MaxHeight="420"
+            Margin="{Binding VariantPanelMargin, ElementName=Root}"
+            VerticalAlignment="Top"
+            Background="{DynamicResource ContentBackgroundAlt3}"
+            BorderBrush="{DynamicResource BorderAlt}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Visibility="{Binding IsVariantPanelVisible, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock
+                    Margin="4,1,4,7"
+                    FontSize="{DynamicResource WolvenKitFontBody}"
+                    FontWeight="SemiBold"
+                    Text="{Binding VariantHeading, ElementName=Root}"
+                    TextTrimming="CharacterEllipsis" />
+
+                <ListBox
+                    x:Name="VariantList"
+                    Grid.Row="1"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    ItemContainerStyle="{StaticResource PaletteListItemStyle}"
+                    ItemTemplate="{StaticResource VariantItemTemplate}"
+                    ItemsSource="{Binding VariantItems, ElementName=Root}"
+                    PreviewMouseLeftButtonUp="VariantList_OnPreviewMouseLeftButtonUp"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                    SelectionMode="Single" />
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
@@ -19,20 +19,20 @@
 
         <DataTemplate x:Key="GlyphIconTemplate">
             <TextBlock
-                Width="20"
-                Height="20"
-                HorizontalAlignment="Center"
+                Width="28"
+                Height="36"
+                HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                FontSize="16"
-                TextAlignment="Center"
+                FontSize="24"
+                TextAlignment="Right"
                 Text="{Binding Glyph}" />
         </DataTemplate>
 
         <DataTemplate x:Key="MaterialIconTemplate">
             <iconPacks:PackIconMaterial
-                Width="16"
-                Height="16"
-                HorizontalAlignment="Center"
+                Width="24"
+                Height="24"
+                HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 Foreground="{DynamicResource WolvenKitYellow}"
                 Kind="{Binding IconKind}" />
@@ -50,14 +50,18 @@
         </Style>
 
         <DataTemplate x:Key="PaletteItemTemplate">
-            <Grid Margin="6,5">
+            <Grid Margin="8,5">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="32" />
+                    <ColumnDefinition Width="36" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="36" />
                 </Grid.ColumnDefinitions>
 
-                <ContentControl Content="{Binding}">
+                <ContentControl
+                    Margin="-4,0,12,0"
+                    HorizontalContentAlignment="Right"
+                    VerticalContentAlignment="Center"
+                    Content="{Binding}">
                     <ContentControl.Style>
                         <Style TargetType="ContentControl">
                             <Setter Property="ContentTemplate" Value="{StaticResource GlyphIconTemplate}" />
@@ -72,11 +76,12 @@
 
                 <StackPanel Grid.Column="1">
                     <TextBlock
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
                         Text="{Binding Title}"
                         TextTrimming="CharacterEllipsis" />
                     <TextBlock
                         Foreground="{DynamicResource BorderAlt2}"
-                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        FontSize="{DynamicResource WolvenKitFontAltTitle}"
                         Text="{Binding Subtitle}"
                         TextTrimming="CharacterEllipsis">
                         <TextBlock.Style>
@@ -95,7 +100,7 @@
                     Grid.Column="2"
                     Width="28"
                     Height="28"
-                    Margin="8,0,0,0"
+                    Margin="0"
                     Padding="0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -119,32 +124,15 @@
         </DataTemplate>
 
         <DataTemplate x:Key="VariantItemTemplate">
-            <Grid Margin="7,6">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="28" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-
-                <ContentControl Content="{Binding}">
-                    <ContentControl.Style>
-                        <Style TargetType="ContentControl">
-                            <Setter Property="ContentTemplate" Value="{StaticResource GlyphIconTemplate}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding HasMaterialIcon}" Value="True">
-                                    <Setter Property="ContentTemplate" Value="{StaticResource MaterialIconTemplate}" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ContentControl.Style>
-                </ContentControl>
-
-                <StackPanel Grid.Column="1">
+            <Grid Margin="8,6">
+                <StackPanel>
                     <TextBlock
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
                         Text="{Binding Title}"
                         TextTrimming="CharacterEllipsis" />
                     <TextBlock
                         Foreground="{DynamicResource BorderAlt2}"
-                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        FontSize="{DynamicResource WolvenKitFontAltTitle}"
                         Text="{Binding Subtitle}"
                         TextTrimming="CharacterEllipsis" />
                 </StackPanel>
@@ -160,13 +148,17 @@
 
         <Border
             x:Name="MainPanel"
-            Width="440"
+            Grid.Column="{Binding MainPanelColumn, ElementName=Root}"
+            Width="380"
+            Height="520"
+            VerticalAlignment="Top"
             Background="{DynamicResource ContentBackgroundAlt3}"
             BorderBrush="{DynamicResource BorderAlt}"
             BorderThickness="1"
             CornerRadius="4">
-            <Grid Margin="8">
+            <Grid Margin="4,8">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -174,7 +166,7 @@
 
                 <TextBlock
                     Margin="4,1,4,7"
-                    FontSize="{DynamicResource WolvenKitFontBody}"
+                    FontSize="{DynamicResource WolvenKitFontSubTitle}"
                     FontWeight="SemiBold"
                     Text="{Binding Heading, ElementName=Root}" />
 
@@ -205,7 +197,7 @@
                             Padding="2,7"
                             Background="Transparent"
                             BorderThickness="0"
-                            FontSize="{DynamicResource WolvenKitFontBody}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
                             Text="{Binding SearchText, ElementName=Root, UpdateSourceTrigger=PropertyChanged}" />
 
                         <TextBlock
@@ -229,16 +221,55 @@
                     </Grid>
                 </Border>
 
+                <Border
+                    Grid.Row="2"
+                    Margin="0,0,0,4"
+                    Padding="0,0,0,7"
+                    BorderBrush="{DynamicResource BorderAlt}"
+                    BorderThickness="0,0,0,1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasItems, ElementName=GraphActionList}" Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+
+                    <StackPanel>
+                        <TextBlock
+                            Margin="8,0,8,5"
+                            Foreground="{DynamicResource BorderAlt2}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            FontWeight="SemiBold"
+                            Text="Graph" />
+
+                        <ListBox
+                            x:Name="GraphActionList"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            ItemContainerStyle="{StaticResource PaletteListItemStyle}"
+                            ItemTemplate="{StaticResource PaletteItemTemplate}"
+                            ItemsSource="{Binding GraphItems, ElementName=Root}"
+                            PreviewMouseLeftButtonUp="ActionList_OnPreviewMouseLeftButtonUp"
+                            PreviewMouseMove="ActionList_OnPreviewMouseMove"
+                            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                            ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                            SelectionMode="Single" />
+                    </StackPanel>
+                </Border>
+
                 <ListBox
                     x:Name="ActionList"
-                    Grid.Row="2"
-                    MaxHeight="420"
+                    Grid.Row="3"
                     Background="Transparent"
                     BorderThickness="0"
                     ItemContainerStyle="{StaticResource PaletteListItemStyle}"
                     ItemTemplate="{StaticResource PaletteItemTemplate}"
                     ItemsSource="{Binding Source={StaticResource GroupedActions}}"
                     PreviewMouseLeftButtonUp="ActionList_OnPreviewMouseLeftButtonUp"
+                    PreviewMouseMove="ActionList_OnPreviewMouseMove"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                     ScrollViewer.VerticalScrollBarVisibility="Auto"
                     SelectionMode="Single"
@@ -248,6 +279,7 @@
                         <GroupStyle>
                             <GroupStyle.ContainerStyle>
                                 <Style TargetType="GroupItem">
+                                    <Setter Property="Margin" Value="0,0,0,6" />
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate TargetType="GroupItem">
@@ -263,7 +295,7 @@
                             <GroupStyle.HeaderTemplate>
                                 <DataTemplate>
                                     <TextBlock
-                                        Margin="7,8,5,3"
+                                        Margin="8,8,8,5"
                                         Foreground="{DynamicResource BorderAlt2}"
                                         FontSize="{DynamicResource WolvenKitFontSubTitle}"
                                         FontWeight="SemiBold"
@@ -278,8 +310,8 @@
 
         <Border
             x:Name="VariantPanel"
-            Grid.Column="1"
-            Width="270"
+            Grid.Column="{Binding VariantPanelColumn, ElementName=Root}"
+            Width="230"
             MaxHeight="420"
             Margin="{Binding VariantPanelMargin, ElementName=Root}"
             VerticalAlignment="Top"
@@ -296,7 +328,7 @@
 
                 <TextBlock
                     Margin="4,1,4,7"
-                    FontSize="{DynamicResource WolvenKitFontBody}"
+                    FontSize="{DynamicResource WolvenKitFontSubTitle}"
                     FontWeight="SemiBold"
                     Text="{Binding VariantHeading, ElementName=Root}"
                     TextTrimming="CharacterEllipsis" />

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace WolvenKit.Views.GraphEditor;
+
+public sealed class GraphActionPaletteItem
+{
+    public string Title { get; init; } = "";
+    public string Subtitle { get; init; } = "";
+    public string Category { get; init; } = "";
+    public string SearchText { get; init; } = "";
+    public string Glyph { get; init; } = "";
+    public string IconKind { get; init; } = "";
+    public string ParentTitle { get; init; } = "";
+    public bool IsVariant { get; init; }
+    public bool HasMaterialIcon => !string.IsNullOrEmpty(IconKind);
+    public IReadOnlyList<GraphActionPaletteItem> Variants { get; init; } = [];
+    public bool HasVariants => Variants.Count > 0;
+    public Action Execute { get; init; } = () => { };
+
+    public bool Matches(string query) =>
+        Title.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+        Subtitle.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+        SearchText.Contains(query, StringComparison.OrdinalIgnoreCase);
+}
+
+public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
+{
+    private IReadOnlyList<GraphActionPaletteItem> _rootItems = [];
+    private GraphActionPaletteItem _variantParent;
+    private string _heading = "All Actions";
+    private string _searchText = "";
+    private string _variantHeading = "";
+    private bool _isVariantPanelVisible;
+    private Thickness _variantPanelMargin = new(4, 0, 0, 0);
+
+    public event EventHandler DismissRequested;
+    public event EventHandler ActionExecuted;
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    public ObservableCollection<GraphActionPaletteItem> VisibleItems { get; } = [];
+    public ObservableCollection<GraphActionPaletteItem> VariantItems { get; } = [];
+
+    public string Heading
+    {
+        get => _heading;
+        private set => SetField(ref _heading, value);
+    }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (SetField(ref _searchText, value))
+            {
+                CloseVariantPanel(false);
+                RefreshVisibleItems();
+            }
+        }
+    }
+
+    public string VariantHeading
+    {
+        get => _variantHeading;
+        private set => SetField(ref _variantHeading, value);
+    }
+
+    public bool IsVariantPanelVisible
+    {
+        get => _isVariantPanelVisible;
+        private set => SetField(ref _isVariantPanelVisible, value);
+    }
+
+    public Thickness VariantPanelMargin
+    {
+        get => _variantPanelMargin;
+        private set => SetField(ref _variantPanelMargin, value);
+    }
+
+    public GraphActionPalette()
+    {
+        InitializeComponent();
+    }
+
+    public void Open(string heading, IReadOnlyList<GraphActionPaletteItem> items)
+    {
+        _rootItems = items;
+        Heading = heading;
+        CloseVariantPanel(false);
+        SearchText = "";
+        RefreshVisibleItems();
+
+        Dispatcher.BeginInvoke(() =>
+        {
+            SearchBox.Focus();
+            Keyboard.Focus(SearchBox);
+            SearchBox.SelectAll();
+        }, DispatcherPriority.Input);
+    }
+
+    public void RefreshItems(IReadOnlyList<GraphActionPaletteItem> items)
+    {
+        var variantParentTitle = _variantParent?.Title;
+        _rootItems = items;
+        RefreshVisibleItems();
+
+        if (variantParentTitle is not null &&
+            _rootItems.FirstOrDefault(item => item.Title == variantParentTitle) is { HasVariants: true } parent)
+        {
+            ShowVariants(parent, null, false);
+        }
+    }
+
+    private void RefreshVisibleItems()
+    {
+        var selectedItem = ActionList.SelectedItem as GraphActionPaletteItem;
+        IEnumerable<GraphActionPaletteItem> items;
+        if (!string.IsNullOrWhiteSpace(SearchText))
+        {
+            var query = SearchText.Trim();
+            items = _rootItems
+                .SelectMany(item => item.Matches(query)
+                    ? [item]
+                    : item.Variants.Where(variant => variant.Matches(query)))
+                .Distinct();
+        }
+        else
+        {
+            items = _rootItems;
+        }
+
+        VisibleItems.Clear();
+        foreach (var item in items)
+        {
+            VisibleItems.Add(item);
+        }
+
+        var selection = selectedItem is null
+            ? VisibleItems.FirstOrDefault()
+            : VisibleItems.FirstOrDefault(item =>
+                item.Title == selectedItem.Title &&
+                item.ParentTitle == selectedItem.ParentTitle) ?? VisibleItems.FirstOrDefault();
+        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, selection);
+        if (selection is not null)
+        {
+            ActionList.ScrollIntoView(selection);
+        }
+    }
+
+    private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Down:
+                MoveSelection(GetActiveList(), 1);
+                e.Handled = true;
+                break;
+            case Key.Up:
+                MoveSelection(GetActiveList(), -1);
+                e.Handled = true;
+                break;
+            case Key.Enter:
+                ExecuteSelectedItem(GetActiveList());
+                e.Handled = true;
+                break;
+            case Key.Right when
+                string.IsNullOrEmpty(SearchText) &&
+                !VariantList.IsKeyboardFocusWithin &&
+                ActionList.SelectedItem is GraphActionPaletteItem { HasVariants: true } item:
+                ShowVariants(item, null, true);
+                e.Handled = true;
+                break;
+            case Key.Left when IsVariantPanelVisible:
+                CloseVariantPanel(true);
+                e.Handled = true;
+                break;
+            case Key.Escape when IsVariantPanelVisible:
+                CloseVariantPanel(true);
+                e.Handled = true;
+                break;
+            case Key.Escape:
+                DismissRequested?.Invoke(this, EventArgs.Empty);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private ListBox GetActiveList() =>
+        VariantList.IsKeyboardFocusWithin ? VariantList : ActionList;
+
+    private static void MoveSelection(ListBox list, int offset)
+    {
+        if (list.Items.Count == 0)
+        {
+            return;
+        }
+
+        var nextIndex = Math.Clamp(list.SelectedIndex + offset, 0, list.Items.Count - 1);
+        list.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedIndexProperty, nextIndex);
+        list.ScrollIntoView(list.SelectedItem);
+    }
+
+    private void ActionList_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (FindVisualParent<Button>(e.OriginalSource as DependencyObject) is not null)
+        {
+            return;
+        }
+
+        if (ItemsControl.ContainerFromElement(ActionList, e.OriginalSource as DependencyObject) is not ListBoxItem item)
+        {
+            return;
+        }
+
+        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item.DataContext);
+        ExecuteSelectedItem(ActionList);
+        e.Handled = true;
+    }
+
+    private void VariantList_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (ItemsControl.ContainerFromElement(VariantList, e.OriginalSource as DependencyObject) is not ListBoxItem item)
+        {
+            return;
+        }
+
+        VariantList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item.DataContext);
+        ExecuteSelectedItem(VariantList);
+        e.Handled = true;
+    }
+
+    private void TemplateVariantsButton_OnMouseEnter(object sender, MouseEventArgs e)
+    {
+        if (sender is Button { Tag: GraphActionPaletteItem { HasVariants: true } item } button)
+        {
+            ShowVariants(item, button, false);
+        }
+    }
+
+    private void TemplateVariantsButton_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is Button { Tag: GraphActionPaletteItem { HasVariants: true } item } button)
+        {
+            ShowVariants(item, button, true);
+            e.Handled = true;
+        }
+    }
+
+    private void ShowVariants(
+        GraphActionPaletteItem item,
+        FrameworkElement anchor,
+        bool selectFirst)
+    {
+        _variantParent = item;
+        VariantHeading = $"{item.Title} Templates";
+        VariantItems.Clear();
+        foreach (var variant in item.Variants)
+        {
+            VariantItems.Add(variant);
+        }
+
+        IsVariantPanelVisible = true;
+        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item);
+        PositionVariantPanel(item, anchor);
+
+        if (selectFirst && VariantItems.Count > 0)
+        {
+            VariantList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedIndexProperty, 0);
+            VariantList.Focus();
+            Keyboard.Focus(VariantList);
+        }
+    }
+
+    private void PositionVariantPanel(GraphActionPaletteItem item, FrameworkElement anchor)
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            var row = FindVisualParent<ListBoxItem>(anchor) ??
+                      ActionList.ItemContainerGenerator.ContainerFromItem(item) as ListBoxItem;
+            if (row is null)
+            {
+                VariantPanelMargin = new Thickness(4, 0, 0, 0);
+                return;
+            }
+
+            var rowTop = row.TranslatePoint(new Point(0, 0), Root).Y;
+            var estimatedPanelHeight = Math.Min(420, 48 + (VariantItems.Count * 48));
+            var maxTop = Math.Max(0, MainPanel.ActualHeight - estimatedPanelHeight);
+            VariantPanelMargin = new Thickness(4, Math.Clamp(rowTop, 0, maxTop), 0, 0);
+        }, DispatcherPriority.Loaded);
+    }
+
+    private void CloseVariantPanel(bool returnFocus)
+    {
+        var parent = _variantParent;
+        _variantParent = null;
+        IsVariantPanelVisible = false;
+        VariantItems.Clear();
+
+        if (!returnFocus)
+        {
+            return;
+        }
+
+        if (parent is not null)
+        {
+            ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, parent);
+            ActionList.ScrollIntoView(parent);
+        }
+
+        ActionList.Focus();
+        Keyboard.Focus(ActionList);
+    }
+
+    private void ExecuteSelectedItem(ListBox list)
+    {
+        if (list.SelectedItem is not GraphActionPaletteItem item)
+        {
+            return;
+        }
+
+        item.Execute();
+        ActionExecuted?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static T FindVisualParent<T>(DependencyObject element) where T : DependencyObject
+    {
+        while (element is not null)
+        {
+            if (element is T match)
+            {
+                return match;
+            }
+
+            element = VisualTreeHelper.GetParent(element);
+        }
+
+        return null;
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+}

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
@@ -22,31 +22,47 @@ public sealed class GraphActionPaletteItem
     public string IconKind { get; init; } = "";
     public string ParentTitle { get; init; } = "";
     public bool IsVariant { get; init; }
+    public bool IsSearchOnly { get; init; }
     public bool HasMaterialIcon => !string.IsNullOrEmpty(IconKind);
     public IReadOnlyList<GraphActionPaletteItem> Variants { get; init; } = [];
     public bool HasVariants => Variants.Count > 0;
     public Action Execute { get; init; } = () => { };
 
-    public bool Matches(string query) =>
-        Title.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-        Subtitle.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-        SearchText.Contains(query, StringComparison.OrdinalIgnoreCase);
+    public bool Matches(string query)
+    {
+        var searchableText = $"{Title} {Subtitle} {SearchText}";
+        return query
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .All(term => searchableText.Contains(term, StringComparison.OrdinalIgnoreCase));
+    }
 }
 
 public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
 {
+    public const double MainPanelWidth = 380;
+    public const double VariantPanelWidth = 230;
+    public const double VariantPanelGap = 4;
+    public const double VariantPanelTotalWidth = VariantPanelWidth + VariantPanelGap;
+
     private IReadOnlyList<GraphActionPaletteItem> _rootItems = [];
     private GraphActionPaletteItem _variantParent;
     private string _heading = "All Actions";
     private string _searchText = "";
     private string _variantHeading = "";
     private bool _isVariantPanelVisible;
+    private bool _variantsOnLeft;
+    private int _mainPanelColumn;
+    private int _variantPanelColumn = 1;
     private Thickness _variantPanelMargin = new(4, 0, 0, 0);
 
     public event EventHandler DismissRequested;
     public event EventHandler ActionExecuted;
+    public event Action<double> MainPanelHorizontalAdjustmentRequested;
     public event PropertyChangedEventHandler PropertyChanged;
 
+    public Func<bool> ShouldPlaceVariantsOnLeft { get; set; } = () => false;
+
+    public ObservableCollection<GraphActionPaletteItem> GraphItems { get; } = [];
     public ObservableCollection<GraphActionPaletteItem> VisibleItems { get; } = [];
     public ObservableCollection<GraphActionPaletteItem> VariantItems { get; } = [];
 
@@ -87,6 +103,18 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         private set => SetField(ref _variantPanelMargin, value);
     }
 
+    public int MainPanelColumn
+    {
+        get => _mainPanelColumn;
+        private set => SetField(ref _mainPanelColumn, value);
+    }
+
+    public int VariantPanelColumn
+    {
+        get => _variantPanelColumn;
+        private set => SetField(ref _variantPanelColumn, value);
+    }
+
     public GraphActionPalette()
     {
         InitializeComponent();
@@ -123,7 +151,7 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
 
     private void RefreshVisibleItems()
     {
-        var selectedItem = ActionList.SelectedItem as GraphActionPaletteItem;
+        var selectedItem = GetSelectedMainItem();
         IEnumerable<GraphActionPaletteItem> items;
         if (!string.IsNullOrWhiteSpace(SearchText))
         {
@@ -136,25 +164,30 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         }
         else
         {
-            items = _rootItems;
+            items = _rootItems.Where(item => !item.IsSearchOnly);
         }
 
+        var filteredItems = items.ToList();
+        GraphItems.Clear();
         VisibleItems.Clear();
-        foreach (var item in items)
+        foreach (var item in filteredItems)
         {
-            VisibleItems.Add(item);
+            if (item.Category == "Graph")
+            {
+                GraphItems.Add(item);
+            }
+            else
+            {
+                VisibleItems.Add(item);
+            }
         }
 
         var selection = selectedItem is null
-            ? VisibleItems.FirstOrDefault()
-            : VisibleItems.FirstOrDefault(item =>
+            ? filteredItems.FirstOrDefault()
+            : filteredItems.FirstOrDefault(item =>
                 item.Title == selectedItem.Title &&
-                item.ParentTitle == selectedItem.ParentTitle) ?? VisibleItems.FirstOrDefault();
-        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, selection);
-        if (selection is not null)
-        {
-            ActionList.ScrollIntoView(selection);
-        }
+                item.ParentTitle == selectedItem.ParentTitle) ?? filteredItems.FirstOrDefault();
+        SelectMainItem(selection);
     }
 
     private void OnPreviewKeyDown(object sender, KeyEventArgs e)
@@ -196,18 +229,44 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
     }
 
     private ListBox GetActiveList() =>
-        VariantList.IsKeyboardFocusWithin ? VariantList : ActionList;
+        VariantList.IsKeyboardFocusWithin
+            ? VariantList
+            : GraphActionList.IsKeyboardFocusWithin || GraphActionList.SelectedItem is not null
+                ? GraphActionList
+                : ActionList;
 
-    private static void MoveSelection(ListBox list, int offset)
+    private void MoveSelection(ListBox list, int offset)
     {
         if (list.Items.Count == 0)
         {
+            var fallbackList = ReferenceEquals(list, GraphActionList) ? ActionList : GraphActionList;
+            SelectListItem(fallbackList, offset > 0 ? 0 : fallbackList.Items.Count - 1);
             return;
         }
 
+        if (!ReferenceEquals(list, VariantList))
+        {
+            if (offset > 0 &&
+                ReferenceEquals(list, GraphActionList) &&
+                list.SelectedIndex == list.Items.Count - 1 &&
+                ActionList.Items.Count > 0)
+            {
+                SelectListItem(ActionList, 0);
+                return;
+            }
+
+            if (offset < 0 &&
+                ReferenceEquals(list, ActionList) &&
+                list.SelectedIndex <= 0 &&
+                GraphActionList.Items.Count > 0)
+            {
+                SelectListItem(GraphActionList, GraphActionList.Items.Count - 1);
+                return;
+            }
+        }
+
         var nextIndex = Math.Clamp(list.SelectedIndex + offset, 0, list.Items.Count - 1);
-        list.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedIndexProperty, nextIndex);
-        list.ScrollIntoView(list.SelectedItem);
+        SelectListItem(list, nextIndex);
     }
 
     private void ActionList_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
@@ -217,14 +276,28 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
             return;
         }
 
-        if (ItemsControl.ContainerFromElement(ActionList, e.OriginalSource as DependencyObject) is not ListBoxItem item)
+        if (sender is not ListBox list ||
+            ItemsControl.ContainerFromElement(list, e.OriginalSource as DependencyObject) is not ListBoxItem item)
         {
             return;
         }
 
-        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item.DataContext);
-        ExecuteSelectedItem(ActionList);
+        SelectListItem(list, list.ItemContainerGenerator.IndexFromContainer(item));
+        ExecuteSelectedItem(list);
         e.Handled = true;
+    }
+
+    private void ActionList_OnPreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (_variantParent is null ||
+            sender is not ListBox list ||
+            ItemsControl.ContainerFromElement(list, e.OriginalSource as DependencyObject) is not ListBoxItem item ||
+            ReferenceEquals(item.DataContext, _variantParent))
+        {
+            return;
+        }
+
+        CloseVariantPanel(false);
     }
 
     private void VariantList_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
@@ -262,7 +335,7 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         bool selectFirst)
     {
         _variantParent = item;
-        VariantHeading = $"{item.Title} Templates";
+        VariantHeading = "Choose template";
         VariantItems.Clear();
         foreach (var variant in item.Variants)
         {
@@ -296,7 +369,11 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
             var rowTop = row.TranslatePoint(new Point(0, 0), Root).Y;
             var estimatedPanelHeight = Math.Min(420, 48 + (VariantItems.Count * 48));
             var maxTop = Math.Max(0, MainPanel.ActualHeight - estimatedPanelHeight);
-            VariantPanelMargin = new Thickness(4, Math.Clamp(rowTop, 0, maxTop), 0, 0);
+            SetVariantPanelPlacement(ShouldPlaceVariantsOnLeft());
+            var top = Math.Clamp(rowTop, 0, maxTop);
+            VariantPanelMargin = _variantsOnLeft
+                ? new Thickness(0, top, VariantPanelGap, 0)
+                : new Thickness(VariantPanelGap, top, 0, 0);
         }, DispatcherPriority.Loaded);
     }
 
@@ -306,6 +383,7 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         _variantParent = null;
         IsVariantPanelVisible = false;
         VariantItems.Clear();
+        SetVariantPanelPlacement(false);
 
         if (!returnFocus)
         {
@@ -320,6 +398,74 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
 
         ActionList.Focus();
         Keyboard.Focus(ActionList);
+    }
+
+    private GraphActionPaletteItem GetSelectedMainItem() =>
+        GraphActionList.SelectedItem as GraphActionPaletteItem ??
+        ActionList.SelectedItem as GraphActionPaletteItem;
+
+    private void SelectMainItem(GraphActionPaletteItem item)
+    {
+        GraphActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, null);
+        ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, null);
+        if (item is null)
+        {
+            return;
+        }
+
+        var list = item.Category == "Graph" ? GraphActionList : ActionList;
+        list.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item);
+        list.ScrollIntoView(item);
+    }
+
+    private void SelectListItem(ListBox list, int index)
+    {
+        if (index < 0 || index >= list.Items.Count)
+        {
+            return;
+        }
+
+        if (!ReferenceEquals(list, VariantList))
+        {
+            var otherList = ReferenceEquals(list, GraphActionList) ? ActionList : GraphActionList;
+            otherList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, null);
+        }
+
+        list.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedIndexProperty, index);
+        list.ScrollIntoView(list.SelectedItem);
+    }
+
+    private void SetVariantPanelPlacement(bool placeOnLeft)
+    {
+        if (_variantsOnLeft == placeOnLeft)
+        {
+            return;
+        }
+
+        double? mainPanelScreenX = PresentationSource.FromVisual(MainPanel) is null
+            ? null
+            : MainPanel.PointToScreen(new Point()).X;
+        _variantsOnLeft = placeOnLeft;
+        MainPanelColumn = placeOnLeft ? 1 : 0;
+        VariantPanelColumn = placeOnLeft ? 0 : 1;
+        if (mainPanelScreenX is null)
+        {
+            return;
+        }
+
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (PresentationSource.FromVisual(MainPanel) is null)
+            {
+                return;
+            }
+
+            var horizontalAdjustment = mainPanelScreenX.Value - MainPanel.PointToScreen(new Point()).X;
+            if (Math.Abs(horizontalAdjustment) > 0.5)
+            {
+                MainPanelHorizontalAdjustmentRequested?.Invoke(horizontalAdjustment);
+            }
+        }, DispatcherPriority.Render);
     }
 
     private void ExecuteSelectedItem(ListBox list)

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -51,13 +52,10 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
     private string _variantHeading = "";
     private bool _isVariantPanelVisible;
     private bool _variantsOnLeft;
-    private int _mainPanelColumn;
-    private int _variantPanelColumn = 1;
-    private Thickness _variantPanelMargin = new(4, 0, 0, 0);
+    private double _variantPanelTop;
 
     public event EventHandler DismissRequested;
     public event EventHandler ActionExecuted;
-    public event Action<double> MainPanelHorizontalAdjustmentRequested;
     public event PropertyChangedEventHandler PropertyChanged;
 
     public Func<bool> ShouldPlaceVariantsOnLeft { get; set; } = () => false;
@@ -97,27 +95,10 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         private set => SetField(ref _isVariantPanelVisible, value);
     }
 
-    public Thickness VariantPanelMargin
-    {
-        get => _variantPanelMargin;
-        private set => SetField(ref _variantPanelMargin, value);
-    }
-
-    public int MainPanelColumn
-    {
-        get => _mainPanelColumn;
-        private set => SetField(ref _mainPanelColumn, value);
-    }
-
-    public int VariantPanelColumn
-    {
-        get => _variantPanelColumn;
-        private set => SetField(ref _variantPanelColumn, value);
-    }
-
     public GraphActionPalette()
     {
         InitializeComponent();
+        VariantPopup.CustomPopupPlacementCallback = PlaceVariantPopup;
     }
 
     public void Open(string heading, IReadOnlyList<GraphActionPaletteItem> items)
@@ -148,6 +129,8 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
             ShowVariants(parent, null, false);
         }
     }
+
+    public void Close() => CloseVariantPanel(false);
 
     private void RefreshVisibleItems()
     {
@@ -342,7 +325,6 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
             VariantItems.Add(variant);
         }
 
-        IsVariantPanelVisible = true;
         ActionList.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedItemProperty, item);
         PositionVariantPanel(item, anchor);
 
@@ -362,19 +344,32 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
                       ActionList.ItemContainerGenerator.ContainerFromItem(item) as ListBoxItem;
             if (row is null)
             {
-                VariantPanelMargin = new Thickness(4, 0, 0, 0);
+                CloseVariantPanel(false);
                 return;
             }
 
-            var rowTop = row.TranslatePoint(new Point(0, 0), Root).Y;
+            var rowTop = row.TranslatePoint(new Point(0, 0), MainPanel).Y;
             var estimatedPanelHeight = Math.Min(420, 48 + (VariantItems.Count * 48));
             var maxTop = Math.Max(0, MainPanel.ActualHeight - estimatedPanelHeight);
-            SetVariantPanelPlacement(ShouldPlaceVariantsOnLeft());
-            var top = Math.Clamp(rowTop, 0, maxTop);
-            VariantPanelMargin = _variantsOnLeft
-                ? new Thickness(0, top, VariantPanelGap, 0)
-                : new Thickness(VariantPanelGap, top, 0, 0);
+            _variantsOnLeft = ShouldPlaceVariantsOnLeft();
+            _variantPanelTop = Math.Clamp(rowTop, 0, maxTop);
+
+            VariantPopup.SetCurrentValue(Popup.IsOpenProperty, false);
+            IsVariantPanelVisible = true;
+            VariantPopup.SetCurrentValue(Popup.IsOpenProperty, true);
         }, DispatcherPriority.Loaded);
+    }
+
+    private CustomPopupPlacement[] PlaceVariantPopup(Size popupSize, Size targetSize, Point offset)
+    {
+        var left = new CustomPopupPlacement(
+            new Point(-(popupSize.Width + VariantPanelGap), _variantPanelTop),
+            PopupPrimaryAxis.Horizontal);
+        var right = new CustomPopupPlacement(
+            new Point(targetSize.Width + VariantPanelGap, _variantPanelTop),
+            PopupPrimaryAxis.Horizontal);
+
+        return _variantsOnLeft ? [left, right] : [right, left];
     }
 
     private void CloseVariantPanel(bool returnFocus)
@@ -382,8 +377,9 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
         var parent = _variantParent;
         _variantParent = null;
         IsVariantPanelVisible = false;
+        VariantPopup.SetCurrentValue(Popup.IsOpenProperty, false);
         VariantItems.Clear();
-        SetVariantPanelPlacement(false);
+        _variantsOnLeft = false;
 
         if (!returnFocus)
         {
@@ -433,39 +429,6 @@ public partial class GraphActionPalette : UserControl, INotifyPropertyChanged
 
         list.SetCurrentValue(System.Windows.Controls.Primitives.Selector.SelectedIndexProperty, index);
         list.ScrollIntoView(list.SelectedItem);
-    }
-
-    private void SetVariantPanelPlacement(bool placeOnLeft)
-    {
-        if (_variantsOnLeft == placeOnLeft)
-        {
-            return;
-        }
-
-        double? mainPanelScreenX = PresentationSource.FromVisual(MainPanel) is null
-            ? null
-            : MainPanel.PointToScreen(new Point()).X;
-        _variantsOnLeft = placeOnLeft;
-        MainPanelColumn = placeOnLeft ? 1 : 0;
-        VariantPanelColumn = placeOnLeft ? 0 : 1;
-        if (mainPanelScreenX is null)
-        {
-            return;
-        }
-
-        Dispatcher.BeginInvoke(() =>
-        {
-            if (PresentationSource.FromVisual(MainPanel) is null)
-            {
-                return;
-            }
-
-            var horizontalAdjustment = mainPanelScreenX.Value - MainPanel.PointToScreen(new Point()).X;
-            if (Math.Abs(horizontalAdjustment) > 0.5)
-            {
-                MainPanelHorizontalAdjustmentRequested?.Invoke(horizontalAdjustment);
-            }
-        }, DispatcherPriority.Render);
     }
 
     private void ExecuteSelectedItem(ListBox list)

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -771,5 +771,14 @@
                 <ContextMenu />
             </nodify:NodifyEditor.ContextMenu>
         </nodify:NodifyEditor>
+
+        <Popup
+            x:Name="ActionPalettePopup"
+            AllowsTransparency="True"
+            Placement="RelativePoint"
+            PlacementTarget="{Binding ElementName=Editor}"
+            StaysOpen="False">
+            <local:GraphActionPalette x:Name="ActionPalette" />
+        </Popup>
     </Grid>
 </UserControl>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -17,6 +17,7 @@ using Nodify;
 using ReactiveUI;
 using Splat;
 using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Controls;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.GraphEditor;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
@@ -27,6 +28,7 @@ using WolvenKit.App.ViewModels.GraphEditor.Nodes;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Behavior;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
+using WolvenKit.Common;
 using WolvenKit.Common.Model;
 using WolvenKit.Common.Services;
 using WolvenKit.Core.Interfaces;
@@ -44,6 +46,8 @@ public partial class GraphEditorView : UserControl
 {
     private readonly RedTypeTemplateService _redTypeTemplateService = Locator.Current.GetService<RedTypeTemplateService>();
     private readonly ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>();
+    private RedTypeTemplateDropdownViewModel _nodeTemplateOptions;
+    private System.Windows.Point _actionPaletteGraphPosition;
 
     private static readonly (string Name, string Color)[] s_commentColorPresets =
     [
@@ -67,6 +71,7 @@ public partial class GraphEditorView : UserControl
             return;
         }
 
+        view.ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.IsOpenProperty, false);
         view.Dispatcher.BeginInvoke(new Action(() =>
         {
             UpdateView(view);
@@ -150,6 +155,8 @@ public partial class GraphEditorView : UserControl
         InitializeComponent();
 
         _appViewModel = Locator.Current.GetService<AppViewModel>();
+        ActionPalette.DismissRequested += (_, _) => CloseActionPalette();
+        ActionPalette.ActionExecuted += (_, _) => CloseActionPalette();
 
         Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
             handler => Editor.ViewportUpdated += handler,
@@ -176,6 +183,7 @@ public partial class GraphEditorView : UserControl
     {
         var graph = Source;
 
+        CloseActionPalette();
         SelectedNode = null;
         SelectedNodes.Clear();
 
@@ -217,7 +225,9 @@ public partial class GraphEditorView : UserControl
 
         if (Source.GraphType is RedGraphType.Quest or RedGraphType.Scene)
         {
-            nodifyEditor.ContextMenu.Items.Add(CreateNodeMenu(mousePosition));
+            OpenGraphActionPalette(mousePosition, Mouse.GetPosition(nodifyEditor));
+            e.Handled = true;
+            return;
         }
 
         if (Source.GraphType == RedGraphType.Behavior && Source.CanCreateBehaviorRoot())
@@ -230,15 +240,6 @@ public partial class GraphEditorView : UserControl
             });
 
             nodifyEditor.ContextMenu.Items.Add(addMenu);
-        }
-
-        if (Source.GraphType is RedGraphType.Quest or RedGraphType.Scene)
-        {
-            var hasNodeSelection = SelectedNodes.OfType<NodeViewModel>().Any();
-            nodifyEditor.ContextMenu.Items.Add(CreateMenuItem(
-                hasNodeSelection ? "Add Comment Around Selection" : "Add Comment",
-                "CommentTextOutline",
-                () => Source.AddComment(mousePosition, SelectedNodes)));
         }
 
         nodifyEditor.ContextMenu.Items.Add(CreateMenuItem("Arrange Items", "ViewDashboard", ArrangeNodes));
@@ -631,7 +632,15 @@ public partial class GraphEditorView : UserControl
 
         groupingNode.ContextMenu ??= new ContextMenu();
         groupingNode.ContextMenu.Items.Clear();
-        groupingNode.ContextMenu.Items.Add(CreateNodeMenu(GetMousePositionInGraph(Editor)));
+        var graphPosition = GetMousePositionInGraph(Editor);
+        var popupPosition = Mouse.GetPosition(Editor);
+        groupingNode.ContextMenu.Items.Add(CreateMenuItem("Add Node ...", "Plus", () =>
+        {
+            groupingNode.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, false);
+            Dispatcher.BeginInvoke(
+                () => OpenGraphActionPalette(graphPosition, popupPosition),
+                DispatcherPriority.ContextIdle);
+        }));
         groupingNode.ContextMenu.Items.Add(new Separator());
         groupingNode.ContextMenu.Items.Add(CreateCommentColorMenu(comment));
         groupingNode.ContextMenu.Items.Add(CreateMenuItem(
@@ -728,112 +737,261 @@ public partial class GraphEditorView : UserControl
         }
     };
 
-    public Task OpenNodeSelectorAtViewportCenter() => OpenNodeSelector(GetViewportCenter());
-
-    private MenuItem CreateNodeMenu(System.Windows.Point position)
-    {
-        var menu = CreateAddMenuItem();
-        var availableTypes = GetNodeCreationTypes();
-        var typeMap = availableTypes
-            .Select(entry => entry.Type)
-            .GroupBy(type => type.Name)
-            .ToDictionary(group => group.Key, group => group.First());
-
-        menu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", () =>
-        {
-            _ = OpenNodeSelector(position);
-        }));
-        menu.Items.Add(new Separator());
-
-        var commonNodeCount = 0;
-        foreach (var typeName in GraphNodeCreationCatalog.CommonTypeNames)
-        {
-            if (AddNodeToMenu(menu, typeName, typeMap, position, true))
-            {
-                commonNodeCount++;
-            }
-        }
-
-        if (commonNodeCount > 0)
-        {
-            menu.Items.Add(new Separator());
-        }
-
-        foreach (var category in GraphNodeCreationCatalog.Categories)
-        {
-            var categoryMenu = CreateCategoryMenuItem(category.Name);
-
-            if (category.Name == "Debug" && Source.GraphType == RedGraphType.Scene)
-            {
-                var title = "UIManager (Debug Warning)";
-                var emoji = GraphNodeStyling.GetIconForNodeTitle(title);
-                categoryMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {title}", () =>
-                {
-                    var nodeId = Source.CreateCompositeSceneNode("DebugWarning", typeof(questUIManagerNodeDefinition), position);
-                    SelectNodeById(nodeId);
-                }, -15));
-            }
-
-            AddCatalogNodeTypes(categoryMenu, category.TypeNames, typeMap, position);
-            if (categoryMenu.Items.Count > 0)
-            {
-                menu.Items.Add(categoryMenu);
-            }
-        }
-
-        return menu;
-    }
-
-    private List<(Type Type, string Category)> GetNodeCreationTypes()
-    {
-        if (Source.GraphType == RedGraphType.Quest)
-        {
-            return Source.GetQuestNodeTypes()
-                .Select(type => (type, "Quest"))
-                .ToList();
-        }
-
-        if (Source.GraphType == RedGraphType.Scene)
-        {
-            return Source.GetSceneNodeTypes()
-                .Select(type => (type, "Scene"))
-                .Concat(Source.GetQuestNodeTypesForScene().Select(type => (type, "Quest")))
-                .ToList();
-        }
-
-        return [];
-    }
-
-    private async Task OpenNodeSelector(System.Windows.Point position)
+    public void OpenActionPaletteAtViewportCenter()
     {
         if (Source?.GraphType is not (RedGraphType.Quest or RedGraphType.Scene))
         {
             return;
         }
 
-        var graph = Source;
-        var types = GetNodeCreationTypes()
-            .Select(entry => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(entry.Type), entry.Category, entry.Type))
-            .OrderBy(entry => entry.Name)
-            .ToList();
+        var popupPosition = new System.Windows.Point(
+            Math.Max(8, (Editor.ActualWidth - 440) / 2),
+            Math.Max(8, (Editor.ActualHeight - 500) / 2));
+        OpenGraphActionPalette(GetViewportCenter(), popupPosition);
+    }
 
-        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
+    private void OpenGraphActionPalette(System.Windows.Point graphPosition, System.Windows.Point popupPosition)
+    {
+        if (Source?.GraphType is not (RedGraphType.Quest or RedGraphType.Scene))
         {
-            DialogHandler = model =>
-            {
-                _appViewModel.CloseDialogCommand.Execute(null);
-                if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } selector)
-                {
-                    return;
-                }
+            return;
+        }
 
-                var nodeId = CreateNode(graph, selectedType, position, selector.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
-                if (ReferenceEquals(Source, graph))
-                {
-                    SelectNodeById(nodeId);
-                }
+        CloseActionPalette();
+        EnsureNodeTemplateOptions();
+        _actionPaletteGraphPosition = graphPosition;
+        ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.HorizontalOffsetProperty, Math.Max(4, popupPosition.X));
+        ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.VerticalOffsetProperty, Math.Max(4, popupPosition.Y));
+        ActionPalette.Open(
+            Source.GraphType == RedGraphType.Quest ? "All Actions for Quest Graph" : "All Actions for Scene Graph",
+            CreateGraphActionPaletteItems(Source, graphPosition));
+        ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.IsOpenProperty, true);
+    }
+
+    private void CloseActionPalette() =>
+        ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.IsOpenProperty, false);
+
+    private void NodeTemplateOptions_OnPostRefresh(object sender, EventArgs e)
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (ActionPalettePopup.IsOpen && Source?.GraphType is (RedGraphType.Quest or RedGraphType.Scene))
+            {
+                ActionPalette.RefreshItems(CreateGraphActionPaletteItems(Source, _actionPaletteGraphPosition));
             }
         });
+    }
+
+    private void EnsureNodeTemplateOptions()
+    {
+        if (_nodeTemplateOptions is not null)
+        {
+            return;
+        }
+
+        _nodeTemplateOptions = new RedTypeTemplateDropdownViewModel(_redTypeTemplateService, _loggerService);
+        _nodeTemplateOptions.PostRefresh += NodeTemplateOptions_OnPostRefresh;
+    }
+
+    private IReadOnlyList<GraphActionPaletteItem> CreateGraphActionPaletteItems(RedGraph graph, System.Windows.Point position)
+    {
+        var items = new List<GraphActionPaletteItem>();
+        var hasNodeSelection = SelectedNodes.OfType<NodeViewModel>().Any();
+
+        items.Add(CreatePaletteCommand(
+            hasNodeSelection ? "Add Comment Around Selection" : "Add Comment",
+            "Graph",
+            "CommentTextOutline",
+            "comment annotation note",
+            () => graph.AddComment(position, SelectedNodes)));
+        items.Add(CreatePaletteCommand("Arrange Items", "Graph", "ViewDashboard", "layout arrange nodes", ArrangeNodes));
+        items.Add(CreatePaletteCommand("Hide/unhide sockets", "Graph", "Eye", "toggle sockets connectors", ToggleAllSockets));
+
+        if (GraphClipboardManager.CanPaste(graph.GraphType))
+        {
+            items.Add(CreatePaletteCommand("Paste Node", "Graph", "ContentPaste", "clipboard paste", () =>
+            {
+                if (GraphClipboardManager.GetCopiedData() is { } copiedData)
+                {
+                    graph.PasteNode(copiedData, position);
+                }
+            }));
+        }
+
+        var availableTypes = GetNodeCreationTypes(graph);
+        var typeMap = availableTypes
+            .GroupBy(entry => entry.Type.Name)
+            .ToDictionary(group => group.Key, group => group.First());
+        var addedTypes = new HashSet<Type>();
+
+        void AddNodeType(string typeName, string category)
+        {
+            if (typeMap.TryGetValue(typeName, out var entry) && addedTypes.Add(entry.Type))
+            {
+                items.Add(CreateNodePaletteItem(graph, entry.Type, category, position));
+            }
+        }
+
+        foreach (var typeName in GraphNodeCreationCatalog.CommonTypeNames)
+        {
+            AddNodeType(typeName, "Common");
+        }
+
+        foreach (var category in GraphNodeCreationCatalog.Categories)
+        {
+            if (category.Name == "Debug" && graph.GraphType == RedGraphType.Scene)
+            {
+                const string title = "UIManager (Debug Warning)";
+                items.Add(new GraphActionPaletteItem
+                {
+                    Title = title,
+                    Subtitle = "Preset scene node",
+                    Category = category.Name,
+                    SearchText = "debug warning ui manager",
+                    Glyph = GraphNodeStyling.GetIconForNodeTitle(title),
+                    Execute = () =>
+                    {
+                        var nodeId = graph.CreateCompositeSceneNode("DebugWarning", typeof(questUIManagerNodeDefinition), position);
+                        if (ReferenceEquals(Source, graph))
+                        {
+                            SelectNodeById(nodeId);
+                        }
+                    }
+                });
+            }
+
+            foreach (var typeName in category.TypeNames.Where(typeName => typeName is not null))
+            {
+                AddNodeType(typeName, category.Name);
+            }
+        }
+
+        foreach (var entry in availableTypes
+                     .Where(entry => !addedTypes.Contains(entry.Type))
+                     .OrderBy(entry => entry.Category)
+                     .ThenBy(entry => GraphNodeStyling.GetTitleForNodeType(entry.Type)))
+        {
+            var category = entry.Category == "Scene" ? "Other Scene Nodes" : "Other Quest Nodes";
+            items.Add(CreateNodePaletteItem(graph, entry.Type, category, position));
+        }
+
+        return items;
+    }
+
+    private GraphActionPaletteItem CreateNodePaletteItem(
+        RedGraph graph,
+        Type type,
+        string category,
+        System.Windows.Point position)
+    {
+        var title = GraphNodeStyling.GetTitleForNodeType(type);
+        var glyph = GraphNodeStyling.GetIconForNodeTitle(title);
+        var templateOptions = GetTemplateOptions(type);
+        var defaultTemplate = GetDefaultTemplateOption(templateOptions);
+        var templateCount = templateOptions.Count(option => option.Source != RedTypeTemplateSelectionOptionSource.Raw);
+        IReadOnlyList<GraphActionPaletteItem> variants = [];
+
+        if (templateCount > 0)
+        {
+            variants = templateOptions
+                .OrderBy(option => option.Name == "default" ? 0 : option.Source == RedTypeTemplateSelectionOptionSource.Raw ? 2 : 1)
+                .ThenBy(option => option.Name)
+                .Select(option => new GraphActionPaletteItem
+                {
+                    Title = option.Name,
+                    Subtitle = option.Source switch
+                    {
+                        RedTypeTemplateSelectionOptionSource.User => "User template",
+                        RedTypeTemplateSelectionOptionSource.System => "System template",
+                        _ => "No template"
+                    },
+                    Category = category,
+                    SearchText = $"{type.Name} {title} {option.Name} template",
+                    Glyph = glyph,
+                    ParentTitle = title,
+                    IsVariant = true,
+                    Execute = () => CreateAndSelectNode(graph, type, position, option)
+                })
+                .ToList();
+        }
+
+        return new GraphActionPaletteItem
+        {
+            Title = title,
+            Subtitle = templateCount > 0
+                ? $"{type.Name} - {templateCount} template{(templateCount == 1 ? "" : "s")}"
+                : type.Name,
+            Category = category,
+            SearchText = type.FullName ?? type.Name,
+            Glyph = glyph,
+            Variants = variants,
+            Execute = () => CreateAndSelectNode(graph, type, position, defaultTemplate)
+        };
+    }
+
+    private IReadOnlyList<RedTypeTemplateSelectionOption> GetTemplateOptions(Type type)
+    {
+        if (_nodeTemplateOptions.TemplatesByType.TryGetValue(type, out var templates))
+        {
+            return templates;
+        }
+
+        return
+        [
+            new RedTypeTemplateSelectionOption("No Template", type, "", RedTypeTemplateSelectionOptionSource.Raw)
+        ];
+    }
+
+    private static RedTypeTemplateSelectionOption GetDefaultTemplateOption(IReadOnlyList<RedTypeTemplateSelectionOption> templates) =>
+        templates.FirstOrDefault(option => option is { Name: "default", Source: RedTypeTemplateSelectionOptionSource.User }) ??
+        templates.FirstOrDefault(option => option is { Name: "default", Source: RedTypeTemplateSelectionOptionSource.System }) ??
+        templates.First(option => option.Source == RedTypeTemplateSelectionOptionSource.Raw);
+
+    private void CreateAndSelectNode(
+        RedGraph graph,
+        Type type,
+        System.Windows.Point position,
+        RedTypeTemplateSelectionOption template)
+    {
+        var nodeId = CreateNode(graph, type, position, template);
+        if (ReferenceEquals(Source, graph))
+        {
+            SelectNodeById(nodeId);
+        }
+    }
+
+    private static GraphActionPaletteItem CreatePaletteCommand(
+        string title,
+        string category,
+        string iconKind,
+        string searchText,
+        Action execute) => new()
+        {
+            Title = title,
+            Category = category,
+            IconKind = iconKind,
+            SearchText = searchText,
+            Execute = execute
+        };
+
+    private static List<(Type Type, string Category)> GetNodeCreationTypes(RedGraph graph)
+    {
+        if (graph.GraphType == RedGraphType.Quest)
+        {
+            return graph.GetQuestNodeTypes()
+                .Select(type => (type, "Quest"))
+                .ToList();
+        }
+
+        if (graph.GraphType == RedGraphType.Scene)
+        {
+            return graph.GetSceneNodeTypes()
+                .Select(type => (type, "Scene"))
+                .Concat(graph.GetQuestNodeTypesForScene().Select(type => (type, "Quest")))
+                .ToList();
+        }
+
+        return [];
     }
 
     private uint CreateNode(RedGraph graph, Type type, System.Windows.Point position, RedTypeTemplateSelectionOption template = null) =>
@@ -843,43 +1001,6 @@ public partial class GraphEditorView : UserControl
             RedGraphType.Scene => graph.CreateSceneNode(type, position, template),
             _ => throw new InvalidOperationException($"Cannot create a quest or scene node in a {graph.GraphType} graph.")
         };
-
-    private int AddCatalogNodeTypes(
-        MenuItem menu,
-        IReadOnlyList<string> typeNames,
-        Dictionary<string, Type> typeMap,
-        System.Windows.Point position)
-    {
-        var addedCount = 0;
-        var separatorPending = false;
-
-        foreach (var typeName in typeNames)
-        {
-            if (typeName is null)
-            {
-                separatorPending = addedCount > 0;
-                continue;
-            }
-
-            if (!typeMap.ContainsKey(typeName))
-            {
-                continue;
-            }
-
-            if (separatorPending)
-            {
-                menu.Items.Add(new Separator());
-                separatorPending = false;
-            }
-
-            if (AddNodeToMenu(menu, typeName, typeMap, position))
-            {
-                addedCount++;
-            }
-        }
-
-        return addedCount;
-    }
 
     private static MenuItem CreateMenuItem(string header, Action click) => CreateMenuItem(header, "Empty", null, click);
 
@@ -1006,25 +1127,6 @@ public partial class GraphEditorView : UserControl
         var emoji = GraphNodeStyling.GetIconForNodeTitle(displayName);
         var leftMargin = isRootItem ? -30 : -15;
         parentMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {displayName}", () => createNode(new NodeCreationParams(nodeType)), leftMargin));
-    }
-
-    private bool AddNodeToMenu(MenuItem parentMenu, string typeName, Dictionary<string, Type> typeMap, System.Windows.Point position, bool isRootItem = false)
-    {
-        if (!typeMap.TryGetValue(typeName, out var nodeType))
-        {
-            return false;
-        }
-
-        var displayName = GraphNodeStyling.GetTitleForNodeType(nodeType);
-        var emoji = GraphNodeStyling.GetIconForNodeTitle(displayName);
-        var leftMargin = isRootItem ? -30 : -15;
-        parentMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {displayName}", () =>
-        {
-            var nodeId = CreateNode(Source, nodeType, position);
-            SelectNodeById(nodeId);
-        }, leftMargin));
-
-        return true;
     }
 
     #region INotifyPropertyChanged

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -158,19 +158,13 @@ public partial class GraphEditorView : UserControl
         _appViewModel = Locator.Current.GetService<AppViewModel>();
         ActionPalette.DismissRequested += (_, _) => CloseActionPalette();
         ActionPalette.ActionExecuted += (_, _) => CloseActionPalette();
+        ActionPalettePopup.Closed += (_, _) => ActionPalette.Close();
         ActionPalette.ShouldPlaceVariantsOnLeft = () =>
         {
             var spaceOnRight = Editor.ActualWidth -
                                (_actionPalettePopupHorizontalOffset + GraphActionPalette.MainPanelWidth);
             return spaceOnRight < GraphActionPalette.VariantPanelTotalWidth &&
                    _actionPalettePopupHorizontalOffset >= GraphActionPalette.VariantPanelTotalWidth;
-        };
-        ActionPalette.MainPanelHorizontalAdjustmentRequested += horizontalAdjustment =>
-        {
-            var offset = ActionPalettePopup.HorizontalOffset + horizontalAdjustment;
-            ActionPalettePopup.SetCurrentValue(
-                System.Windows.Controls.Primitives.Popup.HorizontalOffsetProperty,
-                offset);
         };
 
         Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
@@ -808,8 +802,11 @@ public partial class GraphEditorView : UserControl
         ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.IsOpenProperty, true);
     }
 
-    private void CloseActionPalette() =>
+    private void CloseActionPalette()
+    {
+        ActionPalette.Close();
         ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.IsOpenProperty, false);
+    }
 
     private void NodeTemplateOptions_OnPostRefresh(object sender, EventArgs e)
     {

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -17,7 +18,6 @@ using ReactiveUI;
 using Splat;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
-using WolvenKit.Core.Interfaces;
 using WolvenKit.App.ViewModels.GraphEditor;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
@@ -29,6 +29,7 @@ using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
 using WolvenKit.Common.Model;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.Views.GraphEditor;
@@ -214,202 +215,9 @@ public partial class GraphEditorView : UserControl
         // Get the mouse position in graph coordinates for placing new nodes at cursor location
         var mousePosition = GetMousePositionInGraph(nodifyEditor);
 
-        if (Source.GraphType == RedGraphType.Scene)
+        if (Source.GraphType is RedGraphType.Quest or RedGraphType.Scene)
         {
-            // Get all available node types
-            var sceneNodeTypes = Source.GetSceneNodeTypes();
-            var questNodeTypes = Source.GetQuestNodeTypesForScene();
-            var allTypes = new List<TypeEntry>();
-            allTypes.AddRange(sceneNodeTypes.Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Scene", x)));
-            allTypes.AddRange(questNodeTypes.Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Quest", x)));
-
-            var addMenu = CreateAddMenuItem();
-
-            // Open Dialog option
-            addMenu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", async () =>
-            {
-                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, allTypes.OrderBy(x => x.Name).ToList())
-                {
-                    DialogHandler = model =>
-                    {
-                        _appViewModel.CloseDialogCommand.Execute(null);
-                        if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } tsdvm)
-                        {
-                            return;
-                        }
-
-                        var nodeId = Source.CreateSceneNode(selectedType, mousePosition, tsdvm.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
-                        SelectNodeById(nodeId);
-                    }
-                });
-            }));
-
-            addMenu.Items.Add(new Separator());
-
-            // Create type lookup for easy access
-            var typeMap = new Dictionary<string, Type>();
-            foreach (var nodeType in sceneNodeTypes.Concat(questNodeTypes))
-            {
-                typeMap[nodeType.Name] = nodeType;
-            }
-
-            // Common Nodes (directly at root)
-            AddNodeToMenu(addMenu, "scnSectionNode", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "scnChoiceNode", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "questPauseConditionNodeDefinition", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "questFactsDBManagerNodeDefinition", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "questUseWorkspotNodeDefinition", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "questUIManagerNodeDefinition", typeMap, mousePosition, true);
-            AddNodeToMenu(addMenu, "questJournalNodeDefinition", typeMap, mousePosition, true);
-            addMenu.Items.Add(new Separator());
-
-            // Flow & Logic
-            var flowMenu = CreateCategoryMenuItem("Flow & Logic");
-            AddNodeToMenu(flowMenu, "scnStartNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnEndNode", typeMap, mousePosition);
-            flowMenu.Items.Add(new Separator());
-            AddNodeToMenu(flowMenu, "scnAndNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnHubNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnXorNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnFlowControlNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnCutControlNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnInterruptManagerNode", typeMap, mousePosition);
-            flowMenu.Items.Add(new Separator());
-            AddNodeToMenu(flowMenu, "questConditionNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "scnRandomizerNode", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "questFactsDBManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "questCutControlNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(flowMenu, "questPauseConditionNodeDefinition", typeMap, mousePosition);
-            flowMenu.Items.Add(new Separator());
-            AddNodeToMenu(flowMenu, "questSwitchNodeDefinition", typeMap, mousePosition);
-
-            addMenu.Items.Add(flowMenu);
-
-            // Character & AI
-            var characterMenu = CreateCategoryMenuItem("Character & AI");
-            AddNodeToMenu(characterMenu, "questCharacterManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questBehaviourManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questPuppetAIManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questPuppeteerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questForcedBehaviourNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questUseWorkspotNodeDefinition", typeMap, mousePosition);
-            characterMenu.Items.Add(new Separator());
-            AddNodeToMenu(characterMenu, "questMovePuppetNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questTeleportPuppetNodeDefinition", typeMap, mousePosition);
-            characterMenu.Items.Add(new Separator());
-            AddNodeToMenu(characterMenu, "questMiscAICommandNode", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questCombatNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(characterMenu, "questSendAICommandNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(characterMenu);
-
-            // Game & World
-            var gameMenu = CreateCategoryMenuItem("Game & World");
-            AddNodeToMenu(gameMenu, "questCheckpointNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questTimeManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questEnvironmentManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questWorldDataManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questEntityManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questEventManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questInteractiveObjectManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questTriggerManagerNodeDefinition", typeMap, mousePosition);
-            gameMenu.Items.Add(new Separator());
-            AddNodeToMenu(gameMenu, "questSpawnManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(gameMenu, "questCrowdManagerNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(gameMenu);
-
-            // Journal & Mappins
-            var journalMenu = CreateCategoryMenuItem("Journal & Mappins");
-            AddNodeToMenu(journalMenu, "questJournalNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(journalMenu, "questMappinManagerNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(journalMenu);
-
-            // Vehicle
-            var vehicleMenu = CreateCategoryMenuItem("Vehicle");
-            AddNodeToMenu(vehicleMenu, "questVehicleNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(vehicleMenu, "questVehicleNodeCommandDefinition", typeMap, mousePosition);
-            AddNodeToMenu(vehicleMenu, "questTeleportVehicleNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(vehicleMenu);
-
-            // Items & Inventory
-            var itemsMenu = CreateCategoryMenuItem("Items & Inventory");
-            AddNodeToMenu(itemsMenu, "questItemManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(itemsMenu, "questEquipItemNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(itemsMenu, "questUnequipItemNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(itemsMenu);
-
-            // Audio, FX & Rendering
-            var audioMenu = CreateCategoryMenuItem("Audio & FX");
-            AddNodeToMenu(audioMenu, "questAudioNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(audioMenu, "questAudioCharacterManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(audioMenu, "questVoicesetManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(audioMenu, "questFXManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(audioMenu, "questRenderFxManagerNodeDefinition", typeMap, mousePosition);
-            AddNodeToMenu(audioMenu, "questVisionModesManagerNodeDefinition", typeMap, mousePosition);
-            addMenu.Items.Add(audioMenu);
-
-            // Debug
-            var debugMenu = CreateCategoryMenuItem("Debug");
-            // Add composite debug node with preset configuration
-            var debugWarningTitle = "UIManager (Debug Warning)";
-            var debugWarningEmoji = GraphNodeStyling.GetIconForNodeTitle(debugWarningTitle);
-            var debugWarningMenuItem = CreateEmojiMenuItem($"{debugWarningEmoji}   {debugWarningTitle}", () =>
-            {
-                var nodeId = Source.CreateCompositeSceneNode("DebugWarning", typeof(questUIManagerNodeDefinition), mousePosition);
-                SelectNodeById(nodeId);
-            }, -15);
-            debugMenu.Items.Add(debugWarningMenuItem);
-
-            addMenu.Items.Add(debugMenu);
-            AddNodeToMenu(debugMenu, "scnDeletionMarkerNode", typeMap, mousePosition);
-            AddNodeToMenu(debugMenu, "questPlaceholderNodeDefinition", typeMap, mousePosition);
-
-
-            nodifyEditor.ContextMenu.Items.Add(addMenu);
-        }
-
-        if (Source.GraphType == RedGraphType.Quest)
-        {
-            var nodeTypes = Source.GetQuestNodeTypes();
-            var types = nodeTypes
-                .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "", x))
-                .OrderBy(x => x.Name)
-                .ToList();
-
-            var addMenu = CreateAddMenuItem();
-
-            addMenu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", async () =>
-            {
-                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
-                {
-                    DialogHandler = model =>
-                    {
-                        _appViewModel.CloseDialogCommand.Execute(null);
-                        if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType} tsdvm)
-                        {
-                            return;
-                        }
-
-                        Source.CreateQuestNode(selectedType, mousePosition, tsdvm.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
-                    }
-                });
-            }));
-
-            addMenu.Items.Add(new Separator());
-
-            // Create a debug submenu for quest graphs
-            var questDebugMenu = CreateCategoryMenuItem("Debug");
-            questDebugMenu.Items.Add(CreateMenuItem("Quest Deletion Marker", () => Source.CreateQuestNode(typeof(questDeletionMarkerNodeDefinition), mousePosition)));
-            addMenu.Items.Add(questDebugMenu);
-            addMenu.Items.Add(new Separator());
-
-            foreach (var nodeType in nodeTypes)
-            {
-                var title = GraphNodeStyling.GetTitleForNodeType(nodeType);
-                // Quest graph - use regular menu items without emojis
-                addMenu.Items.Add(CreateMenuItem(title, () => Source.CreateQuestNode(nodeType, mousePosition)));
-            }
-
-            nodifyEditor.ContextMenu.Items.Add(addMenu);
+            nodifyEditor.ContextMenu.Items.Add(CreateNodeMenu(mousePosition));
         }
 
         if (Source.GraphType == RedGraphType.Behavior && Source.CanCreateBehaviorRoot())
@@ -823,6 +631,8 @@ public partial class GraphEditorView : UserControl
 
         groupingNode.ContextMenu ??= new ContextMenu();
         groupingNode.ContextMenu.Items.Clear();
+        groupingNode.ContextMenu.Items.Add(CreateNodeMenu(GetMousePositionInGraph(Editor)));
+        groupingNode.ContextMenu.Items.Add(new Separator());
         groupingNode.ContextMenu.Items.Add(CreateCommentColorMenu(comment));
         groupingNode.ContextMenu.Items.Add(CreateMenuItem(
             "Reset Comment Size",
@@ -917,6 +727,159 @@ public partial class GraphEditorView : UserControl
             Size = (double)Application.Current.Resources["WolvenKitIconMicro"]!
         }
     };
+
+    public Task OpenNodeSelectorAtViewportCenter() => OpenNodeSelector(GetViewportCenter());
+
+    private MenuItem CreateNodeMenu(System.Windows.Point position)
+    {
+        var menu = CreateAddMenuItem();
+        var availableTypes = GetNodeCreationTypes();
+        var typeMap = availableTypes
+            .Select(entry => entry.Type)
+            .GroupBy(type => type.Name)
+            .ToDictionary(group => group.Key, group => group.First());
+
+        menu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", () =>
+        {
+            _ = OpenNodeSelector(position);
+        }));
+        menu.Items.Add(new Separator());
+
+        var commonNodeCount = 0;
+        foreach (var typeName in GraphNodeCreationCatalog.CommonTypeNames)
+        {
+            if (AddNodeToMenu(menu, typeName, typeMap, position, true))
+            {
+                commonNodeCount++;
+            }
+        }
+
+        if (commonNodeCount > 0)
+        {
+            menu.Items.Add(new Separator());
+        }
+
+        foreach (var category in GraphNodeCreationCatalog.Categories)
+        {
+            var categoryMenu = CreateCategoryMenuItem(category.Name);
+
+            if (category.Name == "Debug" && Source.GraphType == RedGraphType.Scene)
+            {
+                var title = "UIManager (Debug Warning)";
+                var emoji = GraphNodeStyling.GetIconForNodeTitle(title);
+                categoryMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {title}", () =>
+                {
+                    var nodeId = Source.CreateCompositeSceneNode("DebugWarning", typeof(questUIManagerNodeDefinition), position);
+                    SelectNodeById(nodeId);
+                }, -15));
+            }
+
+            AddCatalogNodeTypes(categoryMenu, category.TypeNames, typeMap, position);
+            if (categoryMenu.Items.Count > 0)
+            {
+                menu.Items.Add(categoryMenu);
+            }
+        }
+
+        return menu;
+    }
+
+    private List<(Type Type, string Category)> GetNodeCreationTypes()
+    {
+        if (Source.GraphType == RedGraphType.Quest)
+        {
+            return Source.GetQuestNodeTypes()
+                .Select(type => (type, "Quest"))
+                .ToList();
+        }
+
+        if (Source.GraphType == RedGraphType.Scene)
+        {
+            return Source.GetSceneNodeTypes()
+                .Select(type => (type, "Scene"))
+                .Concat(Source.GetQuestNodeTypesForScene().Select(type => (type, "Quest")))
+                .ToList();
+        }
+
+        return [];
+    }
+
+    private async Task OpenNodeSelector(System.Windows.Point position)
+    {
+        if (Source?.GraphType is not (RedGraphType.Quest or RedGraphType.Scene))
+        {
+            return;
+        }
+
+        var graph = Source;
+        var types = GetNodeCreationTypes()
+            .Select(entry => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(entry.Type), entry.Category, entry.Type))
+            .OrderBy(entry => entry.Name)
+            .ToList();
+
+        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
+        {
+            DialogHandler = model =>
+            {
+                _appViewModel.CloseDialogCommand.Execute(null);
+                if (model is not TypeSelectorDialogViewModel { SelectedEntry.UserData: Type selectedType } selector)
+                {
+                    return;
+                }
+
+                var nodeId = CreateNode(graph, selectedType, position, selector.RedTypeTemplateDropdownViewModel.SelectedRedTypeTemplate);
+                if (ReferenceEquals(Source, graph))
+                {
+                    SelectNodeById(nodeId);
+                }
+            }
+        });
+    }
+
+    private uint CreateNode(RedGraph graph, Type type, System.Windows.Point position, RedTypeTemplateSelectionOption template = null) =>
+        graph.GraphType switch
+        {
+            RedGraphType.Quest => graph.CreateQuestNode(type, position, template),
+            RedGraphType.Scene => graph.CreateSceneNode(type, position, template),
+            _ => throw new InvalidOperationException($"Cannot create a quest or scene node in a {graph.GraphType} graph.")
+        };
+
+    private int AddCatalogNodeTypes(
+        MenuItem menu,
+        IReadOnlyList<string> typeNames,
+        Dictionary<string, Type> typeMap,
+        System.Windows.Point position)
+    {
+        var addedCount = 0;
+        var separatorPending = false;
+
+        foreach (var typeName in typeNames)
+        {
+            if (typeName is null)
+            {
+                separatorPending = addedCount > 0;
+                continue;
+            }
+
+            if (!typeMap.ContainsKey(typeName))
+            {
+                continue;
+            }
+
+            if (separatorPending)
+            {
+                menu.Items.Add(new Separator());
+                separatorPending = false;
+            }
+
+            if (AddNodeToMenu(menu, typeName, typeMap, position))
+            {
+                addedCount++;
+            }
+        }
+
+        return addedCount;
+    }
 
     private static MenuItem CreateMenuItem(string header, Action click) => CreateMenuItem(header, "Empty", null, click);
 
@@ -1045,22 +1008,23 @@ public partial class GraphEditorView : UserControl
         parentMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {displayName}", () => createNode(new NodeCreationParams(nodeType)), leftMargin));
     }
 
-    private void AddNodeToMenu(MenuItem parentMenu, string typeName, Dictionary<string, Type> typeMap, System.Windows.Point mousePosition, bool isRootItem = false)
+    private bool AddNodeToMenu(MenuItem parentMenu, string typeName, Dictionary<string, Type> typeMap, System.Windows.Point position, bool isRootItem = false)
     {
-        if (typeMap.TryGetValue(typeName, out var nodeType))
+        if (!typeMap.TryGetValue(typeName, out var nodeType))
         {
-            // Use the same title formatting logic as the actual nodes
-            var displayName = GraphNodeStyling.GetTitleForNodeType(nodeType);
-            var emoji = GraphNodeStyling.GetIconForNodeTitle(displayName);
-            // Use -30 margin for root items in "Add Node" menu, -15 for nested submenu items
-            var leftMargin = isRootItem ? -30 : -15;
-            var menuItem = CreateEmojiMenuItem($"{emoji}   {displayName}", () =>
-            {
-                var nodeId = Source.CreateSceneNode(nodeType, mousePosition);
-                SelectNodeById(nodeId);
-            }, leftMargin);
-            parentMenu.Items.Add(menuItem);
+            return false;
         }
+
+        var displayName = GraphNodeStyling.GetTitleForNodeType(nodeType);
+        var emoji = GraphNodeStyling.GetIconForNodeTitle(displayName);
+        var leftMargin = isRootItem ? -30 : -15;
+        parentMenu.Items.Add(CreateEmojiMenuItem($"{emoji}   {displayName}", () =>
+        {
+            var nodeId = CreateNode(Source, nodeType, position);
+            SelectNodeById(nodeId);
+        }, leftMargin));
+
+        return true;
     }
 
     #region INotifyPropertyChanged
@@ -1339,6 +1303,18 @@ public partial class GraphEditorView : UserControl
             // Update the NodeSelectionService
             NodeSelectionService.Instance.SelectedNode = targetNode;
         }
+    }
+
+    /// <summary>
+    /// Get the center of the visible graph viewport for keyboard-driven node creation.
+    /// </summary>
+    private System.Windows.Point GetViewportCenter()
+    {
+        var viewport = Editor.ViewportLocation;
+        var size = Editor.ViewportSize;
+        return new System.Windows.Point(
+            viewport.X + (size.Width / 2),
+            viewport.Y + (size.Height / 2));
     }
 
     /// <summary>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -48,6 +48,7 @@ public partial class GraphEditorView : UserControl
     private readonly ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>();
     private RedTypeTemplateDropdownViewModel _nodeTemplateOptions;
     private System.Windows.Point _actionPaletteGraphPosition;
+    private double _actionPalettePopupHorizontalOffset;
 
     private static readonly (string Name, string Color)[] s_commentColorPresets =
     [
@@ -157,6 +158,20 @@ public partial class GraphEditorView : UserControl
         _appViewModel = Locator.Current.GetService<AppViewModel>();
         ActionPalette.DismissRequested += (_, _) => CloseActionPalette();
         ActionPalette.ActionExecuted += (_, _) => CloseActionPalette();
+        ActionPalette.ShouldPlaceVariantsOnLeft = () =>
+        {
+            var spaceOnRight = Editor.ActualWidth -
+                               (_actionPalettePopupHorizontalOffset + GraphActionPalette.MainPanelWidth);
+            return spaceOnRight < GraphActionPalette.VariantPanelTotalWidth &&
+                   _actionPalettePopupHorizontalOffset >= GraphActionPalette.VariantPanelTotalWidth;
+        };
+        ActionPalette.MainPanelHorizontalAdjustmentRequested += horizontalAdjustment =>
+        {
+            var offset = ActionPalettePopup.HorizontalOffset + horizontalAdjustment;
+            ActionPalettePopup.SetCurrentValue(
+                System.Windows.Controls.Primitives.Popup.HorizontalOffsetProperty,
+                offset);
+        };
 
         Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
             handler => Editor.ViewportUpdated += handler,
@@ -400,6 +415,17 @@ public partial class GraphEditorView : UserControl
         node.ContextMenu.Items.Add(CreateMenuItem("Duplicate Node", "ContentDuplicate", "WolvenKitYellow", () => Source.DuplicateNode(nvm)));
         node.ContextMenu.Items.Add(CreateMenuItem("Copy Node", "ContentCopy", "WolvenKitYellow", () => GraphClipboardManager.CopyNode(nvm, Source.GraphType)));
 
+        var templateData = GetTemplateData(nvm);
+        if (templateData != null && RedTypeTemplateService.IsTypeTemplatable(templateData.GetType()))
+        {
+            node.ContextMenu.Items.Add(CreateMenuItem(
+                "Create Template from Node",
+                "ContentSaveOutline",
+                "WolvenKitPurple",
+                async () => await _appViewModel.SetActiveDialog(
+                    new CreateTemplateFromChunkDialogViewModel(templateData, _redTypeTemplateService, _appViewModel))));
+        }
+
         if (Source.GraphType == RedGraphType.Scene && node.DataContext is BaseSceneViewModel sceneViewModel)
         {
             node.ContextMenu.Items.Add(CreateMenuItem(
@@ -540,6 +566,16 @@ public partial class GraphEditorView : UserControl
         node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
 
         e.Handled = true;
+    }
+
+    private static IRedType GetTemplateData(NodeViewModel node)
+    {
+        if (node.Data is scnQuestNode sceneQuestNode)
+        {
+            return sceneQuestNode.QuestNode?.Chunk;
+        }
+
+        return node.Data;
     }
 
     public bool AddCommentFromCurrentCursor()
@@ -745,7 +781,7 @@ public partial class GraphEditorView : UserControl
         }
 
         var popupPosition = new System.Windows.Point(
-            Math.Max(8, (Editor.ActualWidth - 440) / 2),
+            Math.Max(8, (Editor.ActualWidth - 380) / 2),
             Math.Max(8, (Editor.ActualHeight - 500) / 2));
         OpenGraphActionPalette(GetViewportCenter(), popupPosition);
     }
@@ -759,8 +795,12 @@ public partial class GraphEditorView : UserControl
 
         CloseActionPalette();
         EnsureNodeTemplateOptions();
+        _nodeTemplateOptions.RefreshFromRegistry();
         _actionPaletteGraphPosition = graphPosition;
-        ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.HorizontalOffsetProperty, Math.Max(4, popupPosition.X));
+        _actionPalettePopupHorizontalOffset = Math.Max(4, popupPosition.X);
+        ActionPalettePopup.SetCurrentValue(
+            System.Windows.Controls.Primitives.Popup.HorizontalOffsetProperty,
+            _actionPalettePopupHorizontalOffset);
         ActionPalettePopup.SetCurrentValue(System.Windows.Controls.Primitives.Popup.VerticalOffsetProperty, Math.Max(4, popupPosition.Y));
         ActionPalette.Open(
             Source.GraphType == RedGraphType.Quest ? "All Actions for Quest Graph" : "All Actions for Scene Graph",
@@ -828,7 +868,12 @@ public partial class GraphEditorView : UserControl
         {
             if (typeMap.TryGetValue(typeName, out var entry) && addedTypes.Add(entry.Type))
             {
-                items.Add(CreateNodePaletteItem(graph, entry.Type, category, position));
+                items.Add(CreateNodePaletteItem(
+                    graph,
+                    entry.Type,
+                    category,
+                    position,
+                    GraphNodeCreationCatalog.IsSearchOnly(entry.Type)));
             }
         }
 
@@ -872,7 +917,12 @@ public partial class GraphEditorView : UserControl
                      .ThenBy(entry => GraphNodeStyling.GetTitleForNodeType(entry.Type)))
         {
             var category = entry.Category == "Scene" ? "Other Scene Nodes" : "Other Quest Nodes";
-            items.Add(CreateNodePaletteItem(graph, entry.Type, category, position));
+            items.Add(CreateNodePaletteItem(
+                graph,
+                entry.Type,
+                category,
+                position,
+                GraphNodeCreationCatalog.IsSearchOnly(entry.Type)));
         }
 
         return items;
@@ -882,7 +932,8 @@ public partial class GraphEditorView : UserControl
         RedGraph graph,
         Type type,
         string category,
-        System.Windows.Point position)
+        System.Windows.Point position,
+        bool isSearchOnly = false)
     {
         var title = GraphNodeStyling.GetTitleForNodeType(type);
         var glyph = GraphNodeStyling.GetIconForNodeTitle(title);
@@ -918,12 +969,11 @@ public partial class GraphEditorView : UserControl
         return new GraphActionPaletteItem
         {
             Title = title,
-            Subtitle = templateCount > 0
-                ? $"{type.Name} - {templateCount} template{(templateCount == 1 ? "" : "s")}"
-                : type.Name,
+            Subtitle = type.Name,
             Category = category,
             SearchText = type.FullName ?? type.Name,
             Glyph = glyph,
+            IsSearchOnly = isSearchOnly,
             Variants = variants,
             Execute = () => CreateAndSelectNode(graph, type, position, defaultTemplate)
         };

--- a/WolvenKit/Views/GraphEditor/GraphNodeCreationCatalog.cs
+++ b/WolvenKit/Views/GraphEditor/GraphNodeCreationCatalog.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+
+namespace WolvenKit.Views.GraphEditor;
+
+#nullable enable
+internal sealed record GraphNodeCreationCategory(string Name, IReadOnlyList<string?> TypeNames);
+
+internal static class GraphNodeCreationCatalog
+{
+    internal static IReadOnlyList<string> CommonTypeNames { get; } =
+    [
+        "scnSectionNode",
+        "scnChoiceNode",
+        "questPauseConditionNodeDefinition",
+        "questFactsDBManagerNodeDefinition",
+        "questUseWorkspotNodeDefinition",
+        "questUIManagerNodeDefinition",
+        "questJournalNodeDefinition"
+    ];
+
+    internal static IReadOnlyList<GraphNodeCreationCategory> Categories { get; } =
+    [
+        new("Flow & Logic",
+        [
+            "scnStartNode",
+            "scnEndNode",
+            null,
+            "scnAndNode",
+            "scnHubNode",
+            "scnXorNode",
+            "scnFlowControlNode",
+            "scnCutControlNode",
+            "scnInterruptManagerNode",
+            null,
+            "questConditionNodeDefinition",
+            "scnRandomizerNode",
+            "questFactsDBManagerNodeDefinition",
+            "questCutControlNodeDefinition",
+            "questPauseConditionNodeDefinition",
+            null,
+            "questSwitchNodeDefinition"
+        ]),
+        new("Character & AI",
+        [
+            "questCharacterManagerNodeDefinition",
+            "questBehaviourManagerNodeDefinition",
+            "questPuppetAIManagerNodeDefinition",
+            "questPuppeteerNodeDefinition",
+            "questForcedBehaviourNodeDefinition",
+            "questUseWorkspotNodeDefinition",
+            null,
+            "questMovePuppetNodeDefinition",
+            "questTeleportPuppetNodeDefinition",
+            null,
+            "questMiscAICommandNode",
+            "questCombatNodeDefinition",
+            "questSendAICommandNodeDefinition"
+        ]),
+        new("Game & World",
+        [
+            "questCheckpointNodeDefinition",
+            "questTimeManagerNodeDefinition",
+            "questEnvironmentManagerNodeDefinition",
+            "questWorldDataManagerNodeDefinition",
+            "questEntityManagerNodeDefinition",
+            "questEventManagerNodeDefinition",
+            "questInteractiveObjectManagerNodeDefinition",
+            "questTriggerManagerNodeDefinition",
+            null,
+            "questSpawnManagerNodeDefinition",
+            "questCrowdManagerNodeDefinition"
+        ]),
+        new("Journal & Mappins",
+        [
+            "questJournalNodeDefinition",
+            "questMappinManagerNodeDefinition"
+        ]),
+        new("Vehicle",
+        [
+            "questVehicleNodeDefinition",
+            "questVehicleNodeCommandDefinition",
+            "questTeleportVehicleNodeDefinition"
+        ]),
+        new("Items & Inventory",
+        [
+            "questItemManagerNodeDefinition",
+            "questEquipItemNodeDefinition",
+            "questUnequipItemNodeDefinition"
+        ]),
+        new("Audio & FX",
+        [
+            "questAudioNodeDefinition",
+            "questAudioCharacterManagerNodeDefinition",
+            "questVoicesetManagerNodeDefinition",
+            "questFXManagerNodeDefinition",
+            "questRenderFxManagerNodeDefinition",
+            "questVisionModesManagerNodeDefinition"
+        ]),
+        new("Debug",
+        [
+            "scnDeletionMarkerNode",
+            "questDeletionMarkerNodeDefinition",
+            "questPlaceholderNodeDefinition"
+        ])
+    ];
+}

--- a/WolvenKit/Views/GraphEditor/GraphNodeCreationCatalog.cs
+++ b/WolvenKit/Views/GraphEditor/GraphNodeCreationCatalog.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.Views.GraphEditor;
 
@@ -13,10 +15,34 @@ internal static class GraphNodeCreationCatalog
         "scnChoiceNode",
         "questPauseConditionNodeDefinition",
         "questFactsDBManagerNodeDefinition",
+        "questJournalNodeDefinition",
         "questUseWorkspotNodeDefinition",
-        "questUIManagerNodeDefinition",
-        "questJournalNodeDefinition"
+        "questConditionNodeDefinition",
+        "questSpawnManagerNodeDefinition"
     ];
+
+    private static readonly HashSet<Type> s_searchOnlyTypes =
+    [
+        typeof(questDebugShowMessageNodeDefinition),
+        typeof(questTestNodeDefinition),
+        typeof(tempshitJournalNodeDefinition),
+        typeof(tempshitMapPinManagerNodeDefinition),
+        typeof(questMultiplayerAIDirectorNodeDefinition),
+        typeof(questMultiplayerChoiceTokenNodeDefinition),
+        typeof(questMultiplayerHeistNodeDefinition),
+        typeof(questMultiplayerJunctionDialogNodeDefinition),
+        typeof(questMultiplayerTeleportPuppetNodeDefinition),
+        typeof(questPopulactionControllerNodeDefinition),
+        typeof(questStartNodeDefinition),
+        typeof(questEndNodeDefinition),
+        typeof(questTeleportVehicleNodeDefinition),
+        typeof(questUnequipItemNodeDefinition),
+        typeof(questRotateToNodeDefinition),
+        typeof(questPuppeteerNodeDefinition),
+        typeof(questAudioCharacterManagerNodeDefinition)
+    ];
+
+    internal static bool IsSearchOnly(Type type) => s_searchOnlyTypes.Contains(type);
 
     internal static IReadOnlyList<GraphNodeCreationCategory> Categories { get; } =
     [
@@ -32,12 +58,20 @@ internal static class GraphNodeCreationCatalog
             "scnCutControlNode",
             "scnInterruptManagerNode",
             null,
+            "questInputNodeDefinition",
+            "questOutputNodeDefinition",
+            null,
+            "questLogicalAndNodeDefinition",
+            "questLogicalHubNodeDefinition",
+            "questLogicalXorNodeDefinition",
+            "questFlowControlNodeDefinition",
+            "questRandomizerNodeDefinition",
             "questConditionNodeDefinition",
-            "scnRandomizerNode",
             "questFactsDBManagerNodeDefinition",
             "questCutControlNodeDefinition",
             "questPauseConditionNodeDefinition",
             null,
+            "scnRandomizerNode",
             "questSwitchNodeDefinition"
         ]),
         new("Character & AI",

--- a/changelog/unreleased/3016.yaml
+++ b/changelog/unreleased/3016.yaml
@@ -1,0 +1,11 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3016
+      author: "misterchedda"
+      description: "Quest and scene graphs now use a searchable action palette for graph actions, categorized node creation, and template selection"
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3016
+      author: "misterchedda"
+      description: "EventManager and InteractiveObjectManager graph nodes now show additional node details"


### PR DESCRIPTION
Replaces the separate quest and scene graph right click context menus with a shared, searchable action palette

<img width="305" height="410" alt="image" src="https://github.com/user-attachments/assets/04e27776-b01c-453d-81d2-17873a3e1d50" />

This refactor also streamlines node template support:
- Cascading menu to view templates per node type
- Adds `Create Template from Node` to node right-click context actions
- Search works for both node types and template names
~~Adds 34 system templates for common quest nodes~~

<img width="470" height="401" alt="image" src="https://github.com/user-attachments/assets/5303a3c8-7cc7-40b0-bad6-0415e98d140f" />

~~@notaspirit : fyi `23e48d0e6b` also includes a fix in `WolvenKit/WolvenKit.csproj` so that system templates get copied in release builds~~