### PR TITLE
Fix Ghost Tree & Mystery Bar

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -1109,8 +1109,7 @@
             Grid.Row="2"
             Margin="0"
             BorderThickness="0"
-            Visibility="{Binding IsFlatModeEnabled,
-                                 Converter={StaticResource BoolInvertConverter}}"
+            Visibility="Visible"
             HeaderRowHeight="3"
             RowHeight="{DynamicResource WolvenKitTreeGridRowHeight}"
             ColumnSizer="Star"
@@ -1181,8 +1180,7 @@
             Grid.Row="2"
             Margin="0"
             BorderThickness="0"
-            Visibility="{Binding IsFlatModeEnabled,
-                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+            Visibility="Visible"
             HeaderRowHeight="{DynamicResource WolvenKitTreeGridRowHeaderHeight}"
             RowHeight="{DynamicResource WolvenKitTreeGridRowHeight}"
             ColumnSizer="Star"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -469,13 +469,30 @@ namespace WolvenKit.Views.Tools
             // Only update layout on the visible tree.
             if (TreeGrid.IsVisible)
             {
+                RefreshColumnWidths(TreeGrid);
                 TreeGrid.UpdateLayout();
             }
 
             if (TreeGridFlat.IsVisible)
             {
+                RefreshColumnWidths(TreeGridFlat);
                 TreeGridFlat.UpdateLayout();
             }
+        }
+
+        /// <summary>
+        /// Needed to prevent a mysterious gray bar from
+        /// hiding part of the view.
+        /// </summary>
+        /// <param name="grid"></param>
+        private static void RefreshColumnWidths(SfTreeGrid grid)
+        {
+            if (grid.ActualWidth <= 0)
+            {
+                return;
+            }
+
+            grid.TreeGridColumnSizer?.Refresh();
         }
 
         /// <summary>

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -94,6 +94,8 @@ namespace WolvenKit.Views.Tools
 
         private ProjectExplorerViewModel.LoadingMode _loadingMode = ProjectExplorerViewModel.LoadingMode.Ready;
 
+        private bool _isShowingLoadingIndicator = true;
+
         #endregion fields
 
         #region Constructor
@@ -291,6 +293,10 @@ namespace WolvenKit.Views.Tools
                 ViewModel.WhenAnyValue(x => x.FileList)
                     .Subscribe(_ => RefreshFlatViewIfNeeded())
                     .DisposeWith(disposables);
+
+                ViewModel.WhenAnyValue(x => x.IsFlatModeEnabled)
+                    .Subscribe(_ => UpdatePaneVisibility())
+                    .DisposeWith(disposables);
             });
 
             this.ExecuteWhenLoaded(() => IndicateProjectLoading());
@@ -360,11 +366,11 @@ namespace WolvenKit.Views.Tools
             }
             else if (ShouldStopLoading(mode) && AlreadyLoadingProject())
             {
-                IndicateProjectNotLoading(ViewModel.IsFlatModeEnabled);
+                IndicateProjectNotLoading();
             }
             else if (ShouldStopTemporaryLoading(mode) && AlreadyTemporaryLoading())
             {
-                IndicateProjectNotLoading(ViewModel.IsFlatModeEnabled);
+                IndicateProjectNotLoading();
             }
             else if (ShouldStartTemporaryLoading(mode) && Ready())
             {
@@ -376,27 +382,31 @@ namespace WolvenKit.Views.Tools
 
         private void IndicateProjectLoading() => Dispatcher.Invoke(() =>
         {
-            Console.WriteLine("IndicateProjectLoading");
-
-            TreeGrid.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
-            TreeGridFlat.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
-            LoadingText.SetCurrentValue(VisibilityProperty, Visibility.Visible);
+            _isShowingLoadingIndicator = true;
+            UpdatePaneVisibility();
         });
 
-        private void IndicateProjectNotLoading(bool isFlatModeEnabled)
+        private void IndicateProjectNotLoading()
         {
-            Console.WriteLine("IndicateProjectNotLoading");
-            LoadingText.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
-
-            if (isFlatModeEnabled)
-            {
-                TreeGridFlat.SetCurrentValue(VisibilityProperty, Visibility.Visible);
-            }
-            else
-            {
-                TreeGrid.SetCurrentValue(VisibilityProperty, Visibility.Visible);
-            }
+            _isShowingLoadingIndicator = false;
+            UpdatePaneVisibility();
+            ScheduleGhostRowCleanup();
         }
+
+        private void UpdatePaneVisibility()
+        {
+            var isFlat = ViewModel?.IsFlatModeEnabled ?? false;
+            var isLoading = _isShowingLoadingIndicator;
+
+            LoadingText.SetCurrentValue(VisibilityProperty, ToVisibility(isLoading));
+            TreeGrid.SetCurrentValue(VisibilityProperty, ToVisibility(!isLoading && !isFlat));
+            TreeGridFlat.SetCurrentValue(VisibilityProperty, ToVisibility(!isLoading && isFlat));
+
+            static Visibility ToVisibility(bool isVisible) => isVisible ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void ScheduleGhostRowCleanup() =>
+            Dispatcher.BeginInvoke(InvalidateLayout, DispatcherPriority.Loaded);
 
         #endregion Project_Loading
 
@@ -420,20 +430,21 @@ namespace WolvenKit.Views.Tools
 
         private async Task BeginDeferredRefreshContext(Func<Task> doBeforeRefresh)
         {
-            // The refresh below disposes every TreeNode; a pending drag-hover auto-expand
-            // would fire on a disposed node afterwards.
             _rowDragDropController.CancelPendingAutoExpand();
+            CompositeDisposable disposables = [];
 
-            CompositeDisposable disposables =
-            [
-                TreeGridFlat.View.DeferRefresh(TreeViewRefreshMode.DeferRefresh),
-                TreeGrid.View.DeferRefresh(TreeViewRefreshMode.DeferRefresh)
-            ];
+            if (TreeGridFlat.View is { } flatView)
+            {
+                disposables.Add(flatView.DeferRefresh(TreeViewRefreshMode.DeferRefresh));
+            }
+
+            if (TreeGrid.View is { } treeView)
+            {
+                disposables.Add(treeView.DeferRefresh(TreeViewRefreshMode.DeferRefresh));
+            }
 
             using (disposables)
             {
-                // Structural mutations only under DeferRefresh.
-                // Do not call any methods on views/grids/filters/refreshes here.
                 await doBeforeRefresh();
             }
 
@@ -445,8 +456,6 @@ namespace WolvenKit.Views.Tools
                 }
 
                 InvalidateLayout();
-
-                // We need a second Invalidate here because of AsyncRelay commands like Delete.
                 Dispatcher.BeginInvoke(InvalidateLayout, DispatcherPriority.Render);
             });
         }
@@ -540,16 +549,12 @@ namespace WolvenKit.Views.Tools
                 return;
             }
 
+            UpdatePaneVisibility();
+            ScheduleGhostRowCleanup();
+
             if (model.IsFlatModeEnabled)
             {
-                TreeGrid.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
-                TreeGridFlat.SetCurrentValue(VisibilityProperty, Visibility.Visible);
                 RefreshFlatViewIfNeeded();
-            }
-            else
-            {
-                TreeGrid.SetCurrentValue(VisibilityProperty, Visibility.Visible);
-                TreeGridFlat.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
             }
 
             ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrWhiteSpace(_currentFolderQuery));


### PR DESCRIPTION
# Fix Ghost Tree & Mystery Bar

**Fixed:**
- Regression of ghost tree in project explorer when reloading a project after having a project open with a different scroll position
- Occurence of a gray bar over the right side of the project explorer view when opening a project with a different layout than the last layout, if the view got wider the bar would be there until you resized.

Ghost tree:
<img width="290" height="351" alt="Screenshot 2026-08-01 200723" src="https://github.com/user-attachments/assets/8b048664-dc02-4140-b68b-8ded0ed1127c" />

Myster bar:
<img width="301" height="362" alt="Screenshot 2026-08-01 222130" src="https://github.com/user-attachments/assets/822e2acb-1ebe-4a86-9624-40269e316373" />


<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->