### PR TITLE
Quest graph loading optimization

### DIFF
--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/GraphNodeStyling.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/GraphNodeStyling.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Windows;
 using System.Windows.Media;
 using WolvenKit.Interfaces.Extensions;
@@ -12,6 +13,9 @@ namespace WolvenKit.App.ViewModels.GraphEditor.Nodes;
 /// </summary>
 public static class GraphNodeStyling
 {
+    private static ConcurrentDictionary<string, Brush> BrushCache = [];
+    private static ConcurrentDictionary<string, string> TitleCache = [];
+
     public static Brush GetBackgroundForSceneNodeType(scnSceneGraphNode node)
     {
         var resourceKey = node switch
@@ -174,20 +178,31 @@ public static class GraphNodeStyling
     /// </summary>
     private static Brush GetResourceWithFallback(string resourceKey, string defaultResourceKey, string hardcodedFallback)
     {
+        if (BrushCache.TryGetValue(resourceKey, out var cachedBrush))
+        {
+            return cachedBrush;
+        }
+
+        Brush brushToCache;
+
         // Try to get the specific resource
         if (Application.Current?.TryFindResource(resourceKey) is Brush brush)
         {
-            return brush;
+            brushToCache = brush;
         }
-        
-        // Fall back to default resource
-        if (Application.Current?.TryFindResource(defaultResourceKey) is Brush defaultBrush)
+        else if (Application.Current?.TryFindResource(defaultResourceKey) is Brush defaultBrush)
         {
-            return defaultBrush;
+            // Fall back to default resource
+            brushToCache = defaultBrush;
         }
-        
-        // Final fallback - hard-coded color for design-time safety
-        return new SolidColorBrush((Color)ColorConverter.ConvertFromString(hardcodedFallback));
+        else
+        {
+            // Final fallback - hard-coded color for design-time safety
+            brushToCache = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hardcodedFallback));
+        }
+
+        _ = BrushCache.TryAdd(resourceKey, brushToCache);
+        return brushToCache;
     }
 
     /// <summary>
@@ -196,23 +211,29 @@ public static class GraphNodeStyling
     public static string GetTitleForNodeType(Type nodeType)
     {
         var typeName = nodeType.Name;
-        
+
+        if (TitleCache.TryGetValue(typeName, out var cachedTitle))
+        {
+            return cachedTitle;
+        }
+
+        string titleToCache;
+
         // Quest node types - handle specific wrapper title overrides first
         if (typeof(questNodeDefinition).IsAssignableFrom(nodeType))
         {
             // Special cases where wrappers override the default title
-            return typeName switch
+            titleToCache = typeName switch
             {
                 "questCutControlNodeDefinition" => "Quest CutControl",
                 _ => GetGenericQuestNodeTitle(typeName)
             };
         }
-        
-        // Scene node types - handle special cases to match wrapper titles
-        if (typeof(scnSceneGraphNode).IsAssignableFrom(nodeType))
+        else if (typeof(scnSceneGraphNode).IsAssignableFrom(nodeType))
         {
+            // Scene node types - handle special cases to match wrapper titles
             // Special cases that have custom titles in their wrappers
-            return typeName switch
+            titleToCache = typeName switch
             {
                 "scnCutControlNode" => "Scene CutControl",
                 "questCutControlNodeDefinition" => "Quest CutControl",
@@ -220,13 +241,19 @@ public static class GraphNodeStyling
                 _ => typeName[3..^4] // Default: Remove "scn" prefix and "Node" suffix
             };
         }
-
-        if (typeof(AIbehaviorTreeNodeDefinition).IsAssignableFrom(nodeType))
+        else if (typeof(AIbehaviorTreeNodeDefinition).IsAssignableFrom(nodeType))
         {
-            return GetGenericBehaviorNodeTitle(typeName);
+            titleToCache = GetGenericBehaviorNodeTitle(typeName);
         }
-        
-        return typeName;
+
+        else
+        {
+            titleToCache = typeName;
+        }
+
+        _ = TitleCache.TryAdd(typeName, titleToCache);
+
+        return titleToCache;
     }
 
     /// <summary>

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Quest.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using WolvenKit.App.Factories;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.ViewModels.Documents;
@@ -17,6 +19,7 @@ public partial class RedGraph
     private static Dictionary<Type, Type> s_questWrapperMap = new();
 
     private static List<Type>? s_questNodeTypes;
+    private static readonly int _maxDoP = Environment.ProcessorCount > 1 ? Environment.ProcessorCount : 1;
 
     private INodeWrapperFactory? _nodeWrapperFactory;
 
@@ -144,7 +147,7 @@ public partial class RedGraph
 
         if (instance is questNodeDefinition nodeDefinition)
         {
-            nodeDefinition.Id = ++_currentQuestNodeId;
+            nodeDefinition.Id = ++CurrentQuestNodeId;
 
             // Special initialization for certain quest node types
             if (nodeDefinition is questFactsDBManagerNodeDefinition factsDBNode)
@@ -637,7 +640,7 @@ public partial class RedGraph
 
         var newNodeId = GetNextAvailableQuestNodeId();
         duplicatedData.Id = newNodeId;
-        _currentQuestNodeId = Math.Max(_currentQuestNodeId, newNodeId);
+        CurrentQuestNodeId = Math.Max(CurrentQuestNodeId, newNodeId);
 
         foreach (var socket in duplicatedData.Sockets)
         {
@@ -708,7 +711,7 @@ public partial class RedGraph
 
         var newNodeId = GetNextAvailableQuestNodeId();
         duplicatedData.Id = newNodeId;
-        _currentQuestNodeId = Math.Max(_currentQuestNodeId, newNodeId);
+        CurrentQuestNodeId = Math.Max(CurrentQuestNodeId, newNodeId);
 
         foreach (var socket in duplicatedData.Sockets)
         {
@@ -870,7 +873,7 @@ public partial class RedGraph
     {
         var questGraph = (graphGraphDefinition)_data;
 
-        ushort candidateId = (ushort)(_currentQuestNodeId + 1);
+        ushort candidateId = (ushort)(CurrentQuestNodeId + 1);
 
         if (candidateId != ushort.MaxValue && !IsQuestNodeIdInUse(candidateId, questGraph))
         {
@@ -1088,7 +1091,7 @@ public partial class RedGraph
             {
                 var newNodeId = GetNextAvailableQuestNodeId();
                 idMap[nodeDef.Id] = newNodeId;
-                _currentQuestNodeId = Math.Max(_currentQuestNodeId, newNodeId);
+                CurrentQuestNodeId = Math.Max(CurrentQuestNodeId, newNodeId);
             }
         }
 
@@ -1464,11 +1467,14 @@ public partial class RedGraph
         var graph = new RedGraph(title, questGraph);
         graph._nodeWrapperFactory = nodeWrapperFactory;
 
-        var socketNodeLookup = new Dictionary<graphGraphSocketDefinition, QuestInputConnectorViewModel>();
+        var socketNodeLookup = new ConcurrentDictionary<graphGraphSocketDefinition, QuestInputConnectorViewModel>();
+        var options = new ParallelOptions { MaxDegreeOfParallelism = _maxDoP };
+        var nodeHandles = questGraph.Nodes.ToArray();
+        var wrappedNodes = new BaseQuestViewModel[nodeHandles.Length];
 
-        var nodeCache = new Dictionary<uint, BaseQuestViewModel>();
-        foreach (var nodeHandle in questGraph.Nodes)
+        Parallel.For(0, nodeHandles.Length, options, i =>
         {
+            var nodeHandle = nodeHandles[i];
             var node = nodeHandle.GetValue();
             if (node is null)
             {
@@ -1477,7 +1483,7 @@ public partial class RedGraph
 
             if (node is questNodeDefinition nodeDefinition)
             {
-                graph._currentQuestNodeId = Math.Max(graph._currentQuestNodeId, nodeDefinition.Id);
+                graph.RaiseCurrentQuestNodeId(nodeDefinition.Id);
             }
 
             var nvm = node switch
@@ -1487,19 +1493,27 @@ public partial class RedGraph
                 _ => throw new Exception($"Node of type \"{node.GetType()}\" isn't supported!")
             };
 
-            nodeCache.Add(nvm.UniqueId, nvm);
-            graph.Nodes.Add(nvm);
+            wrappedNodes[i] = nvm;
 
             foreach (var inputConnector in nvm.Input)
             {
                 var questInputConnector = (QuestInputConnectorViewModel)inputConnector;
-                socketNodeLookup.Add(questInputConnector.Data, questInputConnector);
+                socketNodeLookup.TryAdd(questInputConnector.Data, questInputConnector);
             }
+        });
+
+        // Makes sure this is done on the main thread sequentially, in source order.
+        foreach (var nvm in wrappedNodes)
+        {
+            graph.Nodes.Add(nvm);
         }
 
-        foreach (var node in graph.Nodes)
+        var connectionsPerNode = new List<QuestConnectionViewModel>[wrappedNodes.Length];
+
+        Parallel.For(0, wrappedNodes.Length, options, i =>
         {
-            var questNode = (BaseQuestViewModel)node;
+            var questNode = wrappedNodes[i];
+            var nodeConnections = new List<QuestConnectionViewModel>();
 
             foreach (var outputConnector in questNode.Output)
             {
@@ -1510,9 +1524,20 @@ public partial class RedGraph
                     var connection = connectionHandle.Chunk;
                     if (connection?.Destination?.Chunk != null && socketNodeLookup.TryGetValue(connection.Destination.Chunk, out var targetInput))
                     {
-                        graph.Connections.Add(new QuestConnectionViewModel(questOutputConnector, targetInput, connection));
+                        nodeConnections.Add(new QuestConnectionViewModel(questOutputConnector, targetInput, connection));
                     }
                 }
+            }
+
+            connectionsPerNode[i] = nodeConnections;
+        });
+
+        // Makes sure this is done on the main thread sequentially, in source order.
+        foreach (var nodeConnections in connectionsPerNode)
+        {
+            foreach (var connection in nodeConnections)
+            {
+                graph.Connections.Add(connection);
             }
         }
 

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Msagl.Core.Geometry.Curves;
@@ -39,7 +40,29 @@ public partial class RedGraph : IDisposable
     private IRedType _data;
 
     private uint _currentSceneNodeId;
+    private readonly object _currentQuestLock = new();
     private ushort _currentQuestNodeId;
+
+    private ushort CurrentQuestNodeId
+    {
+        get { lock (_currentQuestLock) { return _currentQuestNodeId; } }
+        set { lock (_currentQuestLock) { _currentQuestNodeId = value; } }
+    }
+
+    /// <summary>
+    /// Atomically raises the node-id high-water mark.
+    /// Callers in parallel loops must use this.
+    /// </summary>
+    private void RaiseCurrentQuestNodeId(ushort candidate)
+    {
+        lock (_currentQuestLock)
+        {
+            if (candidate > _currentQuestNodeId)
+            {
+                _currentQuestNodeId = candidate;
+            }
+        }
+    }
 
     private bool _allowGraphSave = false;
 
@@ -594,7 +617,32 @@ public partial class RedGraph : IDisposable
         RebuildCanvasItems();
     }
 
-    private void NodesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildCanvasItems();
+    private void NodesOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // Apply just the delta.
+        switch (e.Action)
+        {
+            case NotifyCollectionChangedAction.Add when e.NewItems is not null:
+                foreach (var item in e.NewItems)
+                {
+                    CanvasItems.Add(item);
+                }
+
+                return;
+
+            case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
+                foreach (var item in e.OldItems)
+                {
+                    CanvasItems.Remove(item);
+                }
+
+                return;
+
+            default:
+                RebuildCanvasItems();
+                return;
+        }
+    }
 
     private void RebuildCanvasItems()
     {
@@ -660,6 +708,12 @@ public partial class RedGraph : IDisposable
                 {
                     var jsonData = JObject.Parse(File.ReadAllText(statePath));
                     var nodesArray = jsonData.SelectTokens("Nodes.[*]");
+                    var nodesById = new Dictionary<uint, NodeViewModel>(Nodes.Count);
+
+                    foreach (var node in Nodes)
+                    {
+                        nodesById[node.UniqueId] = node;
+                    }
 
                     foreach (var nodeToken in nodesArray)
                     {
@@ -667,8 +721,8 @@ public partial class RedGraph : IDisposable
                         if (nodeIDValue == null) continue;
 
                         var nodeId = nodeIDValue.ToObject<uint>();
-                        var targetNode = Nodes.FirstOrDefault(n => n.UniqueId == nodeId);
-                        if (targetNode == null) continue;
+                        if (!nodesById.TryGetValue(nodeId, out var targetNode))
+                            continue;
 
                         // Load Location
                         var nodeX = nodeToken.SelectToken("X") as JValue;

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -428,31 +428,15 @@
                                     IsConnected="{Binding IsConnected}">
                                     <nodify:NodeInput.Header>
                                         <StackPanel Orientation="Horizontal">
-                                            <!-- Scene nodes: Show Title FIRST and BIG (socket name) -->
+                                            <!--
+                                                Title (socket name) for Scene or Quest nodes.
+                                            -->
                                             <TextBlock
                                                 VerticalAlignment="Center"
                                                 Foreground="{DynamicResource TextFillColorPrimary}"
                                                 FontSize="14"
                                                 FontWeight="Normal"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if no subtitle (quest nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
+                                                Text="{Binding Title}" />
 
                                             <!-- Scene nodes only: Show Subtitle SECOND and SMALL (coordinates) -->
                                             <TextBlock
@@ -477,33 +461,6 @@
                                                                 <Setter Property="Visibility" Value="Collapsed" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-
-                                            <!-- Quest nodes: Show Title only (socket name) -->
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                Foreground="{DynamicResource TextFillColorPrimary}"
-                                                FontSize="14"
-                                                FontWeight="Normal"
-                                                Text="{Binding Title}">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <!-- Hide if subtitle exists (scene nodes) -->
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                            <DataTrigger
-                                                                Binding="{Binding Subtitle}"
-                                                                Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                        <Setter Property="Visibility" Value="Collapsed" />
                                                     </Style>
                                                 </TextBlock.Style>
                                             </TextBlock>

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using Nodify;
+using Syncfusion.SfSkinManager;
 using ReactiveUI;
 using Splat;
 using WolvenKit.App.Services;
@@ -147,6 +148,7 @@ public partial class GraphEditorView : UserControl
     public GraphEditorView()
     {
         InitializeComponent();
+        SfSkinManager.SetTheme(Editor, new Theme("Default"));
 
         _appViewModel = Locator.Current.GetService<AppViewModel>();
 


### PR DESCRIPTION
# Quest graph loading optimizations

**Fixed:**
- shaves 45 seconds off of a 53-second graph load by setting SyncFusion to use the default style (makes no visible difference because nothing under Views/GraphEditor even uses a single Syncfusion control, so that work was pure overhead)
- parallelize graph building in a threadsafe manner and optimize the tree algorithm, bringing it down from O(N^2) to O(N). 
- fixed the issue where adding a node would do O((N^2)/2+N) work; now it just does O(1)
- Previously two identical TextBlocks with complementary Subtitle triggers - one for scene nodes, one for quest nodes - which rendered the same thing either way, accounted for 2/3rds of title rendering. Fixed by collapsing them into one always-visible element
- index once instead of scanning per-saved-node
- cache resource lookups for brush color and title strings (going to Application.Resources is expensive)

**Additional notes:**

Nodify has no virtualization features at all. So there will be a follow-up PR to implement lazy loading, but that's a riskier change and actually loads slower overall so it probably belongs as a separate PR. 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->