### PR TITLE
Fix graph editor lifecycle cleanup

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
@@ -170,6 +170,52 @@ public class GraphDocumentIntegrationTests
     }
 
     [TestMethod]
+    public void RemovingQuestNodeUnsubscribesFromNodePropertyUpdates()
+    {
+        using var fixture = new GraphDocumentTestFixture("mod\\test.questphase");
+        var graphData = GraphTestHelpers.CreateQuestGraph(new questStartNodeDefinition { Id = 1 });
+        using var graph = RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+        AttachDocument(graph, fixture.Document);
+        var wrapper = graph.Nodes.Single();
+
+        AssertMutationUnsubscribesNode(wrapper, () => graph.RemoveNode(wrapper));
+    }
+
+    [TestMethod]
+    public void RemovingSceneNodeUnsubscribesFromNodePropertyUpdates()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var resource = GraphTestHelpers.CreateSceneResource(new scnStartNode { NodeId = new scnNodeId { Id = 1 } });
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+        var wrapper = graph.Nodes.Single();
+
+        AssertMutationUnsubscribesNode(wrapper, () => graph.RemoveNode(wrapper));
+    }
+
+    [TestMethod]
+    public void ReplacingQuestNodeUnsubscribesOriginalWrapperFromNodePropertyUpdates()
+    {
+        using var fixture = new GraphDocumentTestFixture("mod\\test.questphase");
+        var graphData = GraphTestHelpers.CreateQuestGraph(new questSwitchNodeDefinition { Id = 1 });
+        using var graph = RedGraph.GenerateQuestGraph("test.questphase", graphData, Mock.Of<INodeWrapperFactory>());
+        AttachDocument(graph, fixture.Document);
+        var wrapper = graph.Nodes.OfType<BaseQuestViewModel>().Single();
+
+        AssertMutationUnsubscribesNode(wrapper, () => graph.ReplaceNodeWithQuestDeletionMarker(wrapper));
+    }
+
+    [TestMethod]
+    public void ReplacingSceneNodeUnsubscribesOriginalWrapperFromNodePropertyUpdates()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var resource = GraphTestHelpers.CreateSceneResource(new scnAndNode { NodeId = new scnNodeId { Id = 1 } });
+        using var graph = RedGraph.GenerateSceneGraph("test.scene", resource, fixture.Document);
+        var wrapper = graph.Nodes.OfType<BaseSceneViewModel>().Single();
+
+        AssertMutationUnsubscribesNode(wrapper, () => graph.ReplaceNodeWithDeletionMarker(wrapper));
+    }
+
+    [TestMethod]
     public void DisposingDocumentDisposesOwnedGraphTabs()
     {
         using var fixture = new GraphDocumentTestFixture();
@@ -188,6 +234,21 @@ public class GraphDocumentIntegrationTests
         {
             node.DocumentViewModel = document;
         }
+    }
+
+    private static void AssertMutationUnsubscribesNode(WolvenKit.App.ViewModels.GraphEditor.NodeViewModel wrapper, Action mutation)
+    {
+        var notifications = 0;
+        wrapper.PropertyChanged += (_, _) => notifications++;
+
+        NodePropertyUpdateService.NotifyPropertyUpdated(wrapper.Data);
+        Assert.IsTrue(notifications > 0);
+
+        mutation();
+        notifications = 0;
+        NodePropertyUpdateService.NotifyPropertyUpdated(wrapper.Data);
+
+        Assert.AreEqual(0, notifications);
     }
 
     private static void SaveGraphLocation(GraphDocumentTestFixture fixture, string stateParents, Point location)

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/GraphDocumentIntegrationTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using WolvenKit.App.Factories;
 using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.GraphEditor;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
 using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
@@ -167,6 +169,18 @@ public class GraphDocumentIntegrationTests
         Assert.AreEqual(0, notifications);
     }
 
+    [TestMethod]
+    public void DisposingDocumentDisposesOwnedGraphTabs()
+    {
+        using var fixture = new GraphDocumentTestFixture();
+        var tab = new DisposableGraphTab(fixture.Document);
+        fixture.Document.TabItemViewModels.Add(tab);
+
+        fixture.Document.Dispose();
+
+        Assert.IsTrue(tab.IsDisposed);
+    }
+
     private static void AttachDocument(RedGraph graph, WolvenKit.App.ViewModels.Documents.RedDocumentViewModel document)
     {
         graph.DocumentViewModel = document;
@@ -197,6 +211,15 @@ public class GraphDocumentIntegrationTests
         graph.StateParents = stateParents;
         graph.GraphStateLoad();
         return graph.Nodes.Single().Location;
+    }
+
+    private sealed class DisposableGraphTab(RedDocumentViewModel parent) : RedDocumentTabViewModel(parent, "Graph"), IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public override ERedDocumentItemType DocumentItemType => ERedDocumentItemType.Editor;
+
+        public void Dispose() => IsDisposed = true;
     }
 
 }

--- a/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphDocumentTestFixture.cs
+++ b/Tests/WolvenKit.UnitTests/App/GraphEditor/Shared/GraphDocumentTestFixture.cs
@@ -54,6 +54,8 @@ internal sealed class GraphDocumentTestFixture : IDisposable
 
     public void Dispose()
     {
+        Document.Dispose();
+
         if (Directory.Exists(ProjectDirectory))
         {
             Directory.Delete(ProjectDirectory, true);

--- a/WolvenKit.App/Services/TimelineService.cs
+++ b/WolvenKit.App/Services/TimelineService.cs
@@ -22,6 +22,7 @@ public partial class TimelineService : ObservableObject, IDisposable
         Tracks = new ObservableCollection<TimelineTrack>();
         NodeSelectionService.Instance.PropertyChanged += OnNodeSelectionChanged;
         NodePropertyUpdateService.NodePropertyUpdated += OnNodePropertyUpdated;
+        UpdateSelectedNode(NodeSelectionService.Instance.SelectedNode);
     }
 
     public ObservableCollection<TimelineTrack> Tracks { get; }
@@ -66,8 +67,11 @@ public partial class TimelineService : ObservableObject, IDisposable
             return;
         }
 
-        var selectedNode = NodeSelectionService.Instance.SelectedNode;
-        
+        UpdateSelectedNode(NodeSelectionService.Instance.SelectedNode);
+    }
+
+    private void UpdateSelectedNode(object? selectedNode)
+    {
         if (selectedNode is scnSectionNodeWrapper sectionWrapper)
         {
             LoadSectionNode(sectionWrapper);

--- a/WolvenKit.App/ViewModels/Documents/BehaviorGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/BehaviorGraphViewModel.cs
@@ -144,12 +144,6 @@ public partial class BehaviorGraphViewModel : RedDocumentTabViewModel, IDisposab
         UpdateTabContent(value);
     }
 
-    public override void Unload()
-    {
-        Dispose();
-        base.Unload();
-    }
-
     protected virtual void Dispose(bool disposing)
     {
         if (!_disposed && disposing)

--- a/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/QuestPhaseGraphViewModel.cs
@@ -273,17 +273,11 @@ namespace WolvenKit.App.ViewModels.Documents
             UpdateTabContent(value);
         }
 
-        // Override Unload to ensure disposal when tab is closed
-        public override void Unload()
-        {
-            Dispose();
-            base.Unload();
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed && disposing)
             {
+                MainGraph.Dispose();
                 _disposed = true;
             }
         }

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -393,7 +393,8 @@ public partial class RedDocumentViewModel : DocumentViewModel, IDisposable
 
     public void PopulateItems(bool keepRootTab = false)
     {
-        foreach (var tab in TabItemViewModels)
+        var previousTabs = TabItemViewModels.ToList();
+        foreach (var tab in previousTabs)
         {
             switch (tab)
             {
@@ -423,6 +424,19 @@ public partial class RedDocumentViewModel : DocumentViewModel, IDisposable
         }
 
         TabItemViewModels.Clear();
+
+        if (ReferenceEquals(NodeSelectionService.Instance.SelectedNode?.DocumentViewModel, this))
+        {
+            NodeSelectionService.Instance.SelectedNode = null;
+        }
+
+        foreach (var disposableTab in previousTabs.OfType<IDisposable>())
+        {
+            if (!ReferenceEquals(disposableTab, rootTab))
+            {
+                disposableTab.Dispose();
+            }
+        }
 
         TabItemViewModels.Add(rootTab);
         AddTabForRedType(Cr2wFile.RootChunk);

--- a/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RedDocumentViewModel.cs
@@ -33,7 +33,7 @@ public enum ERedDocumentItemType
     Editor
 }
 
-public partial class RedDocumentViewModel : DocumentViewModel
+public partial class RedDocumentViewModel : DocumentViewModel, IDisposable
 {
     private readonly IDocumentTabViewmodelFactory _documentTabViewmodelFactory;
     private readonly IChunkViewmodelFactory _chunkViewmodelFactory;
@@ -54,6 +54,7 @@ public partial class RedDocumentViewModel : DocumentViewModel
 
     private readonly string _path;
     private bool _suppressNextReload;
+    private bool _disposed;
 
     public RedDocumentViewModel(CR2WFile file, string path, AppViewModel appViewModel,
         IDocumentTabViewmodelFactory documentTabViewmodelFactory,
@@ -646,6 +647,26 @@ public partial class RedDocumentViewModel : DocumentViewModel
         var tab = _documentTabViewmodelFactory.RDTDataViewModel(hash.ToString(), file.RootChunk, this, _appViewModel, _chunkViewmodelFactory);
         TabItemViewModels.Add(tab);
         return tab;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        if (ReferenceEquals(NodeSelectionService.Instance.SelectedNode?.DocumentViewModel, this))
+        {
+            NodeSelectionService.Instance.SelectedNode = null;
+        }
+
+        foreach (var disposableTab in TabItemViewModels.OfType<IDisposable>().ToList())
+        {
+            disposableTab.Dispose();
+        }
     }
 
 

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -1107,17 +1107,11 @@ namespace WolvenKit.App.ViewModels.Documents
             }
         }
 
-        // Override Unload to ensure disposal when tab is closed
-        public override void Unload()
-        {
-            Dispose();
-            base.Unload();
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed && disposing)
             {
+                MainGraph.Dispose();
                 _disposed = true;
             }
         }

--- a/WolvenKit.App/ViewModels/GraphEditor/NodeViewModel.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/NodeViewModel.cs
@@ -307,6 +307,7 @@ public abstract partial class NodeViewModel : ObservableObject, IDisposable
                 
                 // Unsubscribe from property update service
                 NodePropertyUpdateService.NodePropertyUpdated -= OnNodePropertyUpdated;
+                Output.CollectionChanged -= OnOutputCollectionChanged;
             }
 
             _disposedValue = true;

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questPhaseNodeDefinitionWrapper.cs
@@ -141,6 +141,16 @@ public class questPhaseNodeDefinitionWrapper : questEmbeddedGraphNodeDefinitionW
 
     internal override void CreateDefaultSockets() => CreateSocket("CutDestination", Enums.questSocketType.CutDestination);
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _graph?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
     /// <summary>
     /// Get the node count from an inline phase graph without loading an external resource
     /// </summary>

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSceneNodeDefinitionWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Quest/questSceneNodeDefinitionWrapper.cs
@@ -152,4 +152,14 @@ public class questSceneNodeDefinitionWrapper : questSignalStoppingNodeDefinition
         CreateSocket("Default INT", Enums.questSocketType.Output);
         CreateSocket("Default RET", Enums.questSocketType.Output);
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _graph?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
 }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -252,6 +252,7 @@ public partial class RedGraph
 
         // 8. Map connections from original node to deletion marker's default sockets
         MapConnectionsToStandardSockets(originalQuestNode, markerWrapper);
+        node.Dispose();
 
         // 9. Update properties in the nodes collection
         if (GetQuestNodesChunkViewModel() is { } nodes)
@@ -397,7 +398,10 @@ public partial class RedGraph
             }
         }
 
-        Nodes.Remove(node);
+        if (Nodes.Remove(node))
+        {
+            node.Dispose();
+        }
     }
 
     private Type GetWrapperType(Type type)
@@ -1343,7 +1347,7 @@ public partial class RedGraph
             var group = incomingGroupedBySource.First();
             var inputNodeDef = inputNodeDefs.First();
             var phaseInSocket = (QuestInputConnectorViewModel)wrappedPhaseNode.Input.First(s => s.Name == "In");
-            var tempWrappedInput = WrapQuestNode(inputNodeDef, true);
+            using var tempWrappedInput = WrapQuestNode(inputNodeDef, true);
             var internalOutSocket = (QuestOutputConnectorViewModel)tempWrappedInput.Output.First();
 
             ConnectQuest((QuestOutputConnectorViewModel)group.Key, phaseInSocket);
@@ -1360,7 +1364,7 @@ public partial class RedGraph
                 var group = incomingGroupedBySource[i];
                 var inputNodeDef = inputNodeDefs[i];
                 var phaseInSocket = (QuestInputConnectorViewModel)wrappedPhaseNode.Input.First(s => s.Name == inputNodeDef.SocketName);
-                var tempWrappedInput = WrapQuestNode(inputNodeDef, true);
+                using var tempWrappedInput = WrapQuestNode(inputNodeDef, true);
                 var internalOutSocket = (QuestOutputConnectorViewModel)tempWrappedInput.Output.First();
 
                 ConnectQuest((QuestOutputConnectorViewModel)group.Key, phaseInSocket);
@@ -1378,7 +1382,7 @@ public partial class RedGraph
             var group = outgoingGroupedBySource[i];
             var outputNodeDef = outputNodeDefs[i];
             var phaseOutSocket = (QuestOutputConnectorViewModel)wrappedPhaseNode.Output.First(s => s.Name == outputNodeDef.SocketName);
-            var tempWrappedOutput = WrapQuestNode(outputNodeDef, true);
+            using var tempWrappedOutput = WrapQuestNode(outputNodeDef, true);
             var internalInSocket = (QuestInputConnectorViewModel)tempWrappedOutput.Input.First(s => ((QuestInputConnectorViewModel)s).Data.Type == Enums.questSocketType.Input);
 
             AddConnectionToData((QuestOutputConnectorViewModel)group.Key, internalInSocket);
@@ -1394,7 +1398,7 @@ public partial class RedGraph
         {
             var phaseCutDestSocket = (QuestInputConnectorViewModel)wrappedPhaseNode.Input.First(s => s.Name == "CutDestination");
 
-            var tempWrappedInternalCutDest = WrapQuestNode(internalCutDestInputNodeDef!, true);
+            using var tempWrappedInternalCutDest = WrapQuestNode(internalCutDestInputNodeDef!, true);
             var internalCutDestOutSocket = (QuestOutputConnectorViewModel)tempWrappedInternalCutDest.Output.First();
 
             foreach (var conn in cutDestinationConnections)
@@ -1407,6 +1411,10 @@ public partial class RedGraph
 
         // 7. Refresh the whole graph view
         RebuildQuestConnections();
+        foreach (var node in questNodes)
+        {
+            node.Dispose();
+        }
         GraphStateSave();
         DocumentViewModel?.SetIsDirty(true);
     }

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -555,6 +555,7 @@ public partial class RedGraph
 
         // 10. Remove the original node from UI
         Nodes.Remove(node);
+        node.Dispose();
 
         // 11. Add the deletion marker wrapper to UI
         Nodes.Add(markerWrapper);
@@ -640,7 +641,10 @@ public partial class RedGraph
             }
         }
 
-        Nodes.Remove(node);
+        if (Nodes.Remove(node))
+        {
+            node.Dispose();
+        }
     }
 
     private BaseSceneViewModel WrapSceneNode(scnSceneGraphNode node)

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -925,6 +925,9 @@ public partial class RedGraph : IDisposable
         {
             if (disposing)
             {
+                Comments.CollectionChanged -= CommentsOnCollectionChanged;
+                Nodes.CollectionChanged -= NodesOnCollectionChanged;
+
                 foreach (var node in Nodes)
                 {
                     node.Dispose();

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -232,6 +232,11 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             dockElement.PropertyChanged -= DockedView_OnPropertyChanged;
             DockedViewVisibleChanged?.Invoke(sender, new DockedViewVisibleChangedEventArgs(dockElement));
+
+            if (dockElement is RedDocumentViewModel redDocument)
+            {
+                redDocument.Dispose();
+            }
         }
 
         foreach (var dockElement in (e.NewItems ?? Array.Empty<object>()).OfType<IDockElement>())

--- a/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
+++ b/WolvenKit.App/ViewModels/Timeline/SectionTimelineViewModel.cs
@@ -120,5 +120,9 @@ public partial class SectionTimelineViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void ExtendSectionDurationToEvents() => _service.ExtendSectionDurationToEvents();
 
-    public void Dispose() => _service.Dispose();
+    public void Dispose()
+    {
+        _service.PropertyChanged -= OnServicePropertyChanged;
+        _service.Dispose();
+    }
 }

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -75,8 +75,27 @@ namespace WolvenKit.Views.Documents
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
 
+            QuestPhaseGraphEditor.SourceChanged += OnEditorSourceChanged;
+
             // Add keyboard shortcut for subgraph navigation (Tab key)
             KeyDown += OnKeyDown;
+        }
+
+        private void OnEditorSourceChanged(object? sender, RedGraph? graph)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (graph is null)
+            {
+                UnsubscribeFromGraph();
+                return;
+            }
+
+            SubscribeToGraph(graph);
+            UpdateConnectionPathTypes(graph);
         }
 
         /// <summary>
@@ -214,6 +233,7 @@ namespace WolvenKit.Views.Documents
 
                 UnsubscribeFromGraph();
 
+                QuestPhaseGraphEditor.SourceChanged -= OnEditorSourceChanged;
                 DataContextChanged -= OnDataContextChanged;
                 KeyDown -= OnKeyDown;
 
@@ -252,8 +272,6 @@ namespace WolvenKit.Views.Documents
                 CleanupEventSubscription();
             }
 
-            UnsubscribeFromGraph();
-
             if (e.NewValue is not QuestPhaseGraphViewModel viewModel)
             {
                 return;
@@ -266,12 +284,9 @@ namespace WolvenKit.Views.Documents
             // Monitor document closing by watching DockedViews collection
             MonitorDocumentClosing();
 
-            SubscribeToGraph(viewModel.MainGraph);
-
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 SetupConnectionTemplate();
-                UpdateConnectionPathTypes(viewModel.MainGraph);
                 BuildBreadcrumb(); // Initialize breadcrumb navigation
 
                 // Add a small delay to ensure smooth loading experience

--- a/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/QuestPhaseGraphView.xaml.cs
@@ -63,6 +63,7 @@ namespace WolvenKit.Views.Documents
         private IDocumentViewModel? _lastActiveDocument;
         private bool _disposed = false;
         private IDocumentViewModel? _currentDocument; // Track current document for disposal detection
+        private RedGraph? _subscribedGraph;
 
         private ILoggerService _loggerService = Locator.Current.GetService<ILoggerService>()!;
 
@@ -211,6 +212,8 @@ namespace WolvenKit.Views.Documents
                     viewModel.GraphSearchNavigationRequested -= OnGraphSearchNavigationRequested;
                 }
 
+                UnsubscribeFromGraph();
+
                 DataContextChanged -= OnDataContextChanged;
                 KeyDown -= OnKeyDown;
 
@@ -249,6 +252,8 @@ namespace WolvenKit.Views.Documents
                 CleanupEventSubscription();
             }
 
+            UnsubscribeFromGraph();
+
             if (e.NewValue is not QuestPhaseGraphViewModel viewModel)
             {
                 return;
@@ -261,8 +266,7 @@ namespace WolvenKit.Views.Documents
             // Monitor document closing by watching DockedViews collection
             MonitorDocumentClosing();
 
-            viewModel.MainGraph.Connections.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
-            viewModel.MainGraph.Nodes.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
+            SubscribeToGraph(viewModel.MainGraph);
 
             Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -276,6 +280,39 @@ namespace WolvenKit.Views.Documents
                     viewModel.SetGraphLoaded();
                 }), DispatcherPriority.Background);
             }), DispatcherPriority.Loaded);
+        }
+
+        private void SubscribeToGraph(RedGraph graph)
+        {
+            if (ReferenceEquals(_subscribedGraph, graph))
+            {
+                return;
+            }
+
+            UnsubscribeFromGraph();
+            _subscribedGraph = graph;
+            graph.Connections.CollectionChanged += OnGraphCollectionChanged;
+            graph.Nodes.CollectionChanged += OnGraphCollectionChanged;
+        }
+
+        private void UnsubscribeFromGraph()
+        {
+            if (_subscribedGraph == null)
+            {
+                return;
+            }
+
+            _subscribedGraph.Connections.CollectionChanged -= OnGraphCollectionChanged;
+            _subscribedGraph.Nodes.CollectionChanged -= OnGraphCollectionChanged;
+            _subscribedGraph = null;
+        }
+
+        private void OnGraphCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_subscribedGraph != null)
+            {
+                UpdateConnectionPathTypes(_subscribedGraph);
+            }
         }
 
 

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml.cs
@@ -37,6 +37,7 @@ namespace WolvenKit.Views.Documents
         // Navigation memory: tracks which child was last visited from each node in each direction
         private readonly Dictionary<(uint nodeId, Key direction), uint> _navigationMemory = new();
         private readonly List<uint> _navigationHistory = new();
+        private RedGraph? _subscribedGraph;
 
         // Selection persistence across document switches
         private static readonly Dictionary<string, uint> s_documentNodeSelections = new();
@@ -53,12 +54,18 @@ namespace WolvenKit.Views.Documents
             InitializeComponent();
             DataContextChanged += OnDataContextChanged;
             Loaded += OnViewLoaded;
+            Unloaded += OnViewUnloaded;
         }
 
         private void OnViewLoaded(object sender, RoutedEventArgs e)
         {
             var viewModel = DataContext as SceneGraphViewModel;
             var document = viewModel?.Parent;
+
+            if (viewModel != null)
+            {
+                SubscribeToGraph(viewModel.MainGraph);
+            }
 
             if (document != null)
             {
@@ -69,12 +76,15 @@ namespace WolvenKit.Views.Documents
             }
         }
 
+        private void OnViewUnloaded(object sender, RoutedEventArgs e) => UnsubscribeFromGraph();
+
         private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
+            UnsubscribeFromGraph();
+
             if (e.NewValue is not SceneGraphViewModel viewModel) return;
 
-            viewModel.MainGraph.Connections.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
-            viewModel.MainGraph.Nodes.CollectionChanged += (_, _) => UpdateConnectionPathTypes(viewModel.MainGraph);
+            SubscribeToGraph(viewModel.MainGraph);
 
             // Initialize centralized selection manager
             InitializeGlobalSelectionManager();
@@ -93,6 +103,39 @@ namespace WolvenKit.Views.Documents
                     RestoreSelectionIfReady(viewModel.Parent);
                 }), System.Windows.Threading.DispatcherPriority.Background);
             }), System.Windows.Threading.DispatcherPriority.Loaded);
+        }
+
+        private void SubscribeToGraph(RedGraph graph)
+        {
+            if (ReferenceEquals(_subscribedGraph, graph))
+            {
+                return;
+            }
+
+            UnsubscribeFromGraph();
+            _subscribedGraph = graph;
+            graph.Connections.CollectionChanged += OnGraphCollectionChanged;
+            graph.Nodes.CollectionChanged += OnGraphCollectionChanged;
+        }
+
+        private void UnsubscribeFromGraph()
+        {
+            if (_subscribedGraph == null)
+            {
+                return;
+            }
+
+            _subscribedGraph.Connections.CollectionChanged -= OnGraphCollectionChanged;
+            _subscribedGraph.Nodes.CollectionChanged -= OnGraphCollectionChanged;
+            _subscribedGraph = null;
+        }
+
+        private void OnGraphCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_subscribedGraph != null)
+            {
+                UpdateConnectionPathTypes(_subscribedGraph);
+            }
         }
 
         private void SetupConnectionTemplate()
@@ -1042,6 +1085,10 @@ namespace WolvenKit.Views.Documents
             }
 
             _disposed = true;
+            UnsubscribeFromGraph();
+            DataContextChanged -= OnDataContextChanged;
+            Loaded -= OnViewLoaded;
+            Unloaded -= OnViewUnloaded;
         }
 
         #endregion

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -59,9 +59,21 @@ public partial class GraphEditorView : UserControl
     public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
         nameof(Source), typeof(RedGraph), typeof(GraphEditorView), new PropertyMetadata(null, OnSourceChanged));
 
+    /// <summary>
+    /// Raised when the graph displayed by the editor changes, including when it is cleared.
+    /// </summary>
+    public event EventHandler<RedGraph> SourceChanged;
+
     private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is not GraphEditorView { Source: not null } view)
+        if (d is not GraphEditorView view)
+        {
+            return;
+        }
+
+        view.SourceChanged?.Invoke(view, e.NewValue as RedGraph);
+
+        if (view.Source is null)
         {
             return;
         }

--- a/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
+++ b/WolvenKit/Views/Timeline/SectionTimelineView.xaml.cs
@@ -51,11 +51,8 @@ public partial class SectionTimelineView : UserControl
     {
         InitializeComponent();
         
-        _viewModel = new SectionTimelineViewModel();
-        DataContext = _viewModel;
-        _viewModel.PropertyChanged += ViewModel_PropertyChanged;
-        
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
         SizeChanged += OnSizeChanged;
         
         PreviewKeyDown += OnPreviewKeyDown;
@@ -99,8 +96,34 @@ public partial class SectionTimelineView : UserControl
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
+        CreateViewModel();
         UpdateViewportWidth();
         QueueRenderTimeline();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_viewModel == null)
+        {
+            return;
+        }
+
+        _viewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        _viewModel.Dispose();
+        _viewModel = null;
+        DataContext = null;
+    }
+
+    private void CreateViewModel()
+    {
+        if (_viewModel != null)
+        {
+            return;
+        }
+
+        _viewModel = new SectionTimelineViewModel();
+        _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+        DataContext = _viewModel;
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)

--- a/changelog/unreleased/3037.yaml
+++ b/changelog/unreleased/3037.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3037
+      author: "misterchedda"
+      description: "Improved long-session quest and scene graph performance by cleaning up graph resources when they are no longer in use"


### PR DESCRIPTION
Fixes graph editor lifecycle cleanup to prevent stale graph objects from remaining subscribed

Addresses the progressive slowdown (reported by some users in discord) in long quest/scene editor sessions


