### PR TITLE
pull updated templates from wolvenkit resources

### DIFF
--- a/WolvenKit.App/Helpers/RedTypeTemplateServiceHelper.cs
+++ b/WolvenKit.App/Helpers/RedTypeTemplateServiceHelper.cs
@@ -1,13 +1,21 @@
 using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
 using WolvenKit.Common;
 using WolvenKit.Common.Model;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.Helpers;
 
 public static class RedTypeTemplateServiceHelper
 {
+    private static readonly HttpClient s_httpClient = new();
+
     /// <summary>
     /// This is a helper method to correctly handle the Raw option when using RedTypeTemplateSelectionOption
     /// </summary>
@@ -24,4 +32,77 @@ public static class RedTypeTemplateServiceHelper
             RedTypeTemplateSelectionOptionSource.System => templateService.CreateTypeInstance(templateOption, TemplateSource.System),
             _ => throw new ArgumentOutOfRangeException(nameof(templateOption), templateOption.Source.ToString())
         };
+
+    /// <summary>
+    /// Updates the system templates from the remote WolvenKit/WolvenKit-Resources repository.
+    /// </summary>
+    /// <param name="loggerService"></param>
+    /// <returns>true if templates are up to date or have been updated, false if status could not be verified or failed to download updated templates</returns>
+    /// <remarks>Does not trigger the template service to load them from disk</remarks>
+    public static async Task<bool> UpdateSystemTemplatesFromRemote(ILoggerService? loggerService = null)
+    {
+        // check remote version (no github API call)
+        var hashUrl = $@"https://wolvenkit.github.io/Wolvenkit-Resources/templatehash.txt";
+        var response = await s_httpClient.GetAsync(new Uri(hashUrl));
+
+        try
+        {
+            response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException ex)
+        {
+            loggerService?.Error($"Failed to respond to url: {hashUrl}");
+            loggerService?.Error(ex);
+            return false;
+        }
+
+        var localHash = "";
+        var templatesDir = new DirectoryInfo(Path.Combine("Resources", "Templates"));
+        FileInfo hashPath = new(Path.Combine("Resources", "templatehash.txt"));
+        if (hashPath.Exists)
+        {
+            localHash = await File.ReadAllTextAsync(hashPath.FullName);
+        }
+
+        using var ms = new MemoryStream();
+        await response.Content.CopyToAsync(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(ms, Encoding.UTF8);
+        var remoteHash = await reader.ReadToEndAsync();
+        remoteHash = remoteHash.TrimEnd('\r', '\n');
+
+        if (localHash == remoteHash)
+        {
+            return true;
+        }
+
+        // clean
+        if (templatesDir.Exists)
+        {
+            templatesDir.Delete(true);
+        }
+        Directory.CreateDirectory(templatesDir.FullName);
+
+        // download zip file
+        var contentUrl = $@"https://wolvenkit.github.io/Wolvenkit-Resources/templates.zip";
+        response = await s_httpClient.GetAsync(new Uri(contentUrl));
+        try
+        {
+            response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException ex)
+        {
+            loggerService?.Warning($"Failed update scripts from {contentUrl}");
+            loggerService?.Warning($"\t{ex.Message}");
+            return false;
+        }
+
+        var zip = await response.Content.ReadAsStreamAsync();
+        zip.Seek(0, SeekOrigin.Begin);
+        ZipArchive zipArchive = new(zip);
+        zipArchive.ExtractToDirectory(templatesDir.FullName, true);
+
+        await File.WriteAllTextAsync(hashPath.FullName, remoteHash);
+        return true;
+    }
 }

--- a/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
+++ b/WolvenKit.App/ViewModels/Controls/RedTypeTemplateDropdownViewModel.cs
@@ -1,20 +1,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Comparers;
+using WolvenKit.App.Helpers;
 using WolvenKit.Common;
 using WolvenKit.Common.Model;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
 
 namespace WolvenKit.App.ViewModels.Controls;
 
 public partial class RedTypeTemplateDropdownViewModel : ObservableObject
 {
     private readonly RedTypeTemplateService _redTypeTemplateService;
+    private readonly ILoggerService _loggerService;
 
     private readonly List<RedTypeTemplateSelectionOption> _defaultList;
 
@@ -32,9 +36,10 @@ public partial class RedTypeTemplateDropdownViewModel : ObservableObject
     [ObservableProperty]
     private Dictionary<Type, List<RedTypeTemplateSelectionOption>> _templatesByType = new();
 
-    public RedTypeTemplateDropdownViewModel(RedTypeTemplateService redTypeTemplateService)
+    public RedTypeTemplateDropdownViewModel(RedTypeTemplateService redTypeTemplateService, ILoggerService loggerService)
     {
         _redTypeTemplateService = redTypeTemplateService;
+        _loggerService = loggerService;
 
         _defaultList = new List<RedTypeTemplateSelectionOption>([
             new RedTypeTemplateSelectionOption("No Template", typeof(object), "", RedTypeTemplateSelectionOptionSource.Raw)
@@ -64,7 +69,9 @@ public partial class RedTypeTemplateDropdownViewModel : ObservableObject
     [RelayCommand]
     private async Task Refresh()
     {
-        await Task.Run(_redTypeTemplateService.LoadTemplates);
+        await Task.Run(() => RedTypeTemplateServiceHelper.UpdateSystemTemplatesFromRemote(_loggerService));
+        _redTypeTemplateService.LoadTemplates();
+
         IndexRedTypeTemplates();
         CurrentRedTypeTemplates.Source = TemplatesByType.TryGetValue(RequestedType, out var list) ? list : _defaultList;
         SelectedRedTypeTemplate = GetInitialTemplateForSelectedFile();

--- a/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/NewFileViewModel.cs
@@ -75,7 +75,7 @@ public partial class NewFileViewModel : DialogViewModel
 
             SelectedCategory = Categories.FirstOrDefault();
 
-            _redTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(_redTypeTemplateService);
+            _redTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(_redTypeTemplateService, _loggerService);
         }
         catch (Exception e)
         {

--- a/WolvenKit.App/ViewModels/Dialogs/RedTypeTemplateManagerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/RedTypeTemplateManagerViewModel.cs
@@ -59,7 +59,7 @@ public partial class RedTypeTemplateManagerViewModel : DialogViewModel
         _loggerService = loggerService;
         _cr2wTools = cr2wTools;
 
-        RedTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(templateService);
+        RedTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(templateService, _loggerService);
         RedTypeTemplateDropdownViewModel.PostRefresh += (_, _) => LoadTemplates();
 
         ValidNewTypes = new ObservableCollection<TypeDesc>(AppDomain.CurrentDomain.GetAssemblies()

--- a/WolvenKit.App/ViewModels/Dialogs/TypeSelectorDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/TypeSelectorDialogViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.ViewModels.Controls;
 using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
@@ -34,12 +35,12 @@ public partial class TypeSelectorDialogViewModel : DialogViewModel
     [ObservableProperty]
     private RedTypeTemplateDropdownViewModel _redTypeTemplateDropdownViewModel;
 
-    public TypeSelectorDialogViewModel(RedTypeTemplateService redTypeTemplateService, List<TypeEntry> entries, bool allowCreating = false)
+    public TypeSelectorDialogViewModel(RedTypeTemplateService redTypeTemplateService, ILoggerService loggerService, List<TypeEntry> entries, bool allowCreating = false)
     {
         _entries = new ObservableCollection<TypeEntry>(entries);
         _allowCreating = allowCreating;
 
-        _redTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(redTypeTemplateService);
+        _redTypeTemplateDropdownViewModel = new RedTypeTemplateDropdownViewModel(redTypeTemplateService, loggerService);
     }
 
     private bool CanExecuteOk()

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -171,7 +171,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
             .Select(fileType => new TypeEntry(fileType.Extension.ToString(), fileType.Description, fileType.RootType))
             .ToList();
 
-        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
         {
             DialogHandler = HandleEmbeddedFile
         });

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -1309,7 +1309,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
         }
 
         await _appViewModel.SetActiveDialog(
-            new TypeSelectorDialogViewModel(_redTypeTemplateService, types, allowCreating) { DialogHandler = HandlePointer });
+            new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types, allowCreating) { DialogHandler = HandlePointer });
     }
 
     private bool CanAddItemToArray() =>
@@ -1364,7 +1364,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             {
                 types = TypeHelper.GetCKeyValueEntryTypes();
                 await _appViewModel.SetActiveDialog(
-                    new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+                    new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
                     {
                         DialogHandler = HandleCKeyValuePair
                     });
@@ -1400,7 +1400,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             return;
         }
 
-        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+        await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
         {
             DialogHandler = handler
         });
@@ -1595,7 +1595,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                 .Select(x => new TypeEntry(x.Name, "", x))
                 .ToList();
 
-            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
             {
                 DialogHandler = HandleNewDynamicProperty
             });
@@ -1707,7 +1707,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                     $"You can't create new items for {Data.RedType} yet. Please create a ticket and tell us what you need here.");
             }
 
-            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types) { DialogHandler = HandleChunk });
+            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types) { DialogHandler = HandleChunk });
         }
     }
 

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -64,6 +64,8 @@ namespace WolvenKit.Views.Documents
         private bool _disposed = false;
         private IDocumentViewModel? _currentDocument; // Track current document for disposal detection
 
+        private ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>()!;
+
         // Node selection persistence across document switches
         private static readonly Dictionary<string, (uint nodeId, int graphLevel)> s_documentNodeSelections = new();
 
@@ -1245,7 +1247,7 @@ namespace WolvenKit.Views.Documents
                     .ToList();
 
                 // Create and show the type selector dialog
-                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, questTypes)
+                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, _loggerService, questTypes)
                 {
                     DialogHandler = model =>
                     {

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -44,6 +44,8 @@ namespace WolvenKit.Views.Documents
         private static IDocumentViewModel? s_lastActiveDocument;
         private static bool s_selectionManagerInitialized = false;
 
+        private readonly ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>()!;
+
         private bool _disposed = false;
 
         public SceneGraphView()
@@ -740,7 +742,7 @@ namespace WolvenKit.Views.Documents
                     .Select(x => new TypeEntry(GraphNodeStyling.GetTitleForNodeType(x), "Scene", x)));
 
                 // Create and show the type selector dialog
-                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, allTypes)
+                await appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(((SceneGraphViewModel)DataContext).RedTypeTemplateService, _loggerService, allTypes)
                 {
                     DialogHandler = model =>
                     {

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -17,6 +17,7 @@ using ReactiveUI;
 using Splat;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.App.ViewModels.GraphEditor;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
@@ -41,6 +42,7 @@ public record NodeCreationParams(Type Type, RedTypeTemplateSelectionOption? RedT
 public partial class GraphEditorView : UserControl
 {
     private readonly RedTypeTemplateService _redTypeTemplateService = Locator.Current.GetService<RedTypeTemplateService>();
+    private readonly ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>();
 
     private static readonly (string Name, string Color)[] s_commentColorPresets =
     [
@@ -226,7 +228,7 @@ public partial class GraphEditorView : UserControl
             // Open Dialog option
             addMenu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", async () =>
             {
-                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, allTypes.OrderBy(x => x.Name).ToList())
+                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, allTypes.OrderBy(x => x.Name).ToList())
                 {
                     DialogHandler = model =>
                     {
@@ -377,7 +379,7 @@ public partial class GraphEditorView : UserControl
 
             addMenu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", async () =>
             {
-                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+                await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
                 {
                     DialogHandler = model =>
                     {
@@ -1009,7 +1011,7 @@ public partial class GraphEditorView : UserControl
 
         parentMenu.Items.Add(CreateMenuItem("Search Node ...", "Magnify", "WolvenKitYellow", async () =>
         {
-            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, types)
+            await _appViewModel.SetActiveDialog(new TypeSelectorDialogViewModel(_redTypeTemplateService, _loggerService, types)
             {
                 DialogHandler = model =>
                 {


### PR DESCRIPTION
# pull updated templates from wolvenkit resources

**Fixed:**
- refreshing templates will now also download templates from [WolvenKit/Wolvenkit-Resources](<https://github.com/WolvenKit/Wolvenkit-Resources>)

**Additional notes:**
depends on [#37: added template and template hash artifact](<https://github.com/WolvenKit/Wolvenkit-Resources/pull/37>)

This can be tested without the pr it depends on by changing `wolvenkit.github.io` to `notaspirit.github.io` in `UpdateSystemTemplatesFromRemote` for both the hash and templates url. This will pull the templates from my fork which already has the required changes merged in. 