### PR TITLE
Improve Archive Manager Load Times

### DIFF
--- a/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerConvertFromJsonIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerConvertFromJsonIntegrationTests.cs
@@ -341,16 +341,15 @@ public class ProjectExplorerConvertFromJsonIntegrationTests : IDisposable
         projectWizard.ProjectPath = _tempProjectRoot;
         await appViewModel.NewProjectTask(projectWizard);
 
+        Assert.True(
+            await AsyncWait.UntilAsync(
+                () => _projectExplorerVm.ActiveProject is not null,
+                TimeSpan.FromSeconds(30)),
+            "Project explorer never adopted the new project.");
+
         Assert.NotNull(projectManager.ActiveProject);
         Assert.NotNull(_projectExplorerVm.ActiveProject);
 
-        var progress = _host.Services.GetRequiredService<IProgressService<double>>();
-        var state = progress.Status;
-
-        while (state != EStatus.Ready)
-        {
-            state = progress.Status;
-            await Task.Delay(100);
-        }
+        await _host!.Services.GetRequiredService<IArchiveManagerLoader>().LoadArchiveManagerAsync();
     }
 }

--- a/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerConvertToJsonIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerConvertToJsonIntegrationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -255,22 +255,16 @@ public class ProjectExplorerConvertToJsonIntegrationTests : IDisposable
         projectWizard.ProjectPath = _tempProjectRoot;
         await appViewModel.NewProjectTask(projectWizard);
 
+        Assert.True(
+            await AsyncWait.UntilAsync(
+                () => _projectExplorerVm.ActiveProject is not null,
+                TimeSpan.FromSeconds(30)),
+            "Project explorer never adopted the new project.");
+
         // Verify the project propagated to the right places
         Assert.NotNull(projectManager.ActiveProject);
         Assert.NotNull(_projectExplorerVm.ActiveProject);
 
-        // Grab the ProgressService
-        var progress = _host?.Services.GetRequiredService<IProgressService<double>>();
-
-        Assert.NotNull(progress);
-
-        var state = progress.Status;
-
-        // Wait until the Archives have loaded
-        while (state != EStatus.Ready)
-        {
-            state = progress.Status;
-            await Task.Delay(100);
-        }
+        await _host!.Services.GetRequiredService<IArchiveManagerLoader>().LoadArchiveManagerAsync();
     }
 }

--- a/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerRenameMoveConsistencyIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/ViewModels/Tools/ProjectExplorerRenameMoveConsistencyIntegrationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -11,15 +11,12 @@ using Splat.Microsoft.Extensions.DependencyInjection;
 using WolvenKit.App.Controllers;
 using WolvenKit.App.Interaction;
 using WolvenKit.App.Models;
-using WolvenKit.App.Models.ProjectManagement.Project;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.App.ViewModels.Tools;
-using WolvenKit.Common.Interfaces;
 using WolvenKit.Common.Model;
 using WolvenKit.Common.Services;
-using WolvenKit.Core.Services;
 using WolvenKit.IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -279,16 +276,16 @@ public class ProjectExplorerRenameMoveConsistencyIntegrationTests : IDisposable
         projectWizard.ProjectPath = _tempProjectRoot;
         await appViewModel.NewProjectTask(projectWizard);
 
+        Assert.True(
+            await AsyncWait.UntilAsync(
+                () => _pe!.ActiveProject is not null,
+                TimeSpan.FromSeconds(30)),
+            "Project explorer never adopted the new project.");
+
         Assert.NotNull(projectManager.ActiveProject);
         Assert.NotNull(_pe!.ActiveProject);
 
-        var progress = _host.Services.GetRequiredService<IProgressService<double>>();
-        var state = progress.Status;
-        while (state != EStatus.Ready)
-        {
-            state = progress.Status;
-            await Task.Delay(100);
-        }
+        await _host!.Services.GetRequiredService<IArchiveManagerLoader>().LoadArchiveManagerAsync();
     }
 
     private static void PumpDispatcher()

--- a/Tests/WolvenKit.IntegrationTests/Helpers/AsyncWait.cs
+++ b/Tests/WolvenKit.IntegrationTests/Helpers/AsyncWait.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace WolvenKit.IntegrationTests.Helpers;
+
+/// <summary>
+/// Polling helpers for state that settles on deferred callbacks rather than on the awaited call.
+/// </summary>
+internal static class AsyncWait
+{
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it holds, or gives up after <paramref name="timeout"/>.
+    /// </summary>
+    /// <remarks>
+    /// Project loading does not finish when the call that started it returns. LoadProjectFromPathAsync
+    /// hands its tail to DispatcherHelper.DelayOnMainThread, which later raises OnInitialProjectLoaded,
+    /// which in turn posts StartWatcher_AndLoadProject onto the dispatcher - only then does the project
+    /// explorer have an ActiveProject. Awaiting NewProjectTask therefore proves nothing; the awaits in
+    /// here are what let those queued callbacks run.
+    /// </remarks>
+    /// <returns>True if the condition held before the timeout.</returns>
+    public static async Task<bool> UntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        while (!condition())
+        {
+            if (stopwatch.Elapsed > timeout)
+            {
+                return false;
+            }
+
+            await Task.Delay(25);
+        }
+
+        return true;
+    }
+}

--- a/Tests/WolvenKit.IntegrationTests/WolvenKit.IntegrationTests.csproj
+++ b/Tests/WolvenKit.IntegrationTests/WolvenKit.IntegrationTests.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Xunit.StaFact" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/WolvenKit.UnitTests/App/Controllers/Red4ControllerLoadingModeTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Controllers/Red4ControllerLoadingModeTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using Moq;
 using WolvenKit.App.Controllers;
 using WolvenKit.App.Helpers;
+using WolvenKit.App.Services;
 using WolvenKit.Core.Services;
 using Wolvenkit.Test.App.Helpers;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Wolvenkit.Test.App.Controllers;
 [Collection(ArchiveLoadHeartbeatCollection.Name)]
 public class Red4ControllerLoadingModeTests
 {
-    private const string Purpose = RED4Controller.ArchiveLoadingPurpose;
+    private const string Purpose = IArchiveManagerLoader.ArchiveLoadingPurpose;
 
     [Fact]
     public void BeginLoadingIndicator_ArmsHeartbeat_AndReleasesOnDispose()

--- a/Tests/WolvenKit.UnitTests/App/Services/ArchiveManagerLoaderTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Services/ArchiveManagerLoaderTests.cs
@@ -2,36 +2,35 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Moq;
-using WolvenKit.App.Controllers;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Services;
 using WolvenKit.Core.Services;
 using Wolvenkit.Test.App.Helpers;
 using Xunit;
 
-namespace Wolvenkit.Test.App.Controllers;
+namespace Wolvenkit.Test.App.Services;
 
 /// <summary>
-/// Covers the RED4Controller archive-loading heartbeat.
+/// Covers the archive-loading heartbeat, which lives on <see cref="ArchiveManagerLoader"/>.
 ///
-/// RED4Controller is registered transient, so the app view model, asset browser and materials
-/// dialog each own an instance and can load archives concurrently. These tests pin the sharing
-/// contract between those instances, which the previous depth-counter implementation got wrong.
+/// The loader is registered transient, so the app view model, asset browser and materials dialog
+/// each own an instance and can load archives concurrently. These tests pin the sharing contract
+/// between those instances, which the previous depth-counter implementation got wrong.
 ///
 /// Every scope is held with <c>using</c> so a failed assertion cannot leak a claim on the shared
 /// purpose into the next test in this collection.
 /// </summary>
 [Collection(ArchiveLoadHeartbeatCollection.Name)]
-public class Red4ControllerLoadingModeTests
+public class ArchiveManagerLoaderTests
 {
     private const string Purpose = IArchiveManagerLoader.ArchiveLoadingPurpose;
 
     [Fact]
     public void BeginLoadingIndicator_ArmsHeartbeat_AndReleasesOnDispose()
     {
-        var controller = CreateUninitializedController(out var progress);
+        var loader = CreateUninitializedLoader(out var progress);
 
-        using (var scope = BeginLoadingIndicator(controller))
+        using (var scope = BeginLoadingIndicator(loader))
         {
             Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
         }
@@ -42,12 +41,12 @@ public class Red4ControllerLoadingModeTests
     }
 
     [Fact]
-    public void BeginLoadingIndicator_NestedOnSameController_StaysArmedUntilOuterScopeCloses()
+    public void BeginLoadingIndicator_NestedOnSameLoader_StaysArmedUntilOuterScopeCloses()
     {
-        var controller = CreateUninitializedController(out _);
+        var loader = CreateUninitializedLoader(out _);
 
-        using var outer = BeginLoadingIndicator(controller);
-        using (var inner = BeginLoadingIndicator(controller))
+        using var outer = BeginLoadingIndicator(loader);
+        using (var inner = BeginLoadingIndicator(loader))
         {
             Assert.Equal(2, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
         }
@@ -57,10 +56,10 @@ public class Red4ControllerLoadingModeTests
     }
 
     [Fact]
-    public void BeginLoadingIndicator_SecondControllerFinishingFirst_DoesNotStopTheFirstControllersHeartbeat()
+    public void BeginLoadingIndicator_SecondLoaderFinishingFirst_DoesNotStopTheFirstLoadersHeartbeat()
     {
-        var first = CreateUninitializedController(out var firstProgress);
-        var second = CreateUninitializedController(out _);
+        var first = CreateUninitializedLoader(out var firstProgress);
+        var second = CreateUninitializedLoader(out _);
 
         using (var firstScope = BeginLoadingIndicator(first))
         {
@@ -80,9 +79,9 @@ public class Red4ControllerLoadingModeTests
     [Fact]
     public void BeginLoadingIndicator_ScopeDisposeIsIdempotent()
     {
-        var controller = CreateUninitializedController(out _);
+        var loader = CreateUninitializedLoader(out _);
 
-        using var scope = BeginLoadingIndicator(controller);
+        using var scope = BeginLoadingIndicator(loader);
         scope.Dispose();
         scope.Dispose();
 
@@ -90,26 +89,30 @@ public class Red4ControllerLoadingModeTests
         Assert.Equal(0, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
     }
 
-    private static IDisposable BeginLoadingIndicator(RED4Controller controller)
+    private static IDisposable BeginLoadingIndicator(ArchiveManagerLoader loader)
     {
-        var method = typeof(RED4Controller).GetMethod(
+        var method = typeof(ArchiveManagerLoader).GetMethod(
             "BeginLoadingIndicator",
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
 
-        var scope = method!.Invoke(controller, null) as IDisposable;
+        var scope = method!.Invoke(loader, null) as IDisposable;
         Assert.NotNull(scope);
         return scope!;
     }
 
-    private static RED4Controller CreateUninitializedController(out Mock<IProgressService<double>> progress)
+    /// <summary>
+    /// Built without running the constructor: the heartbeat only reads _progressService, and the
+    /// real constructor would drag in the archive manager and parser for no benefit here.
+    /// </summary>
+    private static ArchiveManagerLoader CreateUninitializedLoader(out Mock<IProgressService<double>> progress)
     {
         progress = new Mock<IProgressService<double>>();
         progress.SetupAllProperties();
 
-        var controller = (RED4Controller)RuntimeHelpers.GetUninitializedObject(typeof(RED4Controller));
-        SetField(controller, "_progressService", progress.Object);
-        return controller;
+        var loader = (ArchiveManagerLoader)RuntimeHelpers.GetUninitializedObject(typeof(ArchiveManagerLoader));
+        SetField(loader, "_progressService", progress.Object);
+        return loader;
     }
 
     private static void SetField(object target, string name, object? value)

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
@@ -43,6 +43,7 @@ public class AppViewModelProjectLoadTests : IDisposable
     private readonly Mock<ISettingsManager> _settings = new();
     private readonly Mock<IModifierViewStateService> _modifiers = new();
     private readonly Mock<IArchiveManager> _archives = new();
+    private readonly Mock<IArchiveManagerLoader> _archiveLoader = new();
     private readonly ProjectEvents _projectEvents = new();
     private readonly AppViewModel _app;
     private readonly ProjectExplorerViewModel _pe;
@@ -123,7 +124,7 @@ public class AppViewModelProjectLoadTests : IDisposable
         var project = CreateProject("ModA");
         _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
         _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
-        _gameController.Setup(c => c.HandleStartup()).ThrowsAsync(new InvalidOperationException("archive boom"));
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).ThrowsAsync(new InvalidOperationException("archive boom"));
 
         var raised = false;
         _app.OnInitialProjectLoaded += (_, _) => raised = true;
@@ -149,7 +150,7 @@ public class AppViewModelProjectLoadTests : IDisposable
         await _app.LoadProjectFromPathAsync(project.Location);
 
         Assert.True(raised);
-        _gameController.Verify(c => c.HandleStartup(), Times.Never);
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
     }
 
     [Fact]
@@ -181,7 +182,7 @@ public class AppViewModelProjectLoadTests : IDisposable
         await _app.LoadProjectFromPathAsync(requested);
 
         Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
-        _gameController.Verify(c => c.HandleStartup(), Times.Never);
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
     }
 
     [Fact]
@@ -190,7 +191,7 @@ public class AppViewModelProjectLoadTests : IDisposable
         var project = CreateProject("ModA");
         _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
         _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
-        _gameController.Setup(c => c.HandleStartup()).Returns(Task.CompletedTask);
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
 
         var raised = false;
         _app.OnInitialProjectLoaded += (_, _) => raised = true;
@@ -211,7 +212,7 @@ public class AppViewModelProjectLoadTests : IDisposable
             .Callback(() => modeWhenLoadAsyncRan = _pe.CurrentLoadingMode)
             .ReturnsAsync(project);
         _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
-        _gameController.Setup(c => c.HandleStartup()).Returns(Task.CompletedTask);
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
 
         await _app.LoadProjectFromPathAsync(project.Location);
 

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
@@ -3,7 +3,10 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 using Moq;
 using WolvenKit.App.Controllers;
 using WolvenKit.App.Helpers;
@@ -24,9 +27,13 @@ using Xunit;
 namespace Wolvenkit.Test.App.ViewModels.Shell;
 
 /// <summary>
-/// Covers AppViewModel.LoadProjectFromPathAsync lifecycle (review issues 2 and 4):
-/// HandleStartup faults still raise OnInitialProjectLoaded; failed loads cancel PE chrome;
-/// location mismatch vs ProjectManager previous project cancels loading.
+/// Covers AppViewModel.LoadProjectFromPathAsync lifecycle: failed loads cancel PE chrome;
+/// location mismatch vs ProjectManager previous project cancels loading; a successful load
+/// eventually raises OnInitialProjectLoaded.
+///
+/// Note that the success path finishes on a delayed dispatcher callback
+/// (DispatcherHelper.DelayOnMainThread), so awaiting LoadProjectFromPathAsync won't
+/// work... the tests would have to "pump" (see PumpUntil).
 /// </summary>
 [Collection(ProjectLoadHeartbeatCollection.Name)]
 public class AppViewModelProjectLoadTests : IDisposable
@@ -64,6 +71,7 @@ public class AppViewModelProjectLoadTests : IDisposable
         SetField(_app, "_loggerService", _logger.Object);
         SetField(_app, "_notificationService", _notifications.Object);
         SetField(_app, "_gameControllerFactory", _gameControllerFactory.Object);
+        SetField(_app, "_archiveManagerLoader", _archiveLoader.Object);
         SetProperty(_app, nameof(AppViewModel.SettingsManager), _settings.Object);
 
         // DockedViews is initialized by the field initializer; with GetUninitializedObject it is null.
@@ -107,6 +115,68 @@ public class AppViewModelProjectLoadTests : IDisposable
         TempProjectDirectory.Delete(_tempRoot);
     }
 
+    /// <summary>
+    /// A failing archive load must not escape startup. ArchiveManagerLoader logs and rethrows, and
+    /// HandleActivation is reached from the Status setter, so an unguarded fault would propagate
+    /// out of OnStatusChanged and take the launch down. Before archive loading moved to
+    /// HandleActivation this was guarded inside LoadProjectFromPathAsync; these two pin the
+    /// replacement guard.
+    /// </summary>
+    [Fact]
+    public async Task LoadArchivesSafely_LoaderFaults_IsLoggedAndSwallowed()
+    {
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync())
+            .ThrowsAsync(new InvalidOperationException("archive boom"));
+
+        await InvokeLoadArchivesSafely();
+
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Once);
+        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadArchivesSafely_LoaderSucceeds_LogsNoError()
+    {
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
+
+        await InvokeLoadArchivesSafely();
+
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Once);
+        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.Never);
+    }
+
+    /// <summary>
+    /// HandleActivation itself is not reachable from these tests - it also inits plugins, opens
+    /// the home page and fires update commands, none of which exist on a
+    /// GetUninitializedObject AppViewModel - so the guard is exercised directly.
+    /// </summary>
+    private Task InvokeLoadArchivesSafely()
+    {
+        var method = typeof(AppViewModel).GetMethod(
+            "LoadArchivesSafelyAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        return (Task)method!.Invoke(_app, null)!;
+    }
+
+    /// <summary>
+    /// Drains the dispatcher queue until <paramref name="condition"/> holds or we time out.
+    /// Nothing runs a dispatcher frame in a unit test, so callbacks posted by
+    /// DispatcherHelper.DelayOnMainThread would otherwise never execute.
+    /// </summary>
+    private static void PumpUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (!condition() && stopwatch.Elapsed < timeout)
+        {
+            dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+            Thread.Sleep(1);
+        }
+    }
+
     private Cp77Project CreateProject(string name)
     {
         var dir = Path.Combine(_tempRoot, name);
@@ -118,8 +188,14 @@ public class AppViewModelProjectLoadTests : IDisposable
         return project;
     }
 
+    /// <summary>
+    /// Archive loading moved out of the project-load path and into AppViewModel.HandleActivation,
+    /// so a broken archive load can no longer affect opening a project. This test checks
+    /// that these are now decoupled: the archive loader is not consulted here at all,
+    /// and the project still loads.
+    /// </summary>
     [Fact]
-    public async Task LoadProjectFromPathAsync_HandleStartupFault_StillRaisesOnInitialProjectLoaded()
+    public async Task LoadProjectFromPathAsync_DoesNotLoadArchives()
     {
         var project = CreateProject("ModA");
         _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
@@ -131,8 +207,10 @@ public class AppViewModelProjectLoadTests : IDisposable
 
         await _app.LoadProjectFromPathAsync(project.Location);
 
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
+
+        PumpUntil(() => raised, TimeSpan.FromSeconds(10));
         Assert.True(raised);
-        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.AtLeastOnce);
         _notifications.Verify(n => n.Success(It.Is<string>(s => s.Contains("loaded", StringComparison.OrdinalIgnoreCase))), Times.Once);
     }
 
@@ -191,15 +269,18 @@ public class AppViewModelProjectLoadTests : IDisposable
         var project = CreateProject("ModA");
         _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
         _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
-        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
 
         var raised = false;
         _app.OnInitialProjectLoaded += (_, _) => raised = true;
 
         await _app.LoadProjectFromPathAsync(project.Location);
 
-        Assert.True(raised);
+        // ActiveProject is set synchronously; the event is not. The success lane runs on a
+        // DelayOnMainThread callback, so it needs a dispatcher frame and more than that delay.
         Assert.Equal(project, _app.ActiveProject);
+
+        PumpUntil(() => raised, TimeSpan.FromSeconds(10));
+        Assert.True(raised);
     }
 
     [Fact]

--- a/WolvenKit.App/Controllers/IGameController.cs
+++ b/WolvenKit.App/Controllers/IGameController.cs
@@ -76,8 +76,6 @@ public interface IGameController
     /// <returns>bool success</returns>
     Task<bool> AddFileToModModalAsync(ulong hash, ArchiveManagerScope searchScope);
 
-    public Task HandleStartup();
-
     Task<bool> LaunchProjectAsync(LaunchProfile profile);
     Task<bool> InstallProjectHotAsync();
     bool CleanAll(bool isPostBuild = false);

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -44,7 +44,6 @@ public class RED4Controller : ObservableObject, IGameController
     private readonly IAppArchiveManager _archiveManager;
     private readonly IProgressService<double> _progressService;
     private readonly IPluginService _pluginService;
-    private readonly Red4ParserService _parserService;
     private readonly IModifierViewStateService _modifierService;
     private readonly IProjectEvents _projectEvents;
 
@@ -61,7 +60,6 @@ public class RED4Controller : ObservableObject, IGameController
         IProgressService<double> progressService,
         IPluginService pluginService,
         IModifierViewStateService modifierService,
-        Red4ParserService parserService,
         IProjectEvents projectEvents)
     {
         _notificationService = notificationService;
@@ -74,144 +72,7 @@ public class RED4Controller : ObservableObject, IGameController
         _progressService = progressService;
         _pluginService = pluginService;
         _modifierService = modifierService;
-        _parserService = parserService;
         _projectEvents = projectEvents;
-    }
-
-    public async Task HandleStartup()
-    {
-        await LoadArchiveManagerAsync();
-    }
-
-    // TODO: Move this somewhere else
-    private void LoadCustomHashes()
-    {
-        ResourcePath physMatLibPath = "base\\physics\\physicsmaterials.physmatlib";
-        ResourcePath presetPath = "engine\\physics\\collision_presets.json";
-
-        var physMatLib = _archiveManager.Lookup(physMatLibPath);
-        if (physMatLib.HasValue)
-        {
-            using MemoryStream ms = new();
-            physMatLib.Value.Extract(ms);
-            ms.Position = 0;
-
-            if (_parserService.TryReadRed4File(ms, out var file))
-            {
-                var root = (physicsMaterialLibraryResource)file.RootChunk;
-
-                foreach (var physMat in root.MaterialNames)
-                {
-                    if (!physMat.IsResolvable)
-                    {
-                        continue;
-                    }
-
-                    CNamePool.AddOrGetHash(physMat.GetResolvedText()!);
-                }
-            }
-        }
-
-        var preset = _archiveManager.Lookup(presetPath);
-        if (preset.HasValue)
-        {
-            using MemoryStream ms = new();
-            preset.Value.Extract(ms);
-            ms.Position = 0;
-
-            if (_parserService.TryReadRed4File(ms, out var file))
-            {
-                var root = (JsonResource)file.RootChunk;
-                var res = (physicsCollisionPresetsResource)root.Root.Chunk.NotNull();
-
-                foreach (var presetEntry in res.Presets)
-                {
-                    if (presetEntry is not { Name: { IsResolvable: true } name })
-                    {
-                        continue;
-                    }
-
-                    CNamePool.AddOrGetHash(name.GetResolvedText()!);
-                }
-            }
-        }
-    }
-
-    public const string ArchiveLoadingPurpose = "RED4Controller archive loading";
-
-    /// <summary>
-    /// Starts the archive-loading progress heartbeat and returns a scope that releases it.
-    ///
-    /// The heartbeat is reference counted on <see cref="ArchiveLoadingPurpose"/>, so overlapping
-    /// loads — RED4Controller is registered transient, so the app view model, the asset browser
-    /// and the materials dialog each hold their own instance — share a single timer. The
-    /// indicator is only reset to Ready once the last loader disposes its scope, rather than
-    /// whichever loader happens to finish first.
-    /// </summary>
-    private IDisposable BeginLoadingIndicator() =>
-        DispatcherHelper.StartRepeatingAction(
-            purpose: ArchiveLoadingPurpose,
-            () =>
-            {
-                _progressService.IsIndeterminate = true;
-                _progressService.Status = EStatus.Running;
-            },
-            TimeSpan.FromMilliseconds(100),
-            onCancelled: () =>
-            {
-                _progressService.IsIndeterminate = false;
-                _progressService.Status = EStatus.Ready;
-            }
-        );
-
-    /// <summary>
-    /// Loads the basegame + EP1 archives on a background thread.
-    /// While loading, a 100ms repeating timer forces the global ProgressService
-    /// into Running/Indeterminate state. This mitigates the problem that there is
-    /// only a single global "Ready/Running" state — other code can (and does)
-    /// call Completed() or set IsIndeterminate=false while this long job is still
-    /// in progress.
-    /// </summary>
-    private async Task LoadArchiveManagerAsync()
-    {
-        // Fast path checks — do NOT start the loading indicator if there's nothing to do.
-        if (_archiveManager.IsManagerLoaded)
-        {
-            return;
-        }
-
-        if (_settingsManager.CP77ExecutablePath is null)
-        {
-            _loggerService.Warning("Cyberpunk 2077 executable path is not set. Skipping Archive Manager load.");
-            return;
-        }
-
-        using var loadingIndicator = BeginLoadingIndicator();
-
-        try
-        {
-            await Task.Run(() =>
-            {
-                // Keep priority low so the UI stays responsive during the (potentially long)
-                // first-time scan of dozens of large .archive files.
-                Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
-                Thread.CurrentThread.IsBackground = true;
-
-                _loggerService.Info("Loading Archive Manager ... ");
-
-                _archiveManager.LoadGameArchives(new FileInfo(_settingsManager.CP77ExecutablePath));
-
-                // Custom hash population needs the archives to be loaded, so do it here on the same thread.
-                LoadCustomHashes();
-            });
-
-            _loggerService.Success("Finished loading Archive Manager.");
-        }
-        catch (Exception e)
-        {
-            _loggerService.Error(e);
-            throw;
-        }
     }
 
     #region Packing

--- a/WolvenKit.App/Factories/PaneViewModelFactory.cs
+++ b/WolvenKit.App/Factories/PaneViewModelFactory.cs
@@ -36,6 +36,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
     private readonly IModifierViewStateService _modifierSvc;
     private readonly ProjectResourceTools _projectResourceTools;
     private readonly IProjectEvents _projectEvents;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     public PaneViewModelFactory(
         IProjectManager projectManager,
@@ -56,7 +57,8 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         AppScriptService appScriptService,
         ProjectResourceTools projectResourceTools,
         IModifierViewStateService modifierSvc,
-        IProjectEvents projectEvents
+        IProjectEvents projectEvents,
+        IArchiveManagerLoader archiveManagerLoader
         )
     {
         _projectManager = projectManager;
@@ -78,6 +80,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         _modifierSvc = modifierSvc;
         _projectResourceTools = projectResourceTools;
         _projectEvents = projectEvents;
+        _archiveManagerLoader = archiveManagerLoader;
     }
 
     public LogViewModel LogViewModel() => new(_loggerService, _appScriptService, _settingsManager);
@@ -88,7 +91,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         => _propertiesViewModel;
     public AssetBrowserViewModel AssetBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _projectManager, _notificationService, _gameController, _archiveManager, _settingsManager, _progressService,
-            _loggerService, _pluginService, _projectResourceTools);
+            _loggerService, _pluginService, _projectResourceTools, _archiveManagerLoader);
     public TweakBrowserViewModel TweakBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _chunkViewmodelFactory, _settingsManager, _notificationService, _projectManager, _loggerService, _tweakDbService, _locKeyService);
     public LocKeyBrowserViewModel LocKeyBrowserViewModel() => new(_projectManager, _loggerService, _progressService, _modTools, _gameController, _archiveManager, _locKeyService);

--- a/WolvenKit.App/Services/AppArchiveManager.cs
+++ b/WolvenKit.App/Services/AppArchiveManager.cs
@@ -32,14 +32,14 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
         _progressService = progressService;
         _settings = settings;
     }
-    
+
     #region Fields
 
     private readonly IHashService _hashService;
     private readonly ILoggerService _logger;
     private readonly IProgressService<double> _progressService;
     private readonly ISettingsManager _settings;
-    
+
     private readonly SourceList<RedFileSystemModel> _rootCache = new();
 
     private readonly SourceList<RedFileSystemModel> _modCache = new();
@@ -218,11 +218,17 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
 
         var progress = -1;
         var numTotalArchives = (float)GetModArchives().Count();
-        
+        var reportEvery = Math.Max(1, (int)(numTotalArchives / 100));
+
         foreach (var archive in GetModArchives())
         {
             progress++;
-            _progressService.Report(progress / numTotalArchives);
+
+            if (progress % reportEvery == 0)
+            {
+                _progressService.Report(progress / numTotalArchives);
+            }
+
             ArgumentNullException.ThrowIfNull(archive.ArchiveRelativePath,
                 $"{nameof(archive.ArchiveRelativePath)}, archive name: ${archive.Name}");
 
@@ -261,7 +267,7 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
         _progressService.Completed();
     }
 
-    public override Dictionary<string, IEnumerable<IGameFile>> GetGroupedFiles() => 
+    public override Dictionary<string, IEnumerable<IGameFile>> GetGroupedFiles() =>
         GetGroupedFiles(IsModBrowserActive ? ArchiveManagerScope.Mods : ArchiveManagerScope.Basegame);
 
     #endregion Methods

--- a/WolvenKit.App/Services/ArchiveManagerLoader.cs
+++ b/WolvenKit.App/Services/ArchiveManagerLoader.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using WolvenKit.App.Helpers;
+using WolvenKit.Common;
+using WolvenKit.Core.Extensions;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.RED4.CR2W;
+using WolvenKit.RED4.Types;
+using WolvenKit.RED4.Types.Pools;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// Its single responsibility is loading the archive manager.
+/// </summary>
+public sealed class ArchiveManagerLoader: IArchiveManagerLoader
+{
+    private readonly IArchiveManager _archiveManager;
+    private readonly ISettingsManager _settingsManager;
+    private readonly IProgressService<double> _progressService;
+    private readonly Red4ParserService _parserService;
+    private readonly ILoggerService _loggerService;
+
+    public ArchiveManagerLoader(IArchiveManager archiveManager, ISettingsManager settingsManager,
+        IProgressService<double> progressService, Red4ParserService parserService, ILoggerService loggerService)
+    {
+        _archiveManager = archiveManager;
+        _settingsManager = settingsManager;
+        _progressService = progressService;
+        _parserService = parserService;
+        _loggerService = loggerService;
+    }
+
+    /// <summary>
+    /// Loads the basegame + EP1 archives on a background thread.
+    /// While loading, a 100ms repeating timer forces the global ProgressService
+    /// into Running/Indeterminate state. This mitigates the problem that there is
+    /// only a single global "Ready/Running" state — other code can (and does)
+    /// call Completed() or set IsIndeterminate=false while this long job is still
+    /// in progress.
+    /// </summary>
+    public async Task LoadArchiveManagerAsync()
+    {
+        // Fast path checks — do NOT start the loading indicator if there's nothing to do.
+        if (_archiveManager.IsManagerLoaded)
+        {
+            return;
+        }
+
+        if (_settingsManager.CP77ExecutablePath is null)
+        {
+            _loggerService.Warning("Cyberpunk 2077 executable path is not set. Skipping Archive Manager load.");
+            return;
+        }
+
+        using var loadingIndicator = BeginLoadingIndicator();
+
+        try
+        {
+            await Task.Run(() =>
+            {
+                // Keep priority low so the UI stays responsive during the (potentially long)
+                // first-time scan of dozens of large .archive files.
+                Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+                Thread.CurrentThread.IsBackground = true;
+
+                _loggerService.Info("Loading Archive Manager ... ");
+
+                _archiveManager.LoadGameArchives(new FileInfo(_settingsManager.CP77ExecutablePath));
+
+                // Custom hash population needs the archives to be loaded, so do it here on the same thread.
+                LoadCustomHashes();
+            });
+
+            _loggerService.Success("Finished loading Archive Manager.");
+        }
+        catch (Exception e)
+        {
+            _loggerService.Error(e);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Starts the archive-loading progress heartbeat and returns a scope that releases it.
+    ///
+    /// The heartbeat is reference counted on <see cref="ArchiveLoadingPurpose"/>, so overlapping
+    /// loads — RED4Controller is registered transient, so the app view model, the asset browser
+    /// and the materials dialog each hold their own instance — share a single timer. The
+    /// indicator is only reset to Ready once the last loader disposes its scope, rather than
+    /// whichever loader happens to finish first.
+    /// </summary>
+    private IDisposable BeginLoadingIndicator() =>
+        DispatcherHelper.StartRepeatingAction(
+            purpose: IArchiveManagerLoader.ArchiveLoadingPurpose,
+            () =>
+            {
+                _progressService.IsIndeterminate = true;
+                _progressService.Status = EStatus.Running;
+            },
+            TimeSpan.FromMilliseconds(100),
+            onCancelled: () =>
+            {
+                _progressService.IsIndeterminate = false;
+                _progressService.Status = EStatus.Ready;
+            }
+        );
+
+    private void LoadCustomHashes()
+    {
+        ResourcePath physMatLibPath = "base\\physics\\physicsmaterials.physmatlib";
+        ResourcePath presetPath = "engine\\physics\\collision_presets.json";
+
+        var physMatLib = _archiveManager.Lookup(physMatLibPath);
+        if (physMatLib.HasValue)
+        {
+            using MemoryStream ms = new();
+            physMatLib.Value.Extract(ms);
+            ms.Position = 0;
+
+            if (_parserService.TryReadRed4File(ms, out var fileMaybeNull) && fileMaybeNull is { } file)
+            {
+                var root = (physicsMaterialLibraryResource)file.RootChunk;
+
+                foreach (var physMat in root.MaterialNames)
+                {
+                    if (!physMat.IsResolvable)
+                    {
+                        continue;
+                    }
+
+                    CNamePool.AddOrGetHash(physMat.GetResolvedText()!);
+                }
+            }
+        }
+
+        var preset = _archiveManager.Lookup(presetPath);
+        if (preset.HasValue)
+        {
+            using MemoryStream ms = new();
+            preset.Value.Extract(ms);
+            ms.Position = 0;
+
+            if (_parserService.TryReadRed4File(ms, out var fileMaybeNull) && fileMaybeNull is { } file)
+            {
+                var root = (JsonResource)file.RootChunk;
+                var res = (physicsCollisionPresetsResource)root.Root.Chunk.NotNull();
+
+                foreach (var presetEntry in res.Presets)
+                {
+                    if (presetEntry is not { Name: { IsResolvable: true } name })
+                    {
+                        continue;
+                    }
+
+                    CNamePool.AddOrGetHash(name.GetResolvedText()!);
+                }
+            }
+        }
+    }
+}

--- a/WolvenKit.App/Services/IArchiveManagerLoader.cs
+++ b/WolvenKit.App/Services/IArchiveManagerLoader.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace WolvenKit.App.Services;
+
+public interface IArchiveManagerLoader
+{
+    const string ArchiveLoadingPurpose = "RED4Controller archive loading";
+
+    Task LoadArchiveManagerAsync();
+}

--- a/WolvenKit.App/ViewModels/Dialogs/MaterialsRepositoryDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/MaterialsRepositoryDialogViewModel.cs
@@ -36,6 +36,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
     private readonly IGameControllerFactory _gameControllerFactory;
     private readonly IProgressService<double> _progress;
     private readonly IModTools _modTools;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     public MaterialsRepositoryViewModel(
         ISettingsManager settingsManager,
@@ -43,7 +44,8 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         IAppArchiveManager archiveManager,
         IGameControllerFactory gameControllerFactory,
         IProgressService<double> progress,
-        IModTools modTools)
+        IModTools modTools,
+        IArchiveManagerLoader archiveManagerLoader)
     {
         _settingsManager = settingsManager;
         _loggerService = loggerService;
@@ -51,6 +53,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         _gameControllerFactory = gameControllerFactory;
         _progress = progress;
         _modTools = modTools;
+        _archiveManagerLoader = archiveManagerLoader;
 
         ArgumentNullException.ThrowIfNull(_settingsManager.MaterialRepositoryPath);
 
@@ -150,7 +153,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
             ".mlmask"
         };
 
-        await _gameControllerFactory.GetRed4Controller().HandleStartup();
+        await _archiveManagerLoader.LoadArchiveManagerAsync();
 
         var groupedFiles = _archiveManager.GetGroupedFiles();
 
@@ -342,7 +345,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         var depotPath = new DirectoryInfo(_settingsManager.MaterialRepositoryPath);
         if (depotPath.Exists)
         {
-            await _gameControllerFactory.GetRed4Controller().HandleStartup();
+            await _archiveManagerLoader.LoadArchiveManagerAsync();
 
             await Task.Run(() =>
             {

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -313,46 +313,93 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
 
         OnAppLoaded?.Invoke(this, EventArgs.Empty);
-        HandleActivation();
     }
 
     public event EventHandler? OnAppLoaded;
 
-    private void HandleActivation()
+    /// <summary>
+    /// One-time application startup work. Call once, from the shell, after its bindings are in
+    /// place.
+    /// </summary>
+    /// <remarks>
+    /// This used to hang off the <c>Status</c> property setter as a side effect, which meant it
+    /// could not be awaited, could not be ordered relative to the shell's own setup, and turned
+    /// any failure into an exception escaping a property assignment. Being an explicit awaitable
+    /// call also removes the need to branch on <c>TestHelper.InActiveTest</c> - tests simply await
+    /// it.
+    ///
+    /// Never throws: a discarded task's exception would otherwise go unobserved, and none of this
+    /// work is worth failing a launch over.
+    /// </remarks>
+    public async Task InitializeAsync()
     {
-        var thisVersion = Core.CommonFunctions.GetAssemblyVersion(Constants.AssemblyName);
-        if (thisVersion.ToString().Contains("nightly") && SettingsManager.UpdateChannel != EUpdateChannel.Nightly)
+        try
         {
-            SettingsManager.UpdateChannel = EUpdateChannel.Nightly;
-        }
+            var thisVersion = Core.CommonFunctions.GetAssemblyVersion(Constants.AssemblyName);
+            if (thisVersion.ToString().Contains("nightly") && SettingsManager.UpdateChannel != EUpdateChannel.Nightly)
+            {
+                SettingsManager.UpdateChannel = EUpdateChannel.Nightly;
+            }
 
-        _pluginService.Init();
+            _pluginService.Init();
 
-        if (TestHelper.InActiveTest)
-        {
-            _archiveManagerLoader.LoadArchiveManagerAsync().GetAwaiter().GetResult();
-        }
-        else if (Application.Current is { } app )
-        {
-            app.Dispatcher.Invoke(_archiveManagerLoader.LoadArchiveManagerAsync, DispatcherPriority.ApplicationIdle);
-        }
-
-        if (!OpenFileFromLaunchArgs())
-        {
-            ShowHomePageSync();
-        }
+            if (!OpenFileFromLaunchArgs())
+            {
+                ShowHomePageSync();
+            }
 
 #if !DEBUG
-        if (SettingsManager.AutoUpdateOnStartup)
-        {
-            CheckForUpdatesCommand.SafeExecute(true);
-        }
+            if (SettingsManager.AutoUpdateOnStartup)
+            {
+                CheckForUpdatesCommand.SafeExecute(true);
+            }
 #endif
 
-        CheckForScriptUpdatesCommand.SafeExecute();
-        CheckForTemplateUpdatesCommand.SafeExecute();
-        CheckForLongPathSupport();
-        CheckForOneDrivePath();
+            CheckForScriptUpdatesCommand.SafeExecute();
+            CheckForTemplateUpdatesCommand.SafeExecute();
+            CheckForLongPathSupport();
+            CheckForOneDrivePath();
+
+            // Archives load last, and only once the shell has gone idle. The scan allocates
+            // heavily on a background thread, and GC pauses hit the UI thread too - starting it
+            // any earlier visibly stalls the window as it is still drawing itself.
+            if (Application.Current is { } app)
+            {
+                await app.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
+            }
+
+            await LoadArchivesSafelyAsync();
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
+    }
+
+    /// <summary>
+    /// Loads the archive manager, logging rather than propagating a failure.
+    /// </summary>
+    /// <remarks>
+    /// A corrupt, locked or missing archive should cost the user the asset browser, not the whole
+    /// application: before archive loading moved here it ran inside LoadProjectFromPathAsync
+    /// behind exactly this try/catch, and ArchiveManagerLoader still rethrows after logging.
+    /// Without the guard the fault escapes HandleActivation, then OnStatusChanged, then the
+    /// Status setter, and takes startup down with it.
+    ///
+    /// The catch has to live inside the async method rather than around the dispatcher call:
+    /// Dispatcher.Invoke(Func&lt;Task&gt;, ...) hands back the Task and drops it, so anything
+    /// thrown after the first await would be swallowed unobserved instead of logged.
+    /// </remarks>
+    private async Task LoadArchivesSafelyAsync()
+    {
+        try
+        {
+            await _archiveManagerLoader.LoadArchiveManagerAsync();
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
     }
 
     public bool AddDockedPane(string paneString)

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -20,7 +20,6 @@ using CommunityToolkit.Mvvm.Input;
 using DynamicData.Binding;
 using Microsoft.VisualBasic.FileIO;
 using Microsoft.Win32;
-using Splat;
 using WolvenKit.App.Controllers;
 using WolvenKit.App.Extensions;
 using WolvenKit.App.Factories;
@@ -93,6 +92,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     // expose to view
     public ISettingsManager SettingsManager { get; init; }
     public ProjectResourceTools ProjectResourceTools { get; init; }
+    private IArchiveManagerLoader _archiveManagerLoader;
 
     /// <summary>
     /// Class constructor
@@ -123,7 +123,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         ProjectResourceTools projectResourceTools,
         IUpdateService updateService,
         IProjectEvents projectEvents,
-        RedTypeTemplateService redTypeTemplateService
+        RedTypeTemplateService redTypeTemplateService,
+        IArchiveManagerLoader archiveManagerLoader
     )
     {
         _documentViewmodelFactory = documentViewmodelFactory;
@@ -152,6 +153,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         _projectEvents.FilesMoved.Subscribe(msg => SafeRefreshOpenDocuments(() => RefreshOpenDocumentsAfterMoves(msg)));
         _projectEvents.FilesImported.Subscribe(msg => SafeRefreshOpenDocuments(() => RefreshOpenDocumentsAfterImports(msg)));
         _redTypeTemplateService = redTypeTemplateService;
+        _archiveManagerLoader = archiveManagerLoader;
 
         _fileValidationScript = _scriptService.GetScripts().ToList()
             .Where(s => s.Name == "run_FileValidation_on_active_tab")
@@ -325,6 +327,16 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
 
         _pluginService.Init();
+
+        if (TestHelper.InActiveTest)
+        {
+            _archiveManagerLoader.LoadArchiveManagerAsync().GetAwaiter().GetResult();
+        }
+        else if (Application.Current is { } app )
+        {
+            app.Dispatcher.Invoke(_archiveManagerLoader.LoadArchiveManagerAsync, DispatcherPriority.ApplicationIdle);
+        }
+
         if (!OpenFileFromLaunchArgs())
         {
             ShowHomePageSync();
@@ -817,24 +829,18 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             return;
         }
 
-        try
+        DispatcherHelper.DelayOnMainThread(() =>
         {
-            await _gameControllerFactory.GetController().HandleStartup();
-        }
-        catch (Exception ex)
-        {
-            _loggerService.Error(ex);
-        }
+            UpdateTitle();
+            _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
+            // https://github.com/WolvenKit/WolvenKit/issues/1962
+            if (!FilepathValidationTools.IsOsFilePathValid(location))
+            {
+                _notificationService.Warning($"Project path {location} contains invalid characters!");
+            }
 
-        UpdateTitle();
-        _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
-        // https://github.com/WolvenKit/WolvenKit/issues/1962
-        if (!FilepathValidationTools.IsOsFilePathValid(location))
-        {
-            _notificationService.Warning($"Project path {location} contains invalid characters!");
-        }
-
-        OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
+            OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
+        }, 1000);
     }
 
     private static bool ProjectLocationsMatch(string loadedLocation, string requestedLocation)
@@ -2806,9 +2812,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         resources["WolvenKitGridScale"] = gridScale;
     }
 
-    #endregion methods
-
-    # region file_and_document_handling
+    #region Document Open/Close/Save
 
     /// <param name="absolutePath">Absolute path of the file</param>
     /// <param name="ignoreIgnoredExtension">Sometimes, we need to open files for internal script use. Set this flag to true for this case.</param>
@@ -3340,6 +3344,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         return true;
     }
 
-    #endregion
+    #endregion Document Open/Close/Save
 
+    #endregion methods
 }

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -78,6 +78,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     private bool _isLoading = false;
     internal readonly ReadOnlyObservableCollection<RedFileSystemModel> _boundRootNodes;
     private ProjectExplorerViewModel.LoadingMode _projectLoadingMode;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     #endregion fields
 
@@ -93,7 +94,8 @@ public partial class AssetBrowserViewModel : ToolViewModel
         IProgressService<double> progressService,
         ILoggerService loggerService,
         IPluginService pluginService,
-        ProjectResourceTools projectResourceTools) : base(ToolTitle)
+        ProjectResourceTools projectResourceTools,
+        IArchiveManagerLoader archiveManagerLoader) : base(ToolTitle)
     {
         _projectManager = projectManager;
         _notificationService = notificationService;
@@ -105,6 +107,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
         _loggerService = loggerService;
         _appViewModel = appViewModel;
         _projectResourceTools = projectResourceTools;
+        _archiveManagerLoader = archiveManagerLoader;
 
         ContentId = ToolContentId;
 
@@ -326,7 +329,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
         _isLoading = true;
         UpdateLoadArchiveButtonVisibility();
         UpdateLoadingIndicatorVisibility();
-        await _gameController.GetRed4Controller().HandleStartup();
+        await _archiveManagerLoader.LoadArchiveManagerAsync();
     }
 
     [RelayCommand]

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DynamicData;
@@ -149,6 +150,7 @@ namespace WolvenKit.RED4.CR2W.Archive
             baseFiles.Sort(CompareArchives);
 
             var totalCnt = baseFiles.Count;
+            var loadedArchives = new StringBuilder();
 
             var ep1Dir = Path.Combine(di.Parent.Parent.FullName, "archive", "pc", "ep1");
             if (Directory.Exists(ep1Dir))
@@ -159,7 +161,6 @@ namespace WolvenKit.RED4.CR2W.Archive
                 ep1Files.Sort(CompareArchives);
 
                 totalCnt += ep1Files.Count;
-                var archivePaths = "";
 
                 foreach (var file in ep1Files)
                 {
@@ -168,11 +169,9 @@ namespace WolvenKit.RED4.CR2W.Archive
                     LoadArchive(file, EArchiveSource.EP1);
                     cnt++;
 
-                    archivePaths +=
-                        $"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms\r\n";
+                    loadedArchives.AppendLine(
+                        $"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
                 }
-
-                _logger.Debug(archivePaths);
             }
 
             foreach (var file in baseFiles)
@@ -182,7 +181,13 @@ namespace WolvenKit.RED4.CR2W.Archive
                 LoadArchive(file, EArchiveSource.Base);
                 cnt++;
 
-                _logger.Debug($"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
+                loadedArchives.AppendLine(
+                    $"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
+            }
+
+            if (loadedArchives.Length > 0)
+            {
+                _logger.Debug(loadedArchives.ToString().TrimEnd());
             }
 
             sw.Stop();

--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -100,6 +100,7 @@ namespace WolvenKit
                     services.AddSingleton<IModifierViewStateService, ModifierViewStateService>();
                     services.AddSingleton<INodeSelectionService, NodeSelectionService>();
                     services.AddSingleton<IProjectEvents, ProjectEvents>();
+                    services.AddTransient<IArchiveManagerLoader, ArchiveManagerLoader>();
 
                     // factories
                     services.AddTransient<IPageViewModelFactory, PageViewModelFactory>();

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -260,6 +260,11 @@ namespace WolvenKit.Views.Shell
 
                 //set ready status
                 ViewModel.SetStatusReady();
+
+                // Not awaited -
+                // WhenActivated is synchronous and startup must not block on archive
+                // loading. InitializeAsync handles own failures, so discard is safe.
+                _ = ViewModel.InitializeAsync();
             });
         }
 


### PR DESCRIPTION
# Improve Archive Manager Load Times

**Fixed:**
- Fixes an issue where the app would wait until the user opens a project before it starts loading the CP77 game archives, slowing down project loading.
- Now the app starts loading the CP77 archives in the background as soon as possible after launch. This dramatically speeds up being able to start working on your projects after a fresh launch of WolvenKit.

**Additional notes:**
- Will become part of #2945 once its merged to dev and verified
- Works best once #3071 is also merged. 
- Resolves the below longstanding TODO from @rfuzzo by relocating the LoadCustomHashes method to the new class ArchiveManagerLoader:

https://github.com/WolvenKit/WolvenKit/blob/eadb315540ea4e70b9b791b33922aaa0c5e73086/WolvenKit.App/Controllers/RED4Controller.cs#L83-L87

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->