### PR TITLE
DockingAdapter: fix a bug with default layout load

### DIFF
--- a/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
+++ b/WolvenKit/Views/Shell/DockingAdapter.xaml.cs
@@ -141,6 +141,7 @@ namespace WolvenKit.Views.Shell
             var projectLayout = Path.Combine(_viewModel.ActiveProject.ProjectDirectory, "layout.xml");
             if (!File.Exists(projectLayout))
             {
+                LoadDefaultLayout();
                 return;
             }
 

--- a/changelog/unreleased/3080.yaml
+++ b/changelog/unreleased/3080.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3080
+      author: "gistya"
+      description: "Fixed an issue where previously open documents would not reopen for projects that use the default layout."


### PR DESCRIPTION
# DockingAdapter: fix a bug with default layout load

**Fixed:**
- fixes a bug where previously open files would not reopen if your project uses the default layout

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->