### PR TITLE
Revert "fix: initialize graph for questphase on creation"

### DIFF
--- a/WolvenKit.RED4/Types/ClassesExt/questQuestPhaseResource.cs
+++ b/WolvenKit.RED4/Types/ClassesExt/questQuestPhaseResource.cs
@@ -1,9 +1,0 @@
-namespace WolvenKit.RED4.Types;
-
-public partial class questQuestPhaseResource
-{
-    partial void PostConstruct()
-    {
-        Graph ??= new CHandle<graphGraphDefinition>() { Chunk = new questGraphDefinition() };
-    }
-}


### PR DESCRIPTION
# Revert "fix: initialize graph for questphase on creation"

**Fixed:**
- serialization of new questphases 

**Additional notes:**
This reverts commit 2629b28c58b695a4522d2d07aedeaf707ed4f89c.
closes #2933 

In combination with the templater and [#38: add default templates for sectors and quest phase resources](<https://github.com/WolvenKit/Wolvenkit-Resources/pull/38>) user created questphases will continue to have their graph property initialized