### PR TITLE
Animation Buffer - Fix AnimKey Ordering

### DIFF
--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -228,6 +228,47 @@ namespace WolvenKit.Modkit.RED4.Animation
                 ((List<JointsScalesAtTimes>)[incomingAnimBufferData.Scales, incomingAnimBufferData.ConstScales]).All(_ =>
                     _.All(_ => _.Value.All(_ => EqWithEpsilon(_.Value, Scale1to1))));
 
+            // Sort Keys by Bone->Time->KeyType (pos->rot->sca)
+            animKeys.Sort((a, b) =>
+            {
+                int cmp = a!.Idx.CompareTo(b!.Idx);
+                if (cmp != 0) return cmp;
+            
+                cmp = a.Time.CompareTo(b.Time);
+                if (cmp != 0) return cmp;
+            
+                return string.Compare(
+                    a.GetType().Name,
+                    b.GetType().Name,
+                    StringComparison.Ordinal);
+            });
+            animKeysRaw.Sort((a, b) =>
+            {
+                int cmp = a!.Idx.CompareTo(b!.Idx);
+                if (cmp != 0) return cmp;
+            
+                cmp = a.Time.CompareTo(b.Time);
+                if (cmp != 0) return cmp;
+            
+                return string.Compare(
+                    a.GetType().Name,
+                    b.GetType().Name,
+                    StringComparison.Ordinal);
+            });
+            constAnimKeys.Sort((a, b) =>
+            {
+                int cmp = a!.Idx.CompareTo(b!.Idx);
+                if (cmp != 0) return cmp;
+            
+                cmp = a.Time.CompareTo(b.Time);
+                if (cmp != 0) return cmp;
+            
+                return string.Compare(
+                    a.GetType().Name,
+                    b.GetType().Name,
+                    StringComparison.Ordinal);
+            });
+    
             newCompressedBuffer = new animAnimationBufferCompressed()
             {
                 Duration = incomingAnimBufferData.Duration,

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -227,7 +227,25 @@ namespace WolvenKit.Modkit.RED4.Animation
             var allScalesUniform1to1 =
                 ((List<JointsScalesAtTimes>)[incomingAnimBufferData.Scales, incomingAnimBufferData.ConstScales]).All(_ =>
                     _.All(_ => _.Value.All(_ => EqWithEpsilon(_.Value, Scale1to1))));
+        // TODO: migrate this to animAnimationBufferCompressed and refactor to use it 
+        public static ushort ComponentOf(animKey animKey) => animKey switch
+        {
+            animKeyPosition => 0,
+            animKeyRotation => 1,
+            animKeyScale => 2,
+            _ => 0,
+        };
 
+        private static readonly Comparison<animKey?> AnimKeyBufferOrder = (a, b) =>
+        {
+              int cmp = a!.Idx.CompareTo(b!.Idx);
+              if (cmp != 0) return cmp;
+          
+              cmp = a.Time.CompareTo(b.Time);
+              if (cmp != 0) return cmp;
+          
+              return ComponentOf(a).CompareTo(ComponentOf(b));
+         };
             // Sort Keys by Bone->Time->KeyType (pos->rot->sca)
             animKeys.Sort(AnimKeyBufferOrder);
             animKeysRaw.Sort(AnimKeyBufferOrder);

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -249,19 +249,6 @@ namespace WolvenKit.Modkit.RED4.Animation
             // Sort Keys by Bone->Time->KeyType (pos->rot->sca)
             animKeys.Sort(AnimKeyBufferOrder);
             animKeysRaw.Sort(AnimKeyBufferOrder);
-            animKeysRaw.Sort((a, b) =>
-            {
-                int cmp = a!.Idx.CompareTo(b!.Idx);
-                if (cmp != 0) return cmp;
-            
-                cmp = a.Time.CompareTo(b.Time);
-                if (cmp != 0) return cmp;
-            
-                return string.Compare(
-                    a.GetType().Name,
-                    b.GetType().Name,
-                    StringComparison.Ordinal);
-            });
             constAnimKeys.Sort((a, b) =>
             {
                 int cmp = a!.Idx.CompareTo(b!.Idx);

--- a/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
+++ b/WolvenKit.Modkit/RED4/Tools/Animation/AnimSpline.cs
@@ -229,19 +229,8 @@ namespace WolvenKit.Modkit.RED4.Animation
                     _.All(_ => _.Value.All(_ => EqWithEpsilon(_.Value, Scale1to1))));
 
             // Sort Keys by Bone->Time->KeyType (pos->rot->sca)
-            animKeys.Sort((a, b) =>
-            {
-                int cmp = a!.Idx.CompareTo(b!.Idx);
-                if (cmp != 0) return cmp;
-            
-                cmp = a.Time.CompareTo(b.Time);
-                if (cmp != 0) return cmp;
-            
-                return string.Compare(
-                    a.GetType().Name,
-                    b.GetType().Name,
-                    StringComparison.Ordinal);
-            });
+            animKeys.Sort(AnimKeyBufferOrder);
+            animKeysRaw.Sort(AnimKeyBufferOrder);
             animKeysRaw.Sort((a, b) =>
             {
                 int cmp = a!.Idx.CompareTo(b!.Idx);


### PR DESCRIPTION


# Animation Buffer - Fix AnimKey Ordering

**Fixed:**
- Animation Buffer Data Ordering of Transforms/animKeys  (Sort Keys by Bone->Time->KeyType (pos->rot->sca),   instead of Bone->KeyType->Time), 

**Additional notes:**
addresses https://github.com/WolvenKit/WolvenKit/issues/3067
