### PR TITLE
Fix some project loading issues

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Controllers/Red4ControllerLoadingModeTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Controllers/Red4ControllerLoadingModeTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.Core.Services;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Controllers;
+
+/// <summary>
+/// Covers RED4Controller archive-loading heartbeat idempotency (review issue 5)
+/// via reflection on private Enable/DisableLoadingMode, without loading real game archives.
+/// </summary>
+[Collection(DispatcherTimerTestCollection.Name)]
+public class Red4ControllerLoadingModeTests : IDisposable
+{
+    private const string Purpose = "RED4Controller archive loading";
+
+    public void Dispose()
+    {
+        if (DispatcherHelper.TryGetRepeatingAction(Purpose, out var guid))
+        {
+            DispatcherHelper.StopRepeatingAction(guid);
+        }
+    }
+
+    [Fact]
+    public void EnableLoadingMode_Twice_DoesNotThrow_AndSharesHeartbeat()
+    {
+        var controller = CreateUninitializedController(out var progress);
+
+        InvokePrivate(controller, "EnableLoadingMode");
+        InvokePrivate(controller, "EnableLoadingMode");
+
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.True(DispatcherHelper.TryGetRepeatingAction(Purpose, out _));
+
+        InvokePrivate(controller, "DisableLoadingMode");
+        // depth 2 -> 1, still running
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+
+        InvokePrivate(controller, "DisableLoadingMode");
+        // depth 1 -> 0, stopped
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.Equal(EStatus.Ready, progress.Object.Status);
+    }
+
+    [Fact]
+    public void DisableLoadingMode_WithoutEnable_DoesNotThrow()
+    {
+        var controller = CreateUninitializedController(out _);
+        InvokePrivate(controller, "DisableLoadingMode");
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+    }
+
+    private static RED4Controller CreateUninitializedController(out Mock<IProgressService<double>> progress)
+    {
+        progress = new Mock<IProgressService<double>>();
+        progress.SetupAllProperties();
+
+        var controller = (RED4Controller)RuntimeHelpers.GetUninitializedObject(typeof(RED4Controller));
+        SetField(controller, "_progressService", progress.Object);
+        SetField(controller, "_loadingCompletion", Guid.Empty);
+        SetField(controller, "_loadingModeDepth", 0);
+        return controller;
+    }
+
+    private static void InvokePrivate(object target, string methodName)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(target, null);
+    }
+
+    private static void SetField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WolvenKit.App.Helpers;
+using WolvenKit.Core.Exceptions;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// Covers DispatcherHelper repeating-action purpose uniqueness (review issue 6)
+/// and stop/restart lifecycle used by project / archive loading heartbeats.
+/// </summary>
+[Collection(DispatcherTimerTestCollection.Name)]
+public class DispatcherHelperTests
+{
+    private static string UniquePurpose() => "test-purpose-" + Guid.NewGuid().ToString("N");
+
+    [Fact]
+    public void StartRepeatingAction_SamePurpose_Throws()
+    {
+        var purpose = UniquePurpose();
+        var first = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+
+        try
+        {
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+            Assert.True(DispatcherHelper.TryGetRepeatingAction(purpose, out var existing));
+            Assert.Equal(first, existing);
+
+            var ex = Assert.Throws<WolvenKitException>(() =>
+                DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1)));
+            Assert.Contains(purpose, ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DispatcherHelper.StopRepeatingAction(first);
+        }
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+
+    [Fact]
+    public void StopRepeatingAction_AllowsRestartWithSamePurpose()
+    {
+        var purpose = UniquePurpose();
+        var first = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        DispatcherHelper.StopRepeatingAction(first);
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+
+        var second = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        try
+        {
+            Assert.NotEqual(first, second);
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+        }
+        finally
+        {
+            DispatcherHelper.StopRepeatingAction(second);
+        }
+    }
+
+    [Fact]
+    public void StopRepeatingAction_EmptyGuid_IsNoOp()
+    {
+        DispatcherHelper.StopRepeatingAction(Guid.Empty);
+    }
+
+    [Fact]
+    public void StopRepeatingAction_InvokesOnCancelledOnce()
+    {
+        var purpose = UniquePurpose();
+        var calls = 0;
+        var guid = DispatcherHelper.StartRepeatingAction(
+            purpose,
+            () => { },
+            TimeSpan.FromHours(1),
+            onCancelled: () => Interlocked.Increment(ref calls));
+
+        DispatcherHelper.StopRepeatingAction(guid);
+        DispatcherHelper.StopRepeatingAction(guid); // second stop is no-op
+
+        Assert.Equal(1, calls);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+
+    [Fact]
+    public void StartRepeatingAction_DifferentPurposes_CanRunConcurrently()
+    {
+        var a = UniquePurpose();
+        var b = UniquePurpose();
+        var ga = DispatcherHelper.StartRepeatingAction(a, () => { }, TimeSpan.FromHours(1));
+        var gb = DispatcherHelper.StartRepeatingAction(b, () => { }, TimeSpan.FromHours(1));
+
+        try
+        {
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(a));
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(b));
+            Assert.NotEqual(ga, gb);
+        }
+        finally
+        {
+            DispatcherHelper.StopRepeatingAction(ga);
+            DispatcherHelper.StopRepeatingAction(gb);
+        }
+    }
+
+    [Fact]
+    public async Task StartRepeatingAction_ConcurrentSamePurpose_OnlyOneWins()
+    {
+        var purpose = UniquePurpose();
+        var winners = 0;
+        var losers = 0;
+        var guids = new List<Guid>();
+        var lockObj = new object();
+
+        var tasks = new Task[8];
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(() =>
+            {
+                try
+                {
+                    var g = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+                    Interlocked.Increment(ref winners);
+                    lock (lockObj)
+                    {
+                        guids.Add(g);
+                    }
+                }
+                catch (WolvenKitException)
+                {
+                    Interlocked.Increment(ref losers);
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, winners);
+        Assert.Equal(tasks.Length - 1, losers);
+        Assert.Single(guids);
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+
+        DispatcherHelper.StopRepeatingAction(guids[0]);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherTimerTestCollection.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherTimerTestCollection.cs
@@ -1,0 +1,13 @@
+﻿using Xunit;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// DispatcherHelper repeating actions are process-global. Tests that use fixed purpose
+/// strings (or share the purpose map) must not run in parallel with each other.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class DispatcherTimerTestCollection
+{
+    public const string Name = "DispatcherTimerTests";
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.Docking;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Common;
+using WolvenKit.Common.Interfaces;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.Modkit.RED4;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.ViewModels.Shell;
+
+/// <summary>
+/// Covers AppViewModel.LoadProjectFromPathAsync lifecycle (review issues 2 and 4):
+/// HandleStartup faults still raise OnInitialProjectLoaded; failed loads cancel PE chrome;
+/// location mismatch vs ProjectManager previous project cancels loading.
+/// </summary>
+[Collection(DispatcherTimerTestCollection.Name)]
+public class AppViewModelProjectLoadTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<ILoggerService> _logger = new();
+    private readonly Mock<INotificationService> _notifications = new();
+    private readonly Mock<IProgressService<double>> _progress = new();
+    private readonly Mock<IModTools> _modTools = new();
+    private readonly Mock<IGameControllerFactory> _gameControllerFactory = new();
+    private readonly Mock<IGameController> _gameController = new();
+    private readonly Mock<IPluginService> _plugins = new();
+    private readonly Mock<ISettingsManager> _settings = new();
+    private readonly Mock<IModifierViewStateService> _modifiers = new();
+    private readonly Mock<IArchiveManager> _archives = new();
+    private readonly ProjectEvents _projectEvents = new();
+    private readonly AppViewModel _app;
+    private readonly ProjectExplorerViewModel _pe;
+    private readonly string _fakeExePath;
+
+    public AppViewModelProjectLoadTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "AppVmProjectLoad_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+        _fakeExePath = Path.Combine(_tempRoot, "Cyberpunk2077.exe");
+        File.WriteAllText(_fakeExePath, "exe");
+
+        _settings.SetupGet(s => s.CP77ExecutablePath).Returns(_fakeExePath);
+        _gameControllerFactory.Setup(f => f.GetController()).Returns(_gameController.Object);
+
+        _app = (AppViewModel)RuntimeHelpers.GetUninitializedObject(typeof(AppViewModel));
+        SetField(_app, "_projectManager", _projectManager.Object);
+        SetField(_app, "_loggerService", _logger.Object);
+        SetField(_app, "_notificationService", _notifications.Object);
+        SetField(_app, "_gameControllerFactory", _gameControllerFactory.Object);
+        SetProperty(_app, nameof(AppViewModel.SettingsManager), _settings.Object);
+
+        // DockedViews is initialized by the field initializer; with GetUninitializedObject it is null.
+        SetField(_app, "_dockedViews", new ObservableCollection<IDockElement>());
+
+        var projectResourceTools = (ProjectResourceTools)RuntimeHelpers.GetUninitializedObject(typeof(ProjectResourceTools));
+        var importExportHelper = (ImportExportHelper)RuntimeHelpers.GetUninitializedObject(typeof(ImportExportHelper));
+
+        _pe = new ProjectExplorerViewModel(
+            _app,
+            _projectManager.Object,
+            _logger.Object,
+            _notifications.Object,
+            _progress.Object,
+            _modTools.Object,
+            _gameControllerFactory.Object,
+            _plugins.Object,
+            _settings.Object,
+            _modifiers.Object,
+            _archives.Object,
+            projectResourceTools,
+            importExportHelper,
+            _projectEvents);
+
+        _app.DockedViews.Add(_pe);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _pe.CancelProjectLoad();
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private Cp77Project CreateProject(string name)
+    {
+        var dir = Path.Combine(_tempRoot, name);
+        Directory.CreateDirectory(dir);
+        var projectFile = Path.Combine(dir, name + Cp77Project.ProjectFileExtension);
+        File.WriteAllText(projectFile, "<!-- test -->");
+        var project = new Cp77Project(projectFile, name, name);
+        project.CreateDefaultDirectories();
+        return project;
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_HandleStartupFault_StillRaisesOnInitialProjectLoaded()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _gameController.Setup(c => c.HandleStartup()).ThrowsAsync(new InvalidOperationException("archive boom"));
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) => raised = true;
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        Assert.True(raised);
+        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.AtLeastOnce);
+        _notifications.Verify(n => n.Success(It.Is<string>(s => s.Contains("loaded", StringComparison.OrdinalIgnoreCase))), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_MissingExe_RaisesOnInitialProjectLoadedWithoutHandleStartup()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _settings.SetupGet(s => s.CP77ExecutablePath).Returns(Path.Combine(_tempRoot, "missing.exe"));
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) => raised = true;
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        Assert.True(raised);
+        _gameController.Verify(c => c.HandleStartup(), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_NullProject_CancelsPeLoading()
+    {
+        var path = Path.Combine(_tempRoot, "ghost", "ghost.cpmodproj");
+        _projectManager.Setup(m => m.LoadAsync(path)).ReturnsAsync((Cp77Project?)null);
+        _pe.ProjectWillLoad(path);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        await _app.LoadProjectFromPathAsync(path);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_LocationMismatch_CancelsPeLoading()
+    {
+        var existing = CreateProject("Existing");
+        var requested = Path.Combine(_tempRoot, "Other", "Other.cpmodproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(requested)!);
+
+        // Simulates ProjectManager returning previous ActiveProject when new path fails.
+        _projectManager.Setup(m => m.LoadAsync(requested)).ReturnsAsync(existing);
+        _pe.ProjectWillLoad(requested);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        await _app.LoadProjectFromPathAsync(requested);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        _gameController.Verify(c => c.HandleStartup(), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_Success_ArmsProjectWillLoadThenRaisesEvent()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _gameController.Setup(c => c.HandleStartup()).Returns(Task.CompletedTask);
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) =>
+        {
+            raised = true;
+            // After successful load, PE should have been armed (LoadingNewProject) before the event.
+            Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+        };
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        Assert.True(raised);
+        Assert.Equal(project, _app.ActiveProject);
+    }
+
+    private static void SetField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static void SetProperty(object target, string name, object? value)
+    {
+        var prop = target.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(prop);
+        prop!.SetValue(target, value);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerLoadingModeTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerLoadingModeTests.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Common;
+using WolvenKit.Common.Interfaces;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.Modkit.RED4;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.ViewModels.Tools;
+
+/// <summary>
+/// Covers PE loading chrome lifecycle (review issues 3, 4-related CancelProjectLoad, DisableLoadingMode).
+/// Uses an uninitialized AppViewModel so we avoid the heavy DI graph while still exercising PEVM.
+/// </summary>
+[Collection(DispatcherTimerTestCollection.Name)]
+public class ProjectExplorerLoadingModeTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<ILoggerService> _logger = new();
+    private readonly Mock<INotificationService> _notifications = new();
+    private readonly Mock<IProgressService<double>> _progress = new();
+    private readonly Mock<IModTools> _modTools = new();
+    private readonly Mock<IGameControllerFactory> _gameController = new();
+    private readonly Mock<IPluginService> _plugins = new();
+    private readonly Mock<ISettingsManager> _settings = new();
+    private readonly Mock<IModifierViewStateService> _modifiers = new();
+    private readonly Mock<IArchiveManager> _archives = new();
+    private readonly ProjectEvents _projectEvents = new();
+    private readonly ProjectExplorerViewModel _pe;
+    private readonly AppViewModel _appViewModel;
+
+    public ProjectExplorerLoadingModeTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "PELoadingModeTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+
+        _appViewModel = (AppViewModel)RuntimeHelpers.GetUninitializedObject(typeof(AppViewModel));
+        var projectResourceTools = (ProjectResourceTools)RuntimeHelpers.GetUninitializedObject(typeof(ProjectResourceTools));
+        var importExportHelper = (ImportExportHelper)RuntimeHelpers.GetUninitializedObject(typeof(ImportExportHelper));
+
+        _pe = new ProjectExplorerViewModel(
+            _appViewModel,
+            _projectManager.Object,
+            _logger.Object,
+            _notifications.Object,
+            _progress.Object,
+            _modTools.Object,
+            _gameController.Object,
+            _plugins.Object,
+            _settings.Object,
+            _modifiers.Object,
+            _archives.Object,
+            projectResourceTools,
+            importExportHelper,
+            _projectEvents);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _pe.CancelProjectLoad();
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private Cp77Project CreateProject(string name)
+    {
+        var dir = Path.Combine(_tempRoot, name);
+        Directory.CreateDirectory(dir);
+        var projectFile = Path.Combine(dir, name + Cp77Project.ProjectFileExtension);
+        File.WriteAllText(projectFile, "<!-- test -->");
+        var project = new Cp77Project(projectFile, name, name);
+        project.CreateDefaultDirectories();
+        return project;
+    }
+
+    [Fact]
+    public void ProjectWillLoad_ArmsLoadingNewProject()
+    {
+        var project = CreateProject("ModA");
+
+        _pe.ProjectWillLoad(project.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void ProjectWillLoad_SameProjectPath_DoesNotRearm()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+
+        _pe.ProjectWillLoad(project.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void CancelProjectLoad_ClearsLoadingModeWithoutSuccessLog()
+    {
+        var project = CreateProject("ModA");
+        _pe.ProjectWillLoad(project.Location);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        _pe.CancelProjectLoad();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+        _logger.Verify(l => l.Success(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void DisableLoadingMode_StopsHeartbeatAndReportsSuccessWhenProjectActive()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+        _pe.ProjectWillLoad(CreateProject("ModB").Location);
+
+        _pe.DisableLoadingMode();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+        _logger.Verify(l => l.Success(It.Is<string>(s => s.Contains("Loaded project", StringComparison.Ordinal))), Times.Once);
+    }
+
+    [Fact]
+    public void OnInitialProjectLoaded_EqualsBail_DisarmsLoadingChrome()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+
+        // Arm for a different path so chrome is loading, then simulate event for same project.
+        _pe.ProjectWillLoad(CreateProject("ModB").Location);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        InvokeOnInitialProjectLoaded();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void OnInitialProjectLoaded_NullProjectManager_DisarmsLoadingChrome()
+    {
+        _projectManager.SetupGet(m => m.ActiveProject).Returns((Cp77Project?)null);
+        _pe.ProjectWillLoad(CreateProject("ModA").Location);
+
+        InvokeOnInitialProjectLoaded();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+    }
+
+    [Fact]
+    public void EnableLoadingMode_SecondCall_DoesNotThrow()
+    {
+        var a = CreateProject("ModA");
+        var b = CreateProject("ModB");
+
+        _pe.ProjectWillLoad(a.Location);
+        // Second arm for another project while first heartbeat still running (token non-empty).
+        _pe.ProjectWillLoad(b.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    private void InvokeOnInitialProjectLoaded()
+    {
+        var method = typeof(ProjectExplorerViewModel).GetMethod(
+            "AppViewModel_OnInitialProjectLoaded",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(_pe, new object?[] { _appViewModel, EventArgs.Empty });
+    }
+}

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -137,26 +137,57 @@ public class RED4Controller : ObservableObject, IGameController
         }
     }
 
-    private Guid _loadingCompletion = Guid.NewGuid();
+    private const string s_archiveLoadingPurpose = "RED4Controller archive loading";
+    private Guid _loadingCompletion = Guid.Empty;
+    private int _loadingModeDepth;
 
+    /// <summary>
+    /// Starts (or reuses) the archive-loading progress heartbeat.
+    /// Idempotent / re-entrant: overlapping load entry points share one timer via depth counting.
+    /// </summary>
     private void EnableLoadingMode()
     {
+        if (Interlocked.Increment(ref _loadingModeDepth) > 1)
+        {
+            return;
+        }
+
+        if (DispatcherHelper.TryGetRepeatingAction(s_archiveLoadingPurpose, out var existing))
+        {
+            _loadingCompletion = existing;
+            return;
+        }
+
         _loadingCompletion = DispatcherHelper.StartRepeatingAction(
-            purpose: "RED4Controller archive loading", () =>
+            purpose: s_archiveLoadingPurpose,
+            () =>
             {
                 _progressService.IsIndeterminate = true;
                 _progressService.Status = EStatus.Running;
             },
-            TimeSpan.FromMilliseconds(100),
-            DisableLoadingMode
+            TimeSpan.FromMilliseconds(100)
         );
     }
 
     private void DisableLoadingMode()
     {
+        var depth = Interlocked.Decrement(ref _loadingModeDepth);
+        if (depth > 0)
+        {
+            return;
+        }
+
+        if (depth < 0)
+        {
+            Interlocked.Exchange(ref _loadingModeDepth, 0);
+        }
+
         _progressService.IsIndeterminate = false;
         _progressService.Status = EStatus.Ready;
-        DispatcherHelper.StopRepeatingAction(_loadingCompletion);
+
+        var token = _loadingCompletion;
+        _loadingCompletion = Guid.Empty;
+        DispatcherHelper.StopRepeatingAction(token);
     }
 
     /// <summary>

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -142,7 +142,7 @@ public class RED4Controller : ObservableObject, IGameController
     private void EnableLoadingMode()
     {
         _loadingCompletion = DispatcherHelper.StartRepeatingAction(
-            () =>
+            purpose: "RED4Controller archive loading", () =>
             {
                 _progressService.IsIndeterminate = true;
                 _progressService.Status = EStatus.Running;

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
-using Serilog.Debugging;
 using WolvenKit.Core.Exceptions;
 
 namespace WolvenKit.App.Helpers;
@@ -141,7 +139,8 @@ public static class DispatcherHelper
         dispatcher.BeginInvoke(CheckCancellation, DispatcherPriority.Background);
     }
 
-    private static ConcurrentDictionary<Guid, RepeatingAction> _dispatcherTimers = new();
+    private static readonly ConcurrentDictionary<Guid, RepeatingAction> s_dispatcherTimers = new();
+    private static readonly ConcurrentDictionary<string, Guid> s_purposeToGuid = new();
 
     private sealed record RepeatingAction(
         string Purpose,
@@ -149,60 +148,87 @@ public static class DispatcherHelper
     );
 
     /// <summary>
+    /// Returns true if a repeating action with the given purpose is currently registered.
+    /// </summary>
+    public static bool IsRepeatingActionRunning(string purpose) =>
+        !string.IsNullOrEmpty(purpose) && s_purposeToGuid.ContainsKey(purpose);
+
+    /// <summary>
+    /// Tries to get the guid of a running repeating action by purpose.
+    /// </summary>
+    public static bool TryGetRepeatingAction(string purpose, out Guid guid)
+    {
+        if (string.IsNullOrEmpty(purpose))
+        {
+            guid = Guid.Empty;
+            return false;
+        }
+
+        return s_purposeToGuid.TryGetValue(purpose, out guid);
+    }
+
+    /// <summary>
     /// Repeats action every interval TimeSpan until the timer is
     /// stopped by passing the returned guid to StopRepeatingAction.
     ///
-    /// Returns a Guid to call StopRepeatingSetter(guid) with, to stop it.
+    /// Purpose names are unique: a second start with the same purpose throws
+    /// unless the first was stopped. Registration of purpose is atomic.
     ///
+    /// Returns a Guid to call StopRepeatingAction(guid) with, to stop it.
     /// </summary>
-    /// <param name="action"></param>
-    /// <param name="interval"></param>
-    /// <param name="onCancelled"></param>
-    /// <returns>Guid</returns>
     public static Guid StartRepeatingAction(
         string purpose,
         Action action,
         TimeSpan interval,
         Action? onCancelled = null)
     {
+        ArgumentException.ThrowIfNullOrEmpty(purpose);
+        ArgumentNullException.ThrowIfNull(action);
         var guid = Guid.NewGuid();
+
+        if (!s_purposeToGuid.TryAdd(purpose, guid))
+        {
+            throw new WolvenKitException(0xBa57a2d, $"{purpose} is already running.");
+        }
+
         DispatcherTimer timer = new()
         {
             Interval = interval,
             Tag = onCancelled
         };
 
-        if (_dispatcherTimers.Values.Select(x => x.Purpose).Contains(purpose))
+        if (!s_dispatcherTimers.TryAdd(guid, new RepeatingAction(purpose, timer)))
         {
+            s_purposeToGuid.TryRemove(purpose, out _);
             throw new WolvenKitException(0xBa57a2d, $"{purpose} is already running.");
         }
 
-        _dispatcherTimers.TryAdd(guid, new RepeatingAction(purpose, timer));
-
-        timer.Tick += (sender, e) =>
-        {
-            if (sender is DispatcherTimer timer)
-            {
-                action();
-            }
-        };
-
+        timer.Tick += (_, _) => action();
         timer.Start();
 
         return guid;
     }
 
     /// <summary>
-    /// Call with a guid to cancel a repeating setter timer.
+    /// Call with a guid to cancel a repeating action timer.
     /// </summary>
-    /// <param name="guid"></param>
     public static void StopRepeatingAction(Guid guid)
     {
-        if (_dispatcherTimers.TryRemove(guid, out var record))
+        if (guid == Guid.Empty)
         {
-            var onCancelled = record.Timer.Tag as Action;
-            record.Timer.Stop();
-            onCancelled?.Invoke();
+            return;
         }
+
+        if (!s_dispatcherTimers.TryRemove(guid, out var record))
+        {
+            return;
+        }
+
+        s_purposeToGuid.TryRemove(record.Purpose, out _);
+
+        var onCancelled = record.Timer.Tag as Action;
+        record.Timer.Tag = null;
+        record.Timer.Stop();
+        onCancelled?.Invoke();
     }
 }

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
 using Serilog.Debugging;
+using WolvenKit.Core.Exceptions;
 
 namespace WolvenKit.App.Helpers;
 
@@ -139,7 +141,12 @@ public static class DispatcherHelper
         dispatcher.BeginInvoke(CheckCancellation, DispatcherPriority.Background);
     }
 
-    private static ConcurrentDictionary<Guid, DispatcherTimer> _dispatcherTimers = new();
+    private static ConcurrentDictionary<Guid, RepeatingAction> _dispatcherTimers = new();
+
+    private sealed record RepeatingAction(
+        string Purpose,
+        DispatcherTimer Timer
+    );
 
     /// <summary>
     /// Repeats action every interval TimeSpan until the timer is
@@ -153,6 +160,7 @@ public static class DispatcherHelper
     /// <param name="onCancelled"></param>
     /// <returns>Guid</returns>
     public static Guid StartRepeatingAction(
+        string purpose,
         Action action,
         TimeSpan interval,
         Action? onCancelled = null)
@@ -164,7 +172,12 @@ public static class DispatcherHelper
             Tag = onCancelled
         };
 
-        _dispatcherTimers.TryAdd(guid, timer);
+        if (_dispatcherTimers.Values.Select(x => x.Purpose).Contains(purpose))
+        {
+            throw new WolvenKitException(0xBa57a2d, $"{purpose} is already running.");
+        }
+
+        _dispatcherTimers.TryAdd(guid, new RepeatingAction(purpose, timer));
 
         timer.Tick += (sender, e) =>
         {
@@ -185,10 +198,10 @@ public static class DispatcherHelper
     /// <param name="guid"></param>
     public static void StopRepeatingAction(Guid guid)
     {
-        if (_dispatcherTimers.TryRemove(guid, out DispatcherTimer? timer))
+        if (_dispatcherTimers.TryRemove(guid, out var record))
         {
-            var onCancelled = timer.Tag as Action;
-            timer.Stop();
+            var onCancelled = record.Timer.Tag as Action;
+            record.Timer.Stop();
             onCancelled?.Invoke();
         }
     }

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -123,7 +123,7 @@ public partial class WelcomePageViewModel : PageViewModel
         }
 
         _mainViewModel.OpenProjectCommand.Execute(s);
-        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad();
+        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(s);
 
         // clear filters
         RecentFilter = string.Empty;

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -123,7 +123,6 @@ public partial class WelcomePageViewModel : PageViewModel
         }
 
         _mainViewModel.OpenProjectCommand.Execute(s);
-        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(s);
 
         // clear filters
         RecentFilter = string.Empty;

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -123,6 +123,7 @@ public partial class WelcomePageViewModel : PageViewModel
         }
 
         _mainViewModel.OpenProjectCommand.Execute(s);
+        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(s);
 
         // clear filters
         RecentFilter = string.Empty;

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -17,6 +17,7 @@ using WolvenKit.App.Interaction;
 using WolvenKit.App.Models.ProjectManagement;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
 
 namespace WolvenKit.App.ViewModels.HomePage.Pages;
 
@@ -116,7 +117,13 @@ public partial class WelcomePageViewModel : PageViewModel
     [RelayCommand]
     private void OpenProject(string s)
     {
+        if (string.IsNullOrEmpty(s))
+        {
+            return;
+        }
+
         _mainViewModel.OpenProjectCommand.Execute(s);
+        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad();
 
         // clear filters
         RecentFilter = string.Empty;

--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -122,8 +122,8 @@ public partial class WelcomePageViewModel : PageViewModel
             return;
         }
 
-        _mainViewModel.OpenProjectCommand.Execute(s);
         _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(s);
+        _mainViewModel.OpenProjectCommand.Execute(s);
 
         // clear filters
         RecentFilter = string.Empty;

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -688,7 +688,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [RelayCommand]
     private async Task OpenProjectAsync(string location)
     {
-        // "Open Project" button was pushed
+        var projectExplorer = GetToolViewModel<ProjectExplorerViewModel>();
+
         if (string.IsNullOrWhiteSpace(location))
         {
             var dlg = new OpenFileDialog
@@ -701,6 +702,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
             if (dlg.ShowDialog() != true || dlg.FileName is not string result || string.IsNullOrEmpty(result))
             {
+                projectExplorer.CancelProjectLoad();
                 return;
             }
 
@@ -709,6 +711,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (_projectManager.ActiveProject?.Location == location)
         {
+            projectExplorer.CancelProjectLoad();
             CloseModal();
             return;
         }
@@ -723,6 +726,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         // file was moved or deleted
         if (_recentlyUsedItemsService.Items.Items.All(x => x.Name != location))
         {
+            projectExplorer.CancelProjectLoad();
             throw new WolvenKitException(0x5002,
                 "Failed to load project. Please open a github issue and attach a zip so that we can fix it!");
         }
@@ -734,6 +738,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (res is not (WMessageBoxResult.OK or WMessageBoxResult.Yes))
         {
+            projectExplorer.CancelProjectLoad();
             return;
         }
 
@@ -747,6 +752,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (dlg2.ShowDialog() != true || dlg2.FileName is not string filePath || string.IsNullOrEmpty(filePath))
         {
+            projectExplorer.CancelProjectLoad();
             return;
         }
 
@@ -758,21 +764,29 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             CloseModal();
             await LoadProjectFromPathAsync(filePath);
         }
+        else
+        {
+            projectExplorer.CancelProjectLoad();
+        }
     }
 
     public event EventHandler? OnInitialProjectLoaded;
 
     internal async Task LoadProjectFromPathAsync(string location)
     {
+        var projectExplorer = GetToolViewModel<ProjectExplorerViewModel>();
         var p = await _projectManager.LoadAsync(location);
-        if (p is null)
+
+        if (p is null || !ProjectLocationsMatch(p.Location, location))
         {
+            projectExplorer.CancelProjectLoad();
             return;
         }
 
         ActiveProject = p;
 
-        // If the assets can't be found, stop here and notify the user in the log
+        projectExplorer.ProjectWillLoad(location);
+
         if (!File.Exists(SettingsManager.CP77ExecutablePath))
         {
             UpdateTitle();
@@ -781,18 +795,44 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             return;
         }
 
-        await _gameControllerFactory.GetController().HandleStartup().ContinueWith(_ =>
+        try
         {
-            UpdateTitle();
-            _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
-            // https://github.com/WolvenKit/WolvenKit/issues/1962
-            if (!FilepathValidationTools.IsOsFilePathValid(location))
-            {
-                _notificationService.Warning($"Project path {location} contains invalid characters!");
-            }
+            await _gameControllerFactory.GetController().HandleStartup();
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
 
-            OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
-        }, TaskContinuationOptions.OnlyOnRanToCompletion);
+        UpdateTitle();
+        _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
+        // https://github.com/WolvenKit/WolvenKit/issues/1962
+        if (!FilepathValidationTools.IsOsFilePathValid(location))
+        {
+            _notificationService.Warning($"Project path {location} contains invalid characters!");
+        }
+
+        OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static bool ProjectLocationsMatch(string loadedLocation, string requestedLocation)
+    {
+        if (string.IsNullOrWhiteSpace(loadedLocation) || string.IsNullOrWhiteSpace(requestedLocation))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(loadedLocation),
+                Path.GetFullPath(requestedLocation),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            return string.Equals(loadedLocation, requestedLocation, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     [RelayCommand]
@@ -840,8 +880,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
             await _projectManager.SaveAsync();
 
-            GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(projectLocation);
-
             await RunAfterModalClosed(async () =>
             {
                 await LoadProjectFromPathAsync(projectLocation);
@@ -851,6 +889,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             _loggerService.Error("Failed to create a new project!");
             _loggerService.Error(ex);
+            GetToolViewModel<ProjectExplorerViewModel>().CancelProjectLoad();
         }
     }
 

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -56,6 +56,8 @@ using WolvenKit.RED4.Archive.IO;
 using WolvenKit.RED4.CR2W;
 using WolvenKit.RED4.Types;
 using Activator = System.Activator;
+using Application = System.Windows.Application;
+using FileMode = System.IO.FileMode;
 using FileSystem = Microsoft.VisualBasic.FileIO.FileSystem;
 using NativeMethods = WolvenKit.App.Helpers.NativeMethods;
 using Rect = System.Windows.Rect;
@@ -401,7 +403,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         string? projectPathToOpen = null;
 
         // Will be overwritten if the launch args contain a project path
-        if (args.Contains("-reopenProject") && SettingsManager.LastUsedProjectPath is string projectPath)
+        if (args.Contains("-reopenProject") && (SettingsManager.LastUsedProjectPath is string projectPath) && SettingsManager.ReopenLastProject)
         {
             projectPathToOpen = projectPath;
         }
@@ -795,7 +797,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [RelayCommand]
     private async Task NewProject()
     {
-        //IsOverlayShown = false;
         await SetActiveDialog(new ProjectWizardViewModel(SettingsManager)
         {
             FileHandler = NewProject
@@ -817,6 +818,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     internal async Task NewProjectTask(ProjectWizardViewModel project)
     {
+        GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad();
+
         try
         {
             var newProjectName = project.ProjectName.NotNull().Trim();

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -756,7 +756,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         if (File.Exists(filePath))
         {
             CloseModal();
-            await _projectManager.LoadAsync(filePath);
+            await LoadProjectFromPathAsync(filePath);
         }
     }
 
@@ -777,6 +777,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             UpdateTitle();
             _loggerService.Warning($"Cyberpunk 2077 executable path is not set. Asset browser disabled.");
+            OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
             return;
         }
 
@@ -818,8 +819,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     internal async Task NewProjectTask(ProjectWizardViewModel project)
     {
-        GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad();
-
         try
         {
             var newProjectName = project.ProjectName.NotNull().Trim();
@@ -840,6 +839,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             _archiveManager.ProjectArchive = np.AsArchive();
 
             await _projectManager.SaveAsync();
+
+            GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(projectLocation);
 
             await RunAfterModalClosed(async () =>
             {

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -152,7 +152,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
             switch (_projectLoadingMode)
             {
                 case ProjectExplorerViewModel.LoadingMode.LoadingNewProject:
-                    if (ShouldShowLoadButton)
+                    if (ShouldShowLoadArchivesButton)
                     {
                         _isLoading = true;
                     }
@@ -167,10 +167,10 @@ public partial class AssetBrowserViewModel : ToolViewModel
     {
         if (LeftItems.Count == 0 && _archiveManager.ProjectArchive == null && !_isLoading && !_archiveManager.IsManagerLoaded)
         {
-            ShouldShowLoadButton = true;
+            ShouldShowLoadArchivesButton = true;
         } else
         {
-            ShouldShowLoadButton = false;
+            ShouldShowLoadArchivesButton = false;
         }
     }
 
@@ -178,10 +178,10 @@ public partial class AssetBrowserViewModel : ToolViewModel
     {
         if (LeftItems.Count > 0 && !_isLoading)
         {
-            LoadVisibility = Visibility.Collapsed;
         } else if (!IsModBrowserEnabled && !_archiveManager.IsManagerLoaded)
+            LoadingIndicatorVisibility = Visibility.Collapsed;
         {
-            LoadVisibility = Visibility.Visible;
+            LoadingIndicatorVisibility = Visibility.Visible;
         }
     }
 
@@ -253,10 +253,10 @@ public partial class AssetBrowserViewModel : ToolViewModel
     private GridLength _previewWidth = new(0, GridUnitType.Pixel);
 
     [ObservableProperty]
-    private Visibility _loadVisibility = Visibility.Visible;
+    private Visibility _loadingIndicatorVisibility = Visibility.Visible;
 
     [ObservableProperty]
-    private bool _shouldShowLoadButton;
+    private bool _shouldShowLoadArchivesButton;
 
     [ObservableProperty]
     private bool _shouldShowExecutablePathWarning = true;

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -172,14 +172,16 @@ public partial class AssetBrowserViewModel : ToolViewModel
         {
             ShouldShowLoadArchivesButton = false;
         }
+
+        DispatcherHelper.RunOnMainThread(UpdateLoadingIndicatorVisibility);
     }
 
     private void UpdateLoadingIndicatorVisibility()
     {
-        if (LeftItems.Count > 0 && !_isLoading)
+        if (LeftItems.Count > 0 && !_isLoading && LoadingIndicatorVisibility != Visibility.Collapsed)
         {
-        } else if (!IsModBrowserEnabled && !_archiveManager.IsManagerLoaded)
             LoadingIndicatorVisibility = Visibility.Collapsed;
+        } else if (LeftItems.Count == 0 && !IsModBrowserEnabled && LoadingIndicatorVisibility != Visibility.Visible)
         {
             LoadingIndicatorVisibility = Visibility.Visible;
         }
@@ -195,10 +197,13 @@ public partial class AssetBrowserViewModel : ToolViewModel
 
     private void CheckView()
     {
-        ArchiveDirNotFound = _settings.CP77ExecutablePath == null;
-        UpdateLoadArchiveButtonVisibility();
-        UpdateLoadingIndicatorVisibility();
-        ShouldShowExecutablePathWarning = ArchiveDirNotFound;
+        DispatcherHelper.RunOnMainThread(() =>
+        {
+            ArchiveDirNotFound = _settings.CP77ExecutablePath == null;
+            UpdateLoadArchiveButtonVisibility();
+            UpdateLoadingIndicatorVisibility();
+            ShouldShowExecutablePathWarning = ArchiveDirNotFound;
+        });
     }
 
     // if the game exe path changes

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -85,7 +85,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private readonly IArchiveManager _archiveManager;
     private readonly ProjectResourceTools _projectResourceTools;
     private readonly ImportExportHelper _importExportHelper;
-    private readonly TimeSpan _singleOperationTimeout = TimeSpan.FromSeconds(3);
+    private readonly TimeSpan _projectLoadPollingInterval = TimeSpan.FromMilliseconds(50);
     private bool _inFlight = false;
 
     // Bound to TreeGrid.ItemsSource / TreeGridFlat.ItemsSource by the View. The collections are
@@ -160,7 +160,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     {
         if (ActiveProject != null)
         {
-            if (projectPath.Contains(ActiveProject.ProjectDirectory))
+            if (IsSameProjectPath(ActiveProject, projectPath))
             {
                 return;
             }
@@ -171,6 +171,12 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         EnableLoadingMode(LoadingMode.LoadingNewProject);
     }
 
+    /// <summary>
+    /// Clears project-load loading chrome without reporting a successful load.
+    /// Use on cancel / failed open / same-project no-op after ProjectWillLoad armed the UI.
+    /// </summary>
+    public void CancelProjectLoad() => DisableLoadingMode(reportResult: false);
+
     private void AppViewModel_OnInitialProjectLoaded(object? sender, EventArgs e)
     {
         _loggerService.Debug($"Initiating project load.");
@@ -179,11 +185,39 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             var activeProject = _projectManager.ActiveProject;
             if (activeProject == null || activeProject.Equals(ActiveProject))
             {
+                CancelProjectLoad();
                 return;
             }
 
             StartWatcher_AndLoadProject(activeProject, false);
         });
+    }
+
+    private static bool IsSameProjectPath(Cp77Project activeProject, string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var requested = Path.GetFullPath(projectPath);
+            var location = Path.GetFullPath(activeProject.Location);
+            if (string.Equals(requested, location, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var projectDirectory = Path.GetFullPath(activeProject.ProjectDirectory);
+            return string.Equals(requested, projectDirectory, StringComparison.OrdinalIgnoreCase)
+                   || requested.StartsWith(projectDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                   || requested.StartsWith(projectDirectory + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            return string.Equals(activeProject.Location, projectPath, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     private void Svc_ThreadIdleTenSeconds(object? sender, EventArgs e)
@@ -282,17 +316,19 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }
 
         _projectWatcher.ProgressIndicatorCancellationToken = DispatcherHelper.StartRepeatingAction(
-            purpose: "ProjectExplorer load project", () =>
+            purpose: "ProjectExplorer load project",
+            () =>
             {
                 _progressService.IsIndeterminate = true;
                 _progressService.Status = EStatus.Running;
             },
-            _singleOperationTimeout,
-            DisableLoadingMode
+            _projectLoadPollingInterval
         );
     }
 
-    private void DisableLoadingMode()
+    public void DisableLoadingMode() => DisableLoadingMode(reportResult: true);
+
+    private void DisableLoadingMode(bool reportResult)
     {
         if (CurrentLoadingMode == LoadingMode.Ready)
         {
@@ -302,9 +338,16 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         _progressService.IsIndeterminate = false;
         _progressService.Status = EStatus.Ready;
         CurrentLoadingMode = LoadingMode.Ready;
-        OnSetLoading?.Invoke(this, (CurrentLoadingMode));
-        DispatcherHelper.StopRepeatingAction(_projectWatcher.ProgressIndicatorCancellationToken);
+        OnSetLoading?.Invoke(this, CurrentLoadingMode);
+
+        var token = _projectWatcher.ProgressIndicatorCancellationToken;
         _projectWatcher.ProgressIndicatorCancellationToken = Guid.Empty;
+        DispatcherHelper.StopRepeatingAction(token);
+
+        if (!reportResult)
+        {
+            return;
+        }
 
         if (ActiveProject != null)
         {

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -156,10 +156,15 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         _appViewModel.OnInitialProjectLoaded += AppViewModel_OnInitialProjectLoaded;
     }
 
-    public void ProjectWillLoad()
+    public void ProjectWillLoad(string projectPath)
     {
         if (ActiveProject != null)
         {
+            if (projectPath.Contains(ActiveProject.ProjectDirectory))
+            {
+                return;
+            }
+
             SaveProjectState();
         }
 
@@ -298,6 +303,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         _progressService.Status = EStatus.Ready;
         CurrentLoadingMode = LoadingMode.Ready;
         OnSetLoading?.Invoke(this, (CurrentLoadingMode));
+        DispatcherHelper.StopRepeatingAction(_projectWatcher.ProgressIndicatorCancellationToken);
         _projectWatcher.ProgressIndicatorCancellationToken = Guid.Empty;
 
         if (ActiveProject != null)

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -84,7 +84,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private readonly ISettingsManager _settingsManager;
     private readonly IArchiveManager _archiveManager;
     private readonly ProjectResourceTools _projectResourceTools;
-    private Guid _progressIndicatorCancellationToken = Guid.Empty;
     private readonly ImportExportHelper _importExportHelper;
     private readonly TimeSpan _singleOperationTimeout = TimeSpan.FromSeconds(3);
     private bool _inFlight = false;
@@ -154,39 +153,33 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         s_instance = this;
 
-        _projectManager.WhenAnyValue(x => x.ActiveProject)
-            .ObserveOn(RxApp.MainThreadScheduler)
-            .Subscribe(project =>
-            {
-                // Get a fresh reference to the project instead of the one we captured
-                // a long time ago in this closure.
-                var active = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>().ActiveProject;
-                if (project == null || project.Equals(active))
-                {
-                    return;
-                }
-
-                var isReload = project.FileDirectory == _activeProject?.FileDirectory;
-
-                // If a modal or overlay is currently visible (e.g. HomePage, settings, etc.),
-                // defer the (potentially very expensive) watcher + tree build until after the
-                // overlay has finished fading out. This prevents the 0.3s OverlayFadeOut animation
-                // from becoming extremely choppy on large projects.
-                _appViewModel.RunAfterModalClosed(() =>
-                {
-                    // Get a fresh reference to the project instead of the one we captured
-                    // a long time ago in this closure.
-                    var activeProject = _appViewModel.GetToolViewModel<ProjectExplorerViewModel>().ActiveProject;
-                    if (project.Equals(activeProject))
-                    {
-                        return;
-                    }
-
-                    StartWatcher_AndLoadProject(project, isReload);
-                });
-            });
+        _appViewModel.OnInitialProjectLoaded += AppViewModel_OnInitialProjectLoaded;
     }
 
+    public void ProjectWillLoad()
+    {
+        if (ActiveProject != null)
+        {
+            SaveProjectState();
+        }
+
+        EnableLoadingMode(LoadingMode.LoadingNewProject);
+    }
+
+    private void AppViewModel_OnInitialProjectLoaded(object? sender, EventArgs e)
+    {
+        _loggerService.Debug($"Initiating project load.");
+        DispatcherHelper.PostOnMainThread(() =>
+        {
+            var activeProject = _projectManager.ActiveProject;
+            if (activeProject == null || activeProject.Equals(ActiveProject))
+            {
+                return;
+            }
+
+            StartWatcher_AndLoadProject(activeProject, false);
+        });
+    }
 
     private void Svc_ThreadIdleTenSeconds(object? sender, EventArgs e)
     {
@@ -210,15 +203,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     /// <param name="isReload"></param>
     public void StartWatcher_AndLoadProject(Cp77Project activeProject, bool isReload)
     {
-        CurrentLoadingMode = isReload ? LoadingMode.ReloadingSameProject : LoadingMode.LoadingNewProject;
-        EnableLoadingMode(CurrentLoadingMode);
-
-
-        if (_appViewModel.IsDialogShown || _appViewModel.IsOverlayShown)
-        {
-            _appViewModel.RunAfterModalClosed(() => StartWatcher_AndLoadProject(activeProject, isReload));
-            return;
-        }
+        EnableLoadingMode(isReload ? LoadingMode.ReloadingSameProject : LoadingMode.LoadingNewProject);
 
         RefreshAfter(() =>
         {
@@ -237,7 +222,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 ActiveProject = activeProject;
                 _projectWatcher.StartWatcher_AndLoadProject(activeProject);
                 _autoSaveCancelToken = DispatcherHelper.StartRepeatingAction(
-                    () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
+                    purpose: "ProjectExplorer autosave", () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
                     TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
@@ -250,7 +235,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
                 {
                     RestoreProjectState(ActiveProject!);
                     CheckForOneDriveInPath();
-                    DisableLoadingMode();
+                    // Don't run DisableLoadingMode here
                 }
             }
         });
@@ -280,8 +265,19 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        _progressIndicatorCancellationToken = DispatcherHelper.StartRepeatingAction(
-            () =>
+        if (mode != CurrentLoadingMode)
+        {
+            OnSetLoading?.Invoke(this, mode);
+            CurrentLoadingMode = mode;
+        }
+
+        if (_projectWatcher.ProgressIndicatorCancellationToken != Guid.Empty)
+        {
+            return;
+        }
+
+        _projectWatcher.ProgressIndicatorCancellationToken = DispatcherHelper.StartRepeatingAction(
+            purpose: "ProjectExplorer load project", () =>
             {
                 _progressService.IsIndeterminate = true;
                 _progressService.Status = EStatus.Running;
@@ -289,9 +285,6 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             _singleOperationTimeout,
             DisableLoadingMode
         );
-
-        _projectWatcher.ProgressIndicatorCancellationToken = _progressIndicatorCancellationToken;
-        OnSetLoading?.Invoke(this, mode);
     }
 
     private void DisableLoadingMode()
@@ -302,8 +295,10 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }
 
         _progressService.IsIndeterminate = false;
+        _progressService.Status = EStatus.Ready;
         CurrentLoadingMode = LoadingMode.Ready;
         OnSetLoading?.Invoke(this, (CurrentLoadingMode));
+        _projectWatcher.ProgressIndicatorCancellationToken = Guid.Empty;
 
         // The rebuild is done and the grids have their new nodes — walk the machine back to Ready
         // (MakingChangesToFiles -> AwaitingRedrawsOfGrids -> Ready). ForceReady is safe to call from

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -300,11 +300,15 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         OnSetLoading?.Invoke(this, (CurrentLoadingMode));
         _projectWatcher.ProgressIndicatorCancellationToken = Guid.Empty;
 
-        // The rebuild is done and the grids have their new nodes — walk the machine back to Ready
-        // (MakingChangesToFiles -> AwaitingRedrawsOfGrids -> Ready). ForceReady is safe to call from
-        // any mode, so this can't strand the guard if the load took an unusual path.
-
-        _loggerService?.Success($"Loaded project: {ActiveProject!.ProjectDirectory} ({FileList.Count} files). File watcher active.");
+        if (ActiveProject != null)
+        {
+            _loggerService?.Success($"Loaded project: {ActiveProject!.ProjectDirectory} ({FileList.Count} files). File watcher active.");
+        }
+        else
+        {
+            throw new WolvenKitException(0x01a3e717,
+                $"Loading the project has seemed to fail. Please restart WolvenKit and try again. If this issue persists, please contact support on the WolvenKit discord.");
+        }
     }
 
     /// <summary>

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -312,7 +312,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }
         else
         {
-            throw new WolvenKitException(0x01a3e717,
+            _loggerService.Warning(
                 $"Loading the project has seemed to fail. Please restart WolvenKit and try again. If this issue persists, please contact support on the WolvenKit discord.");
         }
     }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -84,7 +84,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private readonly ISettingsManager _settingsManager;
     private readonly IArchiveManager _archiveManager;
     private readonly ProjectResourceTools _projectResourceTools;
-    private Guid _loadingCompletion = Guid.NewGuid();
+    private Guid _progressIndicatorCancellationToken = Guid.Empty;
     private readonly ImportExportHelper _importExportHelper;
     private readonly TimeSpan _singleOperationTimeout = TimeSpan.FromSeconds(3);
     private bool _inFlight = false;
@@ -280,7 +280,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        _loadingCompletion = DispatcherHelper.StartRepeatingAction(
+        _progressIndicatorCancellationToken = DispatcherHelper.StartRepeatingAction(
             () =>
             {
                 _progressService.IsIndeterminate = true;
@@ -290,7 +290,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             DisableLoadingMode
         );
 
-        _projectWatcher.CompletionTimer = _loadingCompletion;
+        _projectWatcher.ProgressIndicatorCancellationToken = _progressIndicatorCancellationToken;
         OnSetLoading?.Invoke(this, mode);
     }
 

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -98,7 +98,7 @@ public partial class ProjectExplorerViewModel
 
         private sealed record SuspendToken;
 
-        public Guid ProgressIndicatorCancellationToken = Guid.NewGuid();
+        public Guid ProgressIndicatorCancellationToken = Guid.Empty;
 
         private static bool HasIgnoredExtension(string? fileName)
         {

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -527,7 +527,7 @@ public partial class ProjectExplorerViewModel
                         ? treeRoot.Children
                         : Array.Empty<FileSystemModel>());
 
-                    DispatcherHelper.StopRepeatingAction(ProgressIndicatorCancellationToken);
+                    Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>().DisableLoadingMode();
                     _loggerService?.Info($"Loaded {FileList.Count} project files.");
                     StartBackgroundPolling();
                     Resume();

--- a/WolvenKit.App/ViewModels/Tools/WatcherService.cs
+++ b/WolvenKit.App/ViewModels/Tools/WatcherService.cs
@@ -98,7 +98,7 @@ public partial class ProjectExplorerViewModel
 
         private sealed record SuspendToken;
 
-        public Guid CompletionTimer = Guid.NewGuid();
+        public Guid ProgressIndicatorCancellationToken = Guid.NewGuid();
 
         private static bool HasIgnoredExtension(string? fileName)
         {
@@ -527,7 +527,7 @@ public partial class ProjectExplorerViewModel
                         ? treeRoot.Children
                         : Array.Empty<FileSystemModel>());
 
-                    DispatcherHelper.StopRepeatingAction(CompletionTimer);
+                    DispatcherHelper.StopRepeatingAction(ProgressIndicatorCancellationToken);
                     _loggerService?.Info($"Loaded {FileList.Count} project files.");
                     StartBackgroundPolling();
                     Resume();

--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -141,6 +141,7 @@ namespace WolvenKit.Views.Shell
             var projectLayout = Path.Combine(_viewModel.ActiveProject.ProjectDirectory, "layout.xml");
             if (!File.Exists(projectLayout))
             {
+                LoadDefaultLayout();
                 return;
             }
 

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -180,7 +180,7 @@
                             Storyboard.TargetProperty="Opacity"
                             From="1.0"
                             To="0.0"
-                            Duration="0:0:0.15" />
+                            Duration="0:0:0.35" />
                         <!--ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)">
                             <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
                             <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}"/>

--- a/WolvenKit/Views/Tools/AssetBrowserView.xaml
+++ b/WolvenKit/Views/Tools/AssetBrowserView.xaml
@@ -652,7 +652,7 @@
             Background="{StaticResource ContentBackgroundAlt3}"
             BorderBrush="Black"
             BorderThickness="0"
-            Visibility="{Binding Path=LoadVisibility,
+            Visibility="{Binding Path=LoadingIndicatorVisibility,
                                  Mode=OneWay,
                                  UpdateSourceTrigger=PropertyChanged}">
             <Grid>
@@ -673,7 +673,7 @@
             x:Name="NoProjectBorder"
             Grid.RowSpan="3"
             Background="{StaticResource ContentBackgroundAlt2}"
-            Visibility="{Binding Path=ShouldShowLoadButton,
+            Visibility="{Binding Path=ShouldShowLoadArchivesButton,
                                  Mode=OneWay,
                                  Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid>


### PR DESCRIPTION
# Fix some project loading issues

see https://github.com/WolvenKit/WolvenKit/issues/3056

**Fixed:**
- Stop relying on timing logic for documents to be reopened in projects
- Fixed a bug where a project without a custom layout.xml file would not trigger the layout phase on project opening, resulting in the possibility of documents from another project appearing in its view and then corrupting the project file (this was an existing bug from main)
- fixed an issue where the app would silently load a project on launch even if the setting to load the last project had not been set (existing bug from main)
- improved transition during project loading (smoother fadeout)
- renamed some variables (solely for clarity; the prior names were easy to get confused)
- improved debuggability of repeating timers
- added improved logging around a rare null dereference (which should not happen in prod, but if it does at least now we'll get a useful message directing users to contact the discord)

**Additional notes:**
- This PR goes to dev, it will get rolled into #2945 before merge to main

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->