### PR TITLE
fix: load sys templates on startup

### DIFF
--- a/WolvenKit.App/Helpers/RedTypeTemplateServiceHelper.cs
+++ b/WolvenKit.App/Helpers/RedTypeTemplateServiceHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using WolvenKit.Common;
 using WolvenKit.Common.Model;
@@ -15,6 +16,7 @@ namespace WolvenKit.App.Helpers;
 public static class RedTypeTemplateServiceHelper
 {
     private static readonly HttpClient s_httpClient = new();
+    private static readonly SemaphoreSlim s_updateLock = new(1, 1);
 
     /// <summary>
     /// This is a helper method to correctly handle the Raw option when using RedTypeTemplateSelectionOption
@@ -41,6 +43,19 @@ public static class RedTypeTemplateServiceHelper
     /// <remarks>Does not trigger the template service to load them from disk</remarks>
     public static async Task<bool> UpdateSystemTemplatesFromRemote(ILoggerService? loggerService = null)
     {
+        await s_updateLock.WaitAsync();
+        try
+        {
+            return await UpdateSystemTemplatesFromRemoteInternal(loggerService);
+        }
+        finally
+        {
+            s_updateLock.Release();
+        }
+    }
+
+    private static async Task<bool> UpdateSystemTemplatesFromRemoteInternal(ILoggerService? loggerService)
+    {
         // check remote version (no github API call)
         var hashUrl = $@"https://wolvenkit.github.io/Wolvenkit-Resources/templatehash.txt";
         var response = await s_httpClient.GetAsync(new Uri(hashUrl));
@@ -57,8 +72,9 @@ public static class RedTypeTemplateServiceHelper
         }
 
         var localHash = "";
-        var templatesDir = new DirectoryInfo(Path.Combine("Resources", "Templates"));
-        FileInfo hashPath = new(Path.Combine("Resources", "templatehash.txt"));
+        var resourcesDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources");
+        var templatesDir = new DirectoryInfo(Path.Combine(resourcesDir, "Templates"));
+        FileInfo hashPath = new(Path.Combine(resourcesDir, "templatehash.txt"));
         if (hashPath.Exists)
         {
             localHash = await File.ReadAllTextAsync(hashPath.FullName);

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -333,6 +333,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 #endif
 
         CheckForScriptUpdatesCommand.SafeExecute();
+        CheckForTemplateUpdatesCommand.SafeExecute();
         CheckForLongPathSupport();
         CheckForOneDrivePath();
     }
@@ -640,6 +641,23 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         await File.WriteAllTextAsync(hashPath.FullName, remoteHash);
         _scriptService.RefreshUIScripts();
+    }
+
+    [RelayCommand]
+    private async Task CheckForTemplateUpdates()
+    {
+        try
+        {
+            if (await RedTypeTemplateServiceHelper.UpdateSystemTemplatesFromRemote(_loggerService))
+            {
+                _redTypeTemplateService.LoadTemplates();
+            }
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Warning("Failed to update system templates");
+            _loggerService.Warning(ex.Message);
+        }
     }
 
     [RelayCommand]

--- a/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphActionPalette.xaml
@@ -19,11 +19,12 @@
 
         <DataTemplate x:Key="GlyphIconTemplate">
             <TextBlock
-                Width="28"
+                Width="32"
                 Height="36"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 FontSize="24"
+                Padding="0,0,4,0"
                 TextAlignment="Right"
                 Text="{Binding Glyph}" />
         </DataTemplate>
@@ -32,6 +33,7 @@
             <iconPacks:PackIconMaterial
                 Width="24"
                 Height="24"
+                Margin="0,0,4,0"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 Foreground="{DynamicResource WolvenKitYellow}"
@@ -58,7 +60,7 @@
                 </Grid.ColumnDefinitions>
 
                 <ContentControl
-                    Margin="-4,0,12,0"
+                    Margin="-4,0,8,0"
                     HorizontalContentAlignment="Right"
                     VerticalContentAlignment="Center"
                     Content="{Binding}">


### PR DESCRIPTION
Load system templates on startup, the implementation mirrors how scripts are checked/loaded

Also includes a (unrelated) commit for a quick fix for an icon clipping issue in quest/scene editor