### PR TITLE
refactor: unify graph node context menu construction

### DIFF
--- a/WolvenKit/Views/GraphEditor/GraphContextMenuBuilder.cs
+++ b/WolvenKit/Views/GraphEditor/GraphContextMenuBuilder.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using WolvenKit.Views.Templates;
+
+namespace WolvenKit.Views.GraphEditor;
+
+#nullable enable
+internal sealed class GraphContextMenuBuilder
+{
+    private readonly ContextMenu _menu;
+    private readonly Style _itemStyle;
+    private readonly Style _separatorStyle;
+    private bool _separatorPending;
+
+    public GraphContextMenuBuilder(ContextMenu menu, Style itemStyle, Style separatorStyle)
+    {
+        _menu = menu;
+        _itemStyle = itemStyle;
+        _separatorStyle = separatorStyle;
+        _menu.Items.Clear();
+    }
+
+    public void StartSection() => _separatorPending = _menu.Items.Count > 0;
+
+    public MenuItem AddAction(string header, string iconKind, Action click, string? description = null) =>
+        AddAction(header, iconKind, null, click, description);
+
+    public MenuItem AddAction(string header, string iconKind, string? iconColor, Action click, string? description = null)
+    {
+        var item = CreateMenuItem(header, iconKind, iconColor, click, description);
+        AddItem(item);
+        return item;
+    }
+
+    public MenuItem AddCategory(string header, string? description = null)
+    {
+        var item = CreateMenuItem(header, "FolderOutline", null, null, description);
+        AddItem(item);
+        return item;
+    }
+
+    public void AddItem(MenuItem item, bool applyDefaultStyle = true)
+    {
+        AddPendingSeparator();
+        if (applyDefaultStyle)
+        {
+            item.Style = _itemStyle;
+        }
+
+        _menu.Items.Add(item);
+    }
+
+    public void Open(ContextMenuEventArgs e)
+    {
+        _menu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
+        e.Handled = true;
+    }
+
+    public static MenuItem CreateMenuItem(
+        string header,
+        string iconKind,
+        string? iconColor,
+        Action? click,
+        string? description = null)
+    {
+        var item = new MenuItem
+        {
+            Header = header,
+            Padding = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!
+        };
+
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            item.ToolTip = description;
+            ToolTipService.SetPlacement(item, PlacementMode.Right);
+            ToolTipService.SetHorizontalOffset(item, 8);
+        }
+
+        if (iconKind is not null)
+        {
+            var hasIcon = iconKind != "Empty";
+            var icon = new IconBox
+            {
+                IconPack = hasIcon ? IconPackType.Material : IconPackType.Empty,
+                Kind = hasIcon ? iconKind : "",
+                Margin = new Thickness(4, 0, 2, 0),
+                Size = (double)Application.Current.Resources["WolvenKitIconMicro"]!
+            };
+
+            if (!string.IsNullOrEmpty(iconColor) &&
+                Application.Current.Resources[iconColor] is Brush brush)
+            {
+                icon.Foreground = brush;
+            }
+
+            item.Icon = icon;
+        }
+
+        if (click is not null)
+        {
+            item.Click += (_, _) => click();
+        }
+
+        return item;
+    }
+
+    private void AddPendingSeparator()
+    {
+        if (!_separatorPending)
+        {
+            return;
+        }
+
+        _menu.Items.Add(new Separator { Style = _separatorStyle });
+        _separatorPending = false;
+    }
+}

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.NodeContextMenus.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.NodeContextMenus.cs
@@ -1,0 +1,291 @@
+using System.Collections.Generic;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.App.ViewModels.GraphEditor;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Behavior;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Quest.Internal;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene;
+using WolvenKit.App.ViewModels.GraphEditor.Nodes.Scene.Internal;
+using WolvenKit.Common.Services;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.Views.GraphEditor;
+
+public partial class GraphEditorView
+{
+    private void BuildBehaviorNodeContextMenu(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        menu.StartSection();
+        if (node is BehaviorNodeViewModel behaviorNode && Source.CanAddBehaviorChild(behaviorNode))
+        {
+            var addChildMenu = menu.AddCategory("Add Child");
+            AddBehaviorNodeCreationItems(addChildMenu, type =>
+            {
+                var nodeId = Source.AddBehaviorChild(behaviorNode, type.Type, type.RedTypeTemplateSelectionOption);
+                SelectNodeById(nodeId);
+            });
+        }
+
+        menu.StartSection();
+        var toggleSlotsText = node.ShowUnusedSockets ? "Hide Structural Slots" : "Show Structural Slots";
+        var toggleSlotsDescription = node.ShowUnusedSockets
+            ? "Hides empty structural child slots without removing them"
+            : "Shows all structural child slots, including empty ones";
+        menu.AddAction(toggleSlotsText, "Eye", "WolvenKitYellow", () =>
+        {
+            node.ShowUnusedSockets = !node.ShowUnusedSockets;
+            Source.GraphStateSave();
+        }, toggleSlotsDescription);
+    }
+
+    private void BuildMultiNodeContextMenu(GraphContextMenuBuilder menu, IReadOnlyList<NodeViewModel> nodes)
+    {
+        menu.StartSection();
+        menu.AddAction(
+            "Destroy Nodes",
+            "CloseBoxOutline",
+            "WolvenKitRed",
+            () => Source.RemoveNodes(nodes),
+            "Permanently removes the selected nodes and their connections without leaving deletion markers");
+
+        if (Source.GraphType == RedGraphType.Quest)
+        {
+            menu.AddAction(
+                "Convert to Phase",
+                "FolderOutline",
+                "WolvenKitRed",
+                () => Source.CreatePhaseFromSelection(nodes),
+                "Moves the selected nodes into a new inline phase and rewires external connections through it");
+        }
+    }
+
+    private void BuildSingleNodeContextMenu(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        AddNodeStructureActions(menu, node);
+        AddNodeDisplayActions(menu, node);
+        AddNodeClipboardActions(menu, node);
+        AddNodeLifecycleActions(menu, node);
+    }
+
+    private void AddNodeStructureActions(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        menu.StartSection();
+
+        if (node is IDynamicInputNode dynamicInputNode)
+        {
+            menu.AddAction(
+                "Add Input",
+                "PlusCircle",
+                () => dynamicInputNode.AddInput(),
+                "Adds another input socket to this node");
+        }
+
+        if (node is IDynamicOutputNode dynamicOutputNode)
+        {
+            var addLabel = dynamicOutputNode is scnSectionNodeWrapper ? "Add Event Socket" : "Add Output";
+            var addDescription = dynamicOutputNode is scnSectionNodeWrapper
+                ? "Adds another event output socket to this section"
+                : "Adds another output socket to this node";
+            menu.AddAction(addLabel, "PlusCircle", () => dynamicOutputNode.AddOutput(), addDescription);
+        }
+
+        if (node is scnChoiceNodeWrapper choice)
+        {
+            menu.AddAction(
+                "Add Choice",
+                "PlusCircle",
+                () => choice.AddChoice(),
+                "Adds another choice output to this node");
+        }
+
+        if (node is questSwitchNodeDefinitionWrapper switchNode)
+        {
+            menu.AddAction(
+                "Add Case",
+                "PlusCircle",
+                () => switchNode.AddCondition(),
+                "Adds another conditional output case to this switch node");
+        }
+
+        if (node is IGraphProvider graphProvider)
+        {
+            menu.AddAction(
+                "Recalculate sockets",
+                "Play",
+                "WolvenKitGreen",
+                () => Source.RecalculateSockets(graphProvider),
+                "Rebuilds sockets from the linked phase or scene and reconnects matching socket names");
+        }
+
+        if (node is questPhaseNodeDefinitionWrapper phaseNode)
+        {
+            menu.AddAction(
+                "Unpack phase",
+                "PackageUp",
+                "WolvenKitRed",
+                () => Source.UnpackPhase(phaseNode),
+                "Moves the nodes from this inline phase into the current graph and rewires its connections");
+        }
+    }
+
+    private void AddNodeDisplayActions(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        menu.StartSection();
+
+        var toggleSocketsText = node.ShowUnusedSockets ? "Hide Unused Sockets" : "Show Unused Sockets";
+        var toggleSocketsDescription = node.ShowUnusedSockets
+            ? "Hides unconnected sockets in the graph view without removing them"
+            : "Shows all sockets in the graph view, including unconnected ones";
+        menu.AddAction(toggleSocketsText, "Eye", "WolvenKitYellow", () =>
+        {
+            node.ShowUnusedSockets = !node.ShowUnusedSockets;
+            Source.GraphStateSave();
+        }, toggleSocketsDescription);
+
+        if (node is questSceneNodeDefinitionWrapper sceneNode)
+        {
+            menu.AddAction(
+                "Add Scene To Project",
+                "ArrowLeftCircle",
+                "WolvenKitYellow",
+                sceneNode.AddSceneToProject,
+                "Adds the scene file referenced by this node to the active project");
+        }
+    }
+
+    private void AddNodeClipboardActions(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        menu.StartSection();
+        menu.AddAction(
+            "Duplicate Node",
+            "ContentDuplicate",
+            "WolvenKitYellow",
+            () => Source.DuplicateNode(node),
+            "Creates a disconnected copy of this node in the current graph with new IDs");
+        menu.AddAction(
+            "Copy Node",
+            "ContentCopy",
+            "WolvenKitYellow",
+            () => GraphClipboardManager.CopyNode(node, Source.GraphType),
+            "Copies this node to the clipboard for pasting into a compatible graph");
+
+        var templateData = GetTemplateData(node);
+        if (templateData != null && RedTypeTemplateService.IsTypeTemplatable(templateData.GetType()))
+        {
+            menu.AddAction(
+                "Create Template from Node",
+                "ContentSaveOutline",
+                "WolvenKitPurple",
+                async () => await _appViewModel.SetActiveDialog(
+                    new CreateTemplateFromChunkDialogViewModel(templateData, _redTypeTemplateService, _appViewModel)),
+                "Saves this node's data as a reusable template");
+        }
+    }
+
+    private void AddNodeLifecycleActions(GraphContextMenuBuilder menu, NodeViewModel node)
+    {
+        menu.StartSection();
+
+        if (Source.GraphType == RedGraphType.Scene && node is BaseSceneViewModel sceneNode)
+        {
+            AddSceneNodeLifecycleActions(menu, sceneNode);
+            return;
+        }
+
+        if (Source.GraphType == RedGraphType.Quest && node is BaseQuestViewModel questNode)
+        {
+            AddQuestNodeLifecycleActions(menu, questNode);
+            return;
+        }
+
+        AddDestroyNodeAction(menu, node);
+    }
+
+    private void AddSceneNodeLifecycleActions(GraphContextMenuBuilder menu, BaseSceneViewModel node)
+    {
+        menu.AddAction(
+            "Detach Node",
+            "LinkOff",
+            "WolvenKitYellow",
+            () => DetachNode(node),
+            "Removes all connections to and from this node without removing the node");
+
+        if (node is scnStartNodeWrapper or scnEndNodeWrapper)
+        {
+            return;
+        }
+
+        if (node is scnDeletionMarkerNodeWrapper)
+        {
+            AddDestroyDeletionMarkerAction(menu, node);
+            return;
+        }
+
+        if (ShouldSceneNodeUseDeletionMarker(node))
+        {
+            menu.AddAction(
+                "Delete Node",
+                "Delete",
+                "WolvenKitRed",
+                () => Source.ReplaceNodeWithDeletionMarker(node),
+                "Replaces this node with a deletion marker while preserving its ID and compatible connections");
+        }
+
+        AddDestroyNodeAction(menu, node);
+    }
+
+    private void AddQuestNodeLifecycleActions(GraphContextMenuBuilder menu, BaseQuestViewModel node)
+    {
+        menu.AddAction(
+            "Detach Node",
+            "LinkOff",
+            "WolvenKitYellow",
+            () => DetachQuestNode(node),
+            "Removes all connections to and from this node without removing the node");
+
+        if (node is questStartNodeDefinitionWrapper or questEndNodeDefinitionWrapper)
+        {
+            return;
+        }
+
+        if (node is questDeletionMarkerNodeDefinitionWrapper)
+        {
+            AddDestroyDeletionMarkerAction(menu, node);
+            return;
+        }
+
+        var shouldUseDeletionMarker = node.Data is questSignalStoppingNodeDefinition ||
+                                      node.Data.GetType() == typeof(questSwitchNodeDefinition) ||
+                                      node.Data.GetType() == typeof(questFlowControlNodeDefinition);
+        if (shouldUseDeletionMarker)
+        {
+            menu.AddAction(
+                "Delete Node",
+                "Delete",
+                "WolvenKitRed",
+                () => Source.ReplaceNodeWithQuestDeletionMarker(node),
+                "Replaces this node with a deletion marker while preserving its ID and compatible connections");
+        }
+
+        AddDestroyNodeAction(menu, node);
+    }
+
+    private void AddDestroyNodeAction(GraphContextMenuBuilder menu, NodeViewModel node) =>
+        menu.AddAction(
+            "Destroy Node",
+            "CloseBoxOutline",
+            "WolvenKitRed",
+            () => Source.RemoveNode(node),
+            "Permanently removes this node and its connections without leaving a deletion marker");
+
+    private void AddDestroyDeletionMarkerAction(GraphContextMenuBuilder menu, NodeViewModel node) =>
+        menu.AddAction(
+            "Destroy Deletion Marker",
+            "CloseBoxOutline",
+            "WolvenKitRed",
+            () => Source.RemoveNode(node),
+            "Permanently removes this deletion marker from the graph");
+
+}

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml
@@ -21,25 +21,60 @@
         <!-- Node icon converter -->
         <converters:NodeIconConverter x:Key="NodeIconConverter" />
 
-        <!-- Style for help/info menu items -->
         <Style
-            x:Key="HelpMenuItemStyle"
-            TargetType="MenuItem">
-            <Setter Property="FontSize" Value="11" />
-            <Setter Property="Icon">
+            x:Key="GraphContextMenuStyle"
+            TargetType="ContextMenu">
+            <Setter Property="Padding" Value="4" />
+            <Setter Property="Background" Value="{DynamicResource ContentBackgroundAlt3}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderAlt}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Template">
                 <Setter.Value>
-                    <iconPacks:PackIconMaterial
-                        Kind="Information"
-                        Width="12"
-                        Height="12"
-                        Margin="{DynamicResource WolvenKitMarginTiny}"
-                        Foreground="{DynamicResource WolvenKitYellow}"
-                        Opacity="0.7" />
+                    <ControlTemplate TargetType="ContextMenu">
+                        <Border
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <StackPanel
+                                IsItemsHost="True"
+                                KeyboardNavigation.DirectionalNavigation="Cycle" />
+                        </Border>
+                    </ControlTemplate>
                 </Setter.Value>
             </Setter>
-            <Setter Property="Opacity" Value="0.7" />
-            <Setter Property="Padding" Value="{DynamicResource WolvenKitMarginTiny}" />
         </Style>
+
+        <Style
+            x:Key="GraphContextMenuItemStyle"
+            BasedOn="{StaticResource {x:Type MenuItem}}"
+            TargetType="MenuItem">
+            <Setter Property="MinHeight" Value="34" />
+            <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+
+        <Style
+            x:Key="GraphContextMenuSeparatorStyle"
+            TargetType="Separator">
+            <Setter Property="Height" Value="1" />
+            <Setter Property="Margin" Value="0,4" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Separator">
+                        <Border
+                            Height="1"
+                            Background="{DynamicResource BorderAlt}"
+                            SnapsToDevicePixels="True" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- Tiled vector grid for the graph background -->
         <DrawingBrush
             x:Key="EditorGridBrush"

--- a/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
+++ b/WolvenKit/Views/GraphEditor/GraphEditorView.xaml.cs
@@ -318,260 +318,28 @@ public partial class GraphEditorView : UserControl
         }
 
         node.ContextMenu ??= new ContextMenu();
+        node.ContextMenu.Style = (Style)Resources["GraphContextMenuStyle"];
 
-        node.ContextMenu.Items.Clear();
+        var menu = new GraphContextMenuBuilder(
+            node.ContextMenu,
+            (Style)Resources["GraphContextMenuItemStyle"],
+            (Style)Resources["GraphContextMenuSeparatorStyle"]);
+        var selectedGraphNodes = SelectedNodes.OfType<NodeViewModel>().ToList();
 
         if (Source.GraphType == RedGraphType.Behavior)
         {
-            if (nvm is BehaviorNodeViewModel behaviorNode && Source.CanAddBehaviorChild(behaviorNode))
-            {
-                var addChildMenu = CreateCategoryMenuItem("Add Child");
-                AddBehaviorNodeCreationItems(addChildMenu, type =>
-                {
-                    var nodeId = Source.AddBehaviorChild(behaviorNode, type.Type, type.RedTypeTemplateSelectionOption);
-                    SelectNodeById(nodeId);
-                });
-
-                node.ContextMenu.Items.Add(addChildMenu);
-                node.ContextMenu.Items.Add(new Separator());
-            }
-
-            var toggleBehaviorSlotsText = nvm.ShowUnusedSockets ? "Hide Structural Slots" : "Show Structural Slots";
-            node.ContextMenu.Items.Add(CreateMenuItem(toggleBehaviorSlotsText, "Eye", "WolvenKitYellow", () =>
-            {
-                nvm.ShowUnusedSockets = !nvm.ShowUnusedSockets;
-                Source.GraphStateSave();
-            }));
-
-            node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
-            e.Handled = true;
-            return;
+            BuildBehaviorNodeContextMenu(menu, nvm);
+        }
+        else if (selectedGraphNodes.Count > 1)
+        {
+            BuildMultiNodeContextMenu(menu, selectedGraphNodes);
+        }
+        else
+        {
+            BuildSingleNodeContextMenu(menu, nvm);
         }
 
-        var selectedGraphNodes = SelectedNodes.OfType<NodeViewModel>().Cast<object>().ToList();
-        if (selectedGraphNodes.Count > 1)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Destroy Nodes", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNodes(selectedGraphNodes)));
-            if (Source.GraphType == RedGraphType.Quest)
-            {
-                node.ContextMenu.Items.Add(CreateMenuItem("Convert to Phase", "FolderOutline", "WolvenKitRed", () => Source.CreatePhaseFromSelection(selectedGraphNodes)));
-            }
-            node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
-
-            e.Handled = true;
-            return;
-        }
-
-        if (node.DataContext is IDynamicInputNode dynamicInputNode)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Add Input", "PlusCircle", () => dynamicInputNode.AddInput()));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (node.DataContext is IDynamicOutputNode dynamicOutputNode)
-        {
-            // Check if it's a section node for specific labeling
-            string addLabel = dynamicOutputNode is scnSectionNodeWrapper ? "Add Event Socket" : "Add Output";
-
-            node.ContextMenu.Items.Add(CreateMenuItem(addLabel, "PlusCircle", () => dynamicOutputNode.AddOutput()));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (node.DataContext is scnChoiceNodeWrapper choice)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Add Choice", "PlusCircle", () => choice.AddChoice()));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (node.DataContext is questSwitchNodeDefinitionWrapper switchNode)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Add Case", "PlusCircle", () => switchNode.AddCondition()));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (node.DataContext is IGraphProvider graphProvider)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Recalculate sockets", "Play", "WolvenKitGreen", () => Source.RecalculateSockets(graphProvider)));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (node.DataContext is questPhaseNodeDefinitionWrapper phaseNode)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Unpack phase", "PackageUp", "WolvenKitRed", () => Source.UnpackPhase(phaseNode)));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        var toggleSocketsText = nvm.ShowUnusedSockets ? "Hide Unused Sockets" : "Show Unused Sockets";
-        node.ContextMenu.Items.Add(CreateMenuItem(toggleSocketsText, "Eye", "WolvenKitYellow",() =>
-        {
-            nvm.ShowUnusedSockets = !nvm.ShowUnusedSockets;
-            Source.GraphStateSave();
-        }));
-
-        if (node.DataContext is questSceneNodeDefinitionWrapper sceneNode)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem(
-                "Add Scene To Project",
-                "ArrowLeftCircle",
-                "WolvenKitYellow",
-                () => sceneNode.AddSceneToProject()));
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        node.ContextMenu.Items.Add(CreateMenuItem("Duplicate Node", "ContentDuplicate", "WolvenKitYellow", () => Source.DuplicateNode(nvm)));
-        node.ContextMenu.Items.Add(CreateMenuItem("Copy Node", "ContentCopy", "WolvenKitYellow", () => GraphClipboardManager.CopyNode(nvm, Source.GraphType)));
-
-        var templateData = GetTemplateData(nvm);
-        if (templateData != null && RedTypeTemplateService.IsTypeTemplatable(templateData.GetType()))
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem(
-                "Create Template from Node",
-                "ContentSaveOutline",
-                "WolvenKitPurple",
-                async () => await _appViewModel.SetActiveDialog(
-                    new CreateTemplateFromChunkDialogViewModel(templateData, _redTypeTemplateService, _appViewModel))));
-        }
-
-        if (Source.GraphType == RedGraphType.Scene && node.DataContext is BaseSceneViewModel sceneViewModel)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem(
-                "Detach Node",
-                "LinkOff",
-                "WolvenKitYellow",
-                () => DetachNode(sceneViewModel)));
-
-            if (!(sceneViewModel is scnStartNodeWrapper || sceneViewModel is scnEndNodeWrapper))
-            {
-                // Check if this node type should use a deletion marker
-                bool shouldUseDeletionMarker = ShouldSceneNodeUseDeletionMarker(sceneViewModel);
-
-                if (sceneViewModel is scnDeletionMarkerNodeWrapper)
-                {
-                    // Deletion markers can always be destroyed
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Deletion Marker",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(sceneViewModel)));
-                }
-                else if (shouldUseDeletionMarker)
-                {
-                    // Critical scene nodes: show both Delete (soft) and Destroy (hard)
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Delete Node",
-                        "Delete",
-                        "WolvenKitRed",
-                        () => Source.ReplaceNodeWithDeletionMarker(sceneViewModel)));
-
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Node",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(sceneViewModel)));
-                }
-                else
-                {
-                    // Non-critical scene nodes: only show Destroy
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Node",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(sceneViewModel)));
-                }
-            }
-
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        if (Source.GraphType == RedGraphType.Quest && node.DataContext is BaseQuestViewModel questViewModel)
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem(
-                "Detach Node",
-                "LinkOff",
-                "WolvenKitYellow",
-                () => DetachQuestNode(questViewModel)));
-
-            if (!(questViewModel is questStartNodeDefinitionWrapper || questViewModel is questEndNodeDefinitionWrapper))
-            {
-                // Check if this node type should use a deletion marker
-                bool shouldUseDeletionMarker = questViewModel.Data is questSignalStoppingNodeDefinition
-                    || questViewModel.Data.GetType() == typeof(questSwitchNodeDefinition)
-                    || questViewModel.Data.GetType() == typeof(questFlowControlNodeDefinition);
-
-                if (questViewModel is questDeletionMarkerNodeDefinitionWrapper)
-                {
-                    // Deletion markers can always be destroyed
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Deletion Marker",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(questViewModel)));
-                }
-                else if (shouldUseDeletionMarker)
-                {
-                    // Signal-stopping nodes: show both Delete (soft) and Destroy (hard)
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Delete Node",
-                        "Delete",
-                        "WolvenKitRed",
-                        () => Source.ReplaceNodeWithQuestDeletionMarker(questViewModel)));
-
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Node",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(questViewModel)));
-                }
-                else
-                {
-                    // Non-signal-stopping nodes: only show Destroy
-                    node.ContextMenu.Items.Add(CreateMenuItem(
-                        "Destroy Node",
-                        "CloseBoxOutline",
-                        "WolvenKitRed",
-                        () => Source.RemoveNode(questViewModel)));
-                }
-            }
-
-            node.ContextMenu.Items.Add(new Separator());
-        }
-
-        // For other node types that aren't scene or quest specific, show destroy option
-        if (!(Source.GraphType == RedGraphType.Scene && node.DataContext is BaseSceneViewModel) &&
-            !(Source.GraphType == RedGraphType.Quest && node.DataContext is BaseQuestViewModel))
-        {
-            node.ContextMenu.Items.Add(CreateMenuItem("Destroy Node", "CloseBoxOutline", "WolvenKitRed", () => Source.RemoveNode(nvm)));
-        }
-
-        // Add deletion markers info for scene graphs for now
-        if (Source.GraphType == RedGraphType.Scene)
-        {
-            node.ContextMenu.Items.Add(new Separator());
-
-            // Create help item using XAML-defined style
-            var infoItem = new MenuItem
-            {
-                Header = "What do these mean?",
-                Style = (Style)Resources["HelpMenuItemStyle"]
-            };
-
-            infoItem.Click += (_, _) => {
-                try
-                {
-                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://wiki.redmodding.org/wolvenkit/wolvenkit-app/editor/scene-editor") { UseShellExecute = true });
-                }
-                catch (Exception)
-                {
-                    // Silently handle any exceptions when opening the link
-                }
-            };
-
-            node.ContextMenu.Items.Add(infoItem);
-        }
-
-        node.ContextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
-
-        e.Handled = true;
+        menu.Open(e);
     }
 
     private static IRedType GetTemplateData(NodeViewModel node)
@@ -1065,33 +833,8 @@ public partial class GraphEditorView : UserControl
 
     private static MenuItem CreateMenuItem(string header, string iconKind, Action click) => CreateMenuItem(header, iconKind, "", click);
 
-    private static MenuItem CreateMenuItem(string header, string iconKind, string iconColor, Action click)
-    {
-        var item = new MenuItem
-        {
-            Header = header,
-            Padding = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
-        };
-
-        if (iconKind != null)
-        {
-            var icon = new IconBox
-            {
-                IconPack = (iconKind == "Empty") ? IconPackType.Empty : IconPackType.Material,
-                Kind = (iconKind == "Empty") ? "" : iconKind,
-                Margin = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
-                Size = (double)Application.Current.Resources["WolvenKitIconMicro"]!
-            };
-
-            if (iconColor != null)
-            {
-                icon.Foreground = (Brush)Application.Current.Resources[iconColor] ?? Brushes.White;
-            }
-            item.Icon = icon;
-        }
-        item.Click += (_, _) => click();
-        return item;
-    }
+    private static MenuItem CreateMenuItem(string header, string iconKind, string iconColor, Action click) =>
+        GraphContextMenuBuilder.CreateMenuItem(header, iconKind, iconColor, click);
 
     /// <summary>
     /// Create a menu item with emoji in the text and no additional icon
@@ -1110,20 +853,7 @@ public partial class GraphEditorView : UserControl
     }
 
     private static MenuItem CreateCategoryMenuItem(string categoryName)
-    {
-        return new MenuItem
-        {
-            Header = categoryName,
-            Padding = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
-            Icon = new IconBox
-            {
-                IconPack = IconPackType.Material,
-                Kind = "FolderOutline",
-                Margin = (Thickness)Application.Current.Resources["WolvenKitMarginTiny"]!,
-                Size = (double)Application.Current.Resources["WolvenKitIconMicro"]!
-            }
-        };
-    }
+        => GraphContextMenuBuilder.CreateMenuItem(categoryName, "FolderOutline", null, null);
 
     private static readonly string[] s_commonBehaviorNodeTypeNames =
     {


### PR DESCRIPTION
Refactors the right-click graph node context menus into a shared implementation across the quest, scene, and behavior graphs

No user facing changes except adding tooltips for node actions

<img width="659" height="223" alt="image" src="https://github.com/user-attachments/assets/f9aee9b5-caed-4511-931d-52d7bdcabf8d" />
