### PR TITLE
fix search: restore forced property initialization on shift

### DIFF
--- a/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/RDTDataViewModel.cs
@@ -557,6 +557,14 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
             return;
         }
 
+        // expand parent nodes if necessary
+        var parent = selectedNode.Parent;
+        while (parent is not null)
+        {
+            parent.IsExpanded = true;
+            parent = parent.Parent;
+        }
+
         SetSelection(selectedNode, addToSelection);
     }
 
@@ -573,6 +581,12 @@ public partial class RDTDataViewModel : RedDocumentTabViewModel
     public void OnSearchChanged(string searchBoxText)
     {
         HasActiveSearch = !string.IsNullOrEmpty(searchBoxText);
+
+        if (ModifierViewStateService.IsShiftBeingHeld)
+        {
+            GetRootChunk()?.CalculatePropertiesRecursive(0, 1024, true, 10);
+        }
+
         foreach (var chunkViewModel in Chunks)
         {
             chunkViewModel.CalculatePropertiesRecursive(0, 1024);

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
@@ -54,7 +54,6 @@ public partial class ChunkViewModel
 
     private bool _isPropertiesInitialized;
 
-    ///
     /// <summary>
     /// If we need a node to be fully initialized (e.g. if we run a search on it)
     /// Cap it off arbitrarily at recursion level 8 (because why not)

--- a/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
+++ b/WolvenKit.App/ViewModels/Tools/ChunkViewModelExtended/ChunkViewModel.UserInteractionStates.cs
@@ -54,19 +54,31 @@ public partial class ChunkViewModel
 
     private bool _isPropertiesInitialized;
 
+    ///
     /// <summary>
     /// If we need a node to be fully initialized (e.g. if we run a search on it)
     /// Cap it off arbitrarily at recursion level 8 (because why not)
     /// </summary>
-    public void CalculatePropertiesRecursive(int recursionLevel = 0, int countLimit = 20)
+    /// <param name="recursionLevel">Current recursion level (don't go too deep)</param>
+    /// <param name="countLimit">Do not recalculate for more than X children</param>
+    /// <param name="forceRecalculate">Always recalculate properties regardless of initialization status</param>
+    /// <param name="recursionLimit">Maximum recursion depth</param>
+    public void CalculatePropertiesRecursive(
+        int recursionLevel = 0,
+        int countLimit = 20,
+        bool forceRecalculate = false,
+        int recursionLimit = 8
+    )
     {
-        if (_isPropertiesInitialized || recursionLevel > 8)
+        _propertiesLoaded = _propertiesLoaded && !forceRecalculate;
+        if ((_isPropertiesInitialized && !forceRecalculate) || recursionLevel > recursionLimit)
         {
             return;
         }
 
-        _isPropertiesInitialized = true;
         CalculateProperties();
+        _isPropertiesInitialized = true;
+
         if (TVProperties.Count > countLimit)
         {
             return;
@@ -74,7 +86,7 @@ public partial class ChunkViewModel
 
         foreach (var child in TVProperties)
         {
-            child.CalculatePropertiesRecursive(recursionLevel + 1, countLimit);
+            child.CalculatePropertiesRecursive(recursionLevel + 1, countLimit, forceRecalculate, recursionLimit);
         }
     }
 

--- a/changelog/unreleased/3093.yaml
+++ b/changelog/unreleased/3093.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3093
+      author: "manavortex"
+      description: "CVM: restored forced search initialization on shift+enter"


### PR DESCRIPTION
# fix search: restore forced property initialization on shift

<img width="2727" height="955" alt="image" src="https://github.com/user-attachments/assets/79eed005-a118-4751-a67c-3eb8663fa97d" />
