### PR TITLE
Project loading indicator improvements

### DIFF
--- a/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
+++ b/WolvenKit.App/ViewModels/HomePage/Pages/WelcomePageViewModel.cs
@@ -17,6 +17,7 @@ using WolvenKit.App.Interaction;
 using WolvenKit.App.Models.ProjectManagement;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
 
 namespace WolvenKit.App.ViewModels.HomePage.Pages;
 
@@ -116,6 +117,7 @@ public partial class WelcomePageViewModel : PageViewModel
     [RelayCommand]
     private void OpenProject(string s)
     {
+        _mainViewModel.GetToolViewModel<ProjectExplorerViewModel>().ProjectWillLoad(s);
         _mainViewModel.OpenProjectCommand.Execute(s);
 
         // clear filters

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -319,16 +319,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     /// One-time application startup work. Call once, from the shell, after its bindings are in
     /// place.
     /// </summary>
-    /// <remarks>
-    /// This used to hang off the <c>Status</c> property setter as a side effect, which meant it
-    /// could not be awaited, could not be ordered relative to the shell's own setup, and turned
-    /// any failure into an exception escaping a property assignment. Being an explicit awaitable
-    /// call also removes the need to branch on <c>TestHelper.InActiveTest</c> - tests simply await
-    /// it.
-    ///
-    /// Never throws: a discarded task's exception would otherwise go unobserved, and none of this
-    /// work is worth failing a launch over.
-    /// </remarks>
     public async Task InitializeAsync()
     {
         try
@@ -358,9 +348,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         CheckForLongPathSupport();
         CheckForOneDrivePath();
 
-            // Archives load last, and only once the shell has gone idle. The scan allocates
-            // heavily on a background thread, and GC pauses hit the UI thread too - starting it
-            // any earlier visibly stalls the window as it is still drawing itself.
             if (Application.Current is { } app)
             {
                 await app.Dispatcher.InvokeAsync(() => { }, DispatcherPriority.ApplicationIdle);
@@ -377,17 +364,6 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     /// <summary>
     /// Loads the archive manager, logging rather than propagating a failure.
     /// </summary>
-    /// <remarks>
-    /// A corrupt, locked or missing archive should cost the user the asset browser, not the whole
-    /// application: before archive loading moved here it ran inside LoadProjectFromPathAsync
-    /// behind exactly this try/catch, and ArchiveManagerLoader still rethrows after logging.
-    /// Without the guard the fault escapes HandleActivation, then OnStatusChanged, then the
-    /// Status setter, and takes startup down with it.
-    ///
-    /// The catch has to live inside the async method rather than around the dispatcher call:
-    /// Dispatcher.Invoke(Func&lt;Task&gt;, ...) hands back the Task and drops it, so anything
-    /// thrown after the first await would be swallowed unobserved instead of logged.
-    /// </remarks>
     private async Task LoadArchivesSafelyAsync()
     {
         try
@@ -768,7 +744,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     [RelayCommand]
     private async Task OpenProjectAsync(string location)
     {
-        // "Open Project" button was pushed
+        var projectExplorer = GetToolViewModel<ProjectExplorerViewModel>();
+
         if (string.IsNullOrWhiteSpace(location))
         {
             var dlg = new OpenFileDialog
@@ -781,6 +758,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
             if (dlg.ShowDialog() != true || dlg.FileName is not string result || string.IsNullOrEmpty(result))
             {
+                projectExplorer.CancelProjectLoad();
                 return;
             }
 
@@ -789,6 +767,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (_projectManager.ActiveProject?.Location == location)
         {
+            projectExplorer.CancelProjectLoad();
             CloseModal();
             return;
         }
@@ -803,6 +782,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         // file was moved or deleted
         if (_recentlyUsedItemsService.Items.Items.All(x => x.Name != location))
         {
+            projectExplorer.CancelProjectLoad();
             throw new WolvenKitException(0x5002,
                 "Failed to load project. Please open a github issue and attach a zip so that we can fix it!");
         }
@@ -814,6 +794,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (res is not (WMessageBoxResult.OK or WMessageBoxResult.Yes))
         {
+            projectExplorer.CancelProjectLoad();
             return;
         }
 
@@ -827,6 +808,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
         if (dlg2.ShowDialog() != true || dlg2.FileName is not string filePath || string.IsNullOrEmpty(filePath))
         {
+            projectExplorer.CancelProjectLoad();
             return;
         }
 
@@ -836,7 +818,11 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         if (File.Exists(filePath))
         {
             CloseModal();
-            await _projectManager.LoadAsync(filePath);
+            await LoadProjectFromPathAsync(filePath);
+        }
+        else
+        {
+            projectExplorer.CancelProjectLoad();
         }
     }
 
@@ -844,34 +830,68 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     internal async Task LoadProjectFromPathAsync(string location)
     {
-        var p = await _projectManager.LoadAsync(location);
-        if (p is null)
-        {
-            return;
-        }
+        var projectExplorer = GetToolViewModel<ProjectExplorerViewModel>();
+        projectExplorer.ProjectWillLoad(location);
 
-        ActiveProject = p;
-
-        // If the assets can't be found, stop here and notify the user in the log
-        if (!File.Exists(SettingsManager.CP77ExecutablePath))
+        try
         {
-            UpdateTitle();
-            _loggerService.Warning($"Cyberpunk 2077 executable path is not set. Asset browser disabled.");
-            return;
-        }
+            var p = await _projectManager.LoadAsync(location);
 
-        DispatcherHelper.DelayOnMainThread(() =>
-        {
-            UpdateTitle();
-            _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
-            // https://github.com/WolvenKit/WolvenKit/issues/1962
-            if (!FilepathValidationTools.IsOsFilePathValid(location))
+            if (p is null || !ProjectLocationsMatch(p.Location, location))
             {
-                _notificationService.Warning($"Project path {location} contains invalid characters!");
+                throw (new WolvenKitException(0x0b20f001, $"Project location to be loaded {location} {Environment.NewLine}did not match actual project location {p?.Location}{Environment.NewLine}. This is a bug, please report to the WolvenKit discord."));
             }
 
-            OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
-        }, 1000);
+            ActiveProject = p;
+
+            // If the assets can't be found, stop here and notify the user in the log
+            if (!File.Exists(SettingsManager.CP77ExecutablePath))
+            {
+                UpdateTitle();
+                _loggerService.Warning($"Cyberpunk 2077 executable path is not set. Asset browser disabled.");
+                // Still load the project even if there's no CP77 path.
+                OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
+            DispatcherHelper.DelayOnMainThread(() =>
+            {
+                UpdateTitle();
+                _notificationService.Success($"Project {Path.GetFileNameWithoutExtension(location)} loaded!");
+                // https://github.com/WolvenKit/WolvenKit/issues/1962
+                if (!FilepathValidationTools.IsOsFilePathValid(location))
+                {
+                    _notificationService.Warning($"Project path {location} contains invalid characters!");
+                }
+
+                OnInitialProjectLoaded?.Invoke(this, EventArgs.Empty);
+            }, 1000);
+        }
+        catch (Exception ex)
+        {
+            projectExplorer.CancelProjectLoad();
+            _loggerService.Error($"Error loading project: {ex}.");
+        }
+    }
+
+    private static bool ProjectLocationsMatch(string loadedLocation, string requestedLocation)
+    {
+        if (string.IsNullOrWhiteSpace(loadedLocation) || string.IsNullOrWhiteSpace(requestedLocation))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(loadedLocation),
+                Path.GetFullPath(requestedLocation),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            return string.Equals(loadedLocation, requestedLocation, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     [RelayCommand]
@@ -929,6 +949,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             _loggerService.Error("Failed to create a new project!");
             _loggerService.Error(ex);
+            GetToolViewModel<ProjectExplorerViewModel>().CancelProjectLoad();
         }
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -86,11 +86,19 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     /// </summary>
     private readonly string _autoSavePurpose = $"ProjectExplorer autosave {Guid.NewGuid():N}";
 
+    /// <summary>
+    /// Live claim on the project-load progress heartbeat, or null when no load is in flight.
+    /// Owned here rather than on the watcher: the view model is what arms and disarms it.
+    /// </summary>
+    private DispatcherHelper.RepeatingActionHandle? _loadingIndicatorHandle;
+
     private readonly ISettingsManager _settingsManager;
     private readonly IArchiveManager _archiveManager;
     private readonly ProjectResourceTools _projectResourceTools;
 
     private readonly ImportExportHelper _importExportHelper;
+    private readonly TimeSpan _projectLoadPollingInterval = TimeSpan.FromMilliseconds(50);
+    //private bool _inFlight = false;
 
     // FileTree / FileList are owned by the watcher service and are the grids' single source of truth.
     public DispatchedObservableCollection<FileSystemModel> FileTree => _projectWatcher.FileTree;
@@ -174,6 +182,9 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     #endregion constructor
 
     #region properties
+
+    [ObservableProperty]
+    private LoadingMode _currentLoadingMode;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(OpenInMlsbCommand))]
@@ -1444,6 +1455,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         if (!IsShiftKeyPressed)
         {
             var selection = SelectedItems!.OfType<FileSystemModel>().Where(IsInRawFolder).ToList();
+            EnableLoadingMode(LoadingMode.ShowLoadingDuringOperation);
 
             if (BeginDeferredRefreshContext == null)
             {
@@ -1452,6 +1464,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             }
 
             await BeginDeferredRefreshContext(() => ConvertFromJsonInternal(selection));
+            DisableLoadingMode();
             return;
         }
 
@@ -1462,6 +1475,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             .Where(IsInArchiveFolder)
             .Where(x => selectedItemPaths.Contains(x.GameRelativePath)).ToList();
 
+        EnableLoadingMode(LoadingMode.ShowLoadingDuringOperation);
+
         if (BeginDeferredRefreshContext == null)
         {
             await ConvertFromJsonInternal(convertSelection);
@@ -1469,6 +1484,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }
 
         await BeginDeferredRefreshContext(() => ConvertFromJsonInternal(convertSelection));
+        DisableLoadingMode();
     }
 
     private async Task ConvertFromJsonInternal(IEnumerable<FileSystemModel> selection)
@@ -1647,6 +1663,13 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
     public event Action? OnProjectChanged;
 
+    /// <summary>
+    /// Event for `isLoading` and `isReload`.
+    /// The latter will be true if the user clicked the "reload" button.
+    /// It will be false if the user has loaded a fresh project or changed projects.
+    /// </summary>
+    public event EventHandler<LoadingMode>? OnSetLoading;
+
     [RelayCommand(CanExecute = nameof(CanOpenInFileExplorer))]
     private void ToggleFlatMode() => OnToggleFlatMode?.Invoke(this, EventArgs.Empty);
 
@@ -1751,13 +1774,64 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         }, DispatcherPriority.ContextIdle);
     }
 
+    /// <summary>
+    /// Announces that a different project is about to load: flushes the outgoing project's state
+    /// and arms the loading chrome. Must be called before the project manager swaps its active
+    /// project, or the outgoing state is saved against the incoming one.
+    ///
+    /// Idempotent — the welcome page arms the chrome on click for responsiveness and the load path
+    /// announces the same load again; only the first call flushes.
+    /// </summary>
+    public void ProjectWillLoad(string projectPath)
+    {
+        if (CurrentLoadingMode == LoadingMode.LoadingNewProject)
+        {
+            return;
+        }
+
+        if (ActiveProject != null)
+        {
+            if (IsSameProjectPath(ActiveProject, projectPath))
+            {
+                return;
+            }
+
+            SaveProjectState();
+        }
+
+        EnableLoadingMode(LoadingMode.LoadingNewProject);
+    }
+
+    /// <summary>
+    /// Clears project-load loading chrome without reporting a successful load.
+    /// Use on cancel / failed open / same-project no-op after ProjectWillLoad armed the UI.
+    /// </summary>
+    public void CancelProjectLoad() => DisableLoadingMode(reportResult: false);
+
     private void AppViewModel_OnInitialProjectLoaded(object? sender, EventArgs e)
     {
         DispatcherHelper.RunOnMainThread(() =>
         {
-            RefreshProjectData();
+            try
+            {
+                EnableLoadingMode(false ? LoadingMode.ReloadingSameProject : LoadingMode.LoadingNewProject);
 
-            CheckForOneDriveInPath();
+                RefreshProjectData();
+
+                CheckForOneDriveInPath();
+            }
+            catch (Exception e)
+            {
+                _loggerService.Error($"Error refreshing project: {e.Message}. Try reloading the app. If this error persists, please reach out on the WolvenKit discord.");
+
+                CancelProjectLoad();
+            }
+            finally
+            {
+                RestoreProjectState(ActiveProject!);
+                CheckForOneDriveInPath();
+                DisableLoadingMode();
+            }
         });
     }
 
@@ -1805,18 +1879,115 @@ public partial class ProjectExplorerViewModel : ToolViewModel
 
     }
 
+    private static bool IsSameProjectPath(Cp77Project activeProject, string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var requested = Path.GetFullPath(projectPath);
+            var location = Path.GetFullPath(activeProject.Location);
+            if (string.Equals(requested, location, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var projectDirectory = Path.GetFullPath(activeProject.ProjectDirectory);
+            return string.Equals(requested, projectDirectory, StringComparison.OrdinalIgnoreCase)
+                   || requested.StartsWith(projectDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                   || requested.StartsWith(projectDirectory + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception)
+        {
+            return string.Equals(activeProject.Location, projectPath, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public enum LoadingMode
+    {
+        Ready,
+        LoadingNewProject,
+        ReloadingSameProject,
+        ShowLoadingDuringOperation
+    }
+
+    private void EnableLoadingMode(LoadingMode mode)
+    {
+        if (mode != LoadingMode.LoadingNewProject && mode != LoadingMode.ReloadingSameProject && mode != LoadingMode.ShowLoadingDuringOperation)
+        {
+            return;
+        }
+
+        if (mode != CurrentLoadingMode)
+        {
+            OnSetLoading?.Invoke(this, mode);
+            CurrentLoadingMode = mode;
+        }
+
+        if (_loadingIndicatorHandle is not null)
+        {
+            return;
+        }
+
+        _loadingIndicatorHandle = DispatcherHelper.StartRepeatingAction(
+            purpose: LoadProjectPurpose,
+            () =>
+            {
+                _progressService.IsIndeterminate = true;
+                _progressService.Status = EStatus.Running;
+            },
+            _projectLoadPollingInterval
+        );
+    }
+
+    public void DisableLoadingMode() => DisableLoadingMode(reportResult: true);
+
+    private void DisableLoadingMode(bool reportResult)
+    {
+        if (CurrentLoadingMode == LoadingMode.Ready)
+        {
+            return;
+        }
+
+        var completedMode = CurrentLoadingMode;
+
+        _progressService.IsIndeterminate = false;
+        _progressService.Status = EStatus.Ready;
+        CurrentLoadingMode = LoadingMode.Ready;
+        OnSetLoading?.Invoke(this, CurrentLoadingMode);
+
+        DispatcherHelper.StopRepeatingAction(_loadingIndicatorHandle);
+        _loadingIndicatorHandle = null;
+
+        if (!reportResult)
+        {
+            return;
+        }
+
+        if (completedMode is not (LoadingMode.LoadingNewProject or LoadingMode.ReloadingSameProject))
+        {
+            return;
+        }
+
+        if (ActiveProject != null)
+        {
+            _loggerService?.Success($"Loaded project: {ActiveProject!.ProjectDirectory} ({FileList.Count} files). File watcher active.");
+        }
+        else
+        {
+            _loggerService.Warning(
+                $"Loading the project has seemed to fail. Please restart WolvenKit and try again. If this issue persists, please contact support on the WolvenKit discord.");
+        }
+    }
+
     /// <summary>
     /// Initialize Avalondock specific defaults that are specific to this tool window.
     /// </summary>
     private void SetupToolDefaults() =>
         ContentId = s_toolContentId;
-    // Define a unique contentId for this toolwindow
-    //BitmapImage bi = new BitmapImage();
-    // Define an icon for this toolwindow
-    // bi.BeginInit();
-    // bi.UriSource = new Uri("pack://application:,,/Resources/Media/Images/property-blue.png");
-    // bi.EndInit();
-    // IconSource = bi;
 
     private void CheckForOneDriveInPath()
     {
@@ -1845,6 +2016,18 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     #endregion Project_Loading
 
     #region save/restore
+
+    private void SaveProjectState()
+    {
+        if (ActiveProject != null)
+        {
+            _hasUnsavedFileTreeChanges = true;
+            SaveOpenFilePaths();
+            SaveProjectExplorerExpansionStateIfDirty();
+            SaveProjectExplorerTabIfDirty();
+            _hasUnsavedFileTreeChanges = false;
+        }
+    }
 
     private void Svc_ThreadIdleTenSeconds(object? sender, EventArgs e)
     {

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -1814,7 +1814,14 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         {
             try
             {
-                EnableLoadingMode(false ? LoadingMode.ReloadingSameProject : LoadingMode.LoadingNewProject);
+                // Enable Loading... indicator if the project dir has changed and the
+                // indicator is not already being shown.
+                if (_projectManager.ActiveProject?.ProjectDirectory is { } newProjectDir
+                    && newProjectDir != ActiveProject?.ProjectDirectory
+                    && CurrentLoadingMode != LoadingMode.LoadingNewProject)
+                {
+                    EnableLoadingMode(LoadingMode.LoadingNewProject);
+                }
 
                 RefreshProjectData();
 

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -1108,8 +1108,7 @@
             Grid.Row="2"
             Margin="0"
             BorderThickness="0"
-            Visibility="{Binding IsFlatModeEnabled,
-                                 Converter={StaticResource BoolInvertConverter}}"
+            Visibility="Visible"
             HeaderRowHeight="3"
             RowHeight="{DynamicResource WolvenKitTreeGridRowHeight}"
             ColumnSizer="Star"
@@ -1183,8 +1182,7 @@
             Grid.Row="2"
             Margin="0"
             BorderThickness="0"
-            Visibility="{Binding IsFlatModeEnabled,
-                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+            Visibility="Visible"
             HeaderRowHeight="{DynamicResource WolvenKitTreeGridRowHeaderHeight}"
             RowHeight="{DynamicResource WolvenKitTreeGridRowHeight}"
             ColumnSizer="Star"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.Messaging;
 using HandyControl.Data;
+using MahApps.Metro.Controls;
 using ReactiveUI;
 using Syncfusion.Data;
 using Syncfusion.UI.Xaml.Grid;

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -384,7 +384,6 @@ namespace WolvenKit.Views.Tools
         {
             _isShowingLoadingIndicator = false;
             UpdatePaneVisibility();
-            //ScheduleGhostRowCleanup();
         }
 
         private void UpdatePaneVisibility()

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -94,6 +94,10 @@ namespace WolvenKit.Views.Tools
         /// </summary>
         private bool _searchMutatedExpansion;
 
+        private ProjectExplorerViewModel.LoadingMode _loadingMode = ProjectExplorerViewModel.LoadingMode.Ready;
+
+        private bool _isShowingLoadingIndicator = true;
+
         #endregion fields
 
         #region Constructor
@@ -280,14 +284,123 @@ namespace WolvenKit.Views.Tools
                     .DisposeWith(disposables);
 
                 ViewModel.OnToggleFlatMode += OnToggleFlatMode;
-                ViewModel.BeginDeferredRefreshContext += BeginDeferredRefreshContext;
+                ViewModel.OnSetLoading += SetLoading;
+                ViewModel.BeginDeferredRefreshContext = BeginDeferredRefreshContext;
 
+                ViewModel.WhenAnyValue(x => x.IsFlatModeEnabled)
+                    .Subscribe(_ => UpdatePaneVisibility())
+                    .DisposeWith(disposables);
             });
+
+            this.ExecuteWhenLoaded(() => IndicateProjectLoading());
         }
 
         #endregion
 
         #region Project_Loading
+
+        private bool ShouldStartLoadingProject(ProjectExplorerViewModel.LoadingMode mode)
+        {
+            return mode == ProjectExplorerViewModel.LoadingMode.LoadingNewProject
+                   || mode == ProjectExplorerViewModel.LoadingMode.ReloadingSameProject;
+        }
+
+        private bool ShouldStopLoading(ProjectExplorerViewModel.LoadingMode mode)
+        {
+            return mode == ProjectExplorerViewModel.LoadingMode.Ready;
+        }
+
+        private bool ShouldStopTemporaryLoading(ProjectExplorerViewModel.LoadingMode mode)
+        {
+            return mode == ProjectExplorerViewModel.LoadingMode.Ready;
+        }
+
+        private bool ShouldStartTemporaryLoading(ProjectExplorerViewModel.LoadingMode mode)
+        {
+            return mode == ProjectExplorerViewModel.LoadingMode.ShowLoadingDuringOperation;
+        }
+
+        private bool IsFreshLoad(ProjectExplorerViewModel.LoadingMode mode)
+        {
+            return mode == ProjectExplorerViewModel.LoadingMode.LoadingNewProject;
+        }
+
+        private bool AlreadyLoadingProject()
+        {
+            return _loadingMode == ProjectExplorerViewModel.LoadingMode.LoadingNewProject
+                   || _loadingMode == ProjectExplorerViewModel.LoadingMode.ReloadingSameProject;
+        }
+
+        private bool AlreadyTemporaryLoading()
+        {
+            return _loadingMode == ProjectExplorerViewModel.LoadingMode.ShowLoadingDuringOperation;
+        }
+
+        private bool Ready()
+        {
+            return _loadingMode == ProjectExplorerViewModel.LoadingMode.Ready;
+        }
+
+        /// <summary>
+        /// Called by the ViewModel when the View should show "Loading" on the file pane.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SetLoading(object sender, ProjectExplorerViewModel.LoadingMode mode)
+        {
+            if (ShouldStartLoadingProject(mode) && Ready())
+            {
+                ResetCurrentFolderQuerySearchFilter();
+
+                if (IsFreshLoad(mode))
+                {
+                    IndicateProjectLoading();
+                }
+            }
+            else if (ShouldStopLoading(mode) && AlreadyLoadingProject())
+            {
+                IndicateProjectNotLoading();
+            }
+            else if (ShouldStopTemporaryLoading(mode) && AlreadyTemporaryLoading())
+            {
+                IndicateProjectNotLoading();
+            }
+            else if (ShouldStartTemporaryLoading(mode) && Ready())
+            {
+                IndicateProjectLoading();
+            }
+
+            _loadingMode = mode;
+        }
+
+        private void IndicateProjectLoading() => Dispatcher.Invoke(() =>
+        {
+            _isShowingLoadingIndicator = true;
+            UpdatePaneVisibility();
+        });
+
+        private void IndicateProjectNotLoading()
+        {
+            _isShowingLoadingIndicator = false;
+            UpdatePaneVisibility();
+            //ScheduleGhostRowCleanup();
+        }
+
+        private void UpdatePaneVisibility()
+        {
+            var isFlat = ViewModel?.IsFlatModeEnabled ?? false;
+            var isLoading = _isShowingLoadingIndicator;
+
+            LoadingText.SetCurrentValue(VisibilityProperty, ToVisibility(isLoading));
+            TreeGrid.SetCurrentValue(VisibilityProperty, ToVisibility(!isLoading && !isFlat));
+            TreeGridFlat.SetCurrentValue(VisibilityProperty, ToVisibility(!isLoading && isFlat));
+
+            static Visibility ToVisibility(bool isVisible) => isVisible ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        #endregion Project_Loading
+
+        #region refresh
 
         public void Receive(ChalkboardService.WillStartLoadingProjectFiles msg)
         {
@@ -312,9 +425,12 @@ namespace WolvenKit.Views.Tools
                 _disposables.Clear();
             });
 
-        #endregion Project_Loading
-
-        #region refresh
+        private void ResetCurrentFolderQuerySearchFilter()
+        {
+            _currentFolderQuery = "";
+            _searchVisiblePaths = null;
+            PESearchBar?.SetCurrentValue(System.Windows.Controls.TextBox.TextProperty, "");
+        }
 
         // Run inside Dispatcher to avoid exception on startup
         private void ResetUiElements() => Dispatcher.Invoke(() =>
@@ -411,6 +527,8 @@ namespace WolvenKit.Views.Tools
             {
                 return;
             }
+
+            UpdatePaneVisibility();
 
             if (model.IsFlatModeEnabled)
             {

--- a/changelog/unreleased/3120.yaml
+++ b/changelog/unreleased/3120.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3120
+      author: "gistya"
+      description: "Fixed tab filters not working in Project Explorer flat tree mode ('archive', 'raw', 'resources')."

--- a/changelog/unreleased/3122.yaml
+++ b/changelog/unreleased/3122.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3122
+      author: "gistya"
+      description: "Project Explorer will now show Loading... pane earlier in the process for smoother UX, and during long batch operations when the tree should not be interacted with."


### PR DESCRIPTION
# Project loading indicator improvements

**Implemented:**
- Project loading indicator now shows earlier as soon as a project starts loading for better UX, and during long batch operations when one should not interact with the file tree lest bad things happen. 
- If project loading fails or is somehow canceled, the app now gracefully handles this, preventing the Loading indicator from being able to get stuck.

**Additional Notes**
- broken out from PR #2945
- resolves issue #3126 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->