### PR TITLE
Load archive manager at launch

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Services/ArchiveManagerLoaderTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Services/ArchiveManagerLoaderTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Services;
+using WolvenKit.Core.Services;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Services;
+
+/// <summary>
+/// Covers the archive-loading heartbeat, which lives on <see cref="ArchiveManagerLoader"/>.
+///
+/// The loader is registered transient, so the app view model, asset browser and materials dialog
+/// each own an instance and can load archives concurrently. These tests pin the sharing contract
+/// between those instances, which the previous depth-counter implementation got wrong.
+///
+/// Every scope is held with <c>using</c> so a failed assertion cannot leak a claim on the shared
+/// purpose into the next test in this collection.
+/// </summary>
+[Collection(ArchiveLoadHeartbeatCollection.Name)]
+public class ArchiveManagerLoaderTests
+{
+    private const string Purpose = IArchiveManagerLoader.ArchiveLoadingPurpose;
+
+    [Fact]
+    public void BeginLoadingIndicator_ArmsHeartbeat_AndReleasesOnDispose()
+    {
+        var loader = CreateUninitializedLoader(out var progress);
+
+        using (var scope = BeginLoadingIndicator(loader))
+        {
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        }
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.Equal(EStatus.Ready, progress.Object.Status);
+        Assert.False(progress.Object.IsIndeterminate);
+    }
+
+    [Fact]
+    public void BeginLoadingIndicator_NestedOnSameLoader_StaysArmedUntilOuterScopeCloses()
+    {
+        var loader = CreateUninitializedLoader(out _);
+
+        using var outer = BeginLoadingIndicator(loader);
+        using (var inner = BeginLoadingIndicator(loader))
+        {
+            Assert.Equal(2, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
+        }
+
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.Equal(1, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
+    }
+
+    [Fact]
+    public void BeginLoadingIndicator_SecondLoaderFinishingFirst_DoesNotStopTheFirstLoadersHeartbeat()
+    {
+        var first = CreateUninitializedLoader(out var firstProgress);
+        var second = CreateUninitializedLoader(out _);
+
+        using (var firstScope = BeginLoadingIndicator(first))
+        {
+            using (var secondScope = BeginLoadingIndicator(second))
+            {
+                Assert.Equal(2, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
+            }
+
+            Assert.True(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+            Assert.NotEqual(EStatus.Ready, firstProgress.Object.Status);
+        }
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.Equal(EStatus.Ready, firstProgress.Object.Status);
+    }
+
+    [Fact]
+    public void BeginLoadingIndicator_ScopeDisposeIsIdempotent()
+    {
+        var loader = CreateUninitializedLoader(out _);
+
+        using var scope = BeginLoadingIndicator(loader);
+        scope.Dispose();
+        scope.Dispose();
+
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(Purpose));
+        Assert.Equal(0, DispatcherHelper.GetRepeatingActionRefCount(Purpose));
+    }
+
+    private static IDisposable BeginLoadingIndicator(ArchiveManagerLoader loader)
+    {
+        var method = typeof(ArchiveManagerLoader).GetMethod(
+            "BeginLoadingIndicator",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var scope = method!.Invoke(loader, null) as IDisposable;
+        Assert.NotNull(scope);
+        return scope!;
+    }
+
+    /// <summary>
+    /// Built without running the constructor: the heartbeat only reads _progressService, and the
+    /// real constructor would drag in the archive manager and parser for no benefit here.
+    /// </summary>
+    private static ArchiveManagerLoader CreateUninitializedLoader(out Mock<IProgressService<double>> progress)
+    {
+        progress = new Mock<IProgressService<double>>();
+        progress.SetupAllProperties();
+
+        var loader = (ArchiveManagerLoader)RuntimeHelpers.GetUninitializedObject(typeof(ArchiveManagerLoader));
+        SetField(loader, "_progressService", progress.Object);
+        return loader;
+    }
+
+    private static void SetField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+}

--- a/WolvenKit.App/Controllers/IGameController.cs
+++ b/WolvenKit.App/Controllers/IGameController.cs
@@ -74,8 +74,6 @@ public interface IGameController
     /// <returns>bool success</returns>
     Task<bool> AddFileToModModalAsync(ulong hash, ArchiveManagerScope searchScope);
 
-    public Task HandleStartup();
-
     Task<bool> LaunchProjectAsync(LaunchProfile profile);
     Task<bool> InstallProjectHotAsync();
     bool CleanAll(bool isPostBuild = false);

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -44,7 +44,6 @@ public class RED4Controller : ObservableObject, IGameController
     private readonly IAppArchiveManager _archiveManager;
     private readonly IProgressService<double> _progressService;
     private readonly IPluginService _pluginService;
-    private readonly Red4ParserService _parserService;
     private readonly IModifierViewStateService _modifierService;
 
     #endregion
@@ -59,8 +58,7 @@ public class RED4Controller : ObservableObject, IGameController
         IAppArchiveManager gameArchiveManager,
         IProgressService<double> progressService,
         IPluginService pluginService,
-        IModifierViewStateService modifierService,
-        Red4ParserService parserService)
+        IModifierViewStateService modifierService)
     {
         _notificationService = notificationService;
         _loggerService = loggerService;
@@ -72,146 +70,6 @@ public class RED4Controller : ObservableObject, IGameController
         _progressService = progressService;
         _pluginService = pluginService;
         _modifierService = modifierService;
-        _parserService = parserService;
-    }
-
-    public async Task HandleStartup()
-    {
-        await LoadArchiveManagerAsync();
-    }
-
-    // TODO: Move this somewhere else
-    private void LoadCustomHashes()
-    {
-        ResourcePath physMatLibPath = "base\\physics\\physicsmaterials.physmatlib";
-        ResourcePath presetPath = "engine\\physics\\collision_presets.json";
-
-        var physMatLib = _archiveManager.Lookup(physMatLibPath);
-        if (physMatLib.HasValue)
-        {
-            using MemoryStream ms = new();
-            physMatLib.Value.Extract(ms);
-            ms.Position = 0;
-
-            if (_parserService.TryReadRed4File(ms, out var file))
-            {
-                var root = (physicsMaterialLibraryResource)file.RootChunk;
-
-                foreach (var physMat in root.MaterialNames)
-                {
-                    if (!physMat.IsResolvable)
-                    {
-                        continue;
-                    }
-
-                    CNamePool.AddOrGetHash(physMat.GetResolvedText()!);
-                }
-            }
-        }
-
-        var preset = _archiveManager.Lookup(presetPath);
-        if (preset.HasValue)
-        {
-            using MemoryStream ms = new();
-            preset.Value.Extract(ms);
-            ms.Position = 0;
-
-            if (_parserService.TryReadRed4File(ms, out var file))
-            {
-                var root = (JsonResource)file.RootChunk;
-                var res = (physicsCollisionPresetsResource)root.Root.Chunk.NotNull();
-
-                foreach (var presetEntry in res.Presets)
-                {
-                    if (presetEntry is not { Name: { IsResolvable: true } name })
-                    {
-                        continue;
-                    }
-
-                    CNamePool.AddOrGetHash(name.GetResolvedText()!);
-                }
-            }
-        }
-    }
-
-    private DispatcherHelper.RepeatingActionHandle _loadingCompletion = new DispatcherHelper.RepeatingActionHandle(_purpose);
-    private static string _purpose = "project_loading_red4";
-
-    private void EnableLoadingMode()
-    {
-        _loadingCompletion = DispatcherHelper.StartRepeatingAction(
-            purpose: _purpose,
-            () =>
-            {
-                _progressService.IsIndeterminate = true;
-                _progressService.Status = EStatus.Running;
-            },
-            TimeSpan.FromMilliseconds(100),
-            DisableLoadingMode
-        );
-    }
-
-    private void DisableLoadingMode()
-    {
-        _progressService.IsIndeterminate = false;
-        _progressService.Status = EStatus.Ready;
-        DispatcherHelper.StopRepeatingAction(_loadingCompletion);
-    }
-
-    /// <summary>
-    /// Loads the basegame + EP1 archives on a background thread.
-    /// While loading, a 100ms repeating timer forces the global ProgressService
-    /// into Running/Indeterminate state. This mitigates the problem that there is
-    /// only a single global "Ready/Running" state — other code can (and does)
-    /// call Completed() or set IsIndeterminate=false while this long job is still
-    /// in progress.
-    /// </summary>
-    private async Task LoadArchiveManagerAsync()
-    {
-        // Fast path checks — do NOT start the loading indicator if there's nothing to do.
-        if (_archiveManager.IsManagerLoaded)
-        {
-            return;
-        }
-
-        if (_settingsManager.CP77ExecutablePath is null)
-        {
-            _loggerService.Warning("Cyberpunk 2077 executable path is not set. Skipping Archive Manager load.");
-            return;
-        }
-
-        EnableLoadingMode();
-
-        try
-        {
-            await Task.Run(() =>
-            {
-                // Keep priority low so the UI stays responsive during the (potentially long)
-                // first-time scan of dozens of large .archive files.
-                Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
-                Thread.CurrentThread.IsBackground = true;
-
-                _loggerService.Info("Loading Archive Manager ... ");
-
-                _archiveManager.LoadGameArchives(new FileInfo(_settingsManager.CP77ExecutablePath));
-
-                // Custom hash population needs the archives to be loaded, so do it here on the same thread.
-                LoadCustomHashes();
-            });
-
-            _loggerService.Success("Finished loading Archive Manager.");
-        }
-        catch (Exception e)
-        {
-            _loggerService.Error(e);
-            throw;
-        }
-        finally
-        {
-            // Always stop the heartbeat timer and release the progress indicator.
-            DisableLoadingMode();
-            LoadCustomHashes();
-        }
     }
 
     #region Packing

--- a/WolvenKit.App/Factories/PaneViewModelFactory.cs
+++ b/WolvenKit.App/Factories/PaneViewModelFactory.cs
@@ -36,6 +36,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
     private readonly IModifierViewStateService _modifierSvc;
     private readonly ProjectResourceTools _projectResourceTools;
     private readonly IWatcherService _watcherService;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     public PaneViewModelFactory(
         IProjectManager projectManager,
@@ -56,7 +57,8 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         AppScriptService appScriptService,
         ProjectResourceTools projectResourceTools,
         IModifierViewStateService modifierSvc,
-        IWatcherService watcherService
+        IWatcherService watcherService,
+        IArchiveManagerLoader archiveManagerLoader
         )
     {
         _projectManager = projectManager;
@@ -78,6 +80,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         _modifierSvc = modifierSvc;
         _projectResourceTools = projectResourceTools;
         _watcherService = watcherService;
+        _archiveManagerLoader = archiveManagerLoader;
     }
 
     public LogViewModel LogViewModel() => new(_loggerService, _appScriptService, _settingsManager);
@@ -88,7 +91,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         => _propertiesViewModel;
     public AssetBrowserViewModel AssetBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _projectManager, _notificationService, _gameController, _archiveManager, _settingsManager, _progressService,
-            _loggerService, _pluginService, _projectResourceTools);
+            _loggerService, _pluginService, _projectResourceTools, _archiveManagerLoader);
     public TweakBrowserViewModel TweakBrowserViewModel(AppViewModel appViewModel)
         => new(appViewModel, _chunkViewmodelFactory, _settingsManager, _notificationService, _projectManager, _loggerService, _tweakDbService, _locKeyService);
     public LocKeyBrowserViewModel LocKeyBrowserViewModel() => new(_projectManager, _loggerService, _progressService, _modTools, _gameController, _archiveManager, _locKeyService);

--- a/WolvenKit.App/Services/AppArchiveManager.cs
+++ b/WolvenKit.App/Services/AppArchiveManager.cs
@@ -32,14 +32,15 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
         _progressService = progressService;
         _settings = settings;
     }
-    
+
     #region Fields
 
     private readonly IHashService _hashService;
     private readonly ILoggerService _logger;
     private readonly IProgressService<double> _progressService;
     private readonly ISettingsManager _settings;
-    
+    private readonly int _maxDoP = Environment.ProcessorCount > 1 ? Environment.ProcessorCount : 1;
+
     private readonly SourceList<RedFileSystemModel> _rootCache = new();
 
     private readonly SourceList<RedFileSystemModel> _modCache = new();
@@ -108,7 +109,9 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
             .GroupBy(x => x.Key)
             .Select(x => x.First());
 
-        Parallel.ForEach(allFiles, (file) =>
+        var options = new ParallelOptions { MaxDegreeOfParallelism = _maxDoP };
+
+        Parallel.ForEach(allFiles, options, (file) =>
         {
             var path = hashService.Get(file.Key);
             if (path == null)
@@ -218,11 +221,17 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
 
         var progress = -1;
         var numTotalArchives = (float)GetModArchives().Count();
-        
+        var reportEvery = Math.Max(1, (int)(numTotalArchives / 100));
+
         foreach (var archive in GetModArchives())
         {
             progress++;
-            _progressService.Report(progress / numTotalArchives);
+
+            if (progress % reportEvery == 0)
+            {
+                _progressService.Report(progress / numTotalArchives);
+            }
+
             ArgumentNullException.ThrowIfNull(archive.ArchiveRelativePath,
                 $"{nameof(archive.ArchiveRelativePath)}, archive name: ${archive.Name}");
 
@@ -261,7 +270,7 @@ public class AppArchiveManager : ArchiveManager, IAppArchiveManager
         _progressService.Completed();
     }
 
-    public override Dictionary<string, IEnumerable<IGameFile>> GetGroupedFiles() => 
+    public override Dictionary<string, IEnumerable<IGameFile>> GetGroupedFiles() =>
         GetGroupedFiles(IsModBrowserActive ? ArchiveManagerScope.Mods : ArchiveManagerScope.Basegame);
 
     #endregion Methods

--- a/WolvenKit.App/Services/ArchiveManagerLoader.cs
+++ b/WolvenKit.App/Services/ArchiveManagerLoader.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using WolvenKit.App.Helpers;
+using WolvenKit.Common;
+using WolvenKit.Core.Extensions;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.RED4.CR2W;
+using WolvenKit.RED4.Types;
+using WolvenKit.RED4.Types.Pools;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// Its single responsibility is loading the archive manager.
+/// </summary>
+public sealed class ArchiveManagerLoader: IArchiveManagerLoader
+{
+    private readonly IArchiveManager _archiveManager;
+    private readonly ISettingsManager _settingsManager;
+    private readonly IProgressService<double> _progressService;
+    private readonly Red4ParserService _parserService;
+    private readonly ILoggerService _loggerService;
+    private static readonly int _maxDoP = Environment.ProcessorCount > 1 ? Environment.ProcessorCount : 1;
+
+    private readonly ParallelOptions _parallelOptions = new()
+    {
+        MaxDegreeOfParallelism = _maxDoP,
+    };
+
+    public ArchiveManagerLoader(IArchiveManager archiveManager, ISettingsManager settingsManager,
+        IProgressService<double> progressService, Red4ParserService parserService, ILoggerService loggerService)
+    {
+        _archiveManager = archiveManager;
+        _settingsManager = settingsManager;
+        _progressService = progressService;
+        _parserService = parserService;
+        _loggerService = loggerService;
+    }
+
+    /// <summary>
+    /// Loads the basegame + EP1 archives on a background thread.
+    /// While loading, a 100ms repeating timer forces the global ProgressService
+    /// into Running/Indeterminate state. This mitigates the problem that there is
+    /// only a single global "Ready/Running" state — other code can (and does)
+    /// call Completed() or set IsIndeterminate=false while this long job is still
+    /// in progress.
+    /// </summary>
+    public async Task LoadArchiveManagerAsync()
+    {
+        // Fast path checks — do NOT start the loading indicator if there's nothing to do.
+        if (_archiveManager.IsManagerLoaded)
+        {
+            return;
+        }
+
+        if (_settingsManager.CP77ExecutablePath is null)
+        {
+            _loggerService.Warning("Cyberpunk 2077 executable path is not set. Skipping Archive Manager load.");
+            return;
+        }
+
+        using var loadingIndicator = BeginLoadingIndicator();
+
+        var executablePath = _settingsManager.CP77ExecutablePath;
+
+        try
+        {
+            await Task.Run(() =>
+            {
+                _loggerService.Info("Loading Archive Manager ... ");
+
+                _archiveManager.LoadGameArchives(new FileInfo(executablePath));
+
+                // Custom hash population needs the archives to be loaded, so do it here on the same thread.
+                LoadCustomHashes();
+            });
+
+            _loggerService.Success("Finished loading Archive Manager.");
+        }
+        catch (Exception e)
+        {
+            _loggerService.Error(e);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Starts the archive-loading progress heartbeat and returns a scope that releases it.
+    ///
+    /// The heartbeat is reference counted on <see cref="ArchiveLoadingPurpose"/>, so overlapping
+    /// loads — RED4Controller is registered transient, so the app view model, the asset browser
+    /// and the materials dialog each hold their own instance — share a single timer. The
+    /// indicator is only reset to Ready once the last loader disposes its scope, rather than
+    /// whichever loader happens to finish first.
+    /// </summary>
+    private IDisposable BeginLoadingIndicator() =>
+        DispatcherHelper.StartRepeatingAction(
+            purpose: IArchiveManagerLoader.ArchiveLoadingPurpose,
+            () =>
+            {
+                _progressService.IsIndeterminate = true;
+                _progressService.Status = EStatus.Running;
+            },
+            TimeSpan.FromMilliseconds(100),
+            onCancelled: () =>
+            {
+                _progressService.IsIndeterminate = false;
+                _progressService.Status = EStatus.Ready;
+            }
+        );
+
+    private void LoadCustomHashes()
+    {
+        ResourcePath physMatLibPath = "base\\physics\\physicsmaterials.physmatlib";
+        ResourcePath presetPath = "engine\\physics\\collision_presets.json";
+
+        var physMatLib = _archiveManager.Lookup(physMatLibPath);
+        if (physMatLib.HasValue)
+        {
+            using MemoryStream ms = new();
+            physMatLib.Value.Extract(ms);
+            ms.Position = 0;
+
+            if (_parserService.TryReadRed4File(ms, out var fileMaybeNull) && fileMaybeNull is { } file)
+            {
+                var root = (physicsMaterialLibraryResource)file.RootChunk;
+
+                Parallel.ForEach(root.MaterialNames, _parallelOptions, (physMat) =>
+                {
+                    if (!physMat.IsResolvable)
+                    {
+                        return;
+                    }
+
+                    CNamePool.AddOrGetHash(physMat.GetResolvedText()!);
+                });
+            }
+        }
+
+        var preset = _archiveManager.Lookup(presetPath);
+        if (preset.HasValue)
+        {
+            using MemoryStream ms = new();
+            preset.Value.Extract(ms);
+            ms.Position = 0;
+
+            if (_parserService.TryReadRed4File(ms, out var fileMaybeNull) && fileMaybeNull is { } file)
+            {
+                var root = (JsonResource)file.RootChunk;
+                var res = (physicsCollisionPresetsResource)root.Root.Chunk.NotNull();
+
+                Parallel.ForEach(res.Presets, _parallelOptions, (presetEntry) =>
+                {
+                    if (presetEntry is not { Name: { IsResolvable: true } name })
+                    {
+                        return;
+                    }
+
+                    CNamePool.AddOrGetHash(name.GetResolvedText()!);
+                });
+            }
+        }
+    }
+}

--- a/WolvenKit.App/Services/IArchiveManagerLoader.cs
+++ b/WolvenKit.App/Services/IArchiveManagerLoader.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace WolvenKit.App.Services;
+
+public interface IArchiveManagerLoader
+{
+    const string ArchiveLoadingPurpose = "RED4Controller archive loading";
+
+    Task LoadArchiveManagerAsync();
+}

--- a/WolvenKit.App/ViewModels/Dialogs/MaterialsRepositoryDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/MaterialsRepositoryDialogViewModel.cs
@@ -36,6 +36,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
     private readonly IGameControllerFactory _gameControllerFactory;
     private readonly IProgressService<double> _progress;
     private readonly IModTools _modTools;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     public MaterialsRepositoryViewModel(
         ISettingsManager settingsManager,
@@ -43,7 +44,8 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         IAppArchiveManager archiveManager,
         IGameControllerFactory gameControllerFactory,
         IProgressService<double> progress,
-        IModTools modTools)
+        IModTools modTools,
+        IArchiveManagerLoader archiveManagerLoader)
     {
         _settingsManager = settingsManager;
         _loggerService = loggerService;
@@ -51,6 +53,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         _gameControllerFactory = gameControllerFactory;
         _progress = progress;
         _modTools = modTools;
+        _archiveManagerLoader = archiveManagerLoader;
 
         ArgumentNullException.ThrowIfNull(_settingsManager.MaterialRepositoryPath);
 
@@ -150,7 +153,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
             ".mlmask"
         };
 
-        await _gameControllerFactory.GetRed4Controller().HandleStartup();
+        await _archiveManagerLoader.LoadArchiveManagerAsync();
 
         var groupedFiles = _archiveManager.GetGroupedFiles();
 
@@ -342,7 +345,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
         var depotPath = new DirectoryInfo(_settingsManager.MaterialRepositoryPath);
         if (depotPath.Exists)
         {
-            await _gameControllerFactory.GetRed4Controller().HandleStartup();
+            await _archiveManagerLoader.LoadArchiveManagerAsync();
 
             await Task.Run(() =>
             {
@@ -385,7 +388,7 @@ public partial class MaterialsRepositoryViewModel : DialogWindowViewModel
 
     public static bool UseNewParallelism { get; set; } = true;
 
-   
+
     private void OpenDepotFolder()
     {
         if (_settingsManager.MaterialRepositoryPath is null)

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -858,7 +858,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             return;
         }
 
-        await _archiveManagerLoader.LoadArchiveManagerAsync().ContinueWith(_ =>
+        DispatcherHelper.DelayOnMainThread(() =>
         {
             UpdateTitle();
             _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
@@ -869,7 +869,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             }
 
             OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
-        }, TaskContinuationOptions.OnlyOnRanToCompletion);
+        }, 1000);
     }
 
     [RelayCommand]

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -90,6 +90,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     // expose to view
     public ISettingsManager SettingsManager { get; init; }
     public ProjectResourceTools ProjectResourceTools { get; init; }
+    private IArchiveManagerLoader _archiveManagerLoader;
 
     /// <summary>
     /// Class constructor
@@ -120,7 +121,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         TemplateFileTools templateFileTools,
         ProjectResourceTools projectResourceTools,
         IUpdateService updateService,
-        RedTypeTemplateService redTypeTemplateService
+        RedTypeTemplateService redTypeTemplateService,
+        IArchiveManagerLoader archiveManagerLoader
     )
     {
         _documentViewmodelFactory = documentViewmodelFactory;
@@ -147,6 +149,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         ProjectResourceTools = projectResourceTools;
         _updateService = updateService;
         _redTypeTemplateService = redTypeTemplateService;
+        _archiveManagerLoader = archiveManagerLoader;
 
         _fileValidationScript = _scriptService.GetScripts().ToList()
             .Where(s => s.Name == "run_FileValidation_on_active_tab")
@@ -306,13 +309,28 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
 
         OnAppLoaded?.Invoke(this, EventArgs.Empty);
-        HandleActivation();
     }
 
     public event EventHandler? OnAppLoaded;
 
-    private void HandleActivation()
+    /// <summary>
+    /// One-time application startup work. Call once, from the shell, after its bindings are in
+    /// place.
+    /// </summary>
+    /// <remarks>
+    /// This used to hang off the <c>Status</c> property setter as a side effect, which meant it
+    /// could not be awaited, could not be ordered relative to the shell's own setup, and turned
+    /// any failure into an exception escaping a property assignment. Being an explicit awaitable
+    /// call also removes the need to branch on <c>TestHelper.InActiveTest</c> - tests simply await
+    /// it.
+    ///
+    /// Never throws: a discarded task's exception would otherwise go unobserved, and none of this
+    /// work is worth failing a launch over.
+    /// </remarks>
+    public async Task InitializeAsync()
     {
+        try
+        {
         var thisVersion = Core.CommonFunctions.GetAssemblyVersion(Constants.AssemblyName);
         if (thisVersion.ToString().Contains("nightly") && SettingsManager.UpdateChannel != EUpdateChannel.Nightly)
         {
@@ -320,6 +338,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
 
         _pluginService.Init();
+
         if (!OpenFileFromLaunchArgs())
         {
             ShowHomePageSync();
@@ -336,6 +355,47 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         CheckForTemplateUpdatesCommand.SafeExecute();
         CheckForLongPathSupport();
         CheckForOneDrivePath();
+
+            // Archives load last, and only once the shell has gone idle. The scan allocates
+            // heavily on a background thread, and GC pauses hit the UI thread too - starting it
+            // any earlier visibly stalls the window as it is still drawing itself.
+            if (Application.Current is { } app)
+            {
+                await app.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
+            }
+
+            await LoadArchivesSafelyAsync();
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
+    }
+
+    /// <summary>
+    /// Loads the archive manager, logging rather than propagating a failure.
+    /// </summary>
+    /// <remarks>
+    /// A corrupt, locked or missing archive should cost the user the asset browser, not the whole
+    /// application: before archive loading moved here it ran inside LoadProjectFromPathAsync
+    /// behind exactly this try/catch, and ArchiveManagerLoader still rethrows after logging.
+    /// Without the guard the fault escapes HandleActivation, then OnStatusChanged, then the
+    /// Status setter, and takes startup down with it.
+    ///
+    /// The catch has to live inside the async method rather than around the dispatcher call:
+    /// Dispatcher.Invoke(Func&lt;Task&gt;, ...) hands back the Task and drops it, so anything
+    /// thrown after the first await would be swallowed unobserved instead of logged.
+    /// </remarks>
+    private async Task LoadArchivesSafelyAsync()
+    {
+        try
+        {
+            await _archiveManagerLoader.LoadArchiveManagerAsync();
+        }
+        catch (Exception ex)
+        {
+            _loggerService.Error(ex);
+        }
     }
 
     public bool AddDockedPane(string paneString)
@@ -798,7 +858,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
             return;
         }
 
-        await _gameControllerFactory.GetController().HandleStartup().ContinueWith(_ =>
+        await _archiveManagerLoader.LoadArchiveManagerAsync().ContinueWith(_ =>
         {
             UpdateTitle();
             _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");

--- a/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/AssetBrowserViewModel.cs
@@ -78,6 +78,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     internal readonly ReadOnlyObservableCollection<RedFileSystemModel> _boundRootNodes;
 
     private bool _manuallyLoading;
+    private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     #endregion fields
 
@@ -93,7 +94,8 @@ public partial class AssetBrowserViewModel : ToolViewModel
         IProgressService<double> progressService,
         ILoggerService loggerService,
         IPluginService pluginService,
-        ProjectResourceTools projectResourceTools) : base(ToolTitle)
+        ProjectResourceTools projectResourceTools,
+        IArchiveManagerLoader archiveManagerLoader) : base(ToolTitle)
     {
         _projectManager = projectManager;
         _notificationService = notificationService;
@@ -105,6 +107,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
         _loggerService = loggerService;
         _appViewModel = appViewModel;
         _projectResourceTools = projectResourceTools;
+        _archiveManagerLoader = archiveManagerLoader;
 
         ContentId = ToolContentId;
 
@@ -260,7 +263,7 @@ public partial class AssetBrowserViewModel : ToolViewModel
     {
         _manuallyLoading = true;
         ShouldShowLoadButton = !_manuallyLoading && !ProjectLoaded && !ArchiveDirNotFound;
-        await _gameController.GetRed4Controller().HandleStartup();
+        await _archiveManagerLoader.LoadArchiveManagerAsync();
     }
 
     [RelayCommand]

--- a/WolvenKit.Modkit/Managers/ArchiveManager.cs
+++ b/WolvenKit.Modkit/Managers/ArchiveManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DynamicData;
@@ -149,6 +150,7 @@ namespace WolvenKit.RED4.CR2W.Archive
             baseFiles.Sort(CompareArchives);
 
             var totalCnt = baseFiles.Count;
+            var loadedArchives = new StringBuilder();
 
             var ep1Dir = Path.Combine(di.Parent.Parent.FullName, "archive", "pc", "ep1");
             if (Directory.Exists(ep1Dir))
@@ -167,7 +169,8 @@ namespace WolvenKit.RED4.CR2W.Archive
                     LoadArchive(file, EArchiveSource.EP1);
                     cnt++;
 
-                    _logger.Debug($"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
+                    loadedArchives.AppendLine(
+                        $"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
                 }
             }
 
@@ -178,7 +181,13 @@ namespace WolvenKit.RED4.CR2W.Archive
                 LoadArchive(file, EArchiveSource.Base);
                 cnt++;
 
-                _logger.Debug($"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
+                loadedArchives.AppendLine(
+                    $"Loaded archive {Path.GetFileName(file)} {cnt}/{totalCnt} in {sw.ElapsedMilliseconds}ms");
+            }
+
+            if (loadedArchives.Length > 0)
+            {
+                _logger.Debug(loadedArchives.ToString().TrimEnd());
             }
 
             sw.Stop();

--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -100,6 +100,7 @@ namespace WolvenKit
                     services.AddSingleton<IModifierViewStateService, ModifierViewStateService>();
                     services.AddSingleton<INodeSelectionService, NodeSelectionService>();
                     services.AddSingleton<IWatcherService, WatcherService>();
+                    services.AddTransient<IArchiveManagerLoader, ArchiveManagerLoader>();
 
                     // factories
                     services.AddTransient<IPageViewModelFactory, PageViewModelFactory>();

--- a/WolvenKit/Views/Shell/MainView.xaml.cs
+++ b/WolvenKit/Views/Shell/MainView.xaml.cs
@@ -260,6 +260,11 @@ namespace WolvenKit.Views.Shell
 
                 //set ready status
                 ViewModel.SetStatusReady();
+
+                // Not awaited -
+                // WhenActivated is synchronous and startup must not block on archive
+                // loading. InitializeAsync handles own failures, so discard is safe.
+                _ = ViewModel.InitializeAsync();
             });
         }
 

--- a/changelog/unreleased/3096.yaml
+++ b/changelog/unreleased/3096.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "changed"
+      packages: ["App"]
+      pr-number: 3096
+      author: "gistya"
+      description: "Archive loading now starts at app launch and finishes much faster, speeding up the time to start working on a project."


### PR DESCRIPTION
# Load archive manager at launch

These changes are already on Dev. 

**Implemented:**
- Load ArchiveManager asynchronously in the background at launch.
- If archives are not present, nothing is loaded and the button can be pressed as usual.
- Avoids UI freezes by being based upon the stacked PRs for improving memory optimization and multithreading.

This is a reworking of https://github.com/WolvenKit/WolvenKit/pull/3073 so that it fits with the stacked PR

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->