### PR TITLE
fix: ent preview dynamic substitution

### DIFF
--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -181,6 +181,8 @@ public static partial class ArchiveXlHelper
     /// Returns any existing depot path, or null. If no substitution is used, it will still check for the file's existence
     /// and return null if it can't be found.
     /// </summary>
+    /// <param name="depotPath">Depot path to resolve. Can be null, can be static.</param>
+    /// <param name="activeProject">As ProjectManager can be null in file, pass this from calling class where available.</param>
     public static string? GetFirstExistingPath(string? depotPath, Cp77Project? activeProject = null)
     {
         if (string.IsNullOrEmpty(depotPath))

--- a/WolvenKit.App/Helpers/ArchiveXlHelper.cs
+++ b/WolvenKit.App/Helpers/ArchiveXlHelper.cs
@@ -183,9 +183,16 @@ public static partial class ArchiveXlHelper
     /// </summary>
     public static string? GetFirstExistingPath(string? depotPath, Cp77Project? activeProject = null)
     {
-        if (depotPath is null || ProjectManager?.ActiveProject?.ModDirectory is not string pathToArchiveFolder
-                              || ProjectManager.ActiveProject?.FileDirectory is not string pathToGameFiles)
+        if (string.IsNullOrEmpty(depotPath))
         {
+            s_loggerService?.Error("Invalid depot path, can't resolve dynamic paths");
+            return null;
+        }
+        activeProject ??= ProjectManager?.ActiveProject;
+        if (activeProject?.ModDirectory is not string pathToArchiveFolder
+            || activeProject.FileDirectory is not string pathToGameFiles)
+        {
+            s_loggerService?.Error("Failed to read file paths from active project");
             return null;
         }
 

--- a/changelog/unreleased/3019.yaml
+++ b/changelog/unreleased/3019.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3019
+      author: "manavortex"
+      description: "Fixed an exception when trying to display a root entity preview with dynamic substitution."


### PR DESCRIPTION
# fix: ent preview dynamic substitution

Fixed an exception when trying to display a root entity preview with dynamic substitution.
