### PR TITLE
DispatcherHelper Threadsafety

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using WolvenKit.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// Covers DispatcherHelper repeating actions: that they actually tick, and that the
+/// reference-counted purpose registry lets several owners share one timer without any of them
+/// tearing it down while another still needs it.
+///
+/// Every test mints its own purpose, so this class needs no xunit collection and runs fully in
+/// parallel with the rest of the assembly.
+/// </summary>
+public class DispatcherHelperTests
+{
+    private static string UniquePurpose() => "test-purpose-" + Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// Drains the dispatcher queue until <paramref name="condition"/> holds or we time out.
+    ///
+    /// Invoking at a priority below Normal forces the queued DispatcherTimer ticks (Normal) to be
+    /// processed first — the standard "DoEvents" pump. Without this no DispatcherTimer would ever
+    /// fire in a unit test, because nothing is running a dispatcher frame.
+    /// </summary>
+    private static void PumpUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (!condition() && stopwatch.Elapsed < timeout)
+        {
+            dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+            Thread.Sleep(1);
+        }
+    }
+
+    [Fact]
+    public void StartRepeatingAction_ActuallyInvokesTheAction()
+    {
+        var purpose = UniquePurpose();
+        var ticks = 0;
+
+        using var handle = DispatcherHelper.StartRepeatingAction(
+            purpose,
+            () => Interlocked.Increment(ref ticks),
+            TimeSpan.FromMilliseconds(5));
+
+        PumpUntil(() => Volatile.Read(ref ticks) >= 2, TimeSpan.FromSeconds(10));
+
+        Assert.True(Volatile.Read(ref ticks) >= 2, $"expected at least 2 ticks, saw {ticks}");
+    }
+
+    [Fact]
+    public void DisposingLastHandle_StopsTheAction()
+    {
+        var purpose = UniquePurpose();
+        var ticks = 0;
+
+        var handle = DispatcherHelper.StartRepeatingAction(
+            purpose,
+            () => Interlocked.Increment(ref ticks),
+            TimeSpan.FromMilliseconds(5));
+
+        PumpUntil(() => Volatile.Read(ref ticks) >= 1, TimeSpan.FromSeconds(10));
+        handle.Dispose();
+
+        var afterDispose = Volatile.Read(ref ticks);
+        PumpUntil(() => false, TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(afterDispose, Volatile.Read(ref ticks));
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+
+    [Fact]
+    public void StartRepeatingAction_SamePurpose_SharesOneTimerAndRefCounts()
+    {
+        var purpose = UniquePurpose();
+        var firstActionRuns = 0;
+        var secondActionRuns = 0;
+
+        using var first = DispatcherHelper.StartRepeatingAction(
+            purpose, () => Interlocked.Increment(ref firstActionRuns), TimeSpan.FromMilliseconds(5));
+
+        using var second = DispatcherHelper.StartRepeatingAction(
+            purpose, () => Interlocked.Increment(ref secondActionRuns), TimeSpan.FromMilliseconds(5));
+
+        Assert.Equal(2, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+
+        PumpUntil(() => Volatile.Read(ref firstActionRuns) >= 1, TimeSpan.FromSeconds(10));
+
+        Assert.True(Volatile.Read(ref firstActionRuns) >= 1);
+        Assert.Equal(0, Volatile.Read(ref secondActionRuns));
+    }
+
+    [Fact]
+    public void ReleasingOneOfTwoHandles_KeepsTimerAliveForTheOther()
+    {
+        var purpose = UniquePurpose();
+
+        var first = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        var second = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+
+        second.Dispose();
+
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+        Assert.Equal(1, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+
+        first.Dispose();
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+        Assert.Equal(0, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+    }
+
+    [Fact]
+    public void OnCancelled_RunsOnceWhenLastHandleIsReleased()
+    {
+        var purpose = UniquePurpose();
+        var cancelledCalls = 0;
+
+        var first = DispatcherHelper.StartRepeatingAction(
+            purpose,
+            () => { },
+            TimeSpan.FromHours(1),
+            onCancelled: () => Interlocked.Increment(ref cancelledCalls));
+
+        var second = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+
+        second.Dispose();
+        Assert.Equal(0, Volatile.Read(ref cancelledCalls));
+
+        first.Dispose();
+        Assert.Equal(1, Volatile.Read(ref cancelledCalls));
+    }
+
+    [Fact]
+    public void Handle_Dispose_IsIdempotent()
+    {
+        var purpose = UniquePurpose();
+        var cancelledCalls = 0;
+
+        var handle = DispatcherHelper.StartRepeatingAction(
+            purpose,
+            () => { },
+            TimeSpan.FromHours(1),
+            onCancelled: () => Interlocked.Increment(ref cancelledCalls));
+
+        Assert.True(handle.IsActive);
+
+        handle.Dispose();
+        handle.Dispose();
+        handle.Dispose();
+
+        Assert.False(handle.IsActive);
+        Assert.Equal(1, Volatile.Read(ref cancelledCalls));
+        Assert.Equal(0, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+    }
+
+    [Fact]
+    public void StopRepeatingAction_NullHandle_IsNoOp()
+    {
+        DispatcherHelper.StopRepeatingAction(null);
+    }
+
+    [Fact]
+    public void StopRepeatingAction_AllowsRestartWithSamePurpose()
+    {
+        var purpose = UniquePurpose();
+
+        var first = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        first.Dispose();
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+
+        using var second = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+
+    [Fact]
+    public void StartRepeatingAction_DifferentPurposes_RunIndependently()
+    {
+        var a = UniquePurpose();
+        var b = UniquePurpose();
+
+        var first = DispatcherHelper.StartRepeatingAction(a, () => { }, TimeSpan.FromHours(1));
+        using var second = DispatcherHelper.StartRepeatingAction(b, () => { }, TimeSpan.FromHours(1));
+
+        first.Dispose();
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(a));
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(b));
+    }
+
+    [Fact]
+    public void StartRepeatingAction_RejectsEmptyPurposeAndNullAction()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            DispatcherHelper.StartRepeatingAction("", () => { }, TimeSpan.FromHours(1)));
+
+        Assert.Throws<ArgumentNullException>(() =>
+            DispatcherHelper.StartRepeatingAction(UniquePurpose(), null!, TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public async Task ConcurrentStartsAndStops_LeaveNoDanglingRegistration()
+    {
+        var purpose = UniquePurpose();
+        var handles = new ConcurrentBag<DispatcherHelper.RepeatingActionHandle>();
+
+        var starts = new Task[16];
+        for (var i = 0; i < starts.Length; i++)
+        {
+            starts[i] = Task.Run(() =>
+                handles.Add(DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1))));
+        }
+
+        await Task.WhenAll(starts);
+
+        Assert.Equal(starts.Length, handles.Count);
+        Assert.Equal(starts.Length, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+
+        await Task.WhenAll(handles.ToArray().Select(h => Task.Run(h.Dispose)).ToArray());
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(purpose));
+        Assert.Equal(0, DispatcherHelper.GetRepeatingActionRefCount(purpose));
+
+        using var restarted = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/LoadingHeartbeatCollections.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/LoadingHeartbeatCollections.cs
@@ -1,0 +1,33 @@
+using Xunit;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// Tests that drive the shared <see cref="WolvenKit.App.ViewModels.Tools.ProjectExplorerViewModel.LoadProjectPurpose"/>
+/// heartbeat.
+///
+/// That purpose is a process-wide constant baked into the view model, so these tests would
+/// otherwise observe each other's registrations. Sharing one xunit collection makes them run
+/// sequentially <em>with respect to each other</em>.
+///
+/// Deliberately does NOT set <c>DisableParallelization</c>: that would serialize this collection
+/// against the whole assembly. Collections run in parallel with one another by default, which is
+/// all we need — tests that use a purpose unique to the test need no collection at all.
+/// </summary>
+[CollectionDefinition(Name)]
+public class ProjectLoadHeartbeatCollection
+{
+    public const string Name = "ProjectLoadHeartbeat";
+}
+
+/// <summary>
+/// Same rationale for the shared
+/// <see cref="WolvenKit.App.Controllers.RED4Controller.ArchiveLoadingPurpose"/> heartbeat.
+/// It is a different purpose string, so this collection runs in parallel with
+/// <see cref="ProjectLoadHeartbeatCollection"/>.
+/// </summary>
+[CollectionDefinition(Name)]
+public class ArchiveLoadHeartbeatCollection
+{
+    public const string Name = "ArchiveLoadHeartbeat";
+}

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -134,11 +134,13 @@ public class RED4Controller : ObservableObject, IGameController
         }
     }
 
-    private Guid _loadingCompletion = Guid.NewGuid();
+    private DispatcherHelper.RepeatingActionHandle _loadingCompletion = new DispatcherHelper.RepeatingActionHandle(_purpose);
+    private static string _purpose = "project_loading_red4";
 
     private void EnableLoadingMode()
     {
         _loadingCompletion = DispatcherHelper.StartRepeatingAction(
+            purpose: _purpose,
             () =>
             {
                 _progressService.IsIndeterminate = true;

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -16,21 +16,19 @@ public static class DispatcherHelper
 
     private static readonly object s_repeatingActionsLock = new();
 
-    public static void RunOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+    public static void RunOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal) => Application.Current.RunOnUIThread(action, priority);
+
+    private static void RunOnUIThread(this DispatcherObject? d, Action action, DispatcherPriority priority = DispatcherPriority.Normal)
     {
-        // If in a unit test there is no current application, so use the current dispatcher.
-        if (TestHelper.InActiveTest)
+        // In a unit test / headless context there is no WPF Application and no Dispatcher.
+        // Run the action synchronously so code paths that rely on DispatcherHelper
+        // (DispatchedObservableCollection, etc.) continue to work.
+        if (d == null && Application.Current == null)
         {
-            Task.Run(action);
+            action();
             return;
         }
 
-        Application.Current.RunOnUIThread(action, priority);
-    }
-
-    private static void RunOnUIThread(this DispatcherObject? d, Action action,
-        DispatcherPriority priority = DispatcherPriority.Normal)
-    {
         if (d is not { Dispatcher: { } dispatcher })
         {
             return;

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -52,6 +52,59 @@ public static class DispatcherHelper
         }
     }
 
+    public static async Task RunOnMainThreadAsync(Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal) => await Application.Current.RunOnUIThreadAsync(action, priority);
+
+    private static async Task RunOnUIThreadAsync(this DispatcherObject? d, Func<Task> action, DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        // In a unit test / headless context there is no WPF Application and no Dispatcher.
+        // Run the action synchronously so code paths that rely on DispatcherHelper
+        // (DispatchedObservableCollection, etc.) continue to work.
+        if (d == null && Application.Current == null)
+        {
+            await action();
+            return;
+        }
+
+        if (d is not { Dispatcher: { } dispatcher })
+        {
+            return;
+        }
+
+        if (dispatcher.CheckAccess())
+        {
+            await action();
+        }
+        else
+        {
+            try
+            {
+                await dispatcher.InvokeAsync(action, priority);
+            }
+            catch (Exception)
+            {
+                // TODO: Add logger here?
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Queues the action to a fresh dispatcher frame, even when already on the UI thread
+    /// (unlike "RunOnMainThread", which runs inline in that case). Use when the
+    /// action must not run inside the currently executing event handler's stack.
+    /// </summary>
+    public static void PostOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
+    {
+        if (Application.Current is not { Dispatcher: { } dispatcher })
+        {
+            // Headless / unit-test context: run synchronously, matching the other helpers.
+            action();
+            return;
+        }
+
+        dispatcher.BeginInvoke(action, priority);
+    }
+
     /// <summary>
     /// Runs `action` on the main thread after specified delay, without blocking.
     /// </summary>

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -10,7 +11,10 @@ namespace WolvenKit.App.Helpers;
 //Assembly: HandyControl, Version=3.2.0.0, Culture=neutral, PublicKeyToken=45be8712787a1e5b
 public static class DispatcherHelper
 {
-    private static ConcurrentDictionary<Guid, DispatcherTimer> _dispatcherTimers = new();
+    private static readonly Dictionary<string, RepeatingActionState> s_repeatingActions =
+        new(StringComparer.Ordinal);
+
+    private static readonly object s_repeatingActionsLock = new();
 
     public static void RunOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal)
     {
@@ -89,55 +93,162 @@ public static class DispatcherHelper
         dispatcher.BeginInvoke(CheckCancellation, DispatcherPriority.Background);
     }
 
+    #region repeating actions
+
     /// <summary>
-    /// Repeats action every interval TimeSpan until the timer is
-    /// stopped by passing the returned guid to StopRepeatingAction.
+    /// Runs <paramref name="action"/> every <paramref name="interval"/> until every handle
+    /// returned for this purpose has been disposed.
     ///
-    /// Returns a Guid to call StopRepeatingSetter(guid) with, to stop it.
+    /// Acquisitions are reference counted: starting a purpose that is already running joins the
+    /// existing timer instead of throwing, and returns an independent handle. This lets several
+    /// owners (for example the transient RED4Controller instances that each drive the archive
+    /// loading indicator) share one heartbeat without one of them tearing it down while another
+    /// still needs it. <paramref name="action"/>, <paramref name="interval"/> and
+    /// <paramref name="onCancelled"/> are therefore only honoured for the FIRST acquirer — use a
+    /// purpose that is unique per owner when the work is instance-specific.
     ///
+    /// <paramref name="onCancelled"/> runs once, when the last handle is released.
     /// </summary>
-    /// <param name="action"></param>
-    /// <param name="interval"></param>
-    /// <param name="onCancelled"></param>
-    /// <returns>Guid</returns>
-    public static Guid StartRepeatingAction(
+    public static RepeatingActionHandle StartRepeatingAction(
+        string purpose,
         Action action,
         TimeSpan interval,
         Action? onCancelled = null)
     {
-        var guid = Guid.NewGuid();
-        DispatcherTimer timer = new()
-        {
-            Interval = interval,
-            Tag = onCancelled
-        };
+        ArgumentException.ThrowIfNullOrEmpty(purpose);
+        ArgumentNullException.ThrowIfNull(action);
 
-        _dispatcherTimers.TryAdd(guid, timer);
-
-        timer.Tick += (sender, e) =>
+        lock (s_repeatingActionsLock)
         {
-            if (sender is DispatcherTimer timer)
+            if (s_repeatingActions.TryGetValue(purpose, out var existing))
             {
-                action();
+                existing.RefCount++;
+                return new RepeatingActionHandle(purpose);
             }
-        };
 
-        timer.Start();
+            // Bind to the application dispatcher rather than whatever thread happens to call in.
+            // A DispatcherTimer created on a pool thread would attach to a dispatcher that never
+            // runs, and would silently never tick.
+            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+            var timer = new DispatcherTimer(DispatcherPriority.Normal, dispatcher) { Interval = interval };
+            timer.Tick += (_, _) => action();
 
-        return guid;
+            s_repeatingActions[purpose] = new RepeatingActionState
+            {
+                Timer = timer,
+                OnCancelled = onCancelled,
+                RefCount = 1
+            };
+
+            timer.Start();
+            return new RepeatingActionHandle(purpose);
+        }
     }
 
     /// <summary>
-    /// Call with a guid to cancel a repeating setter timer.
+    /// Releases a handle if it is non-null. Convenience for the common
+    /// "stop it if we started it" call site.
     /// </summary>
-    /// <param name="guid"></param>
-    public static void StopRepeatingAction(Guid guid)
+    public static void StopRepeatingAction(RepeatingActionHandle? handle) => handle?.Dispose();
+
+    /// <summary>
+    /// Returns true if a repeating action with the given purpose is currently running.
+    /// </summary>
+    public static bool IsRepeatingActionRunning(string purpose)
     {
-        if (_dispatcherTimers.TryRemove(guid, out DispatcherTimer? timer))
+        if (string.IsNullOrEmpty(purpose))
         {
-            var onCancelled = timer.Tag as Action;
-            timer.Stop();
-            onCancelled?.Invoke();
+            return false;
+        }
+
+        lock (s_repeatingActionsLock)
+        {
+            return s_repeatingActions.ContainsKey(purpose);
         }
     }
+
+    /// <summary>
+    /// Number of live handles currently sharing the given purpose (0 if not running).
+    /// Intended for diagnostics and tests.
+    /// </summary>
+    public static int GetRepeatingActionRefCount(string purpose)
+    {
+        if (string.IsNullOrEmpty(purpose))
+        {
+            return 0;
+        }
+
+        lock (s_repeatingActionsLock)
+        {
+            return s_repeatingActions.TryGetValue(purpose, out var state) ? state.RefCount : 0;
+        }
+    }
+
+    /// <summary>
+    /// Releases one claim on a purpose, stopping the timer when the last claim goes away.
+    /// </summary>
+    private static void ReleaseRepeatingAction(string purpose)
+    {
+        Action? onCancelled = null;
+
+        lock (s_repeatingActionsLock)
+        {
+            if (!s_repeatingActions.TryGetValue(purpose, out var state))
+            {
+                return;
+            }
+
+            state.RefCount--;
+            if (state.RefCount > 0)
+            {
+                return;
+            }
+
+            s_repeatingActions.Remove(purpose);
+            state.Timer.Stop();
+            onCancelled = state.OnCancelled;
+        }
+
+        // Invoked outside the lock: callbacks touch view models and the progress service, and
+        // must not be able to re-enter the registry while it is held.
+        onCancelled?.Invoke();
+    }
+
+    private sealed class RepeatingActionState
+    {
+        public required DispatcherTimer Timer { get; init; }
+        public required Action? OnCancelled { get; init; }
+
+        /// <summary>Number of live handles sharing this timer.</summary>
+        public int RefCount { get; set; }
+    }
+
+    /// <summary>
+    /// A live registration of a repeating action. Dispose to release this holder's claim;
+    /// the underlying timer stops once every holder has released it.
+    /// Disposal is idempotent and thread-safe.
+    /// </summary>
+    public sealed class RepeatingActionHandle : IDisposable
+    {
+        private int _released;
+
+        internal RepeatingActionHandle(string purpose) => Purpose = purpose;
+
+        public string Purpose { get; }
+
+        /// <summary>True until this handle is disposed. Does not imply the timer is still running.</summary>
+        public bool IsActive => Volatile.Read(ref _released) == 0;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) != 0)
+            {
+                return;
+            }
+
+            ReleaseRepeatingAction(Purpose);
+        }
+    }
+
+    #endregion repeating actions
 }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -64,6 +64,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     /// </summary>
     private const string s_toolTitle = "Project Explorer";
 
+    public const string LoadProjectPurpose = "ProjectExplorer load project";
+
     private readonly ILoggerService _loggerService;
     private readonly INotificationService _notificationService;
     private readonly IProjectManager _projectManager;
@@ -73,6 +75,14 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private readonly AppViewModel _appViewModel;
     public readonly IModifierViewStateService ModifierStateService;
     private readonly IWatcherService _projectWatcher;
+    private DispatcherHelper.RepeatingActionHandle? _autoSaveCancelToken;
+
+    /// <summary>
+    /// Autosave is per view model, so it gets a purpose unique to this instance. A shared
+    /// purpose would let a second Project Explorer either collide with, or silently inherit,
+    /// the first instance's autosave callback.
+    /// </summary>
+    private readonly string _autoSavePurpose = $"ProjectExplorer autosave {Guid.NewGuid():N}";
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(OpenInMlsbCommand))]
@@ -137,10 +147,12 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
         SelectedTabIndex = ActiveProject?.ActiveTab ?? 0;
 
+        _autoSaveCancelToken = null;
         _appViewModel.OnInitialProjectLoaded += AppViewModel_OnInitialProjectLoaded;
 
-        DispatcherHelper.StartRepeatingAction(
-            () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
+        DispatcherHelper.StopRepeatingAction(_autoSaveCancelToken);
+        _autoSaveCancelToken = DispatcherHelper.StartRepeatingAction(
+            purpose: _autoSavePurpose, () => Svc_ThreadIdleTenSeconds(null, EventArgs.Empty),
             TimeSpan.FromSeconds(10));
 
         s_instance = this;

--- a/changelog/unreleased/3091.yaml
+++ b/changelog/unreleased/3091.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "improved"
+      packages: ["App"]
+      pr-number: 3091
+      author: "gistya"
+      description: "Improved threadsafety of loading/saving timers and added new internal APIs to support async threadsafety for future improvements to UI responsiveness."

--- a/changelog/unreleased/3091.yaml
+++ b/changelog/unreleased/3091.yaml
@@ -1,6 +1,0 @@
-changes:
-    - type: "improved"
-      packages: ["App"]
-      pr-number: 3091
-      author: "gistya"
-      description: "Improved threadsafety of loading/saving timers and added new internal APIs to support async threadsafety for future improvements to UI responsiveness."


### PR DESCRIPTION
# DispatcherHelper Threadsafety

(click links for easily reviewable chunks)

**Implemented:**
- [Improved robustness for repeating timer API](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/c0a1735872c935131a64567ba32dbc249152763e)
- [Uptake the improved repeating timer API](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/7a5ee9fd5f9f7824573d8471a8468d1095e6fc63)
- [New unit tests for repeating timer API](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/d0bef7a42ac897dccd9003f190ca7b26f8079218)
- [Improved test compatibility for DispatcherHelper](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/5b9f433e754d8b0f276809a7eed3faed9a314af3)
- [Added new async APIs for to DispatcherHelper for future use](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/c2bf582bb7dc29cdd47cdd50ed658b385416f128)
- [Changelog](https://github.com/WolvenKit/WolvenKit/pull/3091/changes/b0ae2bc1dae514ddf3fb0c3e89f83fc17637c53d)

**Fixed:**
- Fixes a rare but possible scenario where a repeating timer could get stuck "on."

**Additional notes:**
- This is part of the effort to breakup #2945 into smaller PRs. 
- These changes are already on dev so will cause a merge conflict when merging main to dev. Once this is approved then I will preemptively merge main back to dev to resolve it. 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->