### PR TITLE
feat: add graph node property layout option

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/SectionTimelineViewModelTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Scene/Timeline/SectionTimelineViewModelTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.App.ViewModels.Timeline;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.GraphEditor.Scene.Timeline;
+
+[TestClass]
+[DoNotParallelize]
+public class SectionTimelineViewModelTests
+{
+    [TestMethod]
+    public void FirstSelectedSectionZoomsToFitViewport()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        fixture.ViewModel.ViewportWidth = 400;
+
+        fixture.SelectSection(duration: 2_000);
+
+        Assert.AreEqual(0.18, fixture.ViewModel.PixelsPerMs, 0.00001);
+        Assert.AreEqual(400, fixture.ViewModel.TimelineWidth, 0.00001);
+    }
+
+    [TestMethod]
+    public void SwitchingSectionsRestoresIndependentZoomLevels()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        fixture.ViewModel.ViewportWidth = 400;
+        var first = fixture.CreateSection(duration: 2_000);
+        var second = fixture.CreateSection(duration: 1_000);
+
+        fixture.Select(first);
+        fixture.ViewModel.PixelsPerMs = 0.25;
+
+        fixture.Select(second);
+        fixture.ViewModel.PixelsPerMs = 0.5;
+
+        fixture.Select(first);
+        Assert.AreEqual(0.25, fixture.ViewModel.PixelsPerMs, 0.00001);
+
+        fixture.Select(second);
+        Assert.AreEqual(0.5, fixture.ViewModel.PixelsPerMs, 0.00001);
+    }
+
+    [TestMethod]
+    public void RefreshingCurrentSectionPreservesZoom()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        fixture.SelectSection(duration: 2_000);
+        fixture.ViewModel.PixelsPerMs = 0.3;
+
+        fixture.ViewModel.RefreshAfterDrag();
+
+        Assert.AreEqual(0.3, fixture.ViewModel.PixelsPerMs, 0.00001);
+    }
+
+    [TestMethod]
+    public void TimelineWidthUsesViewportAsMinimumAndExpandsForContent()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        fixture.ViewModel.ViewportWidth = 500;
+
+        Assert.AreEqual(500, fixture.ViewModel.TimelineWidth, 0.00001);
+
+        fixture.SelectSection(duration: 1_000);
+        Assert.AreEqual(500, fixture.ViewModel.TimelineWidth, 0.00001);
+
+        fixture.ViewModel.PixelsPerMs = 0.8;
+        Assert.AreEqual(800, fixture.ViewModel.TimelineWidth, 0.00001);
+    }
+
+    [TestMethod]
+    public void PixelTimeConversionsRespectZoomAndSnapping()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        fixture.ViewModel.PixelsPerMs = 0.2;
+        fixture.ViewModel.IsSnapEnabled = true;
+        fixture.ViewModel.SnapInterval = 100;
+
+        Assert.AreEqual(50, fixture.ViewModel.TimeToPixels(250), 0.00001);
+        Assert.AreEqual(200U, fixture.ViewModel.PixelsToTime(46));
+        Assert.AreEqual(0U, fixture.ViewModel.PixelsToTime(-10));
+    }
+
+    [TestMethod]
+    public void ViewportWidthChangeNotifiesTimelineWidth()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        var changedProperties = new List<string?>();
+        fixture.ViewModel.PropertyChanged += OnPropertyChanged;
+
+        fixture.ViewModel.ViewportWidth = 1_200;
+
+        CollectionAssert.Contains(changedProperties, nameof(SectionTimelineViewModel.TimelineWidth));
+
+        void OnPropertyChanged(object? sender, PropertyChangedEventArgs e) => changedProperties.Add(e.PropertyName);
+    }
+
+    [TestMethod]
+    public void DisposeStopsReactingToNodeSelection()
+    {
+        using var fixture = new TimelineViewModelFixture();
+        var first = fixture.CreateSection(duration: 1_000);
+        var second = fixture.CreateSection(duration: 2_000);
+        fixture.Select(first);
+        fixture.DisposeViewModel();
+
+        fixture.Select(second);
+
+        Assert.AreSame(first, fixture.ViewModel.NodeWrapper);
+        Assert.AreEqual(1_000U, fixture.ViewModel.SectionDuration);
+    }
+
+    private sealed class TimelineViewModelFixture : IDisposable
+    {
+        private readonly List<scnSectionNodeWrapper> _wrappers = [];
+        private uint _nextNodeId = 1;
+        private bool _isViewModelDisposed;
+
+        public TimelineViewModelFixture()
+        {
+            NodeSelectionService.Instance.SelectedNode = null;
+            ViewModel = new SectionTimelineViewModel();
+        }
+
+        public SectionTimelineViewModel ViewModel { get; }
+
+        public scnSectionNodeWrapper CreateSection(uint duration)
+        {
+            var node = new scnSectionNode
+            {
+                NodeId = new scnNodeId { Id = _nextNodeId++ },
+                SectionDuration = new scnSceneTime { Stu = duration }
+            };
+            var wrapper = new scnSectionNodeWrapper(node, new scnSceneResource());
+            _wrappers.Add(wrapper);
+            return wrapper;
+        }
+
+        public void SelectSection(uint duration) => Select(CreateSection(duration));
+
+        public void Select(scnSectionNodeWrapper wrapper) => NodeSelectionService.Instance.SelectedNode = wrapper;
+
+        public void DisposeViewModel()
+        {
+            if (_isViewModelDisposed)
+            {
+                return;
+            }
+
+            ViewModel.Dispose();
+            _isViewModelDisposed = true;
+        }
+
+        public void Dispose()
+        {
+            NodeSelectionService.Instance.SelectedNode = null;
+            DisposeViewModel();
+            foreach (var wrapper in _wrappers)
+            {
+                wrapper.Dispose();
+            }
+        }
+    }
+}

--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -5,7 +5,7 @@ using WolvenKit.Common;
 
 namespace WolvenKit.App.Services;
 
-public enum GraphNodePropertiesLayout
+public enum GraphEditorPropertiesLayout
 {
     SideBySide,
     Stacked
@@ -48,7 +48,7 @@ public interface ISettingsDto
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; }
-    public GraphNodePropertiesLayout GraphEditorNodePropertiesLayout { get; set; }
+    public GraphEditorPropertiesLayout GraphEditorPropertiesLayout { get; set; }
 
     #endregion
 

--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -49,6 +49,7 @@ public interface ISettingsDto
     public EGameLanguage GameLanguage { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; }
     public GraphEditorPropertiesLayout GraphEditorPropertiesLayout { get; set; }
+    public double SceneEditorTimelineHeight { get; set; }
 
     #endregion
 

--- a/WolvenKit.App/Services/ISettingsDto.cs
+++ b/WolvenKit.App/Services/ISettingsDto.cs
@@ -5,6 +5,12 @@ using WolvenKit.Common;
 
 namespace WolvenKit.App.Services;
 
+public enum GraphNodePropertiesLayout
+{
+    SideBySide,
+    Stacked
+}
+
 public interface ISettingsDto
 {
     // I wish there was a better way to inject deps
@@ -42,6 +48,7 @@ public interface ISettingsDto
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; }
     public bool ShowGraphEditorNodeProperties { get; set; }
+    public GraphNodePropertiesLayout GraphEditorNodePropertiesLayout { get; set; }
 
     #endregion
 

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -56,6 +56,7 @@ public class SettingsDto : ISettingsDto
         ShowReferenceGraph = settings.ShowReferenceGraph;
         GameLanguage = settings.GameLanguage;
         ShowGraphEditorNodeProperties = settings.ShowGraphEditorNodeProperties;
+        GraphEditorNodePropertiesLayout = settings.GraphEditorNodePropertiesLayout;
 
         // File Editor
         TreeViewGroups = settings.TreeViewGroups;
@@ -124,6 +125,7 @@ public class SettingsDto : ISettingsDto
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; } = EGameLanguage.en_us;
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
+    public GraphNodePropertiesLayout GraphEditorNodePropertiesLayout { get; set; } = GraphNodePropertiesLayout.SideBySide;
 
     #endregion
 
@@ -202,6 +204,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.ShowReferenceGraph = ShowReferenceGraph;
         settingsManager.GameLanguage = GameLanguage;
         settingsManager.ShowGraphEditorNodeProperties = ShowGraphEditorNodeProperties;
+        settingsManager.GraphEditorNodePropertiesLayout = GraphEditorNodePropertiesLayout;
 
         // File Editor
         settingsManager.TreeViewGroups = TreeViewGroups;

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -56,7 +56,7 @@ public class SettingsDto : ISettingsDto
         ShowReferenceGraph = settings.ShowReferenceGraph;
         GameLanguage = settings.GameLanguage;
         ShowGraphEditorNodeProperties = settings.ShowGraphEditorNodeProperties;
-        GraphEditorNodePropertiesLayout = settings.GraphEditorNodePropertiesLayout;
+        GraphEditorPropertiesLayout = settings.GraphEditorPropertiesLayout;
 
         // File Editor
         TreeViewGroups = settings.TreeViewGroups;
@@ -125,7 +125,7 @@ public class SettingsDto : ISettingsDto
     public bool ShowReferenceGraph { get; set; }
     public EGameLanguage GameLanguage { get; set; } = EGameLanguage.en_us;
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
-    public GraphNodePropertiesLayout GraphEditorNodePropertiesLayout { get; set; } = GraphNodePropertiesLayout.SideBySide;
+    public GraphEditorPropertiesLayout GraphEditorPropertiesLayout { get; set; } = GraphEditorPropertiesLayout.SideBySide;
 
     #endregion
 
@@ -204,7 +204,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.ShowReferenceGraph = ShowReferenceGraph;
         settingsManager.GameLanguage = GameLanguage;
         settingsManager.ShowGraphEditorNodeProperties = ShowGraphEditorNodeProperties;
-        settingsManager.GraphEditorNodePropertiesLayout = GraphEditorNodePropertiesLayout;
+        settingsManager.GraphEditorPropertiesLayout = GraphEditorPropertiesLayout;
 
         // File Editor
         settingsManager.TreeViewGroups = TreeViewGroups;

--- a/WolvenKit.App/Services/SettingsDto.cs
+++ b/WolvenKit.App/Services/SettingsDto.cs
@@ -57,6 +57,7 @@ public class SettingsDto : ISettingsDto
         GameLanguage = settings.GameLanguage;
         ShowGraphEditorNodeProperties = settings.ShowGraphEditorNodeProperties;
         GraphEditorPropertiesLayout = settings.GraphEditorPropertiesLayout;
+        SceneEditorTimelineHeight = settings.SceneEditorTimelineHeight;
 
         // File Editor
         TreeViewGroups = settings.TreeViewGroups;
@@ -126,6 +127,7 @@ public class SettingsDto : ISettingsDto
     public EGameLanguage GameLanguage { get; set; } = EGameLanguage.en_us;
     public bool ShowGraphEditorNodeProperties { get; set; } = true;
     public GraphEditorPropertiesLayout GraphEditorPropertiesLayout { get; set; } = GraphEditorPropertiesLayout.SideBySide;
+    public double SceneEditorTimelineHeight { get; set; }
 
     #endregion
 
@@ -205,6 +207,7 @@ public class SettingsDto : ISettingsDto
         settingsManager.GameLanguage = GameLanguage;
         settingsManager.ShowGraphEditorNodeProperties = ShowGraphEditorNodeProperties;
         settingsManager.GraphEditorPropertiesLayout = GraphEditorPropertiesLayout;
+        settingsManager.SceneEditorTimelineHeight = SceneEditorTimelineHeight;
 
         // File Editor
         settingsManager.TreeViewGroups = TreeViewGroups;

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -64,6 +64,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(ShowReferenceGraph),
             nameof(GameLanguage),
             nameof(ShowGraphEditorNodeProperties),
+            nameof(GraphEditorNodePropertiesLayout),
 
             // FileEditor
             nameof(TreeViewGroups),
@@ -262,6 +263,10 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [Display(Name = "Show Graph Editor Node Properties", GroupName = "Display")]
     [ObservableProperty]
     private bool _showGraphEditorNodeProperties = true;
+
+    [Display(Name = "Graph Editor Node Properties Layout", GroupName = "Display")]
+    [ObservableProperty]
+    private GraphNodePropertiesLayout _graphEditorNodePropertiesLayout = GraphNodePropertiesLayout.SideBySide;
 
     #endregion
 

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -64,7 +64,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(ShowReferenceGraph),
             nameof(GameLanguage),
             nameof(ShowGraphEditorNodeProperties),
-            nameof(GraphEditorNodePropertiesLayout),
+            nameof(GraphEditorPropertiesLayout),
 
             // FileEditor
             nameof(TreeViewGroups),
@@ -264,9 +264,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [ObservableProperty]
     private bool _showGraphEditorNodeProperties = true;
 
-    [Display(Name = "Graph Editor Node Properties Layout", GroupName = "Display")]
+    [Display(Name = "Graph Editor Properties Layout", GroupName = "Display")]
     [ObservableProperty]
-    private GraphNodePropertiesLayout _graphEditorNodePropertiesLayout = GraphNodePropertiesLayout.SideBySide;
+    private GraphEditorPropertiesLayout _graphEditorPropertiesLayout = GraphEditorPropertiesLayout.SideBySide;
 
     #endregion
 

--- a/WolvenKit.App/Services/SettingsManager.cs
+++ b/WolvenKit.App/Services/SettingsManager.cs
@@ -65,6 +65,7 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
             nameof(GameLanguage),
             nameof(ShowGraphEditorNodeProperties),
             nameof(GraphEditorPropertiesLayout),
+            nameof(SceneEditorTimelineHeight),
 
             // FileEditor
             nameof(TreeViewGroups),
@@ -267,6 +268,9 @@ public partial class SettingsManager : ObservableObject, ISettingsManager
     [Display(Name = "Graph Editor Properties Layout", GroupName = "Display")]
     [ObservableProperty]
     private GraphEditorPropertiesLayout _graphEditorPropertiesLayout = GraphEditorPropertiesLayout.SideBySide;
+
+    [ObservableProperty]
+    private double _sceneEditorTimelineHeight;
 
     #endregion
 

--- a/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
+++ b/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -7,12 +8,16 @@ using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Models.Timeline;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.Timeline;
 
 public partial class SectionTimelineViewModel : ObservableObject, IDisposable
 {
     private readonly TimelineService _service;
+    private readonly Dictionary<scnSectionNode, double> _sectionZoomLevels = new(ReferenceEqualityComparer.Instance);
+    private scnSectionNode? _currentSection;
+    private bool _isApplyingSectionZoom;
     
     private const double BaseRowHeight = 56.0;
     private const double BasePixelsPerMs = 0.1;
@@ -56,6 +61,7 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
         switch (e.PropertyName)
         {
             case nameof(TimelineService.ZoomLevel):
+                RememberCurrentSectionZoom();
                 OnPropertyChanged(nameof(PixelsPerMs));
                 OnPropertyChanged(nameof(TimelineWidth));
                 break;
@@ -73,6 +79,7 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
                 OnPropertyChanged(nameof(IsSectionDurationTooShort));
                 break;
             case nameof(TimelineService.Tracks):
+                ApplySectionZoom();
                 OnPropertyChanged(nameof(Tracks));
                 OnPropertyChanged(nameof(TotalTrackHeight));
                 break;
@@ -82,6 +89,43 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
             case nameof(TimelineService.SectionName):
                 OnPropertyChanged(nameof(SectionName));
                 break;
+        }
+    }
+
+    private void ApplySectionZoom()
+    {
+        if (_service.NodeWrapper?.Data is not scnSectionNode sectionNode ||
+            ReferenceEquals(_currentSection, sectionNode))
+        {
+            return;
+        }
+
+        _currentSection = sectionNode;
+        _isApplyingSectionZoom = true;
+        try
+        {
+            if (_sectionZoomLevels.TryGetValue(sectionNode, out var zoomLevel))
+            {
+                _service.ZoomLevel = zoomLevel;
+            }
+            else
+            {
+                _service.ZoomLevel = 1.0;
+                _service.ZoomToFit(ViewportWidth);
+                _sectionZoomLevels[sectionNode] = _service.ZoomLevel;
+            }
+        }
+        finally
+        {
+            _isApplyingSectionZoom = false;
+        }
+    }
+
+    private void RememberCurrentSectionZoom()
+    {
+        if (!_isApplyingSectionZoom && _currentSection is not null)
+        {
+            _sectionZoomLevels[_currentSection] = _service.ZoomLevel;
         }
     }
     

--- a/WolvenKit/Views/Documents/BehaviorGraphView.xaml
+++ b/WolvenKit/Views/Documents/BehaviorGraphView.xaml
@@ -165,14 +165,9 @@
                                     </Style>
                                 </Grid.Style>
 
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="3*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="2*" />
-                                </Grid.ColumnDefinitions>
+                                <local:GraphEditorPropertiesPanel>
 
                                 <tools:RedTreeView
-                                    Grid.Column="0"
                                     ItemsSource="{Binding DataContext.SelectedTabContent,
                                                           RelativeSource={RelativeSource AncestorType={x:Type local:BehaviorGraphView}}}"
                                     SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk,
@@ -183,15 +178,13 @@
                                                             Mode=TwoWay}" />
 
                                 <GridSplitter
-                                    Grid.Column="1"
-                                    Width="4"
-                                    HorizontalAlignment="Stretch"
-                                    Background="#FF404040" />
+                                    Background="#FF404040"
+                                    ResizeBehavior="PreviousAndNext" />
 
                                 <editors:RedTypeView
-                                    Grid.Column="2"
                                     DataContext="{Binding DataContext.RDTViewModel.SelectedChunk,
-                                                          RelativeSource={RelativeSource AncestorType={x:Type local:BehaviorGraphView}}}" />
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:BehaviorGraphView}}}" />
+                                </local:GraphEditorPropertiesPanel>
                             </Grid>
 
                             <local:NodePropertiesView>

--- a/WolvenKit/Views/Documents/GraphEditorPropertiesPanel.cs
+++ b/WolvenKit/Views/Documents/GraphEditorPropertiesPanel.cs
@@ -1,0 +1,100 @@
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Splat;
+using WolvenKit.App.Services;
+using WolvenKit.Views.Editors;
+using WolvenKit.Views.Tools;
+
+namespace WolvenKit.Views.Documents;
+
+public class GraphEditorPropertiesPanel : Grid
+{
+    private readonly ISettingsManager _settingsManager;
+
+    public GraphEditorPropertiesPanel()
+    {
+        _settingsManager = Locator.Current.GetService<ISettingsManager>() ??
+                           throw new ArgumentNullException(nameof(ISettingsManager));
+
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _settingsManager.PropertyChanged += OnSettingsPropertyChanged;
+        ApplyLayout();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e) =>
+        _settingsManager.PropertyChanged -= OnSettingsPropertyChanged;
+
+    private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ISettingsDto.GraphEditorPropertiesLayout))
+        {
+            ApplyLayout();
+        }
+    }
+
+    private void ApplyLayout()
+    {
+        var propertyTree = Children.OfType<RedTreeView>().SingleOrDefault();
+        var propertySplitter = Children.OfType<GridSplitter>().SingleOrDefault();
+        var propertyEditor = Children.OfType<RedTypeView>().SingleOrDefault();
+        if (propertyTree is null || propertySplitter is null || propertyEditor is null)
+        {
+            return;
+        }
+
+        RowDefinitions.Clear();
+        ColumnDefinitions.Clear();
+
+        if (_settingsManager.GraphEditorPropertiesLayout == GraphEditorPropertiesLayout.Stacked)
+        {
+            RowDefinitions.Add(new RowDefinition { Height = new GridLength(2, GridUnitType.Star) });
+            RowDefinitions.Add(new RowDefinition { Height = new GridLength(6) });
+            RowDefinitions.Add(new RowDefinition { Height = new GridLength(3, GridUnitType.Star) });
+            ColumnDefinitions.Add(new ColumnDefinition());
+
+            SetPosition(propertyTree, 0, 0);
+            SetPosition(propertySplitter, 1, 0);
+            SetPosition(propertyEditor, 2, 0);
+
+            propertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeNS);
+            propertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Rows);
+        }
+        else
+        {
+            RowDefinitions.Add(new RowDefinition());
+            ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(3, GridUnitType.Star) });
+            ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(6) });
+            ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+
+            SetPosition(propertyTree, 0, 0);
+            SetPosition(propertySplitter, 0, 1);
+            SetPosition(propertyEditor, 0, 2);
+
+            propertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeWE);
+            propertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Columns);
+        }
+
+        propertySplitter.SetCurrentValue(HeightProperty, double.NaN);
+        propertySplitter.SetCurrentValue(WidthProperty, double.NaN);
+        propertySplitter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
+        propertySplitter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Stretch);
+        propertySplitter.SetCurrentValue(IsHitTestVisibleProperty, true);
+    }
+
+    private static void SetPosition(UIElement element, int row, int column)
+    {
+        SetRow(element, row);
+        SetColumn(element, column);
+    }
+}

--- a/WolvenKit/Views/Documents/NodePropertiesView.xaml
+++ b/WolvenKit/Views/Documents/NodePropertiesView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:services="clr-namespace:WolvenKit.App.Services;assembly=WolvenKit.App"
+             xmlns:local="clr-namespace:WolvenKit.Views.Documents"
              xmlns:graphEditor="clr-namespace:WolvenKit.App.ViewModels.GraphEditor;assembly=WolvenKit.App"
              xmlns:editors="clr-namespace:WolvenKit.Views.Editors"
              xmlns:tools="clr-namespace:WolvenKit.Views.Tools"
@@ -53,9 +54,9 @@
         </Border>
         
                 <!-- Content -->
-        <Grid x:Name="PropertyContentGrid" Grid.Row="1">
-            <Grid.Style>
-                <Style TargetType="Grid">
+        <local:GraphEditorPropertiesPanel Grid.Row="1">
+            <local:GraphEditorPropertiesPanel.Style>
+                <Style TargetType="local:GraphEditorPropertiesPanel">
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding Source={x:Static services:NodeSelectionService.Instance}, Path=SelectedNode}" 
                                      Value="{x:Null}">
@@ -63,7 +64,7 @@
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
-            </Grid.Style>
+            </local:GraphEditorPropertiesPanel.Style>
             
             <!-- Property tree for the selected node -->
             <tools:RedTreeView x:Name="PropertyTree"
@@ -77,13 +78,12 @@
             </tools:RedTreeView>
             
             <GridSplitter
-                x:Name="PropertySplitter"
                 Background="#FF404040"
                 ResizeBehavior="PreviousAndNext" />
             
             <!-- Detail editor for selected property -->
-            <editors:RedTypeView x:Name="PropertyEditor" DataContext="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperty}"/>
-        </Grid>
+            <editors:RedTypeView DataContext="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperty}"/>
+        </local:GraphEditorPropertiesPanel>
         
         <!-- No selection message -->
         <StackPanel Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.6">

--- a/WolvenKit/Views/Documents/NodePropertiesView.xaml
+++ b/WolvenKit/Views/Documents/NodePropertiesView.xaml
@@ -53,7 +53,7 @@
         </Border>
         
                 <!-- Content -->
-        <Grid Grid.Row="1">
+        <Grid x:Name="PropertyContentGrid" Grid.Row="1">
             <Grid.Style>
                 <Style TargetType="Grid">
                     <Style.Triggers>
@@ -65,14 +65,8 @@
                 </Style>
             </Grid.Style>
             
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="2*" />
-            </Grid.ColumnDefinitions>
-
-            <!-- Left: Property tree for the selected node -->
-            <tools:RedTreeView Grid.Column="0" 
+            <!-- Property tree for the selected node -->
+            <tools:RedTreeView x:Name="PropertyTree"
                                SelectedItem="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperty, Mode=TwoWay}"
                                SelectedItems="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperties, Mode=TwoWay}">
                 <tools:RedTreeView.ItemsSource>
@@ -82,10 +76,13 @@
                 </tools:RedTreeView.ItemsSource>
             </tools:RedTreeView>
             
-            <GridSplitter Grid.Column="1" Width="4" HorizontalAlignment="Stretch" Background="#FF404040"/>
+            <GridSplitter
+                x:Name="PropertySplitter"
+                Background="#FF404040"
+                ResizeBehavior="PreviousAndNext" />
             
-            <!-- Right: Detail editor for selected property -->
-            <editors:RedTypeView Grid.Column="2" DataContext="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperty}"/>
+            <!-- Detail editor for selected property -->
+            <editors:RedTypeView x:Name="PropertyEditor" DataContext="{Binding Source={x:Static services:NodePropertiesSelectionService.Instance}, Path=SelectedProperty}"/>
         </Grid>
         
         <!-- No selection message -->
@@ -112,4 +109,4 @@
                        Foreground="Gray"/>
         </StackPanel>
     </Grid>
-</UserControl> 
+</UserControl>

--- a/WolvenKit/Views/Documents/NodePropertiesView.xaml.cs
+++ b/WolvenKit/Views/Documents/NodePropertiesView.xaml.cs
@@ -1,7 +1,11 @@
 #nullable enable
 using System;
+using System.ComponentModel;
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using Splat;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
 
@@ -12,14 +16,79 @@ namespace WolvenKit.Views.Documents
     /// </summary>
     public partial class NodePropertiesView : UserControl
     {
+        private readonly ISettingsManager _settingsManager;
+
         public NodePropertiesView()
         {
             InitializeComponent();
+
+            _settingsManager = Locator.Current.GetService<ISettingsManager>() ?? throw new ArgumentNullException(nameof(ISettingsManager));
+            _settingsManager.PropertyChanged += OnSettingsPropertyChanged;
+            ApplyLayout();
             
             // Subscribe to property panel refresh requests (e.g., from timeline editor)
             NodePropertyUpdateService.PropertyPanelRefreshRequested += OnPropertyPanelRefreshRequested;
             NodePropertyUpdateService.EventSelectionRequested += OnEventSelectionRequested;
             Unloaded += OnUnloaded;
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ISettingsDto.GraphEditorNodePropertiesLayout))
+            {
+                ApplyLayout();
+            }
+        }
+
+        private void ApplyLayout()
+        {
+            PropertyContentGrid.RowDefinitions.Clear();
+            PropertyContentGrid.ColumnDefinitions.Clear();
+
+            if (_settingsManager.GraphEditorNodePropertiesLayout == GraphNodePropertiesLayout.Stacked)
+            {
+                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(2, GridUnitType.Star) });
+                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(6) });
+                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(3, GridUnitType.Star) });
+                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition());
+
+                Grid.SetRow(PropertyTree, 0);
+                Grid.SetColumn(PropertyTree, 0);
+                Grid.SetRow(PropertySplitter, 1);
+                Grid.SetColumn(PropertySplitter, 0);
+                Grid.SetRow(PropertyEditor, 2);
+                Grid.SetColumn(PropertyEditor, 0);
+
+                PropertySplitter.SetCurrentValue(HeightProperty, double.NaN);
+                PropertySplitter.SetCurrentValue(WidthProperty, double.NaN);
+                PropertySplitter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
+                PropertySplitter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Stretch);
+                PropertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeNS);
+                PropertySplitter.SetCurrentValue(IsHitTestVisibleProperty, true);
+                PropertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Rows);
+            }
+            else
+            {
+                PropertyContentGrid.RowDefinitions.Add(new RowDefinition());
+                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(3, GridUnitType.Star) });
+                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(6) });
+                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
+
+                Grid.SetRow(PropertyTree, 0);
+                Grid.SetColumn(PropertyTree, 0);
+                Grid.SetRow(PropertySplitter, 0);
+                Grid.SetColumn(PropertySplitter, 1);
+                Grid.SetRow(PropertyEditor, 0);
+                Grid.SetColumn(PropertyEditor, 2);
+
+                PropertySplitter.SetCurrentValue(HeightProperty, double.NaN);
+                PropertySplitter.SetCurrentValue(WidthProperty, double.NaN);
+                PropertySplitter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
+                PropertySplitter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Stretch);
+                PropertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeWE);
+                PropertySplitter.SetCurrentValue(IsHitTestVisibleProperty, true);
+                PropertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Columns);
+            }
         }
         
         private void OnPropertyPanelRefreshRequested(object? sender, EventArgs e)
@@ -110,6 +179,7 @@ namespace WolvenKit.Views.Documents
         {
             NodePropertyUpdateService.PropertyPanelRefreshRequested -= OnPropertyPanelRefreshRequested;
             NodePropertyUpdateService.EventSelectionRequested -= OnEventSelectionRequested;
+            _settingsManager.PropertyChanged -= OnSettingsPropertyChanged;
         }
     }
 }

--- a/WolvenKit/Views/Documents/NodePropertiesView.xaml.cs
+++ b/WolvenKit/Views/Documents/NodePropertiesView.xaml.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
-using System.ComponentModel;
 using System.Linq;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using Splat;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
 
@@ -16,81 +12,16 @@ namespace WolvenKit.Views.Documents
     /// </summary>
     public partial class NodePropertiesView : UserControl
     {
-        private readonly ISettingsManager _settingsManager;
-
         public NodePropertiesView()
         {
             InitializeComponent();
 
-            _settingsManager = Locator.Current.GetService<ISettingsManager>() ?? throw new ArgumentNullException(nameof(ISettingsManager));
-            _settingsManager.PropertyChanged += OnSettingsPropertyChanged;
-            ApplyLayout();
-            
             // Subscribe to property panel refresh requests (e.g., from timeline editor)
             NodePropertyUpdateService.PropertyPanelRefreshRequested += OnPropertyPanelRefreshRequested;
             NodePropertyUpdateService.EventSelectionRequested += OnEventSelectionRequested;
             Unloaded += OnUnloaded;
         }
 
-        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(ISettingsDto.GraphEditorNodePropertiesLayout))
-            {
-                ApplyLayout();
-            }
-        }
-
-        private void ApplyLayout()
-        {
-            PropertyContentGrid.RowDefinitions.Clear();
-            PropertyContentGrid.ColumnDefinitions.Clear();
-
-            if (_settingsManager.GraphEditorNodePropertiesLayout == GraphNodePropertiesLayout.Stacked)
-            {
-                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(2, GridUnitType.Star) });
-                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(6) });
-                PropertyContentGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(3, GridUnitType.Star) });
-                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition());
-
-                Grid.SetRow(PropertyTree, 0);
-                Grid.SetColumn(PropertyTree, 0);
-                Grid.SetRow(PropertySplitter, 1);
-                Grid.SetColumn(PropertySplitter, 0);
-                Grid.SetRow(PropertyEditor, 2);
-                Grid.SetColumn(PropertyEditor, 0);
-
-                PropertySplitter.SetCurrentValue(HeightProperty, double.NaN);
-                PropertySplitter.SetCurrentValue(WidthProperty, double.NaN);
-                PropertySplitter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
-                PropertySplitter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Stretch);
-                PropertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeNS);
-                PropertySplitter.SetCurrentValue(IsHitTestVisibleProperty, true);
-                PropertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Rows);
-            }
-            else
-            {
-                PropertyContentGrid.RowDefinitions.Add(new RowDefinition());
-                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(3, GridUnitType.Star) });
-                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(6) });
-                PropertyContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) });
-
-                Grid.SetRow(PropertyTree, 0);
-                Grid.SetColumn(PropertyTree, 0);
-                Grid.SetRow(PropertySplitter, 0);
-                Grid.SetColumn(PropertySplitter, 1);
-                Grid.SetRow(PropertyEditor, 0);
-                Grid.SetColumn(PropertyEditor, 2);
-
-                PropertySplitter.SetCurrentValue(HeightProperty, double.NaN);
-                PropertySplitter.SetCurrentValue(WidthProperty, double.NaN);
-                PropertySplitter.SetCurrentValue(HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
-                PropertySplitter.SetCurrentValue(VerticalAlignmentProperty, VerticalAlignment.Stretch);
-                PropertySplitter.SetCurrentValue(CursorProperty, Cursors.SizeWE);
-                PropertySplitter.SetCurrentValue(IsHitTestVisibleProperty, true);
-                PropertySplitter.SetCurrentValue(GridSplitter.ResizeDirectionProperty, GridResizeDirection.Columns);
-            }
-        }
-        
         private void OnPropertyPanelRefreshRequested(object? sender, EventArgs e)
         {
             // Trigger a re-evaluation of the property panel by notifying the selection service
@@ -179,7 +110,6 @@ namespace WolvenKit.Views.Documents
         {
             NodePropertyUpdateService.PropertyPanelRefreshRequested -= OnPropertyPanelRefreshRequested;
             NodePropertyUpdateService.EventSelectionRequested -= OnEventSelectionRequested;
-            _settingsManager.PropertyChanged -= OnSettingsPropertyChanged;
         }
     }
 }

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml
@@ -208,15 +208,10 @@
                                     </Style>
                                 </Grid.Style>
 
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="3*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="2*" />
-                                </Grid.ColumnDefinitions>
+                                <local:GraphEditorPropertiesPanel>
 
                                 <!-- RedTreeView bound directly to the filtered ICollectionView -->
                                 <tools:RedTreeView
-                                    Grid.Column="0"
                                     ItemsSource="{Binding DataContext.SelectedTabContent,
                                                           RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}"
                                     SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk,
@@ -227,15 +222,13 @@
                                                             Mode=TwoWay}" />
 
                                 <GridSplitter
-                                    Grid.Column="1"
-                                    Width="4"
-                                    HorizontalAlignment="Stretch"
-                                    Background="#FF404040" />
+                                    Background="#FF404040"
+                                    ResizeBehavior="PreviousAndNext" />
 
                                 <editors:RedTypeView
-                                    Grid.Column="2"
                                     DataContext="{Binding DataContext.RDTViewModel.SelectedChunk,
-                                                          RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}" />
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:QuestPhaseGraphView}}}" />
+                                </local:GraphEditorPropertiesPanel>
                             </Grid>
 
                             <!-- Node Properties tab shows our custom selection-driven view -->

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -464,6 +464,7 @@
                 Height="4"
                 HorizontalAlignment="Stretch"
                 Background="#FF404040"
+                DragCompleted="TimelineSplitter_OnDragCompleted"
                 Visibility="{Binding ElementName=TimelinePanel, Path=DataContext.HasSectionNode, Converter={StaticResource BooleanToVisibilityConverter}}" />
             
             <!-- Timeline Panel - spans full width, visible only when section node is selected -->

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -351,16 +351,10 @@
                                     </StackPanel>
                                 </Border>
 
-                                <Grid Grid.Row="1">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="3*" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="2*" />
-                                    </Grid.ColumnDefinitions>
+                                <local:GraphEditorPropertiesPanel Grid.Row="1">
 
                                     <!-- RedTreeView bound directly to the filtered ICollectionView -->
                                     <tools:RedTreeView
-                                        Grid.Column="0"
                                         ItemsSource="{Binding DataContext.SelectedTabContent,
                                                               RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}"
                                         SelectedItem="{Binding DataContext.RDTViewModel.SelectedChunk,
@@ -371,16 +365,13 @@
                                                                 Mode=TwoWay}" />
 
                                     <GridSplitter
-                                        Grid.Column="1"
-                                        Width="4"
-                                        HorizontalAlignment="Stretch"
-                                        Background="#FF404040" />
+                                        Background="#FF404040"
+                                        ResizeBehavior="PreviousAndNext" />
 
                                     <editors:RedTypeView
-                                        Grid.Column="2"
                                         DataContext="{Binding DataContext.RDTViewModel.SelectedChunk,
-                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
-                                </Grid>
+                                                                  RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                </local:GraphEditorPropertiesPanel>
                             </Grid>
 
                             <!-- Node Properties tab shows our custom selection-driven view -->

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -38,6 +39,7 @@ namespace WolvenKit.Views.Documents
         private readonly Dictionary<(uint nodeId, Key direction), uint> _navigationMemory = new();
         private readonly List<uint> _navigationHistory = new();
         private RedGraph? _subscribedGraph;
+        private readonly ISettingsManager _settingsManager;
 
         // Selection persistence across document switches
         private static readonly Dictionary<string, uint> s_documentNodeSelections = new();
@@ -49,6 +51,9 @@ namespace WolvenKit.Views.Documents
 
         public SceneGraphView()
         {
+            _settingsManager = Locator.Current.GetService<ISettingsManager>() ??
+                               throw new ArgumentNullException(nameof(ISettingsManager));
+
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
             Loaded += OnViewLoaded;
@@ -1013,7 +1018,43 @@ namespace WolvenKit.Views.Documents
             if (e.NewValue is false)
             {
                 TimelineRow.SetCurrentValue(RowDefinition.HeightProperty, GridLength.Auto);
+                return;
             }
+
+            RestoreTimelineHeight();
+        }
+
+        private void TimelineSplitter_OnDragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            if (TimelinePanel.IsVisible && TimelineRow.ActualHeight >= TimelinePanel.MinHeight)
+            {
+                _settingsManager.SceneEditorTimelineHeight = TimelineRow.ActualHeight;
+            }
+        }
+
+        private void RestoreTimelineHeight()
+        {
+            if (_settingsManager.SceneEditorTimelineHeight <= 0)
+            {
+                TimelineRow.SetCurrentValue(RowDefinition.HeightProperty, GridLength.Auto);
+                return;
+            }
+
+            const double minimumGraphHeight = 200;
+            const double splitterHeight = 4;
+            var maximumTimelineHeight = MainContentGrid.ActualHeight > 0
+                ? Math.Max(
+                    TimelinePanel.MinHeight,
+                    MainContentGrid.ActualHeight - minimumGraphHeight - splitterHeight)
+                : Math.Max(TimelinePanel.MinHeight, _settingsManager.SceneEditorTimelineHeight);
+            var timelineHeight = Math.Clamp(
+                _settingsManager.SceneEditorTimelineHeight,
+                TimelinePanel.MinHeight,
+                maximumTimelineHeight);
+
+            TimelineRow.SetCurrentValue(
+                RowDefinition.HeightProperty,
+                new GridLength(timelineHeight));
         }
     }
 }

--- a/changelog/unreleased/3018.yaml
+++ b/changelog/unreleased/3018.yaml
@@ -1,0 +1,16 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3018
+      author: "misterchedda"
+      description: "Graph editor property panels can now be displayed side by side or stacked under Settings > Display > Graph Editor Properties Layout"
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3018
+      author: "misterchedda"
+      description: "The scene editor now remembers the section timeline height after it is resized"
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3018
+      author: "misterchedda"
+      description: "Section timelines now fit their content on first selection and remember their individual zoom levels while the scene is open"


### PR DESCRIPTION
Adds an opt-in setting to change the graph editor's Node Properties layout between Side by side (current default behaviour) and a new layout option "Stacked" under a new settings option in Settings > Display > Graph Editor Properties Layout

| Side by side view | Stacked view |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/e9a7173e-2f20-4294-8bc5-bed1fa5a4736" width="100%"> | <img src="https://github.com/user-attachments/assets/7b4e3622-7e8c-4d5a-b7aa-540cbe4bd87c" width="100%"> |
