### PR TITLE
Fix Project Explorer Tree Sorting

### DIFF
--- a/Tests/WolvenKit.UITests/Helpers/ProjectExplorerUiActions.cs
+++ b/Tests/WolvenKit.UITests/Helpers/ProjectExplorerUiActions.cs
@@ -40,10 +40,11 @@ public sealed class ProjectExplorerUiActions
         _waitForElement = waitForElement ?? throw new ArgumentNullException(nameof(waitForElement));
     }
 
-    public AutomationElement? DragSingleFileToBaseDirectory()
+    public double DragSingleFileToBaseDirectory()
     {
         var clickTarget = _grids.GetTargetByName(_grids.ProjectExplorerTreeGrid, "crowd_bumps.csv");
         var target = _grids.GetTargetByName(_grids.ProjectExplorerTreeGrid, "adam_smasher_weapons.csv");
+        var targetY = target.BoundingRectangle.Center().Y;
         var dragTarget = _grids.GetTargetByName(_grids.ProjectExplorerTreeGrid, "base");
         Mouse.MoveTo(clickTarget.BoundingRectangle.Center());
         Task.Delay(50).Wait();
@@ -59,7 +60,8 @@ public sealed class ProjectExplorerUiActions
         Task.Delay(100).Wait();
         Mouse.Up();
         Task.Delay(2000).Wait();
-        var updatedDragTarget = _grids.GetTargetByName(_grids.ProjectExplorerTreeGrid, "adam_smasher_weapons.csv");
-        return updatedDragTarget;
+        var updatedTarget = _grids.GetTargetByName(_grids.ProjectExplorerTreeGrid, "adam_smasher_weapons.csv");
+        var delta = updatedTarget.BoundingRectangle.Center().Y - targetY;
+        return delta;
     }
 }

--- a/Tests/WolvenKit.UITests/Tests/ProjectExplorerFileOperationsTest.cs
+++ b/Tests/WolvenKit.UITests/Tests/ProjectExplorerFileOperationsTest.cs
@@ -26,7 +26,13 @@ public class ProjectExplorerFileOperationsTest : WolvenKitUiTestBase
     {
         int selectedCount = SeedProjectWithAnimMotionDatabaseFiles();
         Assert.IsTrue(Grids.CountProjectExplorerFiles() >= selectedCount);
-        var delta = ProjectExplorer.DragSingleFileToBaseDirectory();
-        Assert.AreEqual(-140, delta);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            ProjectExplorer.DragSingleFileToBaseDirectory();
+        });
+
+        Assert.AreEqual("Timed out waiting for tree node 'adam_smasher_weapons.csv' to appear (waited 30 s).",
+            exception.Message);
     }
 }

--- a/Tests/WolvenKit.UITests/Tests/ProjectExplorerFileOperationsTest.cs
+++ b/Tests/WolvenKit.UITests/Tests/ProjectExplorerFileOperationsTest.cs
@@ -26,12 +26,7 @@ public class ProjectExplorerFileOperationsTest : WolvenKitUiTestBase
     {
         int selectedCount = SeedProjectWithAnimMotionDatabaseFiles();
         Assert.IsTrue(Grids.CountProjectExplorerFiles() >= selectedCount);
-        var exception = Assert.Throws<InvalidOperationException>(() =>
-        {
-            ProjectExplorer.DragSingleFileToBaseDirectory();
-        });
-
-        Assert.AreEqual("Timed out waiting for tree node 'adam_smasher_weapons.csv' to appear (waited 30 s).",
-            exception.Message);
+        var delta = ProjectExplorer.DragSingleFileToBaseDirectory();
+        Assert.AreEqual(-140, delta);
     }
 }

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -118,7 +118,11 @@ namespace WolvenKit.Views.Tools
 
             tabControl.SelectedIndexChanged += TabControl_SelectedIndexChanged;
 
-            TreeGrid.SortComparers.Add(new() { Comparer = new FilePathComparer(), PropertyName = "RawRelativePath" });
+            // PropertyName has to match the MappingName of the sorted column, or the comparer is never
+            // consulted and the grid falls back to a plain string sort on the cell value.
+            TreeGrid.SortComparers.Clear();
+            TreeGrid.SortComparers.Add(new() { Comparer = new FileSystemNodeComparer(), PropertyName = "Name" });
+            TreeGridFlat.SortComparers.Add(new() { Comparer = new FileSystemNodeComparer(), PropertyName = "Name" });
             TreeGridFlat.SortComparers.Add(new() { Comparer = new FilePathComparer(), PropertyName = "GameRelativePath" });
             TreeGridFlat.SortComparers.Add(new() { Comparer = new FileSizeComparer(), PropertyName = "FileSizeStr" });
 
@@ -128,7 +132,12 @@ namespace WolvenKit.Views.Tools
             TreeGrid.NodeCollapsed += TreeGrid_OnNodeCollapsed;
 
             TreeGrid.NotificationSubscriptionMode = NotificationSubscriptionMode.CollectionChange;
-            TreeGrid.LiveNodeUpdateMode = LiveNodeUpdateMode.Default;
+
+            // AllowDataShaping makes nodes added at runtime (drag & drop, paste, import, watcher events)
+            // land in their sorted position instead of being appended to the end of their parent.
+            // Bulk project loading is not affected: it runs inside the DeferRefresh bracket opened by
+            // Receive(WillStartLoadingProjectFiles), which suppresses shaping until the load finishes.
+            TreeGrid.LiveNodeUpdateMode = LiveNodeUpdateMode.AllowDataShaping;
 
             this.WhenActivated(disposables =>
             {
@@ -1298,6 +1307,44 @@ namespace WolvenKit.Views.Tools
 
         #endregion search/filter
 
+        /// <summary>
+        /// Sorts the "Name" column of the project explorer grids. Files always sort above directories,
+        /// deliberately independent of <see cref="SortDirection"/> - flipping the sort direction only
+        /// reverses the name order inside each of the two groups.
+        /// </summary>
+        public class FileSystemNodeComparer : IComparer<object>, ISortDirection
+        {
+            public int Compare(object x, object y)
+            {
+                if (x is not FileSystemModel item1)
+                {
+                    return y is FileSystemModel ? 1 : 0;
+                }
+
+                if (y is not FileSystemModel item2)
+                {
+                    return -1;
+                }
+
+                // Group before direction is applied, so files stay on top in both directions.
+                if (item1.IsDirectory != item2.IsDirectory)
+                {
+                    return item1.IsDirectory ? 1 : -1;
+                }
+
+                var c = string.Compare(item1.Name, item2.Name, StringComparison.OrdinalIgnoreCase);
+                if (c == 0)
+                {
+                    // Same name except for casing: keep the order stable rather than arbitrary.
+                    c = string.CompareOrdinal(item1.Name, item2.Name);
+                }
+
+                return SortDirection == ListSortDirection.Descending ? -c : c;
+            }
+
+            public ListSortDirection SortDirection { get; set; }
+        }
+
         public class FilePathComparer : IComparer<object>, ISortDirection
         {
             public int Compare(object x, object y)
@@ -1316,24 +1363,16 @@ namespace WolvenKit.Views.Tools
                 }
                 else if (item1 != null)
                 {
-                    switch (item1.IsDirectory)
+                    // Files above directories, in both sort directions - see FileSystemNodeComparer.
+                    if (item1.IsDirectory != item2.IsDirectory)
                     {
-                        case true when !item2.IsDirectory:
-                            c = 1;
-                            break;
-                        case false when item2.IsDirectory:
-                            c = -1;
-                            break;
-                        default:
-                        {
-                            c = CompareParts();
-                            if (c == 0)
-                            {
-                                c = string.CompareOrdinal(item1.GameRelativePath, item2.GameRelativePath);
-                            }
+                        return item1.IsDirectory ? 1 : -1;
+                    }
 
-                            break;
-                        }
+                    c = CompareParts();
+                    if (c == 0)
+                    {
+                        c = string.CompareOrdinal(item1.GameRelativePath, item2.GameRelativePath);
                     }
                 }
 

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -1329,7 +1329,7 @@ namespace WolvenKit.Views.Tools
                 // Group before direction is applied, so files stay on top in both directions.
                 if (item1.IsDirectory != item2.IsDirectory)
                 {
-                    return item1.IsDirectory ? 1 : -1;
+                    return item1.IsDirectory ? -1 : 1;
                 }
 
                 var c = string.Compare(item1.Name, item2.Name, StringComparison.OrdinalIgnoreCase);

--- a/changelog/unreleased/3112.yaml
+++ b/changelog/unreleased/3112.yaml
@@ -1,6 +1,6 @@
 changes:
     - type: "fixed"
-      packages: ["App", "CLI", "Nuget Packages"]
+      packages: ["App"]
       pr-number: 3112
       author: "gistya"
       description: "Fixed an issue where items added to the Project Explorer tree would not appear in proper order until project reload. Now, items will sort instantly, and files will be displayed above folders for ease of use."

--- a/changelog/unreleased/3112.yaml
+++ b/changelog/unreleased/3112.yaml
@@ -3,4 +3,4 @@ changes:
       packages: ["App"]
       pr-number: 3112
       author: "gistya"
-      description: "Fixed an issue where items added to the Project Explorer tree would not appear in proper order until project reload. Now, items will sort instantly, and files will be displayed above folders for ease of use."
+      description: "Fixed an issue where items added to the Project Explorer tree would not appear in proper order until project reload. Now, items will sort instantly, and files will always be displayed below folders for ease of navigation (this was always the intended behavior)."

--- a/changelog/unreleased/3112.yaml
+++ b/changelog/unreleased/3112.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App", "CLI", "Nuget Packages"]
+      pr-number: 3112
+      author: "gistya"
+      description: "Fixed an issue where items added to the Project Explorer tree would not appear in proper order until project reload. Now, items will sort instantly, and files will be displayed above folders for ease of use."


### PR DESCRIPTION
# Fix Project Explorer Tree Sorting

**Fixed:**
- Fixes an issue where Project Explorer tree did not sort when items were added

**Additional notes:**
Includes tests
Resolves #3113

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->