### PR TITLE
fix_faulty_refresh_behavior

### DIFF
--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -13,6 +13,42 @@ public static class DispatcherHelper
 {
     public static void RunOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal) => Application.Current.RunOnUIThread(action, priority);
 
+    public static async Task RunOnMainThreadAsync(Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal) => await Application.Current.RunOnUIThreadAsync(action, priority);
+
+    private static async Task RunOnUIThreadAsync(this DispatcherObject? d, Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        // In a unit test / headless context there is no WPF Application and no Dispatcher.
+        // Run the action synchronously so code paths that rely on DispatcherHelper
+        // (DispatchedObservableCollection, etc.) continue to work.
+        if (d == null && Application.Current == null)
+        {
+            await action();
+            return;
+        }
+
+        if (d is not { Dispatcher: { } dispatcher })
+        {
+            return;
+        }
+
+        if (dispatcher.CheckAccess())
+        {
+            await action();
+        }
+        else
+        {
+            try
+            {
+                await dispatcher.InvokeAsync(action, priority);
+            }
+            catch (Exception)
+            {
+                // TODO: Add logger here?
+                throw;
+            }
+        }
+    }
+
     private static void RunOnUIThread(this DispatcherObject? d, Action action, DispatcherPriority priority = DispatcherPriority.Normal)
     {
         // In a unit test / headless context there is no WPF Application and no Dispatcher.

--- a/WolvenKit.App/Models/DispatchedObservableCollection.cs
+++ b/WolvenKit.App/Models/DispatchedObservableCollection.cs
@@ -1,17 +1,52 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Windows.Threading;
 using DynamicData;
+using Splat;
 using WolvenKit.App.Helpers;
+using WolvenKit.Core.Interfaces;
 
 namespace WolvenKit.App.Models;
 
 public class DispatchedObservableCollection<T> : ObservableCollection<T>
 {
     public new void Add(T item) => DispatcherHelper.RunOnMainThread(() => base.Add(item));
-    public new void Remove(T item) => DispatcherHelper.RunOnMainThread(() => base.Remove(item));
+
+    public new void Remove(T item) => DispatcherHelper.RunOnMainThread(() =>
+    {
+        try
+        {
+            base.Remove(item);
+        }
+        catch (Exception e)
+        {
+            try
+            {
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+            catch
+            {
+                if (item is FileSystemModel model)
+                {
+                    Locator.Current.GetService<ILoggerService>()
+                        ?.Error($"Error when removing model for file: {model.FullName}: \n {e.Message}");
+                    return;
+                }
+            }
+
+            if (item is FileSystemModel fileModel)
+            {
+                Locator.Current.GetService<ILoggerService>()
+                    ?.Error($"Error when removing model for file: {fileModel.FullName}: \n {e.Message}");
+                return;
+            }
+
+            Locator.Current.GetService<ILoggerService>()?.Error($"Error when removing model: \n {e.Message}");
+        }
+    });
+
     public new void Clear() => DispatcherHelper.RunOnMainThread(() => base.Clear());
 
     public void AddRange(IEnumerable<T> items)

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -220,9 +220,26 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
         _suppressNextReload = true;
 
-        if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
+        var explorer = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>();
+        explorer.SuspendFileWatcher();
+
+        try
         {
-            _suppressNextReload = false; // Clear on failure
+            explorer.RefreshAfter(() =>
+            {
+                if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
+                {
+                    _suppressNextReload = false; // Clear on failure
+                }
+            });
+        }
+        finally
+        {
+            explorer?.ResumeFileWatcher();
+        }
+
+        if (!_suppressNextReload)
+        {
             return false;
         }
 

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -220,26 +220,9 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
         _suppressNextReload = true;
 
-        var explorer = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>();
-        explorer.SuspendFileWatcher();
-
-        try
+        if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
         {
-            explorer.RefreshAfter(() =>
-            {
-                if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
-                {
-                    _suppressNextReload = false; // Clear on failure
-                }
-            });
-        }
-        finally
-        {
-            explorer?.ResumeFileWatcher();
-        }
-
-        if (!_suppressNextReload)
-        {
+            _suppressNextReload = false; // Clear on failure
             return false;
         }
 

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -220,28 +220,13 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
         _suppressNextReload = true;
 
-        var explorer = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>();
-        explorer.SuspendFileWatcher();
-
-        try
+        if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
         {
-            explorer.RefreshAfter(() =>
-            {
-                if (GetMainFile() is null || !_cr2WTools.WriteCr2W(cr2w, filePath))
-                {
-                    _suppressNextReload = false; // Clear on failure
-                }
-            });
-        }
-        finally
-        {
-            explorer?.ResumeFileWatcher();
-        }
-
-        if (!_suppressNextReload)
-        {
+            _suppressNextReload = false; // Clear on failure
             return false;
         }
+
+
 
         LastWriteTime = File.GetLastWriteTime(filePath);
         SetIsDirty(false);

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -221,17 +221,17 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        if (ActiveProject != null)
-        {
-            SaveProjectState();
-            ActiveProject = null;
-            UnwatchProject();
-        }
-
         RefreshAfter(() =>
         {
             try
             {
+                if (ActiveProject != null)
+                {
+                    SaveProjectState();
+                    ActiveProject = null;
+                    UnwatchProject();
+                }
+
                 ActiveProject = activeProject;
                 _projectWatcher.StartWatcher_AndLoadProject(activeProject);
                 LoadExpansionStateDictionary(activeProject);

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -2187,42 +2187,45 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
     public async Task RefreshAfter(Func<Task> action)
     {
-        if (_inFlight)
+        await DispatcherHelper.RunOnMainThreadAsync(async () =>
         {
-            await action();
-            return;
-        }
+            if (_inFlight)
+            {
+                await action();
+                return;
+            }
 
-        _inFlight = true;
-        _gridGuard.BeginChanges();
-
-        if (BeginDeferredRefreshContext == null)
-        {
-            await action();
-            _inFlight = false;
-            return;
-        }
-
-        try
-        {
+            _inFlight = true;
             _gridGuard.BeginChanges();
 
-            await BeginDeferredRefreshContext(
-                action
-            );
-        }
-        catch (WolvenKitException e)
-        {
-            _loggerService.Debug($"Exception caught while refreshing: ${e}.");
-        }
-        finally
-        {
-            DispatcherHelper.DelayOnMainThread(() =>
+            if (BeginDeferredRefreshContext == null)
             {
-                _gridGuard.ForceReady();
+                await action();
                 _inFlight = false;
-            }, 1);
-        }
+                return;
+            }
+
+            try
+            {
+                _gridGuard.BeginChanges();
+
+                await BeginDeferredRefreshContext(
+                    action
+                );
+            }
+            catch (WolvenKitException e)
+            {
+                _loggerService.Debug($"Exception caught while refreshing: ${e}.");
+            }
+            finally
+            {
+                DispatcherHelper.DelayOnMainThread(() =>
+                {
+                    _gridGuard.ForceReady();
+                    _inFlight = false;
+                }, 1);
+            }
+        });
     }
 
     /// <summary>

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
-using DynamicData;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Models;
 using WolvenKit.App.Models.ProjectManagement.Project;
@@ -52,11 +51,17 @@ public partial class ProjectExplorerViewModel
         private readonly Func<string, bool> _getDesiredExpansionState;
         private string _projectDirectory = string.Empty;
         private FileSystemModel? _projectFileSystemModel;
-
         private readonly FileSystemWatcher _modsWatcher;
 
         private readonly object _modLoadingLock = new();
         private readonly object _batchLock = new();
+        private readonly object _suspendLock = new();
+        private readonly object _resumeLock = new();
+
+        /// <summary>
+        /// Keeps track of in-flight suspends so we don't over-resume.
+        /// </summary>
+        private readonly ConcurrentQueue<SuspendToken> _suspendQueue = new();
 
         private Task? _updateTask;
         private CancellationTokenSource _updateThreadCancellationTokenSource = new();
@@ -105,6 +110,8 @@ public partial class ProjectExplorerViewModel
             "blend@", // Blender temp files
             "blend1", // Blender temp files
         ];
+
+        private sealed record SuspendToken;
 
         public Guid CompletionTimer = Guid.NewGuid();
 
@@ -171,11 +178,32 @@ public partial class ProjectExplorerViewModel
 
         #region Start / Resume / Watch / Unwatch Methods
 
-        public void ResumeWatcher_AndLoadProject()
+        private void ResumeWatcher_AndLoadProject()
         {
-            Suspend();
+            switch (_watcherState)
+            {
+                case WatcherState.NoProject:
+                    _loggerService?.Debug("Loading new project.");
+                    _suspendQueue.Clear();
+                    _suspendQueue.Enqueue(new SuspendToken());
+                    break;
+                case WatcherState.Suspended:
+                    throw new WolvenKitException(0xBADB01,
+                        $"Resuming from a suspended state with {_suspendQueue.Count} suspends in the queue.");
+                case WatcherState.Active:
+                    _loggerService?.Debug("Suspending watcher and reloading existing project.");
+                    Suspend();
+                    break;
+                case WatcherState.Error:
+                    _loggerService?.Debug("Reloading project to recover from error.");
+                    break;
+                case WatcherState.Loading:
+                    _loggerService?.Debug("Ignoring resume attempt while already reloading project.");
+                    return;
+            }
+
+            _watcherState = WatcherState.Loading;
             Locked_LoadModProjectFileStructure();
-            Resume();
         }
 
         public void StartWatcher_AndLoadProject(Cp77Project project, Action? completion = null)
@@ -187,24 +215,64 @@ public partial class ProjectExplorerViewModel
 
         public void Resume()
         {
-            if (_projectDirectory == "")
+            lock (_resumeLock)
             {
-                throw new Exception("No project directory to resume watching!.");
+                switch (_watcherState, _suspendQueue.Count)
+                {
+                    // happy path
+                    case (WatcherState.Suspended, > 0):
+                        _ = _suspendQueue.TryDequeue(out _);
+
+                        if (_suspendQueue.Count == 0)
+                        {
+                            InternalResume();
+                        }
+                        else
+                        {
+                            _loggerService?.Debug($"Waiting to resume file watcher for {_suspendQueue.Count} remaining file operations.");
+                        }
+
+                        return;
+
+                    // happy path for reloading/loading
+                    case (WatcherState.Loading, 1):
+                        _ = _suspendQueue.TryDequeue(out _);
+                        InternalResume();
+                        return;
+
+                    // resuming while active has no effect
+                    case (WatcherState.Active, 0):
+                        _loggerService?.Debug(
+                            $"FileWatcher confirmed active with no pending operations.");
+                        return;
+
+                    default:
+                        throw new Exception(
+                            $"Unexpected condition: attempting to resume file watcher while its state was {_watcherState} with {_suspendQueue.Count} suspends on the queue.");
+                }
             }
-            _loggerService?.Debug($"Resuming monitoring of file system events in project: {_projectDirectory}.");
-            _modsWatcher.Path = _projectDirectory;
-            _modsWatcher.IncludeSubdirectories = true;
-            _modsWatcher.EnableRaisingEvents = true;
-            _watcherState = WatcherState.Active;
+
+
+            void InternalResume()
+            {
+                if (_projectDirectory == "")
+                {
+                    throw new Exception("No project directory to resume watching!.");
+                }
+
+                _loggerService?.Debug($"Resuming monitoring of file system events in project: {_projectDirectory}.");
+                _modsWatcher.Path = _projectDirectory;
+                _modsWatcher.IncludeSubdirectories = true;
+                _modsWatcher.EnableRaisingEvents = true;
+                _watcherState = WatcherState.Active;
+            }
         }
 
         /// <summary>
         ///  Does the following:
-        ///     1. Suspend the OS file watcher.
+        ///     1. Suspend the OS file watcher & batch update monitor.
         ///     2. Sets _watcherState to `noProject`
-        ///     3. Clears the _projectDirectory & _projectFileSystemModel vars.
-        ///     4. Stops background polling for things added to the update batches.
-        ///     5. Clears lookup caches, batches, and data models.
+        ///     3. Clears the project references.
         ///
         /// This must be called before performing anything that sends a Reset for
         /// FileList or FileTree collections.
@@ -216,7 +284,6 @@ public partial class ProjectExplorerViewModel
             _projectDirectory = "";
             _projectFileSystemModel = null;
             _loggerService?.Debug($"Closing the current mod and clearing file lists and background tasks.");
-            StopBackgroundPolling();
         }
 
         #endregion
@@ -450,6 +517,7 @@ public partial class ProjectExplorerViewModel
                 _fileLookup.Clear();
                 FileTree.Clear();
                 FileList.Clear();
+                _guard.ProjectReset(FileList, FileTree);
             }
 
             Clear();
@@ -473,8 +541,8 @@ public partial class ProjectExplorerViewModel
                     _guard.ProjectReset(flatListReturn, treeRoot?.Children.ToList() ?? new List<FileSystemModel>());
 
                     DispatcherHelper.StopRepeatingAction(CompletionTimer);
-                    StartBackgroundPolling();
-                    _watcherState = WatcherState.Active;
+                    _loggerService?.Info($"Loaded {FileList.Count} project files.");
+                    Resume();
                 });
             });
         }
@@ -621,9 +689,24 @@ public partial class ProjectExplorerViewModel
 
         public void Suspend()
         {
-            _loggerService?.Debug("Stopping file system watcher in mod folder.");
-            _modsWatcher.EnableRaisingEvents = false;
-            _watcherState = WatcherState.Suspended;
+            lock (_suspendLock)
+            {
+                if (_suspendQueue.IsEmpty)
+                {
+                    _suspendQueue.Enqueue(new SuspendToken());
+                    _loggerService?.Debug("Stopping file system watcher in mod folder.");
+                    _modsWatcher.EnableRaisingEvents = false;
+                    _watcherState = WatcherState.Suspended;
+                    return;
+                }
+
+                if (_watcherState != WatcherState.Suspended)
+                {
+                    _loggerService?.Error($"WatcherState should be suspended but was instead: {_watcherState}");
+                }
+
+                _suspendQueue.Enqueue(new SuspendToken());
+            }
         }
 
         private void CancelFileLoggingToken()

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -280,6 +280,7 @@ public partial class ProjectExplorerViewModel
         public void UnwatchProject()
         {
             Suspend();
+            StopBackgroundPolling();
             _watcherState = WatcherState.NoProject;
             _projectDirectory = "";
             _projectFileSystemModel = null;
@@ -542,6 +543,7 @@ public partial class ProjectExplorerViewModel
 
                     DispatcherHelper.StopRepeatingAction(CompletionTimer);
                     _loggerService?.Info($"Loaded {FileList.Count} project files.");
+                    StartBackgroundPolling();
                     Resume();
                 });
             });

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -461,8 +461,15 @@ public partial class ProjectExplorerViewModel
             if (removedAt != 0)
                 _removedFiles.TryAdd(model.FullName, removedAt);
 
+            Suspend();
+
             // Mirror the removal onto the grid-bound clone subtree.
-            _guard.ProjectRemove(model);
+            Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
+            {
+                _guard.ProjectRemove(model);
+            });
+
+            Resume();
         }
 
         private void RemoveChildModels(FileSystemModel model)
@@ -475,6 +482,16 @@ public partial class ProjectExplorerViewModel
                 _fileLookup.Remove(subModel.FullName, out _);
                 if (FileList.Contains(subModel))
                     FileList.Remove(subModel);
+
+                Suspend();
+
+                // Mirror the removal onto the grid-bound clone subtree.
+                Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
+                {
+                    _guard.ProjectRemove(model);
+                });
+
+                Resume();
             }
         }
 

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -753,7 +753,7 @@ public partial class ProjectExplorerViewModel
 
         private void BatchUpdate(CancellationToken cancellationToken)
         {
-            var batch = new List<FileSystemEventArgsWrapper>(64);
+            var batch = new List<FileSystemEventArgsWrapper>();
             var stopwatch = Stopwatch .StartNew();
 
             while (true)


### PR DESCRIPTION
# Addresses threading and consistency issues with Syncfusion TreeGrid

- Fixes an issue where project refresh might leave SyncFusion grids in an inconsistent state due to not clearing trees
- Fixes an issue where disposing refreshing SyncFusion grids from a background thread could cause issues
- Fixes an issue where Resuming file watcher while it was Suspended multiple times could cause it to pick up unwanted file changes
- Fixes an issue where deleting files could trigger an inconsistency in Syncfusion grid storage

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->