### PR TITLE
Fix ChunkVM: to properly handleTweakDB  exceptions

### DIFF
--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -804,8 +804,16 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
     {
         get
         {
-            var redName = GetRedTypeFromCSType(PropertyType, Flags);
-            return redName != "" ? redName : PropertyType.Name;
+            try
+            {
+                var redName = GetRedTypeFromCSType(PropertyType, Flags);
+                return redName != "" ? redName : PropertyType.Name;
+            }
+            catch (WolvenKitException ex)
+            {
+                _loggerService.Error($"File type could not be determined for a Tweak. Exception: ${ex.Message}");
+                return "";
+            }
         }
     }
 

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -822,7 +822,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                         $"File type could not be determined for a Tweak whose name could not be determined. Exceptions: {Environment.NewLine}1. {ex.Message}{Environment.NewLine}2, {ex2.Message}.");
                 }
 
-                return "";
+                return $"{PropertyType.Name}";
             }
         }
     }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -811,16 +811,8 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             }
             catch (Exception ex)
             {
-                try
-                {
-                    _loggerService.Error(
-                        $"File type could not be determined for a Tweak with name: {PropertyType.Name}. Exception: {ex.Message}.");
-                }
-                catch (Exception ex2)
-                {
-                    _loggerService.Error(
-                        $"File type could not be determined for a Tweak whose name could not be determined. Exceptions: {Environment.NewLine}1. {ex.Message}{Environment.NewLine}2, {ex2.Message}.");
-                }
+                _loggerService.Error(
+                    $"Redtype could not be determined for {Name} with C# type: {PropertyType.Name}. Exception: {ex.Message}.");
 
                 return PropertyType.Name;
             }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -809,14 +809,14 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                 var redName = GetRedTypeFromCSType(PropertyType, Flags);
                 return redName != "" ? redName : PropertyType.Name;
             }
-            catch (WolvenKitException ex)
+            catch (Exception ex)
             {
                 try
                 {
                     _loggerService.Error(
                         $"File type could not be determined for a Tweak with name: {PropertyType.Name}. Exception: {ex.Message}.");
                 }
-                catch (WolvenKitException ex2)
+                catch (Exception ex2)
                 {
                     _loggerService.Error(
                         $"File type could not be determined for a Tweak whose name could not be determined. Exceptions: {Environment.NewLine}1. {ex.Message}{Environment.NewLine}2, {ex2.Message}.");

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -811,7 +811,17 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
             }
             catch (WolvenKitException ex)
             {
-                _loggerService.Error($"File type could not be determined for a Tweak. Exception: ${ex.Message}");
+                try
+                {
+                    _loggerService.Error(
+                        $"File type could not be determined for a Tweak with name: {PropertyType.Name}. Exception: {ex.Message}.");
+                }
+                catch (WolvenKitException ex2)
+                {
+                    _loggerService.Error(
+                        $"File type could not be determined for a Tweak whose name could not be determined. Exceptions: {Environment.NewLine}1. {ex.Message}{Environment.NewLine}2, {ex2.Message}.");
+                }
+
                 return "";
             }
         }

--- a/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/ChunkViewModel.cs
@@ -822,7 +822,7 @@ public partial class ChunkViewModel : ObservableObject, ISelectableTreeViewItemM
                         $"File type could not be determined for a Tweak whose name could not be determined. Exceptions: {Environment.NewLine}1. {ex.Message}{Environment.NewLine}2, {ex2.Message}.");
                 }
 
-                return $"{PropertyType.Name}";
+                return PropertyType.Name;
             }
         }
     }


### PR DESCRIPTION
# Fix ChunkVM: to properly handleTweakDB  exceptions

**Fixed:**
- Fixes an issue where ChunkViewModel does not handle exceptions thrown by `GetRedTypeFromCSType` -- currently it just dumps a stacktrace into the app logs. 
- Now we'll catch the exception and run `_loggerService.Error` for a more sane output.

**Additional notes:**
closes_issue_number

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->