### PR TITLE
Live Search, Search/Reload Bugfixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,23 +64,23 @@
     <PackageVersion Include="Splat" Version="15.3.1" />
     <PackageVersion Include="Splat.Microsoft.Extensions.DependencyInjection" Version="15.3.1" />
     <PackageVersion Include="Splat.Microsoft.Extensions.Logging" Version="15.3.1" />
-    <PackageVersion Include="Syncfusion.Edit.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.PropertyGrid.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfAccordion.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfBusyIndicator.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfGrid.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfHubTile.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfImageEditor.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfProgressBar.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfRadialMenu.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfRichTextBoxAdv.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfSkinManager.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfTextInputLayout.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfTreeNavigator.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.SfTreeView.WPF" Version="33.2.8" />
-    <PackageVersion Include="Syncfusion.Themes.MaterialDark.WPF" Version="33.2.8" />
+    <PackageVersion Include="Syncfusion.Edit.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.PropertyGrid.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfAccordion.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfBusyIndicator.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfGrid.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfHubTile.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfImageEditor.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfInput.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfNavigationDrawer.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfProgressBar.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfRadialMenu.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfRichTextBoxAdv.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfSkinManager.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfTextInputLayout.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfTreeNavigator.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.SfTreeView.WPF" Version="33.2.15" />
+    <PackageVersion Include="Syncfusion.Themes.MaterialDark.WPF" Version="33.2.15" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.2" />

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -15,6 +15,23 @@ public static class DispatcherHelper
 
     public static async Task RunOnMainThreadAsync(Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal) => await Application.Current.RunOnUIThreadAsync(action, priority);
 
+    /// <summary>
+    /// Queues the action to a fresh dispatcher frame, even when already on the UI thread
+    /// (unlike "RunOnMainThread", which runs inline in that case). Use when the
+    /// action must not run inside the currently executing event handler's stack.
+    /// </summary>
+    public static void PostOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        if (Application.Current is not { Dispatcher: { } dispatcher })
+        {
+            // Headless / unit-test context: run synchronously, matching the other helpers.
+            action();
+            return;
+        }
+
+        dispatcher.BeginInvoke(action, priority);
+    }
+
     private static async Task RunOnUIThreadAsync(this DispatcherObject? d, Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal)
     {
         // In a unit test / headless context there is no WPF Application and no Dispatcher.

--- a/WolvenKit.App/Models/DispatchedObservableCollection.cs
+++ b/WolvenKit.App/Models/DispatchedObservableCollection.cs
@@ -14,38 +14,7 @@ public class DispatchedObservableCollection<T> : ObservableCollection<T>
 {
     public new void Add(T item) => DispatcherHelper.RunOnMainThread(() => base.Add(item));
 
-    public new void Remove(T item) => DispatcherHelper.RunOnMainThread(() =>
-    {
-        try
-        {
-            base.Remove(item);
-        }
-        catch (Exception e)
-        {
-            try
-            {
-                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-            }
-            catch
-            {
-                if (item is FileSystemModel model)
-                {
-                    Locator.Current.GetService<ILoggerService>()
-                        ?.Error($"Error when removing model for file: {model.FullName}: \n {e.Message}");
-                    return;
-                }
-            }
-
-            if (item is FileSystemModel fileModel)
-            {
-                Locator.Current.GetService<ILoggerService>()
-                    ?.Error($"Error when removing model for file: {fileModel.FullName}: \n {e.Message}");
-                return;
-            }
-
-            Locator.Current.GetService<ILoggerService>()?.Error($"Error when removing model: \n {e.Message}");
-        }
-    });
+    public new void Remove(T item) => DispatcherHelper.RunOnMainThread(() => base.Remove(item));
 
     public new void Clear() => DispatcherHelper.RunOnMainThread(() => base.Clear());
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -1046,32 +1046,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         _appViewModel.ReloadChangedFiles();
     }
 
-    /// <summary>
-    /// Called by the View after a drag-and-drop has moved and/or copied files on disk. Publishes an
-    /// authoritative reconciliation so the grids update immediately from what actually happened,
-    /// instead of waiting on (flaky) OS file system events. <paramref name="moves"/> are
-    /// (fromAbs -&gt; toAbs) relocations; <paramref name="additions"/> are newly created absolute
-    /// paths (copy targets). The watcher applies this idempotently, so a live FS event for the same
-    /// change is a harmless no-op.
-    /// </summary>
-    public void NotifyDragDropReconciled(
-        IReadOnlyList<(string From, string To)> moves,
-        IReadOnlyList<string> additions)
-    {
-        if (moves.Count == 0 && additions.Count == 0)
-        {
-            return;
-        }
-
-        // Pure additions are modelled as moves with an empty source (OnFilesMoved skips the removal
-        // for an empty From and just materializes the destination).
-        var payload = new List<(string From, string To)>(moves.Count + additions.Count);
-        payload.AddRange(moves);
-        payload.AddRange(additions.Select(a => (string.Empty, a)));
-
-        _projectEvents.PublishFilesMoved(new FilesMovedMessage(payload));
-    }
-
     public void UnwatchProject() => _projectWatcher.UnwatchProject();
 
     public void CloseProject() => _projectWatcher.UnwatchProject();
@@ -2135,7 +2109,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     /// <param name="action"></param>
     /// <param name="shouldSuspend"></param>If the watcher should be suspended during this refresh. (Unless you know what you're doing, leave this as false.)
     /// <returns></returns>
-    public Task RefreshAfter(Action action, bool shouldSuspend = false)
+    public Task RefreshAfter(Action action, bool shouldSuspend = true)
     {
         return RefreshAfter(() =>
         {
@@ -2150,7 +2124,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     /// <param name="action"></param>
     /// <param name="shouldSuspend"></param>If the watcher should be suspended during this refresh. (Unless you know what you're doing, leave this as false.)
     /// <returns>Task</returns>
-    public async Task RefreshAfter(Func<Task> action, bool shouldSuspend = false)
+    public async Task RefreshAfter(Func<Task> action, bool shouldSuspend = true)
     {
         await DispatcherHelper.RunOnMainThreadAsync(async () =>
         {
@@ -2201,19 +2175,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         });
     }
 
-    /// <summary>
-    ///  Since the previous implementation would sometimes fail silently and claim that perfectly viable files weren't found,
-    /// here's an attempt at implementing everything in a more robust way that's also more in line with windows move/copy behaviour.
-    /// </summary>
-    public async Task ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory) =>
-        await RefreshAfter(async () => await InternalProcessFileAction(sourceFiles, targetDirectory));
-
-    /// <summary>
-    ///  Since the previous implementation would sometimes fail silently and claim that perfectly viable files weren't found,
-    /// here's an attempt at implementing everything in a more robust way that's also more in line with windows move/copy behaviour.
-    /// </summary>
-    private async Task InternalProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory)
-    {
+    public void ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory) {
         var isCopy = ModifierViewStateService.IsCtrlBeingHeld;
 
         // Abort if a directory is dragged on itself or its parent
@@ -2301,7 +2263,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         // 1 - 10 files: Show a single dialogue that asks for confirmation
         if (existingFiles.Count is < 10 and > 0)
         {
-            var messageBoxResult = await Interactions.ShowMessageBoxAsync(
+            var messageBoxResult = Interactions.ShowMessageBox(
                 $"Overwrite the following files? \n\n  {string.Join("\n  ", existingFiles)}",
                 "File Overwrite Confirmation", WMessageBoxButtons.YesNoCancel);
 
@@ -2325,7 +2287,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             var canWriteToTargetFile =
                 !File.Exists(targetFile)
                 || isOverwrite
-                || (!skipDialogue && isAskIndividually && await Interactions.ShowMessageBoxAsync(
+                || (!skipDialogue && isAskIndividually && Interactions.ShowMessageBox(
                     $"Overwrite the following file? {targetFile}",
                     "File Overwrite Confirmation",
                     WMessageBoxButtons.YesNo) == WMessageBoxResult.Yes);
@@ -2373,6 +2335,18 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             }
         }
 
-        NotifyDragDropReconciled(movedPairs, addedPaths);
+        if (movedPairs.Count == 0 && addedPaths.Count == 0)
+        {
+            return;
+        }
+
+        var payload = new List<(string From, string To)>(movedPairs.Count + addedPaths.Count);
+        payload.AddRange(movedPairs);
+        payload.AddRange(addedPaths.Select(a => (string.Empty, a)));
+
+        RefreshAfter(() =>
+        {
+            _projectEvents.PublishFilesMoved(new FilesMovedMessage(payload));
+        });
     }
 }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -79,6 +79,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private IPluginService _pluginService;
     private static readonly int _maxDoP = Environment.ProcessorCount > 1 ? Environment.ProcessorCount : 1;
     private object _progressLock = new();
+    private Guid? _autoSaveCancelToken;
 
     private readonly ISettingsManager _settingsManager;
     private readonly IArchiveManager _archiveManager;
@@ -149,9 +150,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         SelectedTabIndex = ActiveProject?.ActiveTab ?? 0;
 
-        DispatcherHelper.StartRepeatingAction(
-            () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
-            TimeSpan.FromSeconds(10));
+        _autoSaveCancelToken = null;
 
         s_instance = this;
 
@@ -162,7 +161,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 // Get a fresh reference to the project instead of the one we captured
                 // a long time ago in this closure.
                 var active = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>().ActiveProject;
-                if (project == null || project == active)
+                if (project == null || project.Equals(active))
                 {
                     return;
                 }
@@ -177,8 +176,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 {
                     // Get a fresh reference to the project instead of the one we captured
                     // a long time ago in this closure.
-                    var active = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>().ActiveProject;
-                    if (project == active)
+                    var activeProject = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>().ActiveProject;
+                    if (project.Equals(activeProject))
                     {
                         return;
                     }
@@ -225,8 +224,10 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         {
             try
             {
-                if (ActiveProject != null)
+                if (ActiveProject != null && _autoSaveCancelToken is { } cancelToken)
                 {
+                    DispatcherHelper.StopRepeatingAction(cancelToken);
+                    _autoSaveCancelToken = null;
                     SaveProjectState();
                     ActiveProject = null;
                     UnwatchProject();
@@ -235,6 +236,9 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 LoadExpansionStateDictionary(activeProject);
                 ActiveProject = activeProject;
                 _projectWatcher.StartWatcher_AndLoadProject(activeProject);
+                _autoSaveCancelToken = DispatcherHelper.StartRepeatingAction(
+                    () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
+                    TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
             {
@@ -246,6 +250,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 {
                     RestoreProjectState(ActiveProject!);
                     CheckForOneDriveInPath();
+                    DisableLoadingMode();
                 }
             }
         });
@@ -270,26 +275,32 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
     private void EnableLoadingMode(LoadingMode mode)
     {
-        if (mode == LoadingMode.LoadingNewProject || mode == LoadingMode.ReloadingSameProject)
+        if (mode != LoadingMode.LoadingNewProject && mode != LoadingMode.ReloadingSameProject)
         {
-            _loadingCompletion = DispatcherHelper.StartRepeatingAction(
-                () =>
-                {
-                    _progressService.IsIndeterminate = true;
-                    _progressService.Status = EStatus.Running;
-                },
-                _singleOperationTimeout,
-                DisableLoadingMode
-            );
-
-            _projectWatcher.CompletionTimer = _loadingCompletion;
+            return;
         }
 
+        _loadingCompletion = DispatcherHelper.StartRepeatingAction(
+            () =>
+            {
+                _progressService.IsIndeterminate = true;
+                _progressService.Status = EStatus.Running;
+            },
+            _singleOperationTimeout,
+            DisableLoadingMode
+        );
+
+        _projectWatcher.CompletionTimer = _loadingCompletion;
         OnSetLoading?.Invoke(this, mode);
     }
 
     private void DisableLoadingMode()
     {
+        if (CurrentLoadingMode == LoadingMode.Ready)
+        {
+            return;
+        }
+
         _progressService.IsIndeterminate = false;
         CurrentLoadingMode = LoadingMode.Ready;
         OnSetLoading?.Invoke(this, (CurrentLoadingMode));

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -93,6 +93,9 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     public DispatchedObservableCollection<FileSystemModel> FileTree => _projectWatcher.FileTree;
     public DispatchedObservableCollection<FileSystemModel> FileList => _projectWatcher.FileList;
     public Func<Func<Task>, Task>? BeginDeferredRefreshContext { get; set; }
+    public Action? OnLiveGridMutationStarting { get; set; }
+    public Action? OnLiveGridMutationCompleted { get; set; }
+
     public Dictionary<string, bool> ExpansionStateDictionary = [];
     public bool IsKeyUpEventAssigned { get; set; }
 
@@ -2175,6 +2178,29 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         });
     }
 
+    public void ApplyGridMutationLive(Action mutate)
+    {
+        DispatcherHelper.PostOnMainThread(() =>
+        {
+            _projectWatcher.Suspend();
+            OnLiveGridMutationStarting?.Invoke();
+            try
+            {
+                mutate();
+            }
+            catch (Exception e)
+            {
+                _loggerService.Debug($"Exception caught during live grid mutation: {e}.");
+            }
+            finally
+            {
+                // Completed must run even on failure so the View can resume suspended grids.
+                OnLiveGridMutationCompleted?.Invoke();
+                _projectWatcher.Resume();
+            }
+        });
+    }
+
     public void ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory) {
         var isCopy = ModifierViewStateService.IsCtrlBeingHeld;
 
@@ -2343,10 +2369,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         var payload = new List<(string From, string To)>(movedPairs.Count + addedPaths.Count);
         payload.AddRange(movedPairs);
         payload.AddRange(addedPaths.Select(a => (string.Empty, a)));
-
-        RefreshAfter(() =>
-        {
-            _projectEvents.PublishFilesMoved(new FilesMovedMessage(payload));
-        });
+        ApplyGridMutationLive(() => _projectEvents.PublishFilesMoved(new FilesMovedMessage(payload)));
     }
 }

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -431,7 +431,8 @@ public partial class ProjectExplorerViewModel
 
                 if (_fileLookup.TryRemove(e.FullPath, out var item))
                 {
-                    RemoveModel(item, e.EventAddedAt);
+                    Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>()
+                        .RefreshAfter(() => RemoveModel(item, e.EventAddedAt), false);
                 }
                 else
                 {
@@ -442,23 +443,20 @@ public partial class ProjectExplorerViewModel
 
         private void RemoveModel(FileSystemModel model, long removedAt = 0)
         {
-            Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().RefreshAfter(() =>
-            {
-                _fileLookup.TryRemove(model.FullName, out _);
+            _fileLookup.TryRemove(model.FullName, out _);
 
-                if (FileTree.Contains(model))
-                    FileTree.Remove(model);
-                if (FileList.Contains(model))
-                    FileList.Remove(model);
+            if (FileTree.Contains(model))
+                FileTree.Remove(model);
+            if (FileList.Contains(model))
+                FileList.Remove(model);
 
-                RemoveChildModels(model);
+            RemoveChildModels(model);
 
-                if (model.Parent != null && model.Parent.Children.Contains(model))
-                    model.Parent.Children.Remove(model);
+            if (model.Parent != null && model.Parent.Children.Contains(model))
+                model.Parent.Children.Remove(model);
 
-                if (removedAt != 0)
-                    _removedFiles.TryAdd(model.FullName, removedAt);
-            }, false);
+            if (removedAt != 0)
+                _removedFiles.TryAdd(model.FullName, removedAt);
         }
 
         private void RemoveChildModels(FileSystemModel model)

--- a/WolvenKit/Views/Others/CancellableRowDragDropController.cs
+++ b/WolvenKit/Views/Others/CancellableRowDragDropController.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using Syncfusion.UI.Xaml.TreeGrid;
+
+namespace WolvenKit.Views.Others;
+
+public class CancellableRowDragDropController : TreeGridRowDragDropController
+{
+    public void CancelPendingAutoExpand()
+    {
+        timer?.Stop();
+        autoExpandNode = null;
+    }
+}

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -974,7 +974,8 @@
                     hc:InfoElement.Placeholder="Search"
                     hc:InfoElement.ShowClearButton="True"
                     FlowDirection="LeftToRight"
-                    SearchStarted="PESearchBar_OnSearchStarted" />
+                    SearchStarted="PESearchBar_OnSearchStarted"
+                    TextChanged="PESearchBar_TextChanged"/>
 
                 <StackPanel
                     Grid.Row="1"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -34,6 +34,7 @@ using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.Tools;
 using WolvenKit.Views.Dialogs;
 using WolvenKit.Views.Dialogs.Windows;
+using WolvenKit.Views.Others;
 using WolvenKit.Views.Templates;
 using RowColumnIndex = Syncfusion.UI.Xaml.ScrollAxis.RowColumnIndex;
 using WolvenKit.Helpers;
@@ -70,6 +71,7 @@ namespace WolvenKit.Views.Tools
         private string _currentFolderQuery = "";
         private bool _isDragging;
         private ISettingsManager _settingsManager;
+        private readonly CancellableRowDragDropController _rowDragDropController;
 
         #region Constructors
 
@@ -80,6 +82,8 @@ namespace WolvenKit.Views.Tools
 
             TreeGrid.ItemsSourceChanged += TreeGrid_ItemsSourceChanged;
             TreeGridFlat.ItemsSourceChanged += TreeGridFlat_ItemsSourceChanged;
+            _rowDragDropController = new CancellableRowDragDropController();
+            TreeGrid.RowDragDropController = _rowDragDropController;
             TreeGrid.RowDragDropController.DragStart += RowDragDropController_DragStart;
             TreeGrid.RowDragDropController.DragOver += RowDragDropController_DragOver;
             TreeGrid.RowDragDropController.Drop += RowDragDropController_Drop;
@@ -395,6 +399,10 @@ namespace WolvenKit.Views.Tools
 
         private async Task BeginDeferredRefreshContext(Func<Task> doBeforeRefresh)
         {
+            // The refresh below disposes every TreeNode; a pending drag-hover auto-expand
+            // would fire on a disposed node afterwards.
+            _rowDragDropController.CancelPendingAutoExpand();
+
             CompositeDisposable disposables =
             [
                 TreeGridFlat.View.DeferRefresh(TreeViewRefreshMode.DeferRefresh),
@@ -412,8 +420,9 @@ namespace WolvenKit.Views.Tools
             {
                 if (!_currentFolderQuery.IsNullOrEmpty())
                 {
+                    // The rebuild recreated every node collapsed and filtered; re-expand
+                    // the ancestor chains of matches so the Extended filter can see them.
                     ReapplyCurrentSearchFilter(expandAllForSearch: true);
-                    return;
                 }
 
                 InvalidateLayout();
@@ -786,7 +795,12 @@ namespace WolvenKit.Views.Tools
             // Filtered by search
             if (!string.IsNullOrWhiteSpace(_currentFolderQuery) && !fm.Name.Contains(_currentFolderQuery))
             {
-                return false;
+                bool matches =
+                    fm.Name.Contains(_currentFolderQuery, StringComparison.OrdinalIgnoreCase) ||
+                    fm.RawRelativePath.Contains(_currentFolderQuery, StringComparison.OrdinalIgnoreCase);
+
+                if (!matches)
+                    return false;
             }
 
             return tabControl.SelectedIndex switch
@@ -875,32 +889,112 @@ namespace WolvenKit.Views.Tools
 
         private void PESearchBar_OnSearchStarted(object sender, FunctionEventArgs<string> e)
         {
-            _currentFolderQuery = e.Info;
-            ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrEmpty(e.Info));
+            _currentFolderQuery = e?.Info ?? PESearchBar?.Text ?? string.Empty;
+            ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrWhiteSpace(_currentFolderQuery));
         }
 
         private void ReapplyCurrentSearchFilter(bool expandAllForSearch)
         {
-            if (TreeGridFlat.View is not null)
+            var hasQuery = !string.IsNullOrWhiteSpace(_currentFolderQuery);
+
+            if (TreeGridFlat?.View is not null)
             {
                 TreeGridFlat.View.Filter = IsFileInFlat;
                 TreeGridFlat.View.RefreshFilter();
             }
 
-            if (TreeGrid.View is null)
+            if (TreeGrid?.View is not null)
+            {
+                TreeGrid.View.Filter = IsFileIn;
+
+                if (expandAllForSearch && hasQuery)
+                {
+                    ExpandAncestorsOfSearchMatches();
+                }
+
+                TreeGrid.View.RefreshFilter();
+            }
+        }
+
+                /// <summary>
+        /// Expands only directory ancestors of nodes that match the current search
+        /// (and matching directories themselves). Avoids ExpandAllNodes, which walks the
+        /// entire project and storms IsExpanded / expansion persistence.
+        /// </summary>
+        private void ExpandAncestorsOfSearchMatches()
+        {
+            if (ViewModel is null || TreeGrid?.View is null || string.IsNullOrWhiteSpace(_currentFolderQuery))
             {
                 return;
             }
 
-            TreeGrid.View.Filter = IsFileIn;
+            // Collect unique directory models that must be expanded for hits to be visible.
+            var parentsToExpand = new HashSet<FileSystemModel>();
 
-            if (expandAllForSearch && !string.IsNullOrEmpty(_currentFolderQuery))
+            foreach (var fm in ViewModel.FileList)
             {
-                TreeGrid.ExpandAllNodes();
+                if (!IsFileIn(fm))
+                {
+                    continue;
+                }
+
+                // Matching directories need to be open so Extended filter children can show.
+                for (var p = fm.IsDirectory ? fm : fm.Parent; p != null; p = p.Parent)
+                {
+                    parentsToExpand.Add(p);
+                }
             }
 
-            TreeGrid.View.RefreshFilter();
+            if (parentsToExpand.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var dir in parentsToExpand
+                         .OrderBy(d => d.RawRelativePath.Length)
+                         .ThenBy(d => d.RawRelativePath, StringComparer.OrdinalIgnoreCase))
+            {
+                var node = FindNodeIgnoringFilter(dir);
+                if (node is { IsExpanded: false })
+                {
+                    TreeGrid.ExpandNode(node);
+                    ViewModel.NotifyDirectoryExpanded((node.Item as FileSystemModel)!);
+                }
+            }
         }
+
+        /// <summary>
+        /// Resolves the TreeNode for a model by walking parent-to-child from the root nodes.
+        /// <see cref="TreeNodeCollection.GetNode"/> only returns visible (unfiltered) nodes,
+        /// so right after a full view rebuild — where every recreated node starts out
+        /// filtered — it returns null for everything and no ancestor chain can be expanded.
+        /// Expanding shallowest-first keeps each parent's ChildNodes populated before its
+        /// children are looked up.
+        /// </summary>
+        private TreeNode FindNodeIgnoringFilter(FileSystemModel model)
+        {
+            var chain = new Stack<FileSystemModel>();
+            for (var p = model; p is not null; p = p.Parent)
+            {
+                chain.Push(p);
+            }
+
+            var level = TreeGrid.View.Nodes.RootNodes;
+            TreeNode node = null;
+            while (chain.Count > 0)
+            {
+                node = level.GetNode(chain.Pop());
+                if (node is null)
+                {
+                    return null;
+                }
+
+                level = node.ChildNodes;
+            }
+
+            return node;
+        }
+
 
         private void RowDragDropController_DragStart(object sender, TreeGridRowDragStartEventArgs e)
         {
@@ -925,6 +1019,7 @@ namespace WolvenKit.Views.Tools
                 treeNodes[0].Item is not FileSystemModel sourceFile ||
                 e.TargetNode?.Item is not FileSystemModel targetFile)
             {
+                e.Handled = true;
                 return;
             }
 
@@ -940,13 +1035,20 @@ namespace WolvenKit.Views.Tools
             }
         }
 
-        private async void RowDragDropController_Drop(object sender, TreeGridRowDropEventArgs e)
+        private void RowDragDropController_Drop(object sender, TreeGridRowDropEventArgs e)
         {
             try
             {
+                // ProcessOnDrop re-arms the hover auto-expand timer via GetDropPosition after
+                // stopping it; kill it here or it fires ExpandNode on a node the deferred
+                // refresh has already disposed (NRE in TreeGridNestedView.RequestTreeItems).
+                _rowDragDropController.CancelPendingAutoExpand();
+
                 e.Handled = _isDragging;
-                if (e.TargetNode.Item is not FileSystemModel targetFile || ViewModel is not ProjectExplorerViewModel vm)
+
+                if (e.TargetNode?.Item is not FileSystemModel targetFile || ViewModel is not ProjectExplorerViewModel vm)
                 {
+                    e.Handled = true;
                     return;
                 }
 
@@ -974,17 +1076,24 @@ namespace WolvenKit.Views.Tools
                 }
 
                 // if dragged on file, use file's parent directory as target dir
-                var targetDirectory = Directory.Exists(targetFile.FullName)
+                var targetDirectory = (Directory.Exists(targetFile.FullName)
                     ? targetFile.FullName
-                    : Path.GetDirectoryName(targetFile.FullName);
+                    : Path.GetDirectoryName(targetFile.FullName)) ?? string.Empty;
+
+                if (targetFile.Parent is { } parent && parent.FullName == targetDirectory)
+                {
+                    e.Handled = true;
+                    return;
+                }
 
                 // 1146: addresses "prevent self-drag-and-drop"
                 if (files.Count == 0 || files[0] == targetDirectory)
                 {
+                    e.Handled = true;
                     return;
                 }
 
-                await ViewModel.ProcessFileAction(files, targetDirectory);
+                ViewModel.ProcessFileAction(files, targetDirectory);
             }
             catch (Exception error)
             {
@@ -1009,6 +1118,7 @@ namespace WolvenKit.Views.Tools
         {
             if (ViewModel?.GetActiveEditorFile() is not IDocumentViewModel activeFile)
             {
+                e.Handled = true;
                 return;
             }
 
@@ -1018,6 +1128,7 @@ namespace WolvenKit.Views.Tools
 
             if (activeFileNode is null)
             {
+                e.Handled = true;
                 return;
             }
 

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -299,9 +299,14 @@ namespace WolvenKit.Views.Tools
         /// <param name="e"></param>
         private void SetLoading(object sender, ProjectExplorerViewModel.LoadingMode mode)
         {
-            if (ShouldStartLoadingProject(mode) && Ready() && IsFreshLoad(mode))
+            if (ShouldStartLoadingProject(mode) && Ready())
             {
-                IndicateProjectLoading();
+                ResetCurrentFolderQuerySearchFilter();
+
+                if (IsFreshLoad(mode))
+                {
+                    IndicateProjectLoading();
+                }
             }
             else if (ShouldStopLoading(mode) && AlreadyLoadingProject())
             {
@@ -380,24 +385,10 @@ namespace WolvenKit.Views.Tools
             }
         }
 
-        // Run inside Dispatcher to avoid exception on startup
-        private void ClearFiltersAndRefreshTrees() {
+        private void ResetCurrentFolderQuerySearchFilter()
+        {
             _currentFolderQuery = "";
             PESearchBar?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, "");
-
-            if (TreeGridFlat.View is not null)
-            {
-                TreeGridFlat.ClearFilters();
-                TreeGridFlat.ClearSelections(false);
-                TreeGridFlat.View.Refresh();
-            }
-
-            if (TreeGrid.View is not null)
-            {
-                TreeGrid.ClearFilters();
-                TreeGrid.ClearSelections(false);
-                TreeGrid.View.Refresh();
-            }
         }
 
         #endregion Project_Loading

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -240,6 +240,23 @@ namespace WolvenKit.Views.Tools
                 // Assign, do NOT '+=': WhenActivated re-runs on every re-activation of this view
                 ViewModel.BeginDeferredRefreshContext = BeginDeferredRefreshContext;
 
+                ViewModel.OnLiveGridMutationStarting = () =>
+                {
+                    // Prevents Null Dereferences in FlatView
+                    TreeGridFlat.View?.Suspend();
+                };
+
+                ViewModel.OnLiveGridMutationCompleted = () =>
+                {
+                    TreeGridFlat.View?.Resume();
+                    RefreshFlatViewIfNeeded(); // no-op while hidden
+
+                    if (!_currentFolderQuery.IsNullOrEmpty())
+                    {
+                        ReapplyCurrentSearchFilter(expandAllForSearch: true);
+                    }
+                };
+
                 ViewModel.WhenAnyValue(x => x.FileList)
                     .Subscribe(_ => RefreshFlatViewIfNeeded())
                     .DisposeWith(disposables);

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -69,6 +69,7 @@ namespace WolvenKit.Views.Tools
         }
 
         private string _currentFolderQuery = "";
+        private readonly DispatcherTimer _searchDebounceTimer;
         private bool _isDragging;
         private ISettingsManager _settingsManager;
         private readonly CancellableRowDragDropController _rowDragDropController;
@@ -78,6 +79,14 @@ namespace WolvenKit.Views.Tools
         public ProjectExplorerView()
         {
             InitializeComponent();
+
+            // Debounce for live search
+            _searchDebounceTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(350)
+            };
+            _searchDebounceTimer.Tick += SearchDebounceTimer_Tick;
+
             _settingsManager = Locator.Current.GetService<ISettingsManager>()!;
 
             TreeGrid.ItemsSourceChanged += TreeGrid_ItemsSourceChanged;
@@ -437,8 +446,6 @@ namespace WolvenKit.Views.Tools
             {
                 if (!_currentFolderQuery.IsNullOrEmpty())
                 {
-                    // The rebuild recreated every node collapsed and filtered; re-expand
-                    // the ancestor chains of matches so the Extended filter can see them.
                     ReapplyCurrentSearchFilter(expandAllForSearch: true);
                 }
 
@@ -904,14 +911,36 @@ namespace WolvenKit.Views.Tools
             }
         }
 
+        private void SearchDebounceTimer_Tick(object sender, EventArgs e)
+        {
+            _searchDebounceTimer.Stop();
+
+            if (PESearchBar == null)
+                return;
+
+            _currentFolderQuery = PESearchBar.Text ?? string.Empty;
+            ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrWhiteSpace(_currentFolderQuery));
+        }
+
+        private void PESearchBar_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (PESearchBar == null)
+                return;
+
+            _searchDebounceTimer.Stop();
+            _searchDebounceTimer.Start();
+        }
+
         private void PESearchBar_OnSearchStarted(object sender, FunctionEventArgs<string> e)
         {
+            _searchDebounceTimer.Stop();
             _currentFolderQuery = e?.Info ?? PESearchBar?.Text ?? string.Empty;
             ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrWhiteSpace(_currentFolderQuery));
         }
 
         private void ReapplyCurrentSearchFilter(bool expandAllForSearch)
         {
+            bool searchBarHadFocus = PESearchBar != null && PESearchBar.IsKeyboardFocused;
             var hasQuery = !string.IsNullOrWhiteSpace(_currentFolderQuery);
 
             if (TreeGridFlat?.View is not null)
@@ -923,17 +952,30 @@ namespace WolvenKit.Views.Tools
             if (TreeGrid?.View is not null)
             {
                 TreeGrid.View.Filter = IsFileIn;
+                // Filter first so only relevant hierarchy is considered for expand.
+                TreeGrid.View.RefreshFilter();
 
                 if (expandAllForSearch && hasQuery)
                 {
                     ExpandAncestorsOfSearchMatches();
                 }
+            }
 
-                TreeGrid.View.RefreshFilter();
+            if (searchBarHadFocus)
+            {
+                DispatcherHelper.RunOnMainThread(() =>
+                {
+                    if (PESearchBar == null || PESearchBar.IsKeyboardFocused)
+                        return;
+
+                    Keyboard.Focus(PESearchBar);
+                    PESearchBar.Focus();
+                    PESearchBar.CaretIndex = PESearchBar.Text?.Length ?? 0;
+                }, DispatcherPriority.ContextIdle);
             }
         }
 
-                /// <summary>
+        /// <summary>
         /// Expands only directory ancestors of nodes that match the current search
         /// (and matching directories themselves). Avoids ExpandAllNodes, which walks the
         /// entire project and storms IsExpanded / expansion persistence.

--- a/changelog/unreleased/3049.yaml
+++ b/changelog/unreleased/3049.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3049
+      author: "gistya"
+      description: "Added Live Search by CHASE_81. Added much faster search performance on large projects. Various other bugfixes and improvements under the hood."


### PR DESCRIPTION
# Live Search, Search/Reload Bugfixes

**Implemented:**
- Live Search by CHASE
- Fixes numerous null dereference and crash issues in Project Explorer related to drag-and-drop and search
- Fixes some comparison and reload issues
- Fixes slow search updating in large projects

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->