### PR TITLE
Cleanup susped resume

### DIFF
--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -71,9 +71,7 @@ public partial class AppScriptService : ScriptService
     public async Task ExecuteAsync(string code, bool enableDebugging = false)
     {
         var vm = GetProjectExplorerViewModel()!;
-        vm.SuspendFileWatcher();
         await vm.RefreshAfter(async () => await ExecuteAsync(code, DefaultHostObject, null, enableDebugging));
-        vm.ResumeFileWatcher();
     }
 
     public void SetAppViewModel(AppViewModel appViewModel) => _wkit.AppViewModel = appViewModel;

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.ComplexFiles.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.ComplexFiles.cs
@@ -52,13 +52,11 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
             : dialogModel.InkatlasFileName;
         var relativeInkatlasFilePath = GetRelativeDestPath(inkatlasFileName);
 
-        GetToolViewModel<ProjectExplorerViewModel>()?.SuspendFileWatcher();
-
-        /*
-         * Copy and connect .app and .ent file
-         */
-        try
+        GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
         {
+            /*
+             * Copy and connect .app and .ent file
+             */
             TemplateFileTools.CreatePhotoModeAppAndEnt(new PhotomodeEntAppOptions()
                 {
                     AppSourceRelPath = dialogModel.SelectedApp,
@@ -177,11 +175,7 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
             }
 
             _loggerService.Success("Done! Your photo mode NPV should now work!");
-        }
-        finally
-        {
-            GetToolViewModel<ProjectExplorerViewModel>()?.ResumeWatcher_AndReloadProject();
-        }
+        });
 
         return;
 

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -861,10 +861,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             return;
         }
-        GetToolViewModel<ProjectExplorerViewModel>().SuspendFileWatcher();
-        _projectEvents.PublishFileChanged(new FileChangedMessage.Document(document));
+
         Save(document);
-        GetToolViewModel<ProjectExplorerViewModel>().ResumeFileWatcher();
     }
 
     private bool CanReloadFile() => ActiveDocument is not null;
@@ -1453,16 +1451,9 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             return;
         }
 
-        GetToolViewModel<ProjectExplorerViewModel>()?.SuspendFileWatcher();
-        try
-        {
-            _archiveXlItemService.CreateEquipmentItem(item);
-        }
-        finally
-        {
-            GetToolViewModel<ProjectExplorerViewModel>()?
-                .ResumeWatcher_AndReloadProject();
-        }
+
+        GetToolViewModel<ProjectExplorerViewModel>()?
+            .RefreshAfter(() => _archiveXlItemService.CreateEquipmentItem(item));
     }
 
     private async Task OpenFromNewFile(NewFileViewModel? file)

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -642,10 +642,8 @@ public partial class AssetBrowserViewModel : ToolViewModel
 
     private async Task InternalAddFiles(IList<IGameFile> files)
     {
-        var explorer = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>()!;
-        explorer.SuspendFileWatcher();
-        await explorer.RefreshAfter(async () => await _gameController.GetController().AddToModAsync(files));
-        explorer.ResumeFileWatcher();
+        await _appViewModel.GetToolViewModel<ProjectExplorerViewModel>()
+            .RefreshAfter(async () => await _gameController.GetController().AddToModAsync(files));
         _loggerService.Success($"Added {files.Count} files to the project.");
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -846,9 +846,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        SuspendFileWatcher();
         await RefreshAfter(() => DeleteRecursively(selected));
-        ResumeFileWatcher();
     }
 
     private void DeleteRecursively(List<FileSystemModel> selected)
@@ -1031,9 +1029,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        SuspendFileWatcher();
-        await RefreshAfter(() => InternalRenameFile(gameRelativePath, newGameRelativePath, prefixPath, refactor));
-        ResumeFileWatcher();
+        await RefreshAfter(async () => await InternalRenameFile(gameRelativePath, newGameRelativePath, prefixPath, refactor));
     }
 
     // add sanitizer to ensure moves can't cross file scope boundary
@@ -1052,14 +1048,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     {
         await _projectResourceTools.MoveAndRefactorAsync(gameRelativePath, newGameRelativePath, prefixPath, refactor);
         _appViewModel.ReloadChangedFiles();
-    }
-
-    public void ResumeFileWatcher()
-    {
-        _projectWatcher.Resume();
-        // The watcher is live again, so the grids are back to a safe, mutable state. ForceReady is a
-        // no-op if we were already Ready, so calling it here can never strand the guard.
-        _gridGuard.ForceReady();
     }
 
     /// <summary>
@@ -1138,9 +1126,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         if (!IsShiftKeyPressed)
         {
-            SuspendFileWatcher();
-            await RefreshAfter(() => ConvertToJsonInternal(selection));
-            ResumeFileWatcher();
+            await RefreshAfter(async () => await ConvertToJsonInternal(selection));
             return;
         }
 
@@ -1152,9 +1138,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         var convertSelection = FileList
             .Where(x => selectedItemPaths.Contains(x.FullName) && File.Exists(x.FullName)).ToList();
 
-        SuspendFileWatcher();
-        await RefreshAfter(() => ConvertToJsonInternal(convertSelection));
-        ResumeFileWatcher();
+        await RefreshAfter(async () => await ConvertToJsonInternal(convertSelection));
     }
 
     private async Task ConvertToJsonInternal(IEnumerable<FileSystemModel> selection)
@@ -1668,12 +1652,10 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         if (!IsShiftKeyPressed)
         {
             var items = SelectedItems!.OfType<FileSystemModel>().Where(IsInRawFolder);
-            SuspendFileWatcher();
             CurrentLoadingMode = LoadingMode.ShowLoadingDuringOperation;
             EnableLoadingMode(CurrentLoadingMode);
             await RefreshAfter(async () => await ConvertFromJsonInternal(items));
             DisableLoadingMode();
-            ResumeFileWatcher();
             return;
         }
 
@@ -1684,12 +1666,10 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             .Where(IsInArchiveFolder)
             .Where(x => selectedItemPaths.Contains(x.GameRelativePath)).ToList();
 
-        SuspendFileWatcher();
         CurrentLoadingMode = LoadingMode.ShowLoadingDuringOperation;
         EnableLoadingMode(CurrentLoadingMode);
         await RefreshAfter(async () => await ConvertFromJsonInternal(convertSelection));
         DisableLoadingMode();
-        ResumeFileWatcher();
     }
 
     private async Task ConvertFromJsonInternal(IEnumerable<FileSystemModel> selection)
@@ -2143,28 +2123,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }
     }
 
-    public void SuspendFileWatcher()
-    {
-        if (ActiveProject is not Cp77Project project)
-        {
-            return;
-        }
-
-        try
-        {
-            _projectWatcher.Suspend();
-            // Suspending the watcher means a high-level operation is about to mutate files behind the
-            // grids. Move the guard into MakingChangesToFiles so GridsLocked is true for the duration;
-            // ResumeFileWatcher (or the next load) walks it back to Ready.
-            _gridGuard.NotifyChangeRequested();
-            _gridGuard.BeginChanges();
-        }
-        catch
-        {
-            _loggerService.Error("Failed to suspend file watcher. Please ignore any errors.");
-        }
-    }
-
     public void OnKeyStateChanged(KeyEventArgs e)
     {
         if (e.Key == Key.W && (e.KeyboardDevice.Modifiers & ModifierKeys.Control) != 0)
@@ -2189,6 +2147,10 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     {
         await DispatcherHelper.RunOnMainThreadAsync(async () =>
         {
+            _projectWatcher.Suspend();
+            _gridGuard.NotifyChangeRequested();
+            _gridGuard.BeginChanges();
+
             if (_inFlight)
             {
                 await action();
@@ -2196,7 +2158,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             }
 
             _inFlight = true;
-            _gridGuard.BeginChanges();
 
             if (BeginDeferredRefreshContext == null)
             {
@@ -2207,8 +2168,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
             try
             {
-                _gridGuard.BeginChanges();
-
                 await BeginDeferredRefreshContext(
                     action
                 );
@@ -2221,8 +2180,9 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             {
                 DispatcherHelper.DelayOnMainThread(() =>
                 {
-                    _gridGuard.ForceReady();
                     _inFlight = false;
+                    _projectWatcher.Resume();
+                    _gridGuard.ForceReady();
                 }, 1);
             }
         });
@@ -2232,12 +2192,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     ///  Since the previous implementation would sometimes fail silently and claim that perfectly viable files weren't found,
     /// here's an attempt at implementing everything in a more robust way that's also more in line with windows move/copy behaviour.
     /// </summary>
-    public async Task ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory)
-    {
-        SuspendFileWatcher();
-        await RefreshAfter(() => InternalProcessFileAction(sourceFiles, targetDirectory));
-        ResumeFileWatcher();
-    }
+    public async Task ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory) =>
+        await RefreshAfter(async () => await InternalProcessFileAction(sourceFiles, targetDirectory));
 
     /// <summary>
     ///  Since the previous implementation would sometimes fail silently and claim that perfectly viable files weren't found,

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -188,12 +188,11 @@ public partial class ProjectExplorerViewModel
                     _suspendQueue.Enqueue(new SuspendToken());
                     break;
                 case WatcherState.Suspended:
-                    throw new WolvenKitException(0xBADB01,
-                        $"Resuming from a suspended state with {_suspendQueue.Count} suspends in the queue.");
-                case WatcherState.Active:
-                    _loggerService?.Debug("Suspending watcher and reloading existing project.");
-                    Suspend();
+                    _loggerService?.Debug("Reloading existing project.");
                     break;
+                case WatcherState.Active:
+                    throw new WolvenKitException(0xBADB01,
+                        $"Resuming from a non-suspended state with {_suspendQueue.Count} suspends in the queue.");
                 case WatcherState.Error:
                     _loggerService?.Debug("Reloading project to recover from error.");
                     break;
@@ -461,15 +460,11 @@ public partial class ProjectExplorerViewModel
             if (removedAt != 0)
                 _removedFiles.TryAdd(model.FullName, removedAt);
 
-            Suspend();
-
             // Mirror the removal onto the grid-bound clone subtree.
             Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
             {
                 _guard.ProjectRemove(model);
             });
-
-            Resume();
         }
 
         private void RemoveChildModels(FileSystemModel model)
@@ -483,15 +478,11 @@ public partial class ProjectExplorerViewModel
                 if (FileList.Contains(subModel))
                     FileList.Remove(subModel);
 
-                Suspend();
-
                 // Mirror the removal onto the grid-bound clone subtree.
                 Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
                 {
                     _guard.ProjectRemove(model);
                 });
-
-                Resume();
             }
         }
 

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -833,7 +833,10 @@ namespace WolvenKit.Views.Documents
         private readonly SemaphoreSlim _addDependencySemaphore = new(1, 1);
 
 
-        private async void OnAddDependencies(object? _, EventArgs eventArgs)
+        private async void OnAddDependencies(object? _, EventArgs eventArgs) =>
+            await _projectExplorer.RefreshAfter(async () => await InternalOnDependencies(eventArgs));
+
+        private async Task InternalOnDependencies(EventArgs eventArgs)
         {
             try
             {
@@ -865,12 +868,7 @@ namespace WolvenKit.Views.Documents
                     return;
                 }
 
-
-                _projectExplorer.SuspendFileWatcher();
-
-                // TODO: Migrate to use RefreshAfter
                 await AddDependenciesToFileAsync(cvm, eventArgs is AddDependenciesFullEventArgs);
-
                 _notificationService.Success("Successfully added dependencies");
                 _loggerService.Success("Successfully added dependencies");
             }
@@ -890,15 +888,7 @@ namespace WolvenKit.Views.Documents
                 {
                     // Don't release?
                 }
-
-                // Project browser will throw an error if we do it immediately - so let's not
-                await Task.Run(() =>
-                {
-                    DispatcherHelper.DelayOnMainThread(() =>
-                            _projectExplorer.ResumeWatcher_AndReloadProject(), 100);
-                });
             }
-
         }
 
         private List<appearanceAppearanceDefinition> GetAppearancesFromSelectionOrRoot()


### PR DESCRIPTION
# Simplify the "RefreshAfter" API by moving file watcher suspend commands inside it

## The problem this PR solves

Without this PR, a safe batch operation while bypassing Windows File System events requires the following calls:

```
_projectExplorerViewModel.SuspendFileWatcher();
await _projectExplorerViewModel.RefreshAfter(async () => await NameOfTaskThatPerformsFileOperations(...));
_projectExplorerViewModel.ResumeFileWatcher();
```

That's too much boilerplate. And it's a maintainability risk because the compiler does not enforce using Suspend/Resume like this.

## The solution

Now the `RefreshAfter` method will call `Suspend` and `Resume` for you, so that all you have to do is wrap your batch operations in `RefreshAfter` and everything will be taken care of. 

Thus we can remove all that Suspend/Resume boilerplate from the existing code.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->