### PR TITLE
fix: add resources subfolder to system template path

### DIFF
--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -73,7 +73,7 @@ namespace WolvenKit
                     services.AddSingleton<ICvmTools, CvmTools>();
 
                     services.AddSingleton<RedTypeTemplateService>(provider => new RedTypeTemplateService(provider.GetRequiredService<ILoggerService>(),
-                        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Templates"),
+                        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "Templates"),
                         ISettingsManager.GetUserTemplateDir()));
 
                     // scripting


### PR DESCRIPTION
# fix: add resources subfolder to system template path

fixes incorrect dir path for system templates which was outside the downloaded resources