### PR TITLE
Prevent creation of duplicate instances of ProjectExplorerVM

### DIFF
--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -61,7 +61,7 @@ public partial class AppScriptService : ScriptService
 
     private ProjectExplorerViewModel? GetProjectExplorerViewModel()
     {
-        _projectExplorerViewModel ??= Locator.Current.GetService<ProjectExplorerViewModel>();
+        _projectExplorerViewModel ??= Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>();
         return _projectExplorerViewModel;
     }
 

--- a/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
+++ b/WolvenKit/Views/Documents/RedDocumentViewMenuBar.xaml.cs
@@ -67,7 +67,7 @@ namespace WolvenKit.Views.Documents
             _archiveManager = Locator.Current.GetService<IAppArchiveManager>()!;
             _modifierStateService = Locator.Current.GetService<IModifierViewStateService>()!;
             _progressService = Locator.Current.GetService<IProgressService<double>>()!;
-            _projectExplorer = Locator.Current.GetService<ProjectExplorerViewModel>()!;
+            _projectExplorer = Locator.Current.GetService<AppViewModel>()!.GetToolViewModel<ProjectExplorerViewModel>();
             _projectResourceTools = Locator.Current.GetService<ProjectResourceTools>()!;
             _cr2WTools = Locator.Current.GetService<Cr2WTools>()!;
             _notificationService = Locator.Current.GetService<INotificationService>()!;


### PR DESCRIPTION
# Project loading speed improvements

**Fixed:**
- fixes an issue where certain actions can create a duplicate ProjectExplorerViewModel instance

    Note: `Locator.Current.GetService<ProjectExplorerViewModel>()` alsways creates a new instance. You have to use `Locator.Current.GetService<AppViewModel>()?.GetToolViewModel<ProjectExplorerViewModel>();`

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->