### PR TITLE
Fix documents not reopening

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -1967,14 +1967,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     /// </summary>
     public void RunAfterModalClosed(Action action)
     {
-        if (!IsDialogShown && !IsOverlayShown)
-        {
-            action();
-        }
-        else
-        {
-            _pendingAfterModalCloseActions.Enqueue(action);
-        }
+        DispatcherHelper.DelayOnMainThread(action, 500);
     }
 
     /// <summary>


### PR DESCRIPTION
# Fixes an issue where documents did not reopen as expected.

There was a timing issue where layout would be performed after project load, causing open documents to be closed. This is resolved by adding a delay to project reload opening. 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->