### PR TITLE
add disclaimer for material preview via a banner

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -2624,6 +2624,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         resources["WolvenKitMarginMicroHorizontal"] = new Thickness(2, 0, 2, 0).Mul(_uiScalePercentage).Round();
         resources["WolvenKitMarginMicroVertical"] = new Thickness(0, 2, 0, 2).Mul(_uiScalePercentage).Round();
 
+        resources["WolvenKitTinyRadius"] = new CornerRadius(2).Mul(_uiScalePercentage).Round();
         resources["WolvenKitSmallRadius"] = new CornerRadius(5).Mul(_uiScalePercentage).Round();
         resources["WolvenKitRadius"] = new CornerRadius(10).Mul(_uiScalePercentage).Round();
 

--- a/WolvenKit/Themes/App.Sizes.xaml
+++ b/WolvenKit/Themes/App.Sizes.xaml
@@ -71,6 +71,7 @@
     <Thickness x:Key="WolvenKitMarginMicroHorizontal">2,0</Thickness>
     <Thickness x:Key="WolvenKitMarginMicroVertical">0,2</Thickness>
 
+    <CornerRadius x:Key="WolvenKitTinyRadius">2</CornerRadius>
     <CornerRadius x:Key="WolvenKitSmallRadius">5</CornerRadius>
     <CornerRadius x:Key="WolvenKitRadius">10</CornerRadius>
 

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -491,6 +491,18 @@
                         Content="Export Appearance with Rig" />
                 </Grid>
 
+                <Border Background="{StaticResource WolvenKitRed}"
+                        CornerRadius="2"
+                        Margin="{DynamicResource WolvenKitMarginTiny}"
+                        Padding="{DynamicResource WolvenKitMarginTiny}"
+                        HorizontalAlignment="Stretch">
+                    <TextBlock Text="The material preview is experimental and may be incorrect in some cases."
+                               Foreground="White"
+                               FontWeight="Regular"
+                               HorizontalAlignment="Stretch"
+                               FontSize="{DynamicResource WolvenKitFontBody}"/>
+                </Border>
+
                 <!-- Collisions/Sectors -->
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/WolvenKit/Views/Documents/RDTMeshView.xaml
+++ b/WolvenKit/Views/Documents/RDTMeshView.xaml
@@ -492,7 +492,7 @@
                 </Grid>
 
                 <Border Background="{StaticResource WolvenKitRed}"
-                        CornerRadius="2"
+                        CornerRadius="{DynamicResource WolvenKitTinyRadius}"
                         Margin="{DynamicResource WolvenKitMarginTiny}"
                         Padding="{DynamicResource WolvenKitMarginTiny}"
                         HorizontalAlignment="Stretch">

--- a/changelog/unreleased/3038.yaml
+++ b/changelog/unreleased/3038.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3038
+      author: "notaspirit"
+      description: "Mesh preview now includes a disclaimer about the possibility of incorrect materials during preview."


### PR DESCRIPTION
# add disclaimer for material preview via a banner

**Implemented:**
- new banner in mesh preview informing the user about the possibility of the material preview being wrong

**Additional notes:**
closes #2887

<img width="1972" height="853" alt="image" src="https://github.com/user-attachments/assets/f884782f-25ee-4906-b509-66f0b4a5b329" />
<img width="1970" height="851" alt="image" src="https://github.com/user-attachments/assets/e6914949-1604-4103-b57d-06c5ea87524e" />
