### PR TITLE
Cache, TweakDB, Hashing, Path, Reflection, Tests

### DIFF
--- a/Tests/WolvenKit.IntegrationTests/App/Services/HashServiceExtGlobalCacheTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/Services/HashServiceExtGlobalCacheTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using WolvenKit.App.Services;
+using WolvenKit.RED4.Types;
+using WolvenKit.RED4.Types.Pools;
+using Xunit;
+
+namespace WolvenKit.IntegrationTests.App.Services;
+
+/// <summary>
+/// Covers <see cref="HashServiceExt"/>'s global ref/tweak cache loading against a throwaway
+/// directory.
+///
+/// These deliberately never touch the real <c>%APPDATA%\REDModding\WolvenKit</c>.
+/// <see cref="TestHashServiceExt"/> overrides the directory
+/// so a test physically cannot reach the developer's own <c>custom_refs.txt</c>.
+/// </summary>
+[Collection(nameof(RedTypePoolCollection))]
+public sealed class HashServiceExtGlobalCacheTests : IDisposable
+{
+    /// <summary>Redirects only the global cache directory; everything else is the real service.</summary>
+    private sealed class TestHashServiceExt : HashServiceExt
+    {
+        private readonly string _directory;
+
+        public TestHashServiceExt(string directory) => _directory = directory;
+
+        protected override string GetGlobalCacheDirectory() => _directory;
+    }
+
+    private readonly string _directory;
+
+    public HashServiceExtGlobalCacheTests()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "wk-globalcache-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, true);
+        }
+        catch (IOException)
+        {
+            // a leaked temp directory must never fail a test run
+        }
+    }
+
+    private string RefsPath => Path.Combine(_directory, "custom_refs.txt");
+
+    private string TweaksPath => Path.Combine(_directory, "custom_tweaks.txt");
+
+    private string LegacyRefsPath => Path.Combine(_directory, "user_hashes.txt");
+
+    private HashServiceExt NewService() => new TestHashServiceExt(_directory);
+
+    /// <summary>Loads, saves, and returns what actually landed on disk.</summary>
+    private (List<string> Refs, List<string> Tweaks) RoundTrip()
+    {
+        var service = NewService();
+        service.LoadGlobalCache();
+        service.SaveGlobalCache();
+
+        return (ReadAllLinesOrEmpty(RefsPath), ReadAllLinesOrEmpty(TweaksPath));
+    }
+
+    private static List<string> ReadAllLinesOrEmpty(string path) =>
+        File.Exists(path) ? File.ReadAllLines(path).ToList() : new List<string>();
+
+    /// <summary>Mirrors the production ordering, which is List&lt;string&gt;.Sort() - culture-sensitive.</summary>
+    private static List<string> ProductionSorted(IEnumerable<string> values)
+    {
+        var list = values.Distinct().ToList();
+        list.Sort();
+        return list;
+    }
+
+    [Fact]
+    public void LoadGlobalCache_WithNoFilesPresent_DoesNothing()
+    {
+        var service = NewService();
+
+        service.LoadGlobalCache();
+        service.SaveGlobalCache();
+
+        // an empty cache must not create files, or every launch would litter the data directory
+        Assert.False(File.Exists(RefsPath));
+        Assert.False(File.Exists(TweaksPath));
+    }
+
+    [Fact]
+    public void LoadGlobalCache_ReadsCustomRefs()
+    {
+        var paths = new[]
+        {
+            @"globalcachetest\alpha\one.mesh",
+            @"globalcachetest\beta\two.mesh",
+            @"globalcachetest\gamma\three.ent",
+        };
+        File.WriteAllLines(RefsPath, paths);
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Equal(ProductionSorted(paths), refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_ReadsCustomTweaks()
+    {
+        var names = new[]
+        {
+            "GlobalCacheTest.Alpha",
+            "GlobalCacheTest.Beta",
+        };
+        File.WriteAllLines(TweaksPath, names);
+
+        var (_, tweaks) = RoundTrip();
+
+        Assert.Equal(ProductionSorted(names), tweaks);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_ReadsBothFilesIndependently()
+    {
+        File.WriteAllLines(RefsPath, new[] { @"globalcachetest\both\ref.mesh" });
+        File.WriteAllLines(TweaksPath, new[] { "GlobalCacheTest.Both" });
+
+        var (refs, tweaks) = RoundTrip();
+
+        Assert.Equal(new[] { @"globalcachetest\both\ref.mesh" }, refs);
+        Assert.Equal(new[] { "GlobalCacheTest.Both" }, tweaks);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_DeduplicatesRepeatedEntries()
+    {
+        const string duplicated = @"globalcachetest\dupe\entry.mesh";
+        File.WriteAllLines(RefsPath, new[] { duplicated, duplicated, duplicated });
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Equal(new[] { duplicated }, refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_PreservesRawTextRatherThanSanitizing()
+    {
+        // the cache stores the line as written; only the pool hash is sanitized
+        const string unsanitized = @"GLOBALCACHETEST/RAW//ENTRY.MESH";
+        File.WriteAllLines(RefsPath, new[] { unsanitized });
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Equal(new[] { unsanitized }, refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_SurvivesBlankAndWhitespaceLines()
+    {
+        File.WriteAllLines(RefsPath, new[] { @"globalcachetest\blank\a.mesh", "", "   ", @"globalcachetest\blank\b.mesh" });
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Contains(@"globalcachetest\blank\a.mesh", refs);
+        Assert.Contains(@"globalcachetest\blank\b.mesh", refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_HandlesCrLfAndLfLineEndings()
+    {
+        File.WriteAllText(RefsPath, "globalcachetest\\eol\\crlf.mesh\r\nglobalcachetest\\eol\\lf.mesh\n");
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Contains(@"globalcachetest\eol\crlf.mesh", refs);
+        Assert.Contains(@"globalcachetest\eol\lf.mesh", refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_HandlesNonAsciiEntries()
+    {
+        var paths = new[] { @"globalcachetest\ünïcödé\file.mesh", @"globalcachetest\日本語\file.mesh" };
+        File.WriteAllLines(RefsPath, paths);
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Equal(ProductionSorted(paths), refs);
+    }
+
+    [Fact]
+    public void SaveGlobalCache_WritesSortedOutput()
+    {
+        var paths = new[]
+        {
+            @"globalcachetest\sort\zulu.mesh",
+            @"globalcachetest\sort\alpha.mesh",
+            @"globalcachetest\sort\mike.mesh",
+        };
+        File.WriteAllLines(RefsPath, paths);
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Equal(ProductionSorted(paths), refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_MigratesLegacyUserHashesFile()
+    {
+        const string legacy = @"globalcachetest\legacy\migrated.mesh";
+        File.WriteAllLines(LegacyRefsPath, new[] { legacy });
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Contains(legacy, refs);
+
+        // the legacy file is consumed, so migration cannot run twice
+        Assert.False(File.Exists(LegacyRefsPath));
+    }
+
+    [Fact]
+    public void LoadGlobalCache_MergesLegacyAndCurrentRefs()
+    {
+        const string legacy = @"globalcachetest\merge\legacy.mesh";
+        const string current = @"globalcachetest\merge\current.mesh";
+
+        File.WriteAllLines(LegacyRefsPath, new[] { legacy });
+        File.WriteAllLines(RefsPath, new[] { current });
+
+        var (refs, _) = RoundTrip();
+
+        Assert.Contains(legacy, refs);
+        Assert.Contains(current, refs);
+        Assert.False(File.Exists(LegacyRefsPath));
+    }
+
+    [Fact]
+    public void LoadGlobalCache_ReplacesPreviousContentsOnReload()
+    {
+        var service = NewService();
+
+        File.WriteAllLines(RefsPath, new[] { @"globalcachetest\reload\first.mesh" });
+        service.LoadGlobalCache();
+
+        File.WriteAllLines(RefsPath, new[] { @"globalcachetest\reload\second.mesh" });
+        service.LoadGlobalCache();
+        service.SaveGlobalCache();
+
+        var refs = ReadAllLinesOrEmpty(RefsPath);
+
+        // LoadGlobalCache clears before repopulating, so the first entry must be gone
+        Assert.Equal(new[] { @"globalcachetest\reload\second.mesh" }, refs);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_IsStableAcrossRepeatedRoundTrips()
+    {
+        var paths = new[] { @"globalcachetest\stable\a.mesh", @"globalcachetest\stable\b.mesh" };
+        File.WriteAllLines(RefsPath, paths);
+
+        var first = RoundTrip().Refs;
+        var second = RoundTrip().Refs;
+        var third = RoundTrip().Refs;
+
+        Assert.Equal(first, second);
+        Assert.Equal(second, third);
+    }
+
+    [Fact]
+    public void LoadGlobalCache_RegistersEntriesWithTheResourcePathPool()
+    {
+        // deliberately unsanitized: the pool must key off the sanitized form
+        const string raw = @"GLOBALCACHETEST/POOL//REGISTERED.MESH";
+        File.WriteAllLines(RefsPath, new[] { raw });
+
+        var service = NewService();
+        service.LoadGlobalCache();
+
+        var sanitized = ResourcePath.SanitizePath(raw);
+        var hash = ResourcePath.CalculateHash(sanitized, false);
+
+        Assert.Equal(sanitized, ResourcePathPool.ResolveHash(hash));
+    }
+
+    [Fact]
+    public void LoadGlobalCache_RegistersEntriesWithTheTweakDbIdPool()
+    {
+        const string name = "GlobalCacheTest.PoolRegistered";
+        File.WriteAllLines(TweaksPath, new[] { name });
+
+        var service = NewService();
+        service.LoadGlobalCache();
+
+        Assert.Equal(name, TweakDBIDPool.ResolveHash(TweakDBID.CalculateHash(name)));
+    }
+
+    [Fact]
+    public void SaveGlobalCache_WithoutLoad_DoesNotCreateFiles()
+    {
+        var service = NewService();
+
+        service.SaveGlobalCache();
+
+        Assert.False(File.Exists(RefsPath));
+        Assert.False(File.Exists(TweaksPath));
+    }
+
+    [Fact]
+    public void GlobalCacheDirectory_IsRedirected_SoRealAppDataIsNeverTouched()
+    {
+        // The guard for every other test here: if the seam were not in effect, the write below would
+        // land in the developer's real %APPDATA% instead of the temp directory.
+        File.WriteAllLines(RefsPath, new[] { @"globalcachetest\seam\proof.mesh" });
+
+        var service = NewService();
+        service.LoadGlobalCache();
+        service.SaveGlobalCache();
+
+        Assert.True(File.Exists(RefsPath));
+        Assert.Contains(@"globalcachetest\seam\proof.mesh", File.ReadAllLines(RefsPath));
+
+        var realAppData = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "REDModding", "WolvenKit");
+
+        Assert.False(string.Equals(_directory, realAppData, StringComparison.OrdinalIgnoreCase));
+    }
+}
+
+/// <summary>
+/// Serializes tests that mutate the process-wide RED4 type pools.
+/// Otherwise these tests will mess with each others' caches and get messed up.
+/// </summary>
+[CollectionDefinition(nameof(RedTypePoolCollection), DisableParallelization = true)]
+public class RedTypePoolCollection;

--- a/Tests/WolvenKit.UnitTests/MemoryOptimizationRegressionTests.cs
+++ b/Tests/WolvenKit.UnitTests/MemoryOptimizationRegressionTests.cs
@@ -1,0 +1,653 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.Common.FNV1A;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.CRC;
+using WolvenKit.Core.Extensions;
+using WolvenKit.Core.Helpers;
+using WolvenKit.RED4.Types;
+using WolvenKit.RED4.Types.Pools;
+
+namespace WolvenKit.UnitTests
+{
+    /// <summary>
+    /// Behavioral regression suite for upcoming future memory optimization fixes.
+    /// </summary>
+    [TestClass]
+    public class MemoryOptimizationRegressionTests
+    {
+        #region Hash stability
+
+        [TestMethod]
+        public void ResourcePath_CalculateHash_IsStable()
+        {
+            Assert.AreEqual(8995421073019654957UL, ResourcePath.CalculateHash(@"base\characters\head.mesh", false));
+            Assert.AreEqual(12638187200555641996UL, ResourcePath.CalculateHash("a", false));
+            Assert.AreEqual(14695981039346656037UL, ResourcePath.CalculateHash(""));
+        }
+
+        [TestMethod]
+        public void ResourcePath_CalculateHash_SanitizesBeforeHashing()
+        {
+            Assert.AreEqual(
+                ResourcePath.CalculateHash(@"base\characters\head.mesh", false),
+                ResourcePath.CalculateHash("BASE/CHARACTERS//HEAD.MESH"));
+
+            Assert.AreEqual(
+                ResourcePath.CalculateHash(@"base\characters\head.mesh", false),
+                ResourcePath.CalculateHash("  '/BASE\\CHARACTERS//HEAD.MESH/'  "));
+        }
+
+        [TestMethod]
+        public void NodeRef_CalculateHash_IsStable()
+        {
+            Assert.AreEqual(4796743598250670598UL, NodeRef.CalculateHash("$/03_night_city/#c_city_center"));
+            Assert.AreEqual(8824766866764965240UL, NodeRef.CalculateHash("$/a/b/c"));
+            Assert.AreEqual(18252272687975150087UL, NodeRef.CalculateHash("plain"));
+            Assert.AreEqual(13215270091511151672UL, NodeRef.CalculateHash("$/x;#alias/y"));
+            Assert.AreEqual(0UL, NodeRef.CalculateHash(""));
+        }
+
+        [TestMethod]
+        public void NodeRef_CalculateHash_SkipsAliasMarkers()
+        {
+            // '#' is skipped, so these are the same path as far as the hash is concerned
+            Assert.AreEqual(NodeRef.CalculateHash("$/a/b/c"), NodeRef.CalculateHash("$/a/#b/c"));
+
+            // a trailing ';#alias' segment is skipped entirely - this collision is by design and is
+            // why some noderefs legitimately resolve to a different string than they were built from
+            Assert.AreEqual(NodeRef.CalculateHash("$/x/#a"), NodeRef.CalculateHash("$/x/#a;#b"));
+        }
+
+        [TestMethod]
+        public void TweakDBID_CalculateHash_IsStable()
+        {
+            Assert.AreEqual(124763843892UL, TweakDBID.CalculateHash("Items.Preset_Lexington_Wilson"));
+            Assert.AreEqual(61847598093UL, TweakDBID.CalculateHash("Character.Test"));
+            Assert.AreEqual(0UL, TweakDBID.CalculateHash(""));
+        }
+
+        [TestMethod]
+        public void TweakDBID_CalculateHash_EncodesLengthInHighBits()
+        {
+            const string name = "Character.Test";
+            Assert.AreEqual((ulong)name.Length, TweakDBID.CalculateHash(name) >> 32);
+        }
+
+        [TestMethod]
+        public void Fnv1A64_IsStable()
+        {
+            Assert.AreEqual(18007334074686647077UL, FNV1A64HashAlgorithm.HashString("test"));
+            Assert.AreEqual(8995421073019654957UL, FNV1A64HashAlgorithm.HashString(@"base\characters\head.mesh"));
+            Assert.AreEqual(5967113427344870998UL, FNV1A64HashAlgorithm.HashString("tëst", Encoding.UTF8, false, true));
+            Assert.AreEqual(8824766866764965240UL, FNV1A64HashAlgorithm.HashStringWithoutAliases("$/a/#b/c"));
+            Assert.AreEqual(17076895143540190469UL, FNV1A64HashAlgorithm.HashStringWithoutAliases("$/test/important;#alias/1"));
+        }
+
+        [TestMethod]
+        public void Fnv1A64_HashReadOnlySpanBytes_MatchesAsciiHashString()
+        {
+            foreach (var s in new[] { "", "a", @"base\characters\head.mesh", "0123456789" })
+            {
+                Assert.AreEqual(
+                    FNV1A64HashAlgorithm.HashString(s),
+                    FNV1A64HashAlgorithm.HashReadOnlySpan(Encoding.ASCII.GetBytes(s).AsSpan()),
+                    $"input: {s}");
+            }
+        }
+
+        [TestMethod]
+        public void Crc32_IsStable()
+        {
+            Assert.AreEqual(907060870u, Crc32Algorithm.Compute("hello"));
+            Assert.AreEqual(209792308u, Crc32Algorithm.Compute("Items.Preset_Lexington_Wilson"));
+        }
+
+        #endregion
+
+        #region SanitizePath
+
+        [TestMethod]
+        [DataRow(null, "")]
+        [DataRow("", "")]
+        [DataRow("    ", "")]
+        [DataRow("///\\\\\\", "")]
+        [DataRow("'\"'", "")]
+        [DataRow("a", "a")]
+        [DataRow("A", "a")]
+        [DataRow("/a/", "a")]
+        [DataRow("a//b", "a\\b")]
+        [DataRow("a\\\\b", "a\\b")]
+        [DataRow("a/\\/\\b", "a\\b")]
+        [DataRow("a.b.c", "a.b.c")]
+        [DataRow("BASE/CHARACTERS//HEAD.MESH", "base\\characters\\head.mesh")]
+        [DataRow("'base\\test.mesh'", "base\\test.mesh")]
+        [DataRow("  \"base/test.mesh\"  \r\n", "base\\test.mesh")]
+        [DataRow("\\\\server\\\\share\\\\file", "server\\share\\file")]
+        public void SanitizePath_ProducesExpectedResult(string? input, string expected) =>
+            Assert.AreEqual(expected, ResourcePath.SanitizePath(input));
+
+        [TestMethod]
+        public void SanitizePath_IsIdempotent()
+        {
+            foreach (var s in new[]
+                     {
+                         "BASE/CHARACTERS//HEAD.MESH", "  '/a//b/'  ", "a", "", "ÄÖÜ\\FILE", "𐐀/𐐁",
+                     })
+            {
+                var once = ResourcePath.SanitizePath(s);
+                Assert.AreEqual(once, ResourcePath.SanitizePath(once), $"input: {s}");
+            }
+        }
+
+        [TestMethod]
+        public void SanitizePath_HandlesLengthsAroundInternalBufferBoundary()
+        {
+            foreach (var length in new[] { 1, 255, 256, 257, 512, 4096 })
+            {
+                var input = string.Join("\\", Enumerable.Repeat("SEGMENT", (length / 8) + 1));
+                Assert.AreEqual(SanitizePathReference(input), ResourcePath.SanitizePath(input), $"length {length}");
+            }
+        }
+
+        [TestMethod]
+        public void SanitizePath_MatchesReference_ForRandomInput()
+        {
+            var alphabets = new[]
+            {
+                "ab\\/".ToCharArray(),
+                "aA\\/'\" \r\n.".ToCharArray(),
+                "abcABC123\\/_-. '\"\r\n".ToCharArray(),
+                "aAbBäÄöÖßİıΣσςÆæ\\/. ".ToCharArray(),
+            };
+
+            var rng = new Random(20260807);
+
+            for (var iteration = 0; iteration < 50_000; iteration++)
+            {
+                var alphabet = alphabets[rng.Next(alphabets.Length)];
+                var builder = new StringBuilder();
+
+                var length = rng.Next(0, 40);
+                for (var i = 0; i < length; i++)
+                {
+                    if (rng.Next(40) == 0)
+                    {
+                        builder.Append(char.ConvertFromUtf32(0x10400 + rng.Next(0x28)));
+                        continue;
+                    }
+
+                    builder.Append(alphabet[rng.Next(alphabet.Length)]);
+                }
+
+                var input = builder.ToString();
+                Assert.AreEqual(SanitizePathReference(input), ResourcePath.SanitizePath(input), $"input: <{input}>");
+            }
+        }
+
+        private static string SanitizePathReference(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return "";
+            }
+
+            var strResult = new StringBuilder();
+
+            char[] trimChars = { '\'', '"', '/', '\\', ' ', '\n', '\r' };
+            text = text.Trim(trimChars);
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (strResult.Length == 0)
+                {
+                    strResult.Append(text[i]);
+                    continue;
+                }
+
+                if (text[i] == '\\' || text[i] == '/')
+                {
+                    if (strResult[^1] != ResourcePath.DirectorySeparatorChar)
+                    {
+                        strResult.Append(ResourcePath.DirectorySeparatorChar);
+                    }
+
+                    continue;
+                }
+
+                strResult.Append(text[i]);
+            }
+
+            return strResult.ToString().ToLowerInvariant();
+        }
+
+        #endregion
+
+        #region ReadLengthPrefixedString
+
+        private static BinaryReader ReaderOver(byte[] bytes) => new(new MemoryStream(bytes));
+
+        private static byte[] WriteUtf16Prefixed(params string[] values)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+
+            foreach (var value in values)
+            {
+                // a positive prefix selects UTF-16; the writer helper only ever emits UTF-8, so the
+                // UTF-16 read path has to be constructed by hand
+                bw.WriteVLQInt32(value.Length);
+                bw.Write(Encoding.Unicode.GetBytes(value));
+            }
+
+            bw.Flush();
+            return ms.ToArray();
+        }
+
+        private static byte[] WriteUtf8Prefixed(params string[] values)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+
+            foreach (var value in values)
+            {
+                bw.WriteLengthPrefixedString(value);
+            }
+
+            bw.Flush();
+            return ms.ToArray();
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("a")]
+        [DataRow("abc")]
+        [DataRow(@"base\characters\head.mesh")]
+        [DataRow("ünïcödé ßtring")]
+        [DataRow("𐐀 surrogate pair 😀")]
+        public void ReadLengthPrefixedString_RoundTripsUtf8(string value)
+        {
+            using var reader = ReaderOver(WriteUtf8Prefixed(value));
+            Assert.AreEqual(value, reader.ReadLengthPrefixedString());
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("a")]
+        [DataRow("abc")]
+        [DataRow("ünïcödé")]
+        public void ReadLengthPrefixedString_ReadsUtf16(string value)
+        {
+            using var reader = ReaderOver(WriteUtf16Prefixed(value));
+            Assert.AreEqual(value, reader.ReadLengthPrefixedString());
+        }
+
+        [TestMethod]
+        public void ReadLengthPrefixedString_HandlesLengthsAroundInternalBufferBoundary()
+        {
+            // the optimized reader stack-allocates at or below 256 bytes and rents above it
+            foreach (var charCount in new[] { 1, 127, 128, 129, 255, 256, 257, 1000 })
+            {
+                var value = new string('x', charCount);
+
+                using (var utf8 = ReaderOver(WriteUtf8Prefixed(value)))
+                {
+                    Assert.AreEqual(value, utf8.ReadLengthPrefixedString(), $"utf8, {charCount} chars");
+                }
+
+                using var utf16 = ReaderOver(WriteUtf16Prefixed(value));
+                Assert.AreEqual(value, utf16.ReadLengthPrefixedString(), $"utf16, {charCount} chars");
+            }
+        }
+
+        [TestMethod]
+        public void ReadLengthPrefixedString_ReadsSequentiallyWithoutCorruption()
+        {
+            // guards buffer reuse: a pooled/stack buffer must not leak between consecutive reads
+            var values = new[] { "first", "", "third-is-considerably-longer", "d", new string('z', 400), "last" };
+
+            using var reader = ReaderOver(WriteUtf8Prefixed(values));
+            foreach (var expected in values)
+            {
+                Assert.AreEqual(expected, reader.ReadLengthPrefixedString());
+            }
+        }
+
+        [TestMethod]
+        public void ReadLengthPrefixedString_AdvancesStreamByExactlyTheEncodedLength()
+        {
+            var bytes = WriteUtf8Prefixed("alpha", "beta");
+            using var stream = new MemoryStream(bytes);
+            using var reader = new BinaryReader(stream);
+
+            Assert.AreEqual("alpha", reader.ReadLengthPrefixedString());
+            var afterFirst = stream.Position;
+
+            Assert.AreEqual("beta", reader.ReadLengthPrefixedString());
+            Assert.AreEqual(bytes.Length, stream.Position);
+            Assert.IsTrue(afterFirst > 0 && afterFirst < bytes.Length);
+        }
+
+        [TestMethod]
+        public void ReadVLQInt32_RoundTrips()
+        {
+            foreach (var value in new[] { 0, 1, 63, 64, 8191, 8192, 1_048_575, 1_048_576, -1, -63, -64, -8192 })
+            {
+                using var ms = new MemoryStream();
+                using (var bw = new BinaryWriter(ms, Encoding.UTF8, true))
+                {
+                    bw.WriteVLQInt32(value);
+                }
+
+                ms.Position = 0;
+                using var br = new BinaryReader(ms);
+                Assert.AreEqual(value, br.ReadVLQInt32(), $"value {value}");
+            }
+        }
+
+        #endregion
+
+        #region LookupTable
+
+        [TestMethod]
+        public void LookupTable_Empty_FindsNothing()
+        {
+            var table = new LookupTable();
+
+            Assert.IsFalse(table.ContainsKey(0));
+            Assert.IsFalse(table.ContainsKey(12345));
+            Assert.IsFalse(table.TryGetValue(12345, out var value));
+            Assert.IsNull(value);
+            Assert.AreEqual(0, table.Count());
+        }
+
+        [TestMethod]
+        public void LookupTable_FromKeysAndValues_ResolvesEveryEntry()
+        {
+            var keys = new ulong[] { 30, 10, 20, 40 };
+            var values = new[] { "thirty", "ten", "twenty", "forty" };
+
+            var table = new LookupTable(keys, values);
+
+            for (var i = 0; i < keys.Length; i++)
+            {
+                Assert.IsTrue(table.ContainsKey(keys[i]), $"missing key {keys[i]}");
+                Assert.IsTrue(table.TryGetValue(keys[i], out var actual));
+                Assert.AreEqual(values[i], actual);
+            }
+
+            Assert.IsFalse(table.ContainsKey(999));
+            Assert.IsFalse(table.TryGetValue(999, out var missing));
+            Assert.IsNull(missing);
+        }
+
+        [TestMethod]
+        public void LookupTable_FromKeysAndValues_EnumeratesSortedByKey()
+        {
+            var table = new LookupTable(new ulong[] { 30, 10, 20 }, new[] { "thirty", "ten", "twenty" });
+
+            var pairs = table.ToList();
+
+            CollectionAssert.AreEqual(new ulong[] { 10, 20, 30 }, pairs.Select(p => p.Key).ToArray());
+            CollectionAssert.AreEqual(new[] { "ten", "twenty", "thirty" }, pairs.Select(p => p.Value).ToArray());
+        }
+
+        [TestMethod]
+        public void LookupTable_FromKeysAndValues_ThrowsOnLengthMismatch() =>
+            Assert.ThrowsException<ArgumentException>(() => new LookupTable(new ulong[] { 1, 2 }, new[] { "one" }));
+
+        [TestMethod]
+        public void LookupTable_FromValuesAndHashFunc_ResolvesEveryEntry()
+        {
+            var values = new[] { "alpha", "beta", "gamma", "delta", "epsilon" };
+
+            var table = new LookupTable(values, 1, s => FNV1A64HashAlgorithm.HashString(s));
+
+            foreach (var value in values)
+            {
+                var hash = FNV1A64HashAlgorithm.HashString(value);
+                Assert.IsTrue(table.ContainsKey(hash), $"missing {value}");
+                Assert.IsTrue(table.TryGetValue(hash, out var actual));
+                Assert.AreEqual(value, actual);
+            }
+        }
+
+        [TestMethod]
+        public void LookupTable_FromValuesAndHashFunc_ParallelAndSerialAgree()
+        {
+            var values = Enumerable.Range(0, 5000).Select(i => $"base\\path\\file_{i}.mesh").ToArray();
+
+            var serial = new LookupTable(values, 1, s => FNV1A64HashAlgorithm.HashString(s));
+            var parallel = new LookupTable(values, 8, s => FNV1A64HashAlgorithm.HashString(s));
+
+            CollectionAssert.AreEqual(serial.ToList(), parallel.ToList());
+
+            foreach (var value in values)
+            {
+                var hash = FNV1A64HashAlgorithm.HashString(value);
+                Assert.IsTrue(parallel.TryGetValue(hash, out var actual));
+                Assert.AreEqual(value, actual);
+            }
+        }
+
+        [TestMethod]
+        public void LookupTable_HandlesUnicodeAndEmptyValues()
+        {
+            var values = new[] { "", "ünïcödé", "𐐀surrogate", "ΣΊΣΥΦΟΣ", "plain" };
+
+            var table = new LookupTable(values, 1, s => FNV1A64HashAlgorithm.HashString(s, Encoding.UTF8));
+
+            foreach (var value in values)
+            {
+                var hash = FNV1A64HashAlgorithm.HashString(value, Encoding.UTF8);
+                Assert.IsTrue(table.TryGetValue(hash, out var actual), $"missing <{value}>");
+                Assert.AreEqual(value, actual);
+            }
+        }
+
+        [TestMethod]
+        public void LookupTable_SingleEntry_Resolves()
+        {
+            var table = new LookupTable(new ulong[] { 42 }, new[] { "answer" });
+
+            Assert.IsTrue(table.TryGetValue(42, out var value));
+            Assert.AreEqual("answer", value);
+            Assert.IsFalse(table.ContainsKey(41));
+            Assert.IsFalse(table.ContainsKey(43));
+        }
+
+        [TestMethod]
+        public void LookupTable_LargeTable_ResolvesEveryEntry()
+        {
+            const int count = 20_000;
+            var keys = Enumerable.Range(0, count).Select(i => (ulong)(i * 7919)).ToArray();
+            var values = Enumerable.Range(0, count).Select(i => $"value_{i}").ToArray();
+
+            var table = new LookupTable(keys, values);
+
+            for (var i = 0; i < count; i++)
+            {
+                Assert.IsTrue(table.TryGetValue(keys[i], out var actual), $"missing index {i}");
+                Assert.AreEqual(values[i], actual);
+            }
+        }
+
+        #endregion
+
+        #region Pool round-trips
+
+        // AddOrGetHash only ever adds to the runtime pool, so these are additive and cannot disturb
+        // other tests. Names are deliberately unique to this suite.
+
+        [TestMethod]
+        public void ResourcePathPool_AddOrGetHash_RoundTripsSanitized()
+        {
+            const string raw = "REGRESSIONTEST/Pool//Path.MESH";
+            var expected = ResourcePath.SanitizePath(raw);
+
+            var hash = ResourcePathPool.AddOrGetHash(raw);
+
+            Assert.AreEqual(ResourcePath.CalculateHash(expected, false), hash);
+            Assert.AreEqual(expected, ResourcePathPool.ResolveHash(hash));
+            Assert.IsTrue(ResourcePathPool.IsRuntime(hash) || ResourcePathPool.IsNative(hash));
+        }
+
+        [TestMethod]
+        public void ResourcePathPool_AddOrGetHash_IsStableAcrossCalls()
+        {
+            const string raw = @"regressiontest\pool\stable.mesh";
+
+            Assert.AreEqual(ResourcePathPool.AddOrGetHash(raw), ResourcePathPool.AddOrGetHash(raw));
+            Assert.AreEqual(ResourcePathPool.AddOrGetHash(raw), ResourcePathPool.AddOrGetHash("REGRESSIONTEST/POOL//STABLE.MESH"));
+        }
+
+        [TestMethod]
+        public void TweakDBIDPool_AddOrGetHash_RoundTrips()
+        {
+            const string name = "RegressionTest.PoolEntry";
+
+            var hash = TweakDBIDPool.AddOrGetHash(name);
+
+            Assert.AreEqual(TweakDBID.CalculateHash(name), hash);
+            Assert.AreEqual(name, TweakDBIDPool.ResolveHash(hash));
+        }
+
+        [TestMethod]
+        public void NodeRefPool_AddOrGetHash_RoundTrips()
+        {
+            const string nodeRef = "$/regressiontest/pool/entry";
+
+            var hash = NodeRefPool.AddOrGetHash(nodeRef);
+
+            Assert.AreEqual(NodeRef.CalculateHash(nodeRef), hash);
+            Assert.AreEqual(nodeRef, NodeRefPool.ResolveHash(hash));
+        }
+
+        [TestMethod]
+        public void NodeRefPool_AddOrGetHash_HandlesAliasSyntaxWithoutThrowing()
+        {
+            foreach (var nodeRef in new[]
+                     {
+                         "$/regressiontest/alias/#marker/tail",
+                         "$/regressiontest/important;#alias/123",
+                         "$/regressiontest/#tailonly",
+                     })
+            {
+                var hash = NodeRefPool.AddOrGetHash(nodeRef);
+                Assert.AreEqual(NodeRef.CalculateHash(nodeRef), hash, $"hash mismatch for {nodeRef}");
+                Assert.AreEqual(nodeRef, NodeRefPool.ResolveHash(hash), $"round-trip failed for {nodeRef}");
+            }
+        }
+
+        [TestMethod]
+        public void NodeRefPool_AddOrGetHash_EmptyIsZero() => Assert.AreEqual(0UL, NodeRefPool.AddOrGetHash(""));
+
+        [TestMethod]
+        public void CNamePool_ResolvesNone() => Assert.AreEqual("None", CNamePool.ResolveHash(0));
+
+        [TestMethod]
+        public void ResourcePath_ImplicitConversion_RoundTrips()
+        {
+            ResourcePath path = @"regressiontest\implicit\conversion.mesh";
+            Assert.AreEqual(@"regressiontest\implicit\conversion.mesh", path.GetResolvedText());
+            Assert.IsTrue(path.IsResolvable);
+        }
+
+        #endregion
+
+        #region RedReflection
+
+        [TestMethod]
+        public void RedReflection_GetTypes_ContainsKnownRedTypes()
+        {
+            var types = RedReflection.GetTypes();
+
+            Assert.IsTrue(types.Count > 1000, $"expected a populated red type cache, got {types.Count}");
+            Assert.IsTrue(types.ContainsKey("entEntity"), "entEntity missing from the red type cache");
+            Assert.IsTrue(types.ContainsKey("CMesh"), "CMesh missing from the red type cache");
+        }
+
+        [TestMethod]
+        public void RedReflection_GetTypeInfo_ReturnsPropertiesForKnownType()
+        {
+            var info = RedReflection.GetTypeInfo(typeof(CMesh));
+
+            Assert.IsNotNull(info);
+            Assert.AreEqual(typeof(CMesh), info.Type);
+            Assert.IsTrue(info.PropertyInfos.Count > 0, "CMesh should expose RED properties");
+        }
+
+        [TestMethod]
+        public void RedReflection_GetTypeInfo_IsCachedPerType()
+        {
+            // whether the cache is filled eagerly or lazily, repeated lookups must agree
+            var first = RedReflection.GetTypeInfo(typeof(entEntity));
+            var second = RedReflection.GetTypeInfo(typeof(entEntity));
+
+            Assert.AreSame(first, second);
+        }
+
+        [TestMethod]
+        public void RedReflection_GetTypeInfo_ResolvesNestedPropertyTypes()
+        {
+            var info = RedReflection.GetTypeInfo(typeof(CMesh));
+
+            foreach (var property in info.PropertyInfos.Take(25))
+            {
+                Assert.IsNotNull(property.Type, $"property {property.Name} has no type");
+
+                var nested = RedReflection.GetTypeInfo(property.Type);
+                Assert.IsNotNull(nested, $"could not resolve type info for {property.Type}");
+                Assert.AreEqual(property.Type, nested.Type);
+            }
+        }
+
+        [TestMethod]
+        public void RedReflection_GetTypeInfo_PropertyNamesAreStable()
+        {
+            var info = RedReflection.GetTypeInfo(typeof(CMesh));
+
+            var names = info.PropertyInfos.Select(p => p.RedName ?? p.Name).ToList();
+
+            CollectionAssert.AllItemsAreNotNull(names);
+            CollectionAssert.AllItemsAreUnique(names);
+        }
+
+        #endregion
+
+        #region RedTypeTemplateService type resolution
+
+        [TestMethod]
+        public void ParseType_ResolvesKnownTypesByName()
+        {
+            Assert.AreEqual(typeof(CMesh), RedTypeTemplateService.ParseType("CMesh"));
+            Assert.AreEqual(typeof(entEntity), RedTypeTemplateService.ParseType("entEntity"));
+        }
+
+        [TestMethod]
+        public void ParseType_ReturnsNullForUnknownType() =>
+            Assert.IsNull(RedTypeTemplateService.ParseType("ThisTypeDoesNotExistAnywhere_RegressionTest"));
+
+        [TestMethod]
+        public void ParseType_IsStableAcrossCalls() =>
+            Assert.AreSame(RedTypeTemplateService.ParseType("CMesh"), RedTypeTemplateService.ParseType("CMesh"));
+
+        [TestMethod]
+        public void IsTypeTemplatable_AcceptsConcreteRedClasses() =>
+            Assert.IsTrue(RedTypeTemplateService.IsTypeTemplatable(typeof(CMesh)));
+
+        [TestMethod]
+        public void IsTypeTemplatable_RejectsPrimitivesAndNonRedTypes()
+        {
+            Assert.IsFalse(RedTypeTemplateService.IsTypeTemplatable(typeof(int)));
+            Assert.IsFalse(RedTypeTemplateService.IsTypeTemplatable(typeof(string)));
+            Assert.IsFalse(RedTypeTemplateService.IsTypeTemplatable(typeof(CName)));
+        }
+
+        #endregion
+    }
+}

--- a/WolvenKit.App/Services/HashServiceExt.cs
+++ b/WolvenKit.App/Services/HashServiceExt.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -24,6 +24,15 @@ public class HashServiceExt : HashService
     }
 
     #endregion Constructors
+
+    /// <summary>
+    /// Directory holding the global <c>custom_refs.txt</c> / <c>custom_tweaks.txt</c> caches.
+    /// </summary>
+    /// <remarks>
+    /// Exists purely as a test hook.
+    /// Production behaviour is identical.
+    /// </remarks>
+    protected virtual string GetGlobalCacheDirectory() => ISettingsManager.GetAppData();
 
     public bool AddResourcePath(string resourcePath)
     {
@@ -53,7 +62,7 @@ public class HashServiceExt : HashService
 
     private void MigrateLegacyGlobalCache()
     {
-        var customRefsFile = Path.Combine(ISettingsManager.GetAppData(), "user_hashes.txt");
+        var customRefsFile = Path.Combine(GetGlobalCacheDirectory(), "user_hashes.txt");
         if (File.Exists(customRefsFile))
         {
             var paths = File.ReadAllLines(customRefsFile);
@@ -74,7 +83,7 @@ public class HashServiceExt : HashService
 
         MigrateLegacyGlobalCache();
 
-        var customRefsFile = Path.Combine(ISettingsManager.GetAppData(), "custom_refs.txt");
+        var customRefsFile = Path.Combine(GetGlobalCacheDirectory(), "custom_refs.txt");
         if (File.Exists(customRefsFile))
         {
             var paths = File.ReadAllLines(customRefsFile);
@@ -85,7 +94,7 @@ public class HashServiceExt : HashService
             }
         }
 
-        var customTweaksFile = Path.Combine(ISettingsManager.GetAppData(), "custom_tweaks.txt");
+        var customTweaksFile = Path.Combine(GetGlobalCacheDirectory(), "custom_tweaks.txt");
         if (File.Exists(customTweaksFile))
         {
             var paths = File.ReadAllLines(customTweaksFile);
@@ -104,7 +113,7 @@ public class HashServiceExt : HashService
             var list = _globalRefCache.Keys.ToList();
             list.Sort();
 
-            File.WriteAllLines(Path.Combine(ISettingsManager.GetAppData(), "custom_refs.txt"), list);
+            File.WriteAllLines(Path.Combine(GetGlobalCacheDirectory(), "custom_refs.txt"), list);
         }
 
         if (!_globalTweakCache.IsEmpty)
@@ -112,7 +121,7 @@ public class HashServiceExt : HashService
             var list = _globalTweakCache.Keys.ToList();
             list.Sort();
 
-            File.WriteAllLines(Path.Combine(ISettingsManager.GetAppData(), "custom_tweaks.txt"), list);
+            File.WriteAllLines(Path.Combine(GetGlobalCacheDirectory(), "custom_tweaks.txt"), list);
         }
     }
 


### PR DESCRIPTION
# Cache, TweakDB, Hashing, Path, Reflection, Tests

**Implemented:**

Regression tests covering various cache, hash, etc. pathways in the app:

- HashServiceExt
- RedTypeTemplateService
- ResourcePath.CalculateHash
- NodeRef.CalculateHash
- TweakDBID.CalculateHash
- FNV1A64HashAlgorithm.HashString
- FNV1A64HashAlgorithm.HashReadOnlySpan'
- Crc32Algorithm.Compute
- ResourcePath.SanitizePath
- ResourcePath.DirectorySeparatorChar
- LookupTable
- ResourcePathPool
- TweakDBIDPool
- NodeRefPool
- RedReflection

**Additional notes:**
- This PR is preliminary to a PR that will optimize the memory usage in these areas. 
- These regression tests will provide confidence when adding the subsequent PR.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->