### PR TITLE
Fix an issue where file system watcher could freeze

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -2154,6 +2154,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             if (_inFlight)
             {
                 await action();
+                _projectWatcher.Resume();
                 return;
             }
 
@@ -2163,6 +2164,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             {
                 await action();
                 _inFlight = false;
+                _projectWatcher.Resume();
                 return;
             }
 

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -399,18 +399,30 @@ public partial class ProjectExplorerViewModel
 
                 foreach (var key in _fileLookup.Keys)
                 {
-                    if (!key.StartsWith(renamedEventArgs.OldName))
+                    var oldFullPathNormalized = (!Directory.Exists(renamedEventArgs.FullPath))
+                        ? renamedEventArgs.OldFullPath
+                        : Path.GetFullPath(renamedEventArgs.OldFullPath)
+                            .TrimEnd(Path.DirectorySeparatorChar,
+                                Path.AltDirectorySeparatorChar);
+
+                    if (!key.StartsWith(oldFullPathNormalized))
                     {
                         continue;
                     }
 
-                    var newKey = renamedEventArgs.Name + key.Substring(renamedEventArgs.OldName.Length);
+                    if (key != oldFullPathNormalized && !key[oldFullPathNormalized.Length..].StartsWith('\\'))
+                    {
+                        // we've matched \my\dir to \my\dir2 because it has substring "\my\dir" so continue
+                        continue;
+                    }
+
+                    var newKey = renamedEventArgs.FullPath + key[oldFullPathNormalized.Length..];
                     if (!_fileLookup.TryRemove(key, out var item) || !_fileLookup.TryAdd(newKey, item))
                     {
                         throw new Exception();
                     }
 
-                    if (key != renamedEventArgs.OldName)
+                    if (key != oldFullPathNormalized)
                     {
                         continue;
                     }
@@ -715,6 +727,7 @@ public partial class ProjectExplorerViewModel
                     _loggerService?.Error($"WatcherState should be suspended but was instead: {_watcherState}");
                 }
 
+                _loggerService?.Debug("Stopping file system watcher in mod folder.");
                 _suspendQueue.Enqueue(new SuspendToken());
             }
         }


### PR DESCRIPTION
# Fixes an issue where Windows File System Events (such as manually adding files or renaming folders) could put the File Watcher into an incorrect state

There were two issues at play. 

1. Watcher could get "over-suspended" and thus, when "resumed" it was not actually resuming. This is now fixed.
2. The "Rename" path for renames detected through Windows File System events was still using incorrect RawRelativePaths for file lookup, resulting in files not appearing in the tree until after a refresh. (For folders manually renamed in Windows Explorer.)

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->