### PR TITLE
cvm: 'overwrite with selection' no longer has index offset by 1

### DIFF
--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -715,7 +715,8 @@ namespace WolvenKit.Views.Tools
                     {
                         // delete selection, then paste at index of last selected child
                         group.Key.DeleteNodes(selectedNodes);
-                        var pasteIndex = group.LastOrDefault()?.NodeIdxInParent -1 ?? -1;
+                        var offset = useSingle ? 0 : 1;
+                        var pasteIndex = (group.LastOrDefault()?.NodeIdxInParent - offset) ?? -1;
                         group.Key.PasteAtIndex(copiedChunks, pasteIndex);
                     }
                 }

--- a/WolvenKit/Views/Tools/RedTreeView.xaml.cs
+++ b/WolvenKit/Views/Tools/RedTreeView.xaml.cs
@@ -715,7 +715,7 @@ namespace WolvenKit.Views.Tools
                     {
                         // delete selection, then paste at index of last selected child
                         group.Key.DeleteNodes(selectedNodes);
-                        var pasteIndex = group.LastOrDefault()?.NodeIdxInParent ?? -1;
+                        var pasteIndex = group.LastOrDefault()?.NodeIdxInParent -1 ?? -1;
                         group.Key.PasteAtIndex(copiedChunks, pasteIndex);
                     }
                 }

--- a/changelog/unreleased/3035.yaml
+++ b/changelog/unreleased/3035.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3035
+      author: "manavortex"
+      description: "cvm: 'overwrite with selection' no longer has index offset by 1"


### PR DESCRIPTION
# cvm: 'overwrite with selection' no longer has index offset by 1

**Fixed:**
- cvm: 'overwrite with selection' no longer has index offset by 1