### PR TITLE
Fix file system model spam

### DIFF
--- a/WolvenKit.App/Models/FileSystemModel.cs
+++ b/WolvenKit.App/Models/FileSystemModel.cs
@@ -4,8 +4,10 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using WolvenKit.Common;
+using WolvenKit.Core.Extensions;
 using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.Models;
@@ -14,6 +16,8 @@ public class FileSystemModel : INotifyPropertyChanged
 {
     public const string ProjectDirName = "<ProjectDir>";
 
+    private readonly bool _shouldPublish;
+    private readonly string _projectDirectory;
     private string _name;
     private string _gameRelativePath = null!;
     private long _fileSize;
@@ -39,8 +43,28 @@ public class FileSystemModel : INotifyPropertyChanged
 
     [Display(Name = "System Path")] public string FullName { get; private set; } = null!;
 
-    [Browsable(false)] public ulong Hash { get; private set; }
-    [Display(Name = "Hash")] public string HashStr { get; private set; } = "0";
+    [Browsable(false)]
+    public ulong Hash
+    {
+        get
+        {
+            if (Parent?.Extension == Constants.ModDirectoryTop)
+            {
+                if (Parent.RawRelativePath == "archive" && ulong.TryParse(Path.GetFileNameWithoutExtension(Name), out var hash))
+                {
+                    return hash;
+                }
+                else
+                {
+                    return ResourcePath.CalculateHash(GameRelativePath);
+                }
+            }
+
+            return 0;
+        }
+    }
+
+    [Display(Name = "Hash")] public string HashStr => Hash.ToString();
 
     [Browsable(false)]
     public long FileSize
@@ -82,15 +106,26 @@ public class FileSystemModel : INotifyPropertyChanged
     /// </summary>
     /// <param name="parent"></param><remark>FileSystemModel of the parent.</remark>
     /// <param name="name"></param><remark>Name of the file with extension but no paths.</remark>
-    /// <param name="relativePath"></param><remark>Path above 'source' to the file. E.g. archive/worlds/myfile.ent</remark>
+    /// <param name="rawRelativePath"></param><remark>Path above 'source' to the file. E.g. archive/worlds/myfile.ent</remark>
     /// <param name="isDirectory"></param>
-    public FileSystemModel(FileSystemModel? parent, string name, string relativePath, bool isDirectory, bool isExpanded = false)
+    public FileSystemModel(FileSystemModel? parent, string name, string rawRelativePath, bool isDirectory, bool isExpanded = false, bool shouldPublish = true)
     {
         Parent = parent;
+
+        if (Parent == null)
+        {
+            _projectDirectory = rawRelativePath;
+        }
+        else
+        {
+            _projectDirectory = Parent._projectDirectory;
+        }
+
         _name = name;
-        RawRelativePath = relativePath;
+        RawRelativePath = rawRelativePath;
         IsDirectory = isDirectory;
         _isExpanded = isDirectory && isExpanded; // only directories can be expanded
+        _shouldPublish = shouldPublish;
 
         GetMetadata();
     }
@@ -130,62 +165,56 @@ public class FileSystemModel : INotifyPropertyChanged
 
     private void GetMetadata()
     {
-        var hashParts = new List<string>();
-
-        var root = this;
-        var current = this;
-        while (current != null)
-        {
-            if (current.Parent?.Name != ProjectDirName && current.Name != ProjectDirName)
-            {
-                hashParts.Add(current.Name);
-            }
-
-            root = current;
-            current = current.Parent;
-        }
-        hashParts.Reverse();
-
-        GameRelativePath = string.Join(ResourcePath.DirectorySeparatorChar, hashParts);
-        FullName = Path.Combine(root.RawRelativePath, RawRelativePath);
-
-        if (Parent?.Extension == Constants.ModDirectoryTop)
-        {
-            if (Parent.RawRelativePath == "archive" && ulong.TryParse(Path.GetFileNameWithoutExtension(Name), out var hash))
-            {
-                Hash = hash;
-            }
-            else
-            {
-                Hash = ResourcePath.CalculateHash(GameRelativePath);
-            }
-
-            HashStr = Hash.ToString();
-        }
+        FullName = Path.Combine(_projectDirectory, RawRelativePath);
 
         if (IsDirectory)
         {
-            Extension = ECustomImageKeys.OpenDirImageKey.ToString();
             if (RawRelativePath.Equals("archive", StringComparison.CurrentCultureIgnoreCase))
             {
                 Extension = Constants.ModDirectoryTop;
+                GameRelativePath = "";
             }
             else if (RawRelativePath.Equals("raw", StringComparison.CurrentCultureIgnoreCase))
             {
                 Extension = Constants.RawDirectoryTop;
+                GameRelativePath = "";
             }
             else if (RawRelativePath.Equals("resources", StringComparison.CurrentCultureIgnoreCase))
             {
                 Extension = Constants.ResourceDirectoryTop;
+                GameRelativePath = "";
             }
             else if (Parent != null)
             {
                 Extension = Parent.Extension;
+
+                switch (Extension)
+                {
+                    case Constants.ModDirectoryTop:
+                        GameRelativePath = RawRelativePath[8..];
+                        break;
+                    case Constants.RawDirectoryTop:
+                        GameRelativePath = RawRelativePath[4..];
+                        break;
+                    case Constants.ResourceDirectoryTop:
+                        GameRelativePath = RawRelativePath[10..];
+                        break;
+                    default:
+                        var split =
+                            RawRelativePath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)[1..];
+                        GameRelativePath = Path.Combine(split);
+                        break;
+                }
             }
         }
         else
         {
             Extension = Path.GetExtension(Name).TrimStart('.');
+
+            if (Parent != null)
+            {
+                GameRelativePath = Parent.GameRelativePath + Path.DirectorySeparatorChar + Name;
+            }
 
             UpdateFileInfo();
         }
@@ -208,10 +237,10 @@ public class FileSystemModel : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
-    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+     private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
         if (EqualityComparer<T>.Default.Equals(field, value))
         {
@@ -219,8 +248,24 @@ public class FileSystemModel : INotifyPropertyChanged
         }
 
         field = value;
-        OnPropertyChanged(propertyName);
+
+        if (ShouldPublish(propertyName))
+        {
+            OnPropertyChanged(propertyName);
+        }
+
         return true;
+    }
+
+    private bool ShouldPublish(string? propertyName)
+    {
+        var isBlacklisted =
+            propertyName == null
+            || propertyName == nameof(RawRelativePath)
+            || propertyName == nameof(IsDirectory)
+            || propertyName == nameof(FullName);
+
+        return _shouldPublish && !isBlacklisted;
     }
 
     #endregion

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1391,7 +1391,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (assetBrowser.RightItems.FirstOrDefault(f => f.FullName.Contains(result)) is FileSystemViewModel mod)
         {
-            assetBrowser.ShowFile(new FileSystemModel(null, result, mod.FullName, true));
+            assetBrowser.ShowFile(new FileSystemModel(null, result, mod.FullName, true, shouldPublish: false));
         }
         else
         {

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -208,14 +208,13 @@ public partial class ProjectExplorerViewModel
         public void StartWatcher_AndLoadProject(Cp77Project project, Action? completion = null)
         {
             _projectDirectory = project.FileDirectory;
-            _projectFileSystemModel = new FileSystemModel(null, FileSystemModel.ProjectDirName, _projectDirectory, true);
+            _projectFileSystemModel = new FileSystemModel(null, FileSystemModel.ProjectDirName, _projectDirectory, true,
+                shouldPublish: false);
             ResumeWatcher_AndLoadProject();
         }
 
         public void Resume()
         {
-            lock (_resumeLock)
-            {
                 switch (_watcherState, _suspendQueue.Count)
                 {
                     // happy path
@@ -225,10 +224,6 @@ public partial class ProjectExplorerViewModel
                         if (_suspendQueue.Count == 0)
                         {
                             InternalResume();
-                        }
-                        else
-                        {
-                            _loggerService?.Debug($"Waiting to resume file watcher for {_suspendQueue.Count} remaining file operations.");
                         }
 
                         return;
@@ -248,7 +243,6 @@ public partial class ProjectExplorerViewModel
                     default:
                         throw new Exception(
                             $"Unexpected condition: attempting to resume file watcher while its state was {_watcherState} with {_suspendQueue.Count} suspends on the queue.");
-                }
             }
 
 
@@ -572,7 +566,7 @@ public partial class ProjectExplorerViewModel
         private (List<FileSystemModel> FlatList, FileSystemModel? TreeRoot) BuildFullFileStructure()
         {
             var flatList = new List<FileSystemModel>(10000);
-            var rootModel = _projectFileSystemModel ?? new FileSystemModel(null, FileSystemModel.ProjectDirName, _projectDirectory, true);
+            var rootModel = _projectFileSystemModel ?? new FileSystemModel(null, FileSystemModel.ProjectDirName, _projectDirectory, true, shouldPublish: false);
             var stack = new Stack<(DirectoryInfo Dir, FileSystemModel Parent)>();
             stack.Push((new DirectoryInfo(rootModel.FullName), rootModel));
 
@@ -711,8 +705,6 @@ public partial class ProjectExplorerViewModel
 
         public void Suspend()
         {
-            lock (_suspendLock)
-            {
                 if (_suspendQueue.IsEmpty)
                 {
                     _suspendQueue.Enqueue(new SuspendToken());
@@ -727,9 +719,7 @@ public partial class ProjectExplorerViewModel
                     _loggerService?.Error($"WatcherState should be suspended but was instead: {_watcherState}");
                 }
 
-                _loggerService?.Debug("Stopping file system watcher in mod folder.");
                 _suspendQueue.Enqueue(new SuspendToken());
-            }
         }
 
         private void CancelFileLoggingToken()
@@ -934,7 +924,7 @@ public partial class ProjectExplorerViewModel
                 var name = Path.GetFileName(e.FullPath);
 
                 bool desiredExpansion = isDirectory && _getDesiredExpansionState(relativePath);
-                var model = new FileSystemModel(parent, name, relativePath, isDirectory, desiredExpansion);
+                var model = new FileSystemModel(parent, name, relativePath, isDirectory, desiredExpansion, shouldPublish: false);
                 return model;
             }
             catch (Exception ex)
@@ -1182,7 +1172,7 @@ public partial class ProjectExplorerViewModel
             var name = Path.GetFileName(absolutePath);
             var desiredExpansion = isDirectory && _getDesiredExpansionState(relativePath);
 
-            var model = new FileSystemModel(parentModel, name, relativePath, isDirectory, desiredExpansion);
+            var model = new FileSystemModel(parentModel, name, relativePath, isDirectory, desiredExpansion, shouldPublish: false);
 
             if (!parentModel.Children.Contains(model))
             {
@@ -1320,7 +1310,7 @@ public partial class ProjectExplorerViewModel
             {
                 if (!parent.Children.Any(m => m.FullName == fullPath) && !_fileLookup.ContainsKey(fullPath))
                 {
-                    var fileSystemModel = new FileSystemModel(parent, fileName, rawRelativePath, false);
+                    var fileSystemModel = new FileSystemModel(parent, fileName, rawRelativePath, false, shouldPublish: false);
                     parent.Children.Add(fileSystemModel);
                     _fileLookup.TryAdd(fullPath, fileSystemModel);
                     batch.Add(fileSystemModel);
@@ -1381,7 +1371,7 @@ public partial class ProjectExplorerViewModel
 
             if (!_fileLookup.ContainsKey(fullPath))
             {
-                var newFileModel = new FileSystemModel(parentModel, fileName, rawRelativePath, false);
+                var newFileModel = new FileSystemModel(parentModel, fileName, rawRelativePath, false, shouldPublish: false);
                 batch.Add(newFileModel);
                 parentModel.Children.Add(newFileModel);
                 _fileLookup.TryAdd(fullPath, newFileModel);


### PR DESCRIPTION
# Performance optimization of FileSystemModel

Now that we have GridGuard maintaining a shadow tree, we don't need the domain models in FileWatcher to publish INotifcation events (since there's no grid listening to them). So we can optimize performance by not publishing from non-live-grid models. 

The other thing we can do is not calculate the expensive hashes on every model, instead just calculate the hash when/if it's ever needed. Further we can avoid having to reverse-walk the parents to find the root, instead we can just pass the project dir down through the file tree from parent to son/daughter/etc. 

Profiling revealed these were major performance bottlenecks and this PR cuts the time to rename a folder of 2500 files by more than half. 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->