### PR TITLE
Fix tab filters in flat mode (Project Explorer)

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -422,6 +422,8 @@ namespace WolvenKit.Views.Tools
                 TreeGrid.SetCurrentValue(VisibilityProperty, Visibility.Visible);
                 TreeGridFlat.SetCurrentValue(VisibilityProperty, Visibility.Collapsed);
             }
+
+            ReapplyCurrentSearchFilter(expandAllForSearch: !string.IsNullOrWhiteSpace(_currentFolderQuery));
         }
 
         private void OnContextMenuOpen(object sender, ContextMenuEventArgs e)


### PR DESCRIPTION
# Fix tab filters in flat mode (Project Explorer)

**Fixed:**
- Fixes a longstanding issue in Project Explorer where the tab filters would not be applied in some (all?) situations

**Additional notes:**
- This is another fix broken out from #2945

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->