### PR TITLE
Minor fix and rename for Watcher tests

### DIFF
--- a/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerWatcherGameArchiveIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerWatcherGameArchiveIntegrationTests.cs
@@ -42,7 +42,7 @@ namespace WolvenKit.IntegrationTests.App.ViewModels.Tools;
 /// Tests in the same area that use synthetic <c>FakeGameFile</c> data stay in
 /// WolvenKit.UnitTests/App/ViewModels/Tools/WatcherServiceTests.cs.
 /// </summary>
-public class WatcherServiceGameArchiveIntegrationTests : IDisposable
+public class ProjectExplorerWatcherGameArchiveIntegrationTests : IDisposable
 {
     private readonly Mock<ILoggerService> _loggerMock;
     private readonly ProjectEvents _projectEvents;
@@ -100,7 +100,7 @@ public class WatcherServiceGameArchiveIntegrationTests : IDisposable
             .ToList();
     }
 
-    public WatcherServiceGameArchiveIntegrationTests()
+    public ProjectExplorerWatcherGameArchiveIntegrationTests()
     {
         _loggerMock = new Mock<ILoggerService>();
         _projectEvents = new ProjectEvents();

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerWatcherTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerWatcherTests.cs
@@ -34,7 +34,7 @@ namespace Wolvenkit.Test.App.ViewModels.Tools;
 /// These tests deliberately avoid the real FileSystemWatcher where possible and drive the service
 /// through its public surface + the new publish mechanism.
 /// </summary>
-public class WatcherServiceTests : IDisposable
+public class ProjectExplorerWatcherTests : IDisposable
 {
     private readonly Mock<ILoggerService> _loggerMock;
     private readonly ProjectEvents _projectEvents;
@@ -47,7 +47,7 @@ public class WatcherServiceTests : IDisposable
     // Everything in this class must run on a machine with no game installed, so it uses only
     // synthetic FakeGameFile data.
 
-    public WatcherServiceTests()
+    public ProjectExplorerWatcherTests()
     {
         _loggerMock = new Mock<ILoggerService>();
         _projectEvents = new ProjectEvents();

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
@@ -473,8 +473,7 @@ public partial class ProjectExplorerViewModel
 
             if (_fileLookup.TryRemove(e.FullPath, out var item))
             {
-                Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>()
-                    .RefreshAfter(() => RemoveModel(item, e.EventAddedAt), false);
+                RefreshAfter(() => RemoveModel(item, e.EventAddedAt), false);
             }
             else
             {

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
@@ -1315,10 +1315,7 @@ public partial class ProjectExplorerViewModel
         var parentDirInfo = Directory.GetParent(fullPath);
         var parentPath = parentDirInfo!.FullName;
         var rawRelativePath = fullPath.Substring(_projectDirectory.Length + 1);
-        // Optional: unit tests and headless hosts have no AppViewModel in the Splat locator.
-        // Expansion still works via ExpandParents; persistence goes through PE when available.
-        var projectExplorer = Locator.Current.GetService<AppViewModel>()
-            ?.GetToolViewModel<ProjectExplorerViewModel>();
+
         Dictionary<string, FileSystemModel> expandedLeaves = new();
 
         if (_fileLookup.TryGetValue(parentPath, out var parent))
@@ -1330,7 +1327,7 @@ public partial class ProjectExplorerViewModel
                 _fileLookup.TryAdd(fullPath, fileSystemModel);
                 batch.Add(fileSystemModel);
 
-                ExpandAllParents(parent, expandedLeaves, projectExplorer);
+                ExpandAllParents(parent, expandedLeaves);
             }
             return;
         }
@@ -1380,7 +1377,7 @@ public partial class ProjectExplorerViewModel
             parentModel.Children.Add(newCurrentModel);
             _fileLookup.TryAdd(current.FullName, newCurrentModel);
             batch.Add(newCurrentModel);
-            ExpandAllParents(parentModel, expandedLeaves, projectExplorer);
+            ExpandAllParents(parentModel, expandedLeaves);
             parentModel = newCurrentModel;
         }
 
@@ -1393,7 +1390,7 @@ public partial class ProjectExplorerViewModel
         }
     }
 
-    private static void ExpandAllParents(FileSystemModel parent, Dictionary<string, FileSystemModel> expandedLeaves, ProjectExplorerViewModel? projectExplorer)
+    private void ExpandAllParents(FileSystemModel parent, Dictionary<string, FileSystemModel> expandedLeaves)
     {
         FileSystemModel? expandParent = parent;
 
@@ -1405,17 +1402,7 @@ public partial class ProjectExplorerViewModel
                 continue;
             }
 
-            // Auto-expand the existing parent. Prefer PE so expansion state is persisted when
-            // running in the app; fall back to IsExpanded for headless/unit-test hosts.
-            if (projectExplorer != null)
-            {
-                projectExplorer.NotifyDirectoryExpanded(expandParent);
-            }
-            else if (expandParent.IsDirectory && !expandParent.IsExpanded)
-            {
-                expandParent.IsExpanded = true;
-            }
-
+            NotifyDirectoryExpanded(expandParent);
             expandedLeaves[expandParent.FullName] = expandParent;
             expandParent = expandParent.Parent;
         }


### PR DESCRIPTION
# Minor fix and rename for Watcher tests

**Fixed:**
- Fixed an issue where the integration tests would fail because AppViewModel is not in Splat

Details: In the prior WatcherService class it would use Splat to get AppViewModel to get ProjectExplorer. But we don't need to use this pattern anymore because WatcherService no longer exists as a separate class (all its content was merged into ProjectExplorer itself). This should have been fixed in my last PR but I missed it. It has no impact on app behavior and is only a fix for unit tests.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->