### PR TITLE
Scene Editor: Import dialogue lines

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
@@ -1,0 +1,298 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Helpers;
+
+namespace WolvenKit.UnitTests.App.Helpers;
+
+/// <summary>
+/// The payload contract between the Scene Editor's dialogue import and whoever writes an export -
+/// the Dialogue Browser CET mod writes one from its conversation panel. The JSON in these tests is
+/// shaped exactly as that exporter writes it: keys sorted, locstring ids as strings.
+/// </summary>
+[TestClass]
+public class DialogueImportHelperTests
+{
+    private const string ConversationExport = """
+        {
+          "conversation": "Ripperdoc",
+          "conversationId": "conv1755043200_1",
+          "exportedAt": 1755043200,
+          "format": "wolvenkit.scene.dialogue",
+          "lines": [
+            {
+              "addressee": "V",
+              "context": "Vo_Context_Quest",
+              "duration": 2.6,
+              "expression": "Vo_Expression_Spoken",
+              "femaleLipsyncAnim": "f_1A95FA94452C5000",
+              "femaleText": "Wakey wakey, choom.",
+              "hasFemale": true,
+              "hasMale": false,
+              "kind": "line",
+              "locStringId": "45896283497",
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 1,
+              "quest": "q000",
+              "scene": "base\\quest\\test.scene",
+              "speaker": "Viktor Vektor",
+              "subtitlePath": "base\\localization\\test.json",
+              "text": "Wakey wakey, choom."
+            },
+            {
+              "femaleText": "",
+              "hasFemale": false,
+              "hasMale": true,
+              "kind": "line",
+              "locStringId": "45896283498",
+              "maleLipsyncAnim": "m_2B95FA94452C5001",
+              "maleText": "You got a plan?",
+              "order": 2,
+              "speaker": "V",
+              "text": "You got a plan?"
+            }
+          ],
+          "source": "DialogueBrowser 1.0.0",
+          "version": 1
+        }
+        """;
+
+    [TestMethod]
+    public void ParsesAConversationExport()
+    {
+        var payload = DialogueImportHelper.Parse(ConversationExport);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.IsNull(payload.Error);
+        Assert.AreEqual("Ripperdoc", payload.ConversationName);
+        Assert.AreEqual("DialogueBrowser 1.0.0", payload.Source);
+        Assert.AreEqual(0, payload.SkippedCount);
+        Assert.AreEqual(2, payload.Lines.Count);
+    }
+
+    [TestMethod]
+    public void CarriesEverythingAScreenplayLineNeeds()
+    {
+        var line = DialogueImportHelper.Parse(ConversationExport).Lines[0];
+
+        Assert.AreEqual(45896283497UL, line.LocStringId);
+        Assert.AreEqual("Wakey wakey, choom.", line.Text);
+        Assert.AreEqual("Viktor Vektor", line.Speaker);
+        Assert.AreEqual("V", line.Addressee);
+        Assert.AreEqual("f_1A95FA94452C5000", line.FemaleLipsyncAnim);
+        Assert.AreEqual("", line.MaleLipsyncAnim);
+        Assert.IsFalse(line.IsChoiceOption);
+    }
+
+    [TestMethod]
+    public void LeavesTheAddresseeEmptyWhenTheExportDoesNotNameOne()
+    {
+        Assert.AreEqual("", DialogueImportHelper.Parse(ConversationExport).Lines[1].Addressee);
+    }
+
+    [TestMethod]
+    public void ReadsTheLipsyncNameOfEitherRecordedVariant()
+    {
+        var line = DialogueImportHelper.Parse(ConversationExport).Lines[1];
+
+        Assert.AreEqual("", line.FemaleLipsyncAnim);
+        Assert.AreEqual("m_2B95FA94452C5001", line.MaleLipsyncAnim);
+    }
+
+    [TestMethod]
+    public void FallsBackToARecordedVariantWhenThereIsNoDisplayText()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            { "lines": [ { "locStringId": "12345", "femaleText": "Only the female take was written." } ] }
+            """);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual("Only the female take was written.", payload.Lines[0].Text);
+    }
+
+    [TestMethod]
+    public void ReadsALocStringIdWrittenAsANumber()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            { "lines": [ { "locStringId": 45896283497, "text": "Numbered." } ] }
+            """);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual(45896283497UL, payload.Lines[0].LocStringId);
+    }
+
+    [TestMethod]
+    public void ReadsABareArrayOfLines()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            [ { "locStringId": "1", "text": "One." }, { "locStringId": "2", "text": "Two." } ]
+            """);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual(2, payload.Lines.Count);
+    }
+
+    [TestMethod]
+    public void RoutesChoiceOptionsToTheirOwnHalfOfTheStore()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            { "lines": [ { "locStringId": "1", "kind": "option", "text": "Ask about the price." } ] }
+            """);
+
+        Assert.IsTrue(payload.Lines[0].IsChoiceOption);
+    }
+
+    [TestMethod]
+    public void KeepsOneLinePerLocStringId()
+    {
+        // A conversation may hold the same line twice - a character can repeat themselves - but the
+        // scene only ever wants one screenplay entry pointing at a recording.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                { "locStringId": "42", "text": "Said once." },
+                { "locStringId": "42", "text": "Said again." }
+              ]
+            }
+            """);
+
+        Assert.AreEqual(1, payload.Lines.Count);
+        Assert.AreEqual(1, payload.SkippedCount);
+    }
+
+    [TestMethod]
+    public void DropsLinesWithNoUsableLocStringId()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                { "locStringId": "", "text": "No id." },
+                { "text": "No id at all." },
+                { "locStringId": "0", "text": "Zero is not an id." },
+                { "locStringId": "77", "text": "Keeps this one." }
+              ]
+            }
+            """);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual(1, payload.Lines.Count);
+        Assert.AreEqual(77UL, payload.Lines.Single().LocStringId);
+        Assert.AreEqual(3, payload.SkippedCount);
+    }
+
+    [TestMethod]
+    public void RefusesAPayloadWrittenForSomethingElse()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            { "format": "some.other.format", "lines": [ { "locStringId": "1" } ] }
+            """);
+
+        Assert.IsFalse(payload.IsValid);
+        Assert.IsTrue(payload.Error?.Contains(DialogueImportHelper.PayloadFormat) == true);
+    }
+
+    [TestMethod]
+    public void ReportsMalformedInputRatherThanThrowing()
+    {
+        foreach (var input in new[] { "", "   ", "not json at all", "{ \"lines\": [", "{}", "{ \"lines\": [] }" })
+        {
+            var payload = DialogueImportHelper.Parse(input);
+
+            Assert.IsFalse(payload.IsValid, $"'{input}' should not parse");
+            Assert.IsNotNull(payload.Error, $"'{input}' should say why");
+        }
+    }
+
+    [TestMethod]
+    public void PointsAtTheModsExportFolderUnderAGameInstall()
+    {
+        var directory = DialogueImportHelper.GetExportDirectory(@"C:\Games\Cyberpunk 2077");
+
+        Assert.AreEqual(
+            @"C:\Games\Cyberpunk 2077\bin\x64\plugins\cyber_engine_tweaks\mods\DialogueBrowser\data\exports",
+            directory);
+    }
+
+    /// <summary>The scene an import's speaker and addressee names are matched against here.</summary>
+    private static DialogueSpeakerResolver Cast() =>
+        new([
+            new SceneActorOption(0, "Viktor Vektor"),
+            new SceneActorOption(1, "takemura_goro"),
+            new SceneActorOption(2, ""),
+            new SceneActorOption(3, "Player", isPlayer: true)
+        ]);
+
+    [TestMethod]
+    public void MatchesANameToTheActorTheSceneKnowsByIt()
+    {
+        Assert.AreEqual<uint?>(0u, Cast().Resolve("Viktor Vektor")?.ActorId);
+    }
+
+    [TestMethod]
+    public void MatchesANameHoweverItWasTyped()
+    {
+        // An export names a character the way the game's subtitles do; a scene however its author
+        // felt like typing it.
+        Assert.AreEqual<uint?>(0u, Cast().Resolve("viktor vektor")?.ActorId);
+        Assert.AreEqual<uint?>(0u, Cast().Resolve("  Viktor Vektor  ")?.ActorId);
+        Assert.AreEqual<uint?>(1u, Cast().Resolve("Takemura Goro")?.ActorId);
+    }
+
+    [TestMethod]
+    public void ResolvesVToTheFirstPlayerActor()
+    {
+        // Whatever the scene calls its player actor, and whatever else it names "V".
+        var resolver = new DialogueSpeakerResolver([
+            new SceneActorOption(7, "V"),
+            new SceneActorOption(3, "Player", isPlayer: true),
+            new SceneActorOption(4, "Second V", isPlayer: true)
+        ]);
+
+        Assert.AreEqual<uint?>(3u, resolver.Resolve("v")?.ActorId);
+    }
+
+    [TestMethod]
+    public void MatchesNothingForANameTheSceneDoesNotCast()
+    {
+        Assert.IsNull(Cast().Resolve("Johnny Silverhand"));
+        Assert.IsNull(Cast().Resolve(""));
+        Assert.IsNull(Cast().Resolve("   "));
+        Assert.IsNull(Cast().Resolve(null));
+
+        // A scene with no player actor has nothing for "V" to mean.
+        Assert.IsNull(new DialogueSpeakerResolver([new SceneActorOption(1, "Viktor Vektor")]).Resolve("V"));
+    }
+
+    [TestMethod]
+    public void KeepsTheFirstActorOfAName()
+    {
+        var resolver = new DialogueSpeakerResolver([
+            new SceneActorOption(4, "Guard"),
+            new SceneActorOption(5, "Guard")
+        ]);
+
+        Assert.AreEqual<uint?>(4u, resolver.Resolve("Guard")?.ActorId);
+    }
+
+    [TestMethod]
+    public void NamesEveryActorTheDropdownOffers()
+    {
+        // The id is always named: a scene may cast two actors alike, or leave one unnamed, and only
+        // the id tells those apart in a dropdown.
+        Assert.AreEqual("(no actor)", SceneActorOption.None.DisplayName);
+        Assert.AreEqual("2: (unnamed)", new SceneActorOption(2, "").DisplayName);
+        Assert.AreEqual("1: Viktor Vektor", new SceneActorOption(1, " Viktor Vektor ").DisplayName);
+    }
+
+    [TestMethod]
+    public void RecognisesWhatIsWorthReadingOffTheClipboard()
+    {
+        Assert.IsTrue(DialogueImportHelper.LooksLikePayload(ConversationExport));
+        Assert.IsTrue(DialogueImportHelper.LooksLikePayload("""[ { "locStringId": "1" } ]"""));
+
+        Assert.IsFalse(DialogueImportHelper.LooksLikePayload(null));
+        Assert.IsFalse(DialogueImportHelper.LooksLikePayload(""));
+        Assert.IsFalse(DialogueImportHelper.LooksLikePayload("base\\quest\\some\\path.scene"));
+        Assert.IsFalse(DialogueImportHelper.LooksLikePayload("""{ "some": "other json" }"""));
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
@@ -76,12 +76,44 @@ public class DialogueImportHelperTests
         var line = DialogueImportHelper.Parse(ConversationExport).Lines[0];
 
         Assert.AreEqual(45896283497UL, line.LocStringId);
-        Assert.AreEqual("Wakey wakey, choom.", line.Text);
+        Assert.AreEqual("Wakey wakey, choom.", line.EmbeddedText);
         Assert.AreEqual("Viktor Vektor", line.Speaker);
         Assert.AreEqual("V", line.Addressee);
         Assert.AreEqual("f_1A95FA94452C5000", line.FemaleLipsyncAnim);
         Assert.AreEqual("", line.MaleLipsyncAnim);
         Assert.IsFalse(line.IsChoiceOption);
+    }
+
+    [TestMethod]
+    public void SpotsALineWordedForThePlayersGender()
+    {
+        // Vanilla keeps both wordings against one locstring, told apart by the locstore descriptor's
+        // gender signature. Only one of them can be embedded, so the dialog says when there are two.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                {
+                  "locStringId": "1677648457431117824",
+                  "text": "Got 'nads on you, girl.",
+                  "femaleText": "Got 'nads on you, girl.",
+                  "maleText": "Got balls on you, boy."
+                },
+                {
+                  "locStringId": "2",
+                  "text": "Same either way.",
+                  "femaleText": "Same either way.",
+                  "maleText": "Same either way."
+                },
+                { "locStringId": "3", "text": "Only one take.", "femaleText": "Only one take." }
+              ]
+            }
+            """);
+
+        Assert.IsTrue(payload.Lines[0].HasGenderedText);
+        Assert.AreEqual("Got balls on you, boy.", payload.Lines[0].MaleText);
+
+        Assert.IsFalse(payload.Lines[1].HasGenderedText, "the same wording twice is not gendered");
+        Assert.IsFalse(payload.Lines[2].HasGenderedText, "one variant cannot differ from the other");
     }
 
     [TestMethod]
@@ -107,7 +139,7 @@ public class DialogueImportHelperTests
             """);
 
         Assert.IsTrue(payload.IsValid);
-        Assert.AreEqual("Only the female take was written.", payload.Lines[0].Text);
+        Assert.AreEqual("Only the female take was written.", payload.Lines[0].EmbeddedText);
     }
 
     [TestMethod]

--- a/Tests/WolvenKit.UnitTests/App/Helpers/SceneEditingHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/SceneEditingHelperTests.cs
@@ -1,0 +1,120 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Helpers;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.Helpers;
+
+/// <summary>
+/// How a screenplay store hands out its next item id. Graph events bind to their screenplay entry
+/// by item id, so an id handed out twice makes a scnDialogLineEvent play the wrong line.
+/// </summary>
+[TestClass]
+public class SceneEditingHelperScreenplayItemIdTests
+{
+    private const uint Step = SceneEditingHelper.ScreenplayItemIdStep;
+    private const uint Unassigned = SceneEditingHelper.UnassignedScreenplayItemId;
+
+    [TestMethod]
+    public void StartsEachHalfOfTheStoreWhereTheGameStartsIt()
+    {
+        Assert.AreEqual(1u, SceneEditingHelper.GetNextScreenplayItemId([], 1));
+        Assert.AreEqual(2u, SceneEditingHelper.GetNextScreenplayItemId([], 2));
+
+        Assert.AreEqual(1u, SceneEditingHelper.GetNextDialogLineItemId([]));
+        Assert.AreEqual(2u, SceneEditingHelper.GetNextChoiceOptionItemId([]));
+    }
+
+    [TestMethod]
+    public void CountsAStepUpFromTheHighestIdInUse()
+    {
+        Assert.AreEqual(257u, SceneEditingHelper.GetNextScreenplayItemId([1], 1));
+        Assert.AreEqual(769u, SceneEditingHelper.GetNextScreenplayItemId([1, 257, 513], 1));
+    }
+
+    [TestMethod]
+    public void CountsFromTheHighestIdWhereverTheStoreKeepsIt()
+    {
+        // Nothing sorts the array, so a store whose entries were added or reordered through the raw
+        // chunk editor can carry its highest id anywhere. Taking the last one would hand out 257 -
+        // an id already in use.
+        Assert.AreEqual(769u, SceneEditingHelper.GetNextScreenplayItemId([513, 1, 257], 1));
+        Assert.AreEqual(770u, SceneEditingHelper.GetNextScreenplayItemId([514, 2, 258], 2));
+    }
+
+    [TestMethod]
+    public void LeavesTheFirstIdAloneWhenEverythingInTheStoreIsBelowIt()
+    {
+        Assert.AreEqual(2u, SceneEditingHelper.GetNextScreenplayItemId([0], 2));
+    }
+
+    [TestMethod]
+    public void PassesOverAnEntryTheRawEditorLeftUnassigned()
+    {
+        // A screenplay entry added through the raw array editor carries the ctor default. Counting a
+        // step up from it wraps a 32 bit uint to 0, which every other unassigned entry answers to.
+        Assert.AreEqual(0u, unchecked(Unassigned + Step), "the wrap this guards against");
+
+        Assert.AreEqual(1u, SceneEditingHelper.GetNextScreenplayItemId([Unassigned], 1));
+        Assert.AreEqual(513u, SceneEditingHelper.GetNextScreenplayItemId([1, Unassigned, 257], 1));
+    }
+
+    [TestMethod]
+    public void PassesOverAnyIdTooHighToStepPast()
+    {
+        Assert.AreEqual(1u, SceneEditingHelper.GetNextScreenplayItemId([uint.MaxValue], 1));
+        Assert.AreEqual(uint.MaxValue, SceneEditingHelper.GetNextScreenplayItemId([uint.MaxValue - Step], 1));
+    }
+
+    [TestMethod]
+    public void ReadsTheIdsOffTheStoreItself()
+    {
+        var lines = new[]
+        {
+            new scnscreenplayDialogLine { ItemId = new scnscreenplayItemId { Id = 513 } },
+            new scnscreenplayDialogLine { ItemId = new scnscreenplayItemId { Id = 1 } },
+            // Added through the raw array editor and never given an id.
+            new scnscreenplayDialogLine()
+        };
+
+        Assert.AreEqual(769u, SceneEditingHelper.GetNextDialogLineItemId(lines));
+    }
+
+    [TestMethod]
+    public void ReadsTheIdsOffTheOptionsHalfToo()
+    {
+        var options = new[]
+        {
+            new scnscreenplayChoiceOption { ItemId = new scnscreenplayItemId { Id = 2 } },
+            new scnscreenplayChoiceOption { ItemId = new scnscreenplayItemId { Id = 514 } }
+        };
+
+        Assert.AreEqual(770u, SceneEditingHelper.GetNextChoiceOptionItemId(options));
+    }
+
+    [TestMethod]
+    public void TakesAStoreThatIsNotThere()
+    {
+        Assert.AreEqual(1u, SceneEditingHelper.GetNextDialogLineItemId(null));
+        Assert.AreEqual(2u, SceneEditingHelper.GetNextChoiceOptionItemId(null));
+    }
+
+    [TestMethod]
+    public void KeepsTheStepTheGameNumbersBy()
+    {
+        // Lower and the previous entry's text is used; higher and nothing is shown at all.
+        var ids = new uint[16];
+        var next = SceneEditingHelper.GetNextDialogLineItemId([]);
+
+        for (var i = 0; i < ids.Length; i++)
+        {
+            ids[i] = next;
+            next = SceneEditingHelper.GetNextScreenplayItemId(ids.Take(i + 1), 1);
+        }
+
+        Assert.AreEqual(ids.Length, ids.Distinct().Count());
+        CollectionAssert.AreEqual(
+            Enumerable.Range(0, ids.Length).Select(i => 1u + ((uint)i * Step)).ToArray(),
+            ids);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
@@ -106,6 +106,37 @@ public class DialogueImportDialogViewModelTests
     }
 
     [TestMethod]
+    public void ShowsBothWordingsOfALineWordedForThePlayersGender()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload("""
+            {
+              "lines": [
+                {
+                  "locStringId": "1",
+                  "text": "Got 'nads on you, girl.",
+                  "femaleText": "Got 'nads on you, girl.",
+                  "maleText": "Got balls on you, boy."
+                },
+                { "locStringId": "2", "text": "Same either way." }
+              ]
+            }
+            """);
+
+        var gendered = viewModel.Entries[0];
+
+        Assert.IsTrue(gendered.HasGenderedText);
+        Assert.AreEqual("Got 'nads on you, girl.", gendered.Text, "the column shows what gets embedded");
+        Assert.IsTrue(gendered.TextToolTip.Contains("Got balls on you, boy."), "and the tooltip the other");
+        Assert.IsTrue(gendered.TextToolTip.Contains("Only the first is embedded"));
+
+        // An ordinary line says nothing about gender, and its tooltip is just the line.
+        Assert.IsFalse(viewModel.Entries[1].HasGenderedText);
+        Assert.AreEqual("Same either way.", viewModel.Entries[1].TextToolTip);
+    }
+
+    [TestMethod]
     public void LeavesAChoiceOptionWithoutActorsToSet()
     {
         var viewModel = ViewModel();

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
@@ -1,0 +1,330 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Interaction.Options;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.UnitTests.App.ViewModels.Dialogs;
+
+/// <summary>
+/// The dialogue import dialog: what it makes of a payload, what it refuses, and what it hands back
+/// when the user is done with it.
+/// </summary>
+[TestClass]
+public class DialogueImportDialogViewModelTests
+{
+    private const string ThreeLines = """
+        {
+          "format": "wolvenkit.scene.dialogue",
+          "conversation": "Ripperdoc",
+          "source": "DialogueBrowser 1.0.0",
+          "lines": [
+            {
+              "locStringId": "1001",
+              "text": "Wakey wakey, choom.",
+              "speaker": "Viktor Vektor",
+              "addressee": "V",
+              "femaleLipsyncAnim": "f_1A95FA94452C5000",
+              "kind": "line"
+            },
+            {
+              "locStringId": "1002",
+              "text": "You got a plan?",
+              "speaker": "V",
+              "maleLipsyncAnim": "m_2B95FA94452C5001",
+              "kind": "line"
+            },
+            {
+              "locStringId": "1003",
+              "text": "Ask about the price.",
+              "kind": "option"
+            }
+          ]
+        }
+        """;
+
+    /// <summary>The scene these tests import into: two cast members and a player actor.</summary>
+    private static DialogueImportDialogViewModel ViewModel(
+        IEnumerable<ulong>? existingLines = null,
+        IEnumerable<ulong>? existingOptions = null) =>
+        new(new DialogueImportDialogOptions(
+            "q000_ripperdoc",
+            existingLines ?? [],
+            existingOptions ?? [],
+            [
+                new SceneActorOption(0, "Viktor Vektor"),
+                new SceneActorOption(1, "Jackie Welles"),
+                new SceneActorOption(2, "Player", isPlayer: true)
+            ]));
+
+    [TestMethod]
+    public void NamesTheSceneItIsImportingInto()
+    {
+        Assert.AreEqual("Import Dialogue - q000_ripperdoc", ViewModel().Title);
+    }
+
+    [TestMethod]
+    public void OffersNoActorAheadOfTheScenesCast()
+    {
+        var actorOptions = ViewModel().ActorOptions;
+
+        Assert.AreEqual(4, actorOptions.Count);
+        Assert.IsTrue(actorOptions[0].IsNone);
+        Assert.AreEqual("0: Viktor Vektor", actorOptions[1].DisplayName);
+    }
+
+    [TestMethod]
+    public void ListsThePayloadsLines()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.AreEqual(3, viewModel.Entries.Count);
+        Assert.AreEqual(3, viewModel.EntryCount);
+        Assert.AreEqual(3, viewModel.SelectedCount);
+        Assert.AreEqual(0, viewModel.DuplicateCount);
+        Assert.IsTrue(viewModel.HasEntries);
+        Assert.IsTrue(viewModel.CanImport);
+        Assert.IsFalse(viewModel.IsStatusError);
+        Assert.IsTrue(viewModel.StatusMessage.Contains("Ripperdoc"));
+    }
+
+    [TestMethod]
+    public void MatchesSpeakerAndAddresseeAgainstTheScenesCast()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload(ThreeLines);
+
+        // "V" always means the scene's first player actor, whatever it is named.
+        Assert.AreEqual(0u, viewModel.Entries[0].SpeakerActor.ActorId);
+        Assert.AreEqual(2u, viewModel.Entries[0].AddresseeActor.ActorId);
+        Assert.AreEqual(2u, viewModel.Entries[1].SpeakerActor.ActorId);
+        Assert.IsTrue(viewModel.Entries[1].AddresseeActor.IsNone);
+    }
+
+    [TestMethod]
+    public void LeavesAChoiceOptionWithoutActorsToSet()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.IsFalse(viewModel.Entries[2].CanSetActors);
+        Assert.AreEqual("New choice option", viewModel.Entries[2].Status);
+    }
+
+    [TestMethod]
+    public void LocksALineTheSceneAlreadyCarries()
+    {
+        var viewModel = ViewModel(existingLines: [1002UL]);
+
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.IsTrue(viewModel.Entries[1].IsDuplicate);
+        Assert.IsFalse(viewModel.Entries[1].CanImport);
+        Assert.IsFalse(viewModel.Entries[1].IsSelected);
+        Assert.AreEqual("Already in scene", viewModel.Entries[1].Status);
+        Assert.AreEqual(1, viewModel.DuplicateCount);
+        Assert.AreEqual(2, viewModel.SelectedCount);
+    }
+
+    [TestMethod]
+    public void ChecksAnOptionAgainstTheOptionsHalfOfTheStore()
+    {
+        // The two halves of the screenplay store number and key themselves independently, so a
+        // locstring in one says nothing about the other.
+        var viewModel = ViewModel(existingLines: [1003UL], existingOptions: [1001UL]);
+
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.IsFalse(viewModel.Entries[0].IsDuplicate, "a line is not an option");
+        Assert.IsFalse(viewModel.Entries[2].IsDuplicate, "an option is not a line");
+    }
+
+    [TestMethod]
+    public void HandsBackWhatTheUserSettledOn()
+    {
+        var viewModel = ViewModel();
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.Entries[1].IsSelected = false;
+        viewModel.Entries[0].AddresseeActor = viewModel.ActorOptions.Single(actor => actor.ActorId == 1);
+
+        var imported = viewModel.GetLinesToImport();
+
+        Assert.AreEqual(2, imported.Count);
+        Assert.AreEqual(1001UL, imported[0].Line.LocStringId);
+        Assert.AreEqual<uint?>(0u, imported[0].SpeakerActorId);
+        Assert.AreEqual<uint?>(1u, imported[0].AddresseeActorId, "the user's pick beats the matched name");
+        Assert.AreEqual(1003UL, imported[1].Line.LocStringId);
+    }
+
+    [TestMethod]
+    public void WritesNoActorWhereTheUserLeftOneUnset()
+    {
+        var viewModel = ViewModel();
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.Entries[0].SpeakerActor = SceneActorOption.None;
+
+        var imported = viewModel.GetLinesToImport();
+
+        Assert.IsNull(imported[0].SpeakerActorId);
+        Assert.AreEqual<uint?>(2u, imported[0].AddresseeActorId);
+    }
+
+    [TestMethod]
+    public void NeverHandsBackALineTheSceneAlreadyCarries()
+    {
+        var viewModel = ViewModel(existingLines: [1001UL]);
+        viewModel.LoadPayload(ThreeLines);
+
+        // Even asked for outright: a duplicate is filtered on the way out as well as locked in the
+        // list, so a payload swapped out from under the selection cannot smuggle one in.
+        viewModel.Entries[0].IsSelected = true;
+
+        Assert.IsFalse(viewModel.GetLinesToImport().Any(selection => selection.Line.LocStringId == 1001UL));
+    }
+
+    [TestMethod]
+    public void SelectsAndDeselectsEverythingItIsAllowedTo()
+    {
+        var viewModel = ViewModel(existingLines: [1001UL]);
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.SelectNoneCommand.Execute(null);
+
+        Assert.AreEqual(0, viewModel.SelectedCount);
+        Assert.IsFalse(viewModel.CanImport);
+
+        viewModel.SelectAllCommand.Execute(null);
+
+        Assert.AreEqual(2, viewModel.SelectedCount, "the duplicate stays out of it");
+        Assert.IsFalse(viewModel.Entries[0].IsSelected);
+        Assert.IsTrue(viewModel.CanImport);
+    }
+
+    [TestMethod]
+    public void KeepsTheCountsWithASingleRowsCheckbox()
+    {
+        var viewModel = ViewModel();
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.Entries[0].IsSelected = false;
+
+        Assert.AreEqual(2, viewModel.SelectedCount);
+
+        viewModel.Entries[0].IsSelected = true;
+
+        Assert.AreEqual(3, viewModel.SelectedCount);
+    }
+
+    [TestMethod]
+    public void TypingInThePayloadBoxLeavesTheListAlone()
+    {
+        // Rebuilding the list throws away every speaker, addressee and checkbox the user has set,
+        // so an edit in the box marks it stale rather than doing it out from under them.
+        var viewModel = ViewModel();
+        viewModel.SetPayload(ThreeLines, "the clipboard");
+        viewModel.Entries[0].IsSelected = false;
+
+        Assert.IsFalse(viewModel.IsPayloadStale);
+
+        viewModel.JsonText = ThreeLines + " ";
+
+        Assert.IsTrue(viewModel.IsPayloadStale);
+        Assert.AreEqual(3, viewModel.Entries.Count);
+        Assert.IsFalse(viewModel.Entries[0].IsSelected, "the user's selection survived the edit");
+    }
+
+    [TestMethod]
+    public void RereadsThePayloadWhenAskedTo()
+    {
+        var viewModel = ViewModel();
+        viewModel.SetPayload(ThreeLines, "the clipboard");
+        viewModel.Entries[0].IsSelected = false;
+
+        viewModel.JsonText = """{ "lines": [ { "locStringId": "9001", "text": "Only this one now." } ] }""";
+        viewModel.ReadPayloadCommand.Execute(null);
+
+        Assert.IsFalse(viewModel.IsPayloadStale);
+        Assert.AreEqual(1, viewModel.Entries.Count);
+        Assert.AreEqual("9001", viewModel.Entries[0].LocStringId);
+        Assert.AreEqual(1, viewModel.SelectedCount);
+    }
+
+    [TestMethod]
+    public void ReplacesAnImportRatherThanAddingToIt()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload(ThreeLines);
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.AreEqual(3, viewModel.Entries.Count);
+        Assert.AreEqual(3, viewModel.SelectedCount);
+    }
+
+    [TestMethod]
+    public void ClearsBackToWhereItStarted()
+    {
+        var viewModel = ViewModel();
+        viewModel.SetPayload(ThreeLines, "the clipboard");
+
+        viewModel.ClearCommand.Execute(null);
+
+        Assert.AreEqual("", viewModel.JsonText);
+        Assert.AreEqual(0, viewModel.Entries.Count);
+        Assert.IsFalse(viewModel.HasEntries);
+        Assert.IsFalse(viewModel.CanImport);
+        Assert.IsFalse(viewModel.IsPayloadStale);
+        Assert.IsFalse(viewModel.IsStatusError);
+    }
+
+    [TestMethod]
+    public void NamesWhereAHandedOverPayloadCameFrom()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.SetPayload(ThreeLines, "the clipboard");
+
+        Assert.AreEqual(ThreeLines, viewModel.JsonText);
+        Assert.AreEqual(3, viewModel.Entries.Count);
+        Assert.IsFalse(viewModel.IsPayloadStale);
+        Assert.IsTrue(viewModel.StatusMessage.Contains("the clipboard"));
+    }
+
+    [TestMethod]
+    public void ReportsTheSameFileHandedOverTwice()
+    {
+        // The text does not change on the second pass, so nothing but an outright read would say so.
+        var viewModel = ViewModel();
+        viewModel.SetPayload(ThreeLines, "export.json");
+
+        // A read of the same text with nobody behind it - the status stops naming a source.
+        viewModel.LoadPayload(ThreeLines);
+        Assert.IsFalse(viewModel.StatusMessage.Contains("export.json"));
+
+        viewModel.SetPayload(ThreeLines, "export.json");
+
+        Assert.IsTrue(viewModel.StatusMessage.Contains("export.json"));
+        Assert.AreEqual(3, viewModel.Entries.Count);
+    }
+
+    [TestMethod]
+    public void SaysWhatIsWrongWithAPayloadItCannotRead()
+    {
+        var viewModel = ViewModel();
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.LoadPayload("not json at all");
+
+        Assert.IsTrue(viewModel.IsStatusError);
+        Assert.AreEqual(0, viewModel.Entries.Count);
+        Assert.IsFalse(viewModel.HasEntries);
+        Assert.IsFalse(viewModel.CanImport);
+    }
+}

--- a/WolvenKit.App/Helpers/DialogueImportHelper.cs
+++ b/WolvenKit.App/Helpers/DialogueImportHelper.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WolvenKit.App.Helpers;
+
+/// <summary>
+/// One dialogue line handed over by an external tool, e.g. the Dialogue Browser CET mod.
+/// Everything but the locstring id is optional: the id is what the scene is keyed on, the rest
+/// fills in the screenplay entry or describes the line to the user before they take it.
+/// </summary>
+public sealed class ImportedDialogueLine
+{
+    /// <summary>Locstring id the recording is registered under.</summary>
+    public ulong LocStringId { get; init; }
+
+    /// <summary>Subtitle text, ready to be embedded into the scene's locstore.</summary>
+    public string Text { get; init; } = "";
+
+    public string FemaleText { get; init; } = "";
+
+    public string MaleText { get; init; } = "";
+
+    public string Speaker { get; init; } = "";
+
+    /// <summary>Who the line is said to, when the export names them.</summary>
+    public string Addressee { get; init; } = "";
+
+    public string FemaleLipsyncAnim { get; init; } = "";
+
+    public string MaleLipsyncAnim { get; init; } = "";
+
+    /// <summary>
+    /// Whether the line belongs in the screenplay store's options rather than its lines. A choice
+    /// option has no recording behind it, so exports from a conversation are never one.
+    /// </summary>
+    public bool IsChoiceOption { get; init; }
+}
+
+/// <summary>
+/// What <see cref="DialogueImportHelper.Parse"/> made of a payload.
+/// </summary>
+public sealed class DialogueImportPayload
+{
+    public List<ImportedDialogueLine> Lines { get; init; } = [];
+
+    /// <summary>Name of the conversation the lines were exported from, when it said.</summary>
+    public string ConversationName { get; init; } = "";
+
+    /// <summary>Tool and version that wrote the payload, when it said.</summary>
+    public string Source { get; init; } = "";
+
+    /// <summary>Entries that carried no usable locstring id and were dropped.</summary>
+    public int SkippedCount { get; init; }
+
+    /// <summary>Why nothing could be read, when nothing could.</summary>
+    public string? Error { get; init; }
+
+    public bool IsValid => Error is null && Lines.Count > 0;
+
+    public static DialogueImportPayload Failed(string error) => new() { Error = error };
+}
+
+/// <summary>
+/// One of the scene's actors, as the import dialog offers it: what an export's speaker name is
+/// matched against, and what the user picks from when the match is not the one they wanted.
+/// </summary>
+public sealed class SceneActorOption
+{
+    /// <summary>
+    /// The actor id an unset speaker or addressee carries, which is what the scene's own editor
+    /// writes for a line nobody is assigned to.
+    /// </summary>
+    public const uint NoActorId = uint.MaxValue;
+
+    /// <summary>Standing in for "leave this line's actor unset", first in every dropdown.</summary>
+    public static readonly SceneActorOption None = new(NoActorId, "");
+
+    public SceneActorOption(uint actorId, string? name, bool isPlayer = false)
+    {
+        ActorId = actorId;
+        Name = name?.Trim() ?? "";
+        IsPlayer = isPlayer;
+    }
+
+    public uint ActorId { get; }
+
+    public string Name { get; }
+
+    /// <summary>Whether this is one of the scene's player actors rather than one of its cast.</summary>
+    public bool IsPlayer { get; }
+
+    public bool IsNone => ActorId == NoActorId;
+
+    /// <summary>
+    /// What the dropdown shows. The id is named too: a scene may cast two actors under one name,
+    /// or none at all, and the id is the only thing that always tells them apart.
+    /// </summary>
+    public string DisplayName => IsNone
+        ? "(no actor)"
+        : string.IsNullOrEmpty(Name) ? $"{ActorId}: (unnamed)" : $"{ActorId}: {Name}";
+
+    public override string ToString() => DisplayName;
+}
+
+/// <summary>
+/// Turns the speaker and addressee names an export carries into the scene's own actors, so an
+/// imported line arrives pointing at whoever says it and whoever it is said to. Built once per
+/// import from the scene's cast; a name the scene does not know matches nothing, and the line is
+/// left for the user to assign by hand.
+/// </summary>
+public sealed class DialogueSpeakerResolver
+{
+    /// <summary>
+    /// What an export calls the player. It always means the scene's first player actor, whatever
+    /// that actor happens to be named - a scene is free to call them "Player", or nothing at all.
+    /// </summary>
+    public const string PlayerSpeakerName = "V";
+
+    private readonly Dictionary<string, SceneActorOption> _byName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, SceneActorOption> _byLooseName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SceneActorOption? _playerActor;
+
+    /// <param name="actors">The scene's cast, player actors included, in the order it lists them.</param>
+    public DialogueSpeakerResolver(IEnumerable<SceneActorOption> actors)
+    {
+        foreach (var actor in actors)
+        {
+            if (actor.IsNone)
+            {
+                continue;
+            }
+
+            if (_playerActor is null && actor.IsPlayer)
+            {
+                _playerActor = actor;
+            }
+
+            if (string.IsNullOrWhiteSpace(actor.Name))
+            {
+                continue;
+            }
+
+            // The first actor of a name keeps it: a scene that names two actors alike gives nothing
+            // to tell which of them was meant.
+            _byName.TryAdd(actor.Name, actor);
+
+            var loose = Loosen(actor.Name);
+
+            if (loose.Length > 0)
+            {
+                _byLooseName.TryAdd(loose, actor);
+            }
+        }
+    }
+
+    /// <summary>The actor the scene knows by this name, or null when it knows none.</summary>
+    public SceneActorOption? Resolve(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        var trimmed = name.Trim();
+
+        if (string.Equals(trimmed, PlayerSpeakerName, StringComparison.OrdinalIgnoreCase))
+        {
+            return _playerActor;
+        }
+
+        if (_byName.TryGetValue(trimmed, out var byName))
+        {
+            return byName;
+        }
+
+        // "Viktor Vektor" against an actor the scene calls "viktor_vektor": an export names a
+        // character the way the game's subtitles do, a scene however its author typed it.
+        var loose = Loosen(trimmed);
+
+        return loose.Length > 0 && _byLooseName.TryGetValue(loose, out var byLooseName) ? byLooseName : null;
+    }
+
+    /// <summary>A name with everything but its letters and digits dropped.</summary>
+    private static string Loosen(string name)
+    {
+        var loose = new StringBuilder(name.Length);
+
+        foreach (var character in name)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                loose.Append(character);
+            }
+        }
+
+        return loose.ToString();
+    }
+}
+
+/// <summary>
+/// Reads dialogue lines exported by another tool. The format is the one Dialogue Browser writes
+/// (<see cref="PayloadFormat"/>): an object with a <c>lines</c> array, or - for a payload put
+/// together by hand - the bare array on its own.
+/// </summary>
+public static class DialogueImportHelper
+{
+    public const string PayloadFormat = "wolvenkit.scene.dialogue";
+
+    /// <summary>
+    /// Where the Dialogue Browser writes its exports, relative to a Cyberpunk install. Named here
+    /// rather than in the file picker so the dialog can tell the user the same path it opens.
+    /// </summary>
+    public static readonly string ExportDirectoryRelativePath = Path.Combine(
+        "bin", "x64", "plugins", "cyber_engine_tweaks", "mods", "DialogueBrowser", "data", "exports");
+
+    /// <summary>The mod's export folder under a given game root.</summary>
+    public static string GetExportDirectory(string gameRootDir) =>
+        Path.Combine(gameRootDir, ExportDirectoryRelativePath);
+
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+
+    /// <summary>
+    /// Whether a blob of text looks like something worth parsing. Used to decide if the clipboard
+    /// is worth reading on its own, without putting an error in front of a user who has something
+    /// else entirely on it.
+    /// </summary>
+    public static bool LooksLikePayload(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var trimmed = text.TrimStart();
+
+        return (trimmed.StartsWith('{') || trimmed.StartsWith('[')) &&
+               (text.Contains(PayloadFormat, StringComparison.OrdinalIgnoreCase) ||
+                text.Contains("locStringId", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Reads a payload. Never throws: a parse failure comes back as
+    /// <see cref="DialogueImportPayload.Error"/>, which is what the dialog puts in front of the
+    /// user.
+    /// </summary>
+    public static DialogueImportPayload Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return DialogueImportPayload.Failed("Nothing to import yet.");
+        }
+
+        PayloadDto? payload;
+
+        try
+        {
+            var trimmed = json.TrimStart();
+
+            payload = trimmed.StartsWith('[')
+                ? new PayloadDto { Lines = JsonSerializer.Deserialize<List<LineDto>>(json, s_options) }
+                : JsonSerializer.Deserialize<PayloadDto>(json, s_options);
+        }
+        catch (JsonException ex)
+        {
+            return DialogueImportPayload.Failed($"That is not valid JSON: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return DialogueImportPayload.Failed($"Could not read the import: {ex.Message}");
+        }
+
+        if (payload is null)
+        {
+            return DialogueImportPayload.Failed("Could not read the import.");
+        }
+
+        // A payload that names a format has to name this one. One that names none is taken as
+        // hand-written and read anyway - the lines either parse or they do not.
+        if (!string.IsNullOrEmpty(payload.Format) &&
+            !string.Equals(payload.Format, PayloadFormat, StringComparison.OrdinalIgnoreCase))
+        {
+            return DialogueImportPayload.Failed(
+                $"This is a '{payload.Format}' payload - expected '{PayloadFormat}'.");
+        }
+
+        if (payload.Lines is null || payload.Lines.Count == 0)
+        {
+            return DialogueImportPayload.Failed("No dialogue lines in that import.");
+        }
+
+        var lines = new List<ImportedDialogueLine>(payload.Lines.Count);
+        var skipped = 0;
+        var seen = new HashSet<ulong>();
+
+        foreach (var dto in payload.Lines)
+        {
+            if (dto is null || !TryReadLocStringId(dto.LocStringId, out var locStringId) || locStringId == 0)
+            {
+                skipped++;
+                continue;
+            }
+
+            // The same line twice in one conversation is legitimate - a character can repeat
+            // themselves - but the scene only ever wants one screenplay entry for it.
+            if (!seen.Add(locStringId))
+            {
+                skipped++;
+                continue;
+            }
+
+            var text = FirstNonEmpty(dto.Text, dto.FemaleText, dto.MaleText);
+
+            lines.Add(new ImportedDialogueLine
+            {
+                LocStringId = locStringId,
+                Text = text,
+                FemaleText = dto.FemaleText?.Trim() ?? "",
+                MaleText = dto.MaleText?.Trim() ?? "",
+                Speaker = dto.Speaker?.Trim() ?? "",
+                Addressee = dto.Addressee?.Trim() ?? "",
+                FemaleLipsyncAnim = dto.FemaleLipsyncAnim?.Trim() ?? "",
+                MaleLipsyncAnim = dto.MaleLipsyncAnim?.Trim() ?? "",
+                IsChoiceOption = string.Equals(dto.Kind, "option", StringComparison.OrdinalIgnoreCase)
+            });
+        }
+
+        if (lines.Count == 0)
+        {
+            return DialogueImportPayload.Failed("None of those lines carry a usable locstring id.");
+        }
+
+        return new DialogueImportPayload
+        {
+            Lines = lines,
+            ConversationName = payload.Conversation?.Trim() ?? "",
+            Source = payload.Source?.Trim() ?? "",
+            SkippedCount = skipped
+        };
+    }
+
+    /// <summary>
+    /// Locstring ids are 64 bit, so an exporter is free to write one as a string to keep it out of
+    /// a language's float; both forms are read here.
+    /// </summary>
+    private static bool TryReadLocStringId(JsonElement element, out ulong value)
+    {
+        value = 0;
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return ulong.TryParse(element.GetString()?.Trim(), NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetUInt64(out value);
+        }
+
+        return false;
+    }
+
+    private static string FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return "";
+    }
+
+    private sealed class PayloadDto
+    {
+        public string? Format { get; set; }
+        public string? Conversation { get; set; }
+        public string? Source { get; set; }
+        public List<LineDto>? Lines { get; set; }
+    }
+
+    private sealed class LineDto
+    {
+        [JsonPropertyName("locStringId")] public JsonElement LocStringId { get; set; }
+        public string? Text { get; set; }
+        public string? FemaleText { get; set; }
+        public string? MaleText { get; set; }
+        public string? Speaker { get; set; }
+        public string? Addressee { get; set; }
+        public string? FemaleLipsyncAnim { get; set; }
+        public string? MaleLipsyncAnim { get; set; }
+        public string? Kind { get; set; }
+    }
+}

--- a/WolvenKit.App/Helpers/DialogueImportHelper.cs
+++ b/WolvenKit.App/Helpers/DialogueImportHelper.cs
@@ -18,12 +18,29 @@ public sealed class ImportedDialogueLine
     /// <summary>Locstring id the recording is registered under.</summary>
     public ulong LocStringId { get; init; }
 
-    /// <summary>Subtitle text, ready to be embedded into the scene's locstore.</summary>
-    public string Text { get; init; } = "";
+    /// <summary>
+    /// The one subtitle the scene's locstore gets for this line, picked from the variants below.
+    /// A locstore descriptor is keyed on locstring, locale and gender, and the gender it is written
+    /// under here is "both" - so one text is all a line can carry.
+    /// </summary>
+    public string EmbeddedText { get; init; } = "";
 
+    /// <summary>
+    /// What female V hears the line as, which is the game's own primary variant: the male one is an
+    /// override an export only carries where the wording actually differs.
+    /// </summary>
     public string FemaleText { get; init; } = "";
 
+    /// <inheritdoc cref="FemaleText"/>
     public string MaleText { get; init; } = "";
+
+    /// <summary>
+    /// Whether the two variants say different things, i.e. the line is worded for the player's
+    /// gender. Only <see cref="EmbeddedText"/> reaches the scene, so this is what the import dialog
+    /// warns on rather than something it can write out.
+    /// </summary>
+    public bool HasGenderedText =>
+        MaleText.Length > 0 && FemaleText.Length > 0 && MaleText != FemaleText;
 
     public string Speaker { get; init; } = "";
 
@@ -323,7 +340,7 @@ public static class DialogueImportHelper
             lines.Add(new ImportedDialogueLine
             {
                 LocStringId = locStringId,
-                Text = text,
+                EmbeddedText = text,
                 FemaleText = dto.FemaleText?.Trim() ?? "",
                 MaleText = dto.MaleText?.Trim() ?? "",
                 Speaker = dto.Speaker?.Trim() ?? "",

--- a/WolvenKit.App/Helpers/SceneEditingHelper.cs
+++ b/WolvenKit.App/Helpers/SceneEditingHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.RED4.Types;
 
@@ -220,5 +221,80 @@ namespace WolvenKit.App.Helpers
             }
             return null;
         }
+
+#region screenplay item ids
+
+        /// <summary>
+        /// The step between screenplay item ids, as the game's own scenes number them. An id lower
+        /// than the one before it makes the previous entry's text play; a gap larger than a step
+        /// makes nothing play at all.
+        /// </summary>
+        public const uint ScreenplayItemIdStep = 256;
+
+        /// <summary>What dialogue lines number from when the screenplay store holds none.</summary>
+        public const uint FirstDialogLineItemId = 1;
+
+        /// <summary>What choice options number from when the screenplay store holds none.</summary>
+        public const uint FirstChoiceOptionItemId = 2;
+
+        /// <summary>
+        /// The id <c>new scnscreenplayItemId()</c> starts on, which is what an entry added through
+        /// the raw array editor carries until someone gives it one. Never a real id, and too near
+        /// the top of a uint to count a step up from.
+        /// </summary>
+        public const uint UnassignedScreenplayItemId = 4294967040;
+
+        /// <summary>
+        /// The next free item id for one half of a screenplay store.
+        /// </summary>
+        /// <remarks>
+        /// The highest id in use is counted up from, not the last entry's: nothing keeps the array
+        /// in order, so a store whose entries were added or reordered through the raw chunk editor
+        /// can carry its highest id anywhere. Handing out an id that is already taken is not a
+        /// cosmetic problem - graph events bind to their screenplay entry by item id, so a
+        /// collision makes a <c>scnDialogLineEvent</c> play the wrong line.
+        /// </remarks>
+        /// <param name="itemIds">The ids already in that half of the store, in any order.</param>
+        /// <param name="firstItemId">What the half numbers from when it is empty.</param>
+        public static uint GetNextScreenplayItemId(IEnumerable<uint> itemIds, uint firstItemId)
+        {
+            var next = firstItemId;
+
+            foreach (var itemId in itemIds)
+            {
+                // Ids too near the top of a uint to step past - the unassigned one above among them
+                // - are left out of the reckoning. Counting up from one wraps to 0, which is an id
+                // every unassigned entry would then answer to.
+                if (itemId > uint.MaxValue - ScreenplayItemIdStep)
+                {
+                    continue;
+                }
+
+                if (itemId >= next)
+                {
+                    next = itemId + ScreenplayItemIdStep;
+                }
+            }
+
+            return next;
+        }
+
+        /// <inheritdoc cref="GetNextScreenplayItemId(IEnumerable{uint}, uint)"/>
+        public static uint GetNextDialogLineItemId(IEnumerable<scnscreenplayDialogLine>? lines) =>
+            GetNextScreenplayItemId(
+                lines?.Select(line => ItemIdOf(line?.ItemId)) ?? [],
+                FirstDialogLineItemId);
+
+        /// <inheritdoc cref="GetNextScreenplayItemId(IEnumerable{uint}, uint)"/>
+        public static uint GetNextChoiceOptionItemId(IEnumerable<scnscreenplayChoiceOption>? options) =>
+            GetNextScreenplayItemId(
+                options?.Select(option => ItemIdOf(option?.ItemId)) ?? [],
+                FirstChoiceOptionItemId);
+
+        /// <summary>An entry's id, or the unassigned one where the raw editor left it without.</summary>
+        private static uint ItemIdOf(scnscreenplayItemId? itemId) =>
+            itemId is null ? UnassignedScreenplayItemId : itemId.Id;
+
+#endregion
     }
 }

--- a/WolvenKit.App/Interaction/Interactions.cs
+++ b/WolvenKit.App/Interaction/Interactions.cs
@@ -243,6 +243,17 @@ public static class Interactions
 
 
     /// <summary>
+    /// Shows the dialogue import dialog: takes an export written by another tool and lets the user
+    /// pick which of its lines go into the scene. Null when the user cancelled.
+    /// </summary>
+    public static Func<DialogueImportDialogOptions, DialogueImportDialogViewModel?> ShowDialogueImport
+    {
+        get;
+        set;
+    } = _ => throw new NotImplementedException();
+
+
+    /// <summary>
     /// Ask user for folder path. Will enforce validity for path-type arguments and check if directory exists.
     /// </summary>
     public static Func<(string, Cp77Project), string> AskForFolderPathInput { get; set; } = _ => throw new NotImplementedException();

--- a/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
+++ b/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.App.Interaction.Options;
+
+/// <summary>
+/// Input parameters for <see cref="DialogueImportDialogViewModel"/>
+/// </summary>
+public class DialogueImportDialogOptions
+{
+    public DialogueImportDialogOptions(
+        string sceneName,
+        IEnumerable<ulong> existingLineLocStrings,
+        IEnumerable<ulong> existingOptionLocStrings,
+        IEnumerable<SceneActorOption> actors)
+    {
+        SceneName = sceneName;
+        ExistingLineLocStrings = existingLineLocStrings.ToHashSet();
+        ExistingOptionLocStrings = existingOptionLocStrings.ToHashSet();
+        Actors = actors.ToList();
+    }
+
+    /// <summary>Named in the dialog title, so it is clear which scene is being imported into.</summary>
+    public string SceneName { get; init; }
+
+    /// <summary>Locstring ids already in the screenplay store's lines. Imports matching one are refused.</summary>
+    public HashSet<ulong> ExistingLineLocStrings { get; init; }
+
+    /// <inheritdoc cref="ExistingLineLocStrings"/>
+    public HashSet<ulong> ExistingOptionLocStrings { get; init; }
+
+    /// <summary>
+    /// The scene's cast, in the order it lists them: what each line's speaker and addressee are
+    /// matched against, and what the user picks from when a match wants correcting.
+    /// </summary>
+    public IReadOnlyList<SceneActorOption> Actors { get; init; }
+}

--- a/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
@@ -84,7 +84,37 @@ public partial class DialogueImportEntryViewModel : ObservableObject
 
     public string AddresseeToolTip => DescribeExportedName("addressee", Line.Addressee);
 
-    public string Text => string.IsNullOrEmpty(Line.Text) ? "(no text)" : Line.Text;
+    public string Text => string.IsNullOrEmpty(Line.EmbeddedText) ? "(no text)" : Line.EmbeddedText;
+
+    /// <summary>
+    /// Whether the line is worded for the player's gender. Worth saying because only one of the two
+    /// wordings can be embedded: a locstore descriptor is keyed on locstring, locale and gender, and
+    /// the scene editor writes one under "both".
+    /// </summary>
+    public bool HasGenderedText => Line.HasGenderedText;
+
+    /// <summary>
+    /// The line in full, with both wordings where it has two. The column itself is one line high and
+    /// trimmed, so this is where a line long enough to be cut off can actually be read.
+    /// </summary>
+    public string TextToolTip
+    {
+        get
+        {
+            if (!HasGenderedText)
+            {
+                return Text;
+            }
+
+            return $"""
+                Female V: {Line.FemaleText}
+                Male V: {Line.MaleText}
+
+                Only the first is embedded - the scene's locstore keeps one text per line. Leave
+                "Embed the text into the scene" off to let the game use its own, which has both.
+                """;
+        }
+    }
 
     /// <summary>
     /// The lipsync animations, named per recorded variant: the index knows a female name for

--- a/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
@@ -136,6 +136,16 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
     /// <summary>Where the payload being read came from, named once in the status line.</summary>
     private string _sourceName = "";
 
+    /// <summary>What the list was last built from, which is what makes an edit to the box stale.</summary>
+    private string _readJson = "";
+
+    /// <summary>
+    /// Whether the list is being rebuilt or set wholesale. The counts are worth one pass at the end
+    /// of that rather than one per line, which is what a handler per entry and per collection change
+    /// would otherwise cost on every load and every Select all.
+    /// </summary>
+    private bool _isUpdatingEntries;
+
     public DialogueImportDialogViewModel(DialogueImportDialogOptions dialogOptions)
     {
         _existingLineLocStrings = dialogOptions.ExistingLineLocStrings;
@@ -166,8 +176,15 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
     public string ExportFolderPath { get; } =
         Path.Combine("Cyberpunk 2077", DialogueImportHelper.ExportDirectoryRelativePath);
 
-    /// <summary>The payload itself. Parsed on every change, so pasting into the box is enough.</summary>
+    /// <summary>
+    /// The payload itself. Read when the user asks for it rather than on every keystroke: rebuilding
+    /// the list throws away every speaker, addressee and checkbox they have set, so re-reading is
+    /// theirs to ask for. The paste and load buttons are that ask; typing in the box is not.
+    /// </summary>
     [ObservableProperty] private string _jsonText = "";
+
+    /// <summary>Whether the box holds something other than what the list was built from.</summary>
+    [ObservableProperty] private bool _isPayloadStale;
 
     /// <summary>What the import says about itself: where it came from, and how much of it is new.</summary>
     [ObservableProperty] private string _statusMessage =
@@ -196,7 +213,19 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
     public bool CanImport => SelectedCount > 0;
 
-    partial void OnJsonTextChanged(string value) => LoadPayload(value);
+    partial void OnJsonTextChanged(string value) => IsPayloadStale = value != _readJson;
+
+    /// <summary>Reads what is in the payload box, at the user's asking.</summary>
+    [RelayCommand]
+    private void ReadPayload() => LoadPayload(JsonText);
+
+    /// <summary>Puts the dialog back where it started, payload box and all.</summary>
+    [RelayCommand]
+    private void Clear()
+    {
+        JsonText = "";
+        LoadPayload("");
+    }
 
     /// <summary>
     /// Reads a payload into the list. Anything already listed is dropped first: a second paste
@@ -209,6 +238,31 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
         var sourceName = _sourceName;
         _sourceName = "";
 
+        _readJson = json ?? "";
+        IsPayloadStale = JsonText != _readJson;
+
+        // One pass over the counts at the end rather than one per line cleared and one per line
+        // added, each of which walks the whole list twice.
+        _isUpdatingEntries = true;
+
+        try
+        {
+            RebuildEntries(json, sourceName);
+        }
+        finally
+        {
+            _isUpdatingEntries = false;
+        }
+
+        RefreshCounts();
+    }
+
+    /// <summary>
+    /// The list itself, dropped and built back up. Only ever called with the counts held, which is
+    /// what <see cref="LoadPayload"/> is for.
+    /// </summary>
+    private void RebuildEntries(string? json, string sourceName)
+    {
         foreach (var entry in Entries)
         {
             entry.PropertyChanged -= OnEntryPropertyChanged;
@@ -219,7 +273,6 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
         if (string.IsNullOrWhiteSpace(json))
         {
             SetStatus("Paste an export from the Dialogue Browser, or load one from a file.", false);
-            RefreshCounts();
             return;
         }
 
@@ -228,7 +281,6 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
         if (!payload.IsValid)
         {
             SetStatus(payload.Error ?? "Could not read the import.", true);
-            RefreshCounts();
             return;
         }
 
@@ -242,26 +294,19 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
             Entries.Add(entry);
         }
 
-        RefreshCounts();
         SetStatus(DescribePayload(payload, sourceName), false);
     }
 
     /// <summary>
-    /// Takes a payload, named by where it came from. Goes through here rather than through
+    /// Takes a payload, named by where it came from. Reads it itself rather than leaving that to
     /// <see cref="JsonText"/> so that handing over the same thing twice still reports itself - the
     /// property only raises a change when the text differs.
     /// </summary>
     public void SetPayload(string json, string sourceName)
     {
         _sourceName = sourceName;
-
-        if (JsonText == json)
-        {
-            LoadPayload(json);
-            return;
-        }
-
         JsonText = json;
+        LoadPayload(json);
     }
 
     [RelayCommand]
@@ -324,10 +369,23 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
     private void SetSelection(bool isSelected)
     {
-        foreach (var entry in Entries.Where(entry => entry.CanImport))
+        // Each row raising its own change would have the counts recomputed once per row; they are
+        // the same counts either way, so they are taken once at the end.
+        _isUpdatingEntries = true;
+
+        try
         {
-            entry.IsSelected = isSelected;
+            foreach (var entry in Entries.Where(entry => entry.CanImport))
+            {
+                entry.IsSelected = isSelected;
+            }
         }
+        finally
+        {
+            _isUpdatingEntries = false;
+        }
+
+        RefreshCounts();
     }
 
     private void SetStatus(string message, bool isError)
@@ -366,9 +424,29 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
     private void RefreshCounts()
     {
+        if (_isUpdatingEntries)
+        {
+            return;
+        }
+
+        var duplicates = 0;
+        var selected = 0;
+
+        foreach (var entry in Entries)
+        {
+            if (entry.IsDuplicate)
+            {
+                duplicates++;
+            }
+            else if (entry.IsSelected)
+            {
+                selected++;
+            }
+        }
+
         EntryCount = Entries.Count;
-        DuplicateCount = Entries.Count(entry => entry.IsDuplicate);
-        SelectedCount = Entries.Count(entry => entry is { IsSelected: true, CanImport: true });
+        DuplicateCount = duplicates;
+        SelectedCount = selected;
     }
 
     private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RefreshCounts();

--- a/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
@@ -1,0 +1,383 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Interaction.Options;
+using Clipboard = System.Windows.Clipboard;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+/// <summary>
+/// A line the user is taking, with the actors they settled on for it. The names an export carries
+/// are only a starting point: the dialog matches them against the scene's cast and the user has the
+/// last word, so what comes back out is actor ids, not names.
+/// </summary>
+public sealed class DialogueImportSelection
+{
+    public required ImportedDialogueLine Line { get; init; }
+
+    /// <summary>Actor to write as the line's speaker, or null to leave it unset.</summary>
+    public uint? SpeakerActorId { get; init; }
+
+    /// <inheritdoc cref="SpeakerActorId"/>
+    public uint? AddresseeActorId { get; init; }
+}
+
+/// <summary>
+/// One line of an import, with what the scene already knows about it. A line whose locstring id is
+/// in the scene cannot be taken again: importing it a second time would leave two screenplay
+/// entries pointing at one recording, which is the one thing the scene editor cannot tell apart
+/// afterwards.
+/// </summary>
+public partial class DialogueImportEntryViewModel : ObservableObject
+{
+    public DialogueImportEntryViewModel(
+        ImportedDialogueLine line,
+        bool isDuplicate,
+        IReadOnlyList<SceneActorOption> actorOptions,
+        DialogueSpeakerResolver resolver)
+    {
+        Line = line;
+        IsDuplicate = isDuplicate;
+        IsSelected = !isDuplicate;
+        ActorOptions = actorOptions;
+
+        // What the export says, matched against the scene's cast. Whatever it did not match is left
+        // unset for the user to pick, which is the same "no actor" a line added by hand starts with.
+        _speakerActor = resolver.Resolve(line.Speaker) ?? SceneActorOption.None;
+        _addresseeActor = resolver.Resolve(line.Addressee) ?? SceneActorOption.None;
+    }
+
+    public ImportedDialogueLine Line { get; }
+
+    /// <summary>Whether the scene already carries a screenplay entry for this locstring id.</summary>
+    public bool IsDuplicate { get; }
+
+    /// <summary>Whether the line is the user's to take. Duplicates never are.</summary>
+    public bool CanImport => !IsDuplicate;
+
+    [ObservableProperty] private bool _isSelected;
+
+    /// <summary>The scene's cast, shared by every row: one list, one set of dropdown items.</summary>
+    public IReadOnlyList<SceneActorOption> ActorOptions { get; }
+
+    [ObservableProperty] private SceneActorOption _speakerActor;
+
+    [ObservableProperty] private SceneActorOption _addresseeActor;
+
+    /// <summary>
+    /// Whether this line has actors to assign at all. A choice option is something the player says
+    /// by picking it, and the screenplay store keeps no speaker for one.
+    /// </summary>
+    public bool CanSetActors => !Line.IsChoiceOption;
+
+    public string LocStringId => Line.LocStringId.ToString();
+
+    /// <summary>What the export called the speaker, kept where the user can check the match.</summary>
+    public string SpeakerToolTip => DescribeExportedName("speaker", Line.Speaker);
+
+    public string AddresseeToolTip => DescribeExportedName("addressee", Line.Addressee);
+
+    public string Text => string.IsNullOrEmpty(Line.Text) ? "(no text)" : Line.Text;
+
+    /// <summary>
+    /// The lipsync animations, named per recorded variant: the index knows a female name for
+    /// nearly every line and a male one for only a few, so which is which has to be said.
+    /// </summary>
+    public string LipsyncAnimNames
+    {
+        get
+        {
+            var names = new List<string>(2);
+
+            if (!string.IsNullOrEmpty(Line.FemaleLipsyncAnim))
+            {
+                names.Add($"F: {Line.FemaleLipsyncAnim}");
+            }
+
+            if (!string.IsNullOrEmpty(Line.MaleLipsyncAnim))
+            {
+                names.Add($"M: {Line.MaleLipsyncAnim}");
+            }
+
+            return names.Count > 0 ? string.Join("  ", names) : "—";
+        }
+    }
+
+    public string Status => IsDuplicate
+        ? "Already in scene"
+        : Line.IsChoiceOption
+            ? "New choice option"
+            : "New line";
+
+    private static string DescribeExportedName(string role, string name) =>
+        string.IsNullOrEmpty(name)
+            ? $"The export names no {role} for this line"
+            : $"The export names \"{name}\" as the {role}";
+}
+
+/// <summary>
+/// ViewModel for the dialogue import dialog: takes an export written by another tool (the Dialogue
+/// Browser CET mod writes one from its conversation panel), says what is in it, and hands back the
+/// lines the user picked.
+/// </summary>
+public partial class DialogueImportDialogViewModel : DialogViewModel
+{
+    private readonly HashSet<ulong> _existingLineLocStrings;
+    private readonly HashSet<ulong> _existingOptionLocStrings;
+    private readonly DialogueSpeakerResolver _speakerResolver;
+
+    /// <summary>Where the payload being read came from, named once in the status line.</summary>
+    private string _sourceName = "";
+
+    public DialogueImportDialogViewModel(DialogueImportDialogOptions dialogOptions)
+    {
+        _existingLineLocStrings = dialogOptions.ExistingLineLocStrings;
+        _existingOptionLocStrings = dialogOptions.ExistingOptionLocStrings;
+        _speakerResolver = new DialogueSpeakerResolver(dialogOptions.Actors);
+
+        // "No actor" leads the list: it is what an unmatched line starts on, and what a user takes
+        // back to when the scene has nobody for a line.
+        ActorOptions = [SceneActorOption.None, .. dialogOptions.Actors];
+
+        Title = string.IsNullOrEmpty(dialogOptions.SceneName)
+            ? "Import Dialogue"
+            : $"Import Dialogue - {dialogOptions.SceneName}";
+
+        Entries.CollectionChanged += OnEntriesChanged;
+    }
+
+    public ObservableCollection<DialogueImportEntryViewModel> Entries { get; } = [];
+
+    /// <summary>The scene's cast as every row's dropdown offers it, "no actor" first.</summary>
+    public IReadOnlyList<SceneActorOption> ActorOptions { get; }
+
+    public string Title { get; set; }
+
+    /// <summary>
+    /// Where the mod writes its exports, named in the introduction and opened by the file picker.
+    /// </summary>
+    public string ExportFolderPath { get; } =
+        Path.Combine("Cyberpunk 2077", DialogueImportHelper.ExportDirectoryRelativePath);
+
+    /// <summary>The payload itself. Parsed on every change, so pasting into the box is enough.</summary>
+    [ObservableProperty] private string _jsonText = "";
+
+    /// <summary>What the import says about itself: where it came from, and how much of it is new.</summary>
+    [ObservableProperty] private string _statusMessage =
+        "Paste an export from the Dialogue Browser, or load one from a file.";
+
+    [ObservableProperty] private bool _isStatusError;
+
+    /// <summary>
+    /// Whether the lines' text is embedded into the scene's locstore. Without it the scene points
+    /// at recordings whose subtitles live in the game's own string tables, which is what a scene
+    /// referencing existing dialogue wants; with it the text travels with the scene.
+    /// </summary>
+    [ObservableProperty] private bool _createEmbeddedText = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasEntries))]
+    private int _entryCount;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanImport))]
+    private int _selectedCount;
+
+    [ObservableProperty] private int _duplicateCount;
+
+    public bool HasEntries => EntryCount > 0;
+
+    public bool CanImport => SelectedCount > 0;
+
+    partial void OnJsonTextChanged(string value) => LoadPayload(value);
+
+    /// <summary>
+    /// Reads a payload into the list. Anything already listed is dropped first: a second paste
+    /// replaces an import rather than adding to it.
+    /// </summary>
+    public void LoadPayload(string? json)
+    {
+        // Named by whoever handed it over, and only for as long as it is theirs: an edit in the
+        // payload box afterwards is nobody's file.
+        var sourceName = _sourceName;
+        _sourceName = "";
+
+        foreach (var entry in Entries)
+        {
+            entry.PropertyChanged -= OnEntryPropertyChanged;
+        }
+
+        Entries.Clear();
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            SetStatus("Paste an export from the Dialogue Browser, or load one from a file.", false);
+            RefreshCounts();
+            return;
+        }
+
+        var payload = DialogueImportHelper.Parse(json);
+
+        if (!payload.IsValid)
+        {
+            SetStatus(payload.Error ?? "Could not read the import.", true);
+            RefreshCounts();
+            return;
+        }
+
+        foreach (var line in payload.Lines)
+        {
+            var existing = line.IsChoiceOption ? _existingOptionLocStrings : _existingLineLocStrings;
+            var entry = new DialogueImportEntryViewModel(
+                line, existing.Contains(line.LocStringId), ActorOptions, _speakerResolver);
+
+            entry.PropertyChanged += OnEntryPropertyChanged;
+            Entries.Add(entry);
+        }
+
+        RefreshCounts();
+        SetStatus(DescribePayload(payload, sourceName), false);
+    }
+
+    /// <summary>
+    /// Takes a payload, named by where it came from. Goes through here rather than through
+    /// <see cref="JsonText"/> so that handing over the same thing twice still reports itself - the
+    /// property only raises a change when the text differs.
+    /// </summary>
+    public void SetPayload(string json, string sourceName)
+    {
+        _sourceName = sourceName;
+
+        if (JsonText == json)
+        {
+            LoadPayload(json);
+            return;
+        }
+
+        JsonText = json;
+    }
+
+    [RelayCommand]
+    private void PasteFromClipboard()
+    {
+        try
+        {
+            if (!Clipboard.ContainsText())
+            {
+                SetStatus("There is no text on the clipboard.", true);
+                return;
+            }
+
+            SetPayload(Clipboard.GetText(), "the clipboard");
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Could not read the clipboard: {ex.Message}", true);
+        }
+    }
+
+    /// <summary>Reads a payload off disk. The view picks the file; this reads it.</summary>
+    public void LoadFile(string path)
+    {
+        try
+        {
+            SetPayload(File.ReadAllText(path), Path.GetFileName(path));
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Could not read {Path.GetFileName(path)}: {ex.Message}", true);
+        }
+    }
+
+    [RelayCommand]
+    private void SelectAll() => SetSelection(true);
+
+    [RelayCommand]
+    private void SelectNone() => SetSelection(false);
+
+    /// <summary>
+    /// The lines the user settled on, each with the actors they left it pointing at. Duplicates are
+    /// filtered out here as well as being locked in the list, so nothing gets in by way of a payload
+    /// swapped out from under the selection.
+    /// </summary>
+    public List<DialogueImportSelection> GetLinesToImport() =>
+        Entries
+            .Where(entry => entry.IsSelected && entry.CanImport)
+            .Select(entry => new DialogueImportSelection
+            {
+                Line = entry.Line,
+                SpeakerActorId = ActorIdOf(entry.SpeakerActor),
+                AddresseeActorId = ActorIdOf(entry.AddresseeActor)
+            })
+            .ToList();
+
+    /// <summary>An actor id to write, or null where the user left the line unassigned.</summary>
+    private static uint? ActorIdOf(SceneActorOption? option) =>
+        option is null || option.IsNone ? null : option.ActorId;
+
+    private void SetSelection(bool isSelected)
+    {
+        foreach (var entry in Entries.Where(entry => entry.CanImport))
+        {
+            entry.IsSelected = isSelected;
+        }
+    }
+
+    private void SetStatus(string message, bool isError)
+    {
+        StatusMessage = message;
+        IsStatusError = isError;
+    }
+
+    private static string DescribePayload(DialogueImportPayload payload, string sourceName)
+    {
+        var message = $"{payload.Lines.Count} line{(payload.Lines.Count == 1 ? "" : "s")}";
+
+        if (!string.IsNullOrEmpty(payload.ConversationName))
+        {
+            message += $" from \"{payload.ConversationName}\"";
+        }
+
+        if (!string.IsNullOrEmpty(payload.Source))
+        {
+            message += $" ({payload.Source})";
+        }
+
+        if (!string.IsNullOrEmpty(sourceName))
+        {
+            message += $", read from {sourceName}";
+        }
+
+        if (payload.SkippedCount > 0)
+        {
+            message += $". {payload.SkippedCount} entr{(payload.SkippedCount == 1 ? "y" : "ies")} " +
+                       "had no usable locstring id and were dropped";
+        }
+
+        return message + ".";
+    }
+
+    private void RefreshCounts()
+    {
+        EntryCount = Entries.Count;
+        DuplicateCount = Entries.Count(entry => entry.IsDuplicate);
+        SelectedCount = Entries.Count(entry => entry is { IsSelected: true, CanImport: true });
+    }
+
+    private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RefreshCounts();
+
+    private void OnEntryPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DialogueImportEntryViewModel.IsSelected))
+        {
+            RefreshCounts();
+        }
+    }
+}

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -443,7 +443,7 @@ namespace WolvenKit.App.ViewModels.Documents
                         LocstringId = new scnlocLocstringId { Ruid = (CRUID)locStringIdValue },
                         VariantId = new scnlocVariantId { Ruid = variantCruid },
                         VpeIndex = (uint)(_sceneData.LocStore.VpEntries.Count - 1),
-                        Signature = new scnlocSignature { Val = 3 }, // en_us locale signature
+                        Signature = new scnlocSignature { Val = 3 }, // gender mask: 1 = male, 2 = female, 3 = both
                         LocaleId = Enums.scnlocLocaleId.en_us
                     });
                 }
@@ -545,7 +545,7 @@ namespace WolvenKit.App.ViewModels.Documents
                         LocstringId = new scnlocLocstringId { Ruid = (CRUID)locStringIdValue },
                         VariantId = new scnlocVariantId { Ruid = variantCruid },
                         VpeIndex = (uint)(_sceneData.LocStore.VpEntries.Count - 1),
-                        Signature = new scnlocSignature { Val = 3 }, // en_us locale signature
+                        Signature = new scnlocSignature { Val = 3 }, // gender mask: 1 = male, 2 = female, 3 = both
                         LocaleId = Enums.scnlocLocaleId.en_us
                     });
                 }
@@ -714,7 +714,7 @@ namespace WolvenKit.App.ViewModels.Documents
                         addedLines++;
                     }
 
-                    if (createEmbeddedText && AddEmbeddedText(line.LocStringId, line.Text, random, describedLocStrings))
+                    if (createEmbeddedText && AddEmbeddedText(line.LocStringId, line.EmbeddedText, random, describedLocStrings))
                     {
                         addedTexts++;
                     }
@@ -852,7 +852,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 LocstringId = new scnlocLocstringId { Ruid = (CRUID)locStringId },
                 VariantId = new scnlocVariantId { Ruid = variantCruid },
                 VpeIndex = (uint)(_sceneData.LocStore.VpEntries.Count - 1),
-                Signature = new scnlocSignature { Val = 3 }, // en_us locale signature
+                Signature = new scnlocSignature { Val = 3 }, // gender mask: 1 = male, 2 = female, 3 = both
                 LocaleId = Enums.scnlocLocaleId.en_us
             });
 

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -66,6 +66,10 @@ namespace WolvenKit.App.ViewModels.Documents
 
         public bool IsOptionCreationVisible => SelectedTab?.Header == "Dialogue";
 
+        /// <summary>
+        /// Named in its own right so the Import Dialogue button says what it is bound to, though it
+        /// is on the same tab as the two above and so adds nothing to <see cref="IsButtonBarVisible"/>.
+        /// </summary>
         public bool IsDialogueImportVisible => SelectedTab?.Header == "Dialogue";
 
         public bool IsWorkspotCreationVisible => SelectedTab?.Header == "Asset Library";
@@ -74,7 +78,7 @@ namespace WolvenKit.App.ViewModels.Documents
 
         public bool IsAnimationCreationVisible => SelectedTab?.Header == "Asset Library";
 
-        public bool IsButtonBarVisible => IsActorCreationVisible || IsPropCreationVisible || IsDialogueCreationVisible || IsOptionCreationVisible || IsDialogueImportVisible || IsWorkspotCreationVisible || IsEffectCreationVisible || IsAnimationCreationVisible;
+        public bool IsButtonBarVisible => IsActorCreationVisible || IsPropCreationVisible || IsDialogueCreationVisible || IsOptionCreationVisible || IsWorkspotCreationVisible || IsEffectCreationVisible || IsAnimationCreationVisible;
 
         public override ERedDocumentItemType DocumentItemType => ERedDocumentItemType.MainFile;
 
@@ -304,7 +308,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created actor
-                ExpandToNewEntry("actors", "", 0);
+                ExpandToNewEntry("actors", "");
 
                 // Update total actors count in the UI
                 OnPropertyChanged(nameof(TotalActors));
@@ -361,7 +365,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created prop
-                ExpandToNewEntry("props", "", 0);
+                ExpandToNewEntry("props", "");
 
                 // Update total props count in the UI
                 OnPropertyChanged(nameof(TotalProps));
@@ -398,11 +402,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 var createEmbedText = dialogResult.enableSecondary;
                 var embeddedText = dialogResult.secondaryInput;
 
-                var itemId = (uint)1; // First id is always 1
-                if (_sceneData.ScreenplayStore.Lines.Count > 0)
-                {
-                    itemId = _sceneData.ScreenplayStore.Lines[^1].ItemId.Id + 256;
-                }
+                var itemId = SceneEditingHelper.GetNextDialogLineItemId(_sceneData.ScreenplayStore.Lines);
 
                 var random = new Random();
                 var cruid = (CRUID)random.NextCRUID();
@@ -465,7 +465,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created dialogue line
-                ExpandToNewEntry("screenplayStore", "lines", itemId);
+                ExpandToNewEntry("screenplayStore", "lines");
 
                 // Update total dialogues count in the UI
                 OnPropertyChanged(nameof(TotalDialogues));
@@ -504,11 +504,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 var createEmbedText = dialogResult.enableSecondary;
                 var embeddedText = dialogResult.secondaryInput;
 
-                var itemId = (uint)2; // First id is always 2
-                if (_sceneData.ScreenplayStore.Options.Count > 0)
-                {
-                    itemId = _sceneData.ScreenplayStore.Options[^1].ItemId.Id + 256;
-                }
+                var itemId = SceneEditingHelper.GetNextChoiceOptionItemId(_sceneData.ScreenplayStore.Options);
 
                 var random = new Random();
                 var cruid = (CRUID)random.NextCRUID();
@@ -571,7 +567,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created choice option
-                ExpandToNewEntry("screenplayStore", "options", itemId);
+                ExpandToNewEntry("screenplayStore", "options");
 
                 // Update total dialogues count in the UI
                 OnPropertyChanged(nameof(TotalDialogues));
@@ -633,17 +629,13 @@ namespace WolvenKit.App.ViewModels.Documents
 
                 // Item ids run in steps of 256, as the game's own scenes do, and both halves of the
                 // screenplay store number themselves independently.
-                var nextLineItemId = (uint)1;
-                if (screenplayLines.Count > 0)
-                {
-                    nextLineItemId = screenplayLines[^1].ItemId.Id + 256;
-                }
+                var nextLineItemId = SceneEditingHelper.GetNextDialogLineItemId(screenplayLines);
+                var nextOptionItemId = SceneEditingHelper.GetNextChoiceOptionItemId(screenplayOptions);
 
-                var nextOptionItemId = (uint)2;
-                if (screenplayOptions.Count > 0)
-                {
-                    nextOptionItemId = screenplayOptions[^1].ItemId.Id + 256;
-                }
+                // The locstrings the scene already carries embedded text for, read once rather than
+                // per line: an import of any size against a scene of any size would otherwise walk
+                // the whole locStore for every line it takes. Grows as text is embedded below.
+                var describedLocStrings = GetLocStringIds(_sceneData.LocStore?.VdEntries?.Select(entry => entry.LocstringId));
 
                 var addedLines = 0;
                 var addedOptions = 0;
@@ -722,7 +714,7 @@ namespace WolvenKit.App.ViewModels.Documents
                         addedLines++;
                     }
 
-                    if (createEmbeddedText && AddEmbeddedText(line.LocStringId, line.Text, random))
+                    if (createEmbeddedText && AddEmbeddedText(line.LocStringId, line.Text, random, describedLocStrings))
                     {
                         addedTexts++;
                     }
@@ -750,8 +742,17 @@ namespace WolvenKit.App.ViewModels.Documents
                     UpdateTabContent(SelectedTab);
                 }
 
-                // Auto-expand to show what came in
-                ExpandToNewEntry("screenplayStore", addedLines > 0 ? "lines" : "options", 0);
+                // Auto-expand to show what came in. A payload can hold both, and both halves of the
+                // store are worth revealing when it does.
+                if (addedLines > 0)
+                {
+                    ExpandToNewEntry("screenplayStore", "lines");
+                }
+
+                if (addedOptions > 0)
+                {
+                    ExpandToNewEntry("screenplayStore", "options");
+                }
 
                 // Update dialogue and choice counts in the UI
                 OnPropertyChanged(nameof(TotalDialogues));
@@ -817,8 +818,12 @@ namespace WolvenKit.App.ViewModels.Documents
         /// Embeds a line's text into the scene's locStore, as a payload entry plus the descriptor
         /// that points a locstring at it.
         /// </summary>
+        /// <param name="describedLocStrings">
+        /// The locstrings the locStore already describes, which this adds to. Handed in rather than
+        /// read from the store so that importing n lines does not walk it n times.
+        /// </param>
         /// <returns>False when there was nothing to embed, or the locStore already describes this locstring.</returns>
-        private bool AddEmbeddedText(ulong locStringId, string text, Random random)
+        private bool AddEmbeddedText(ulong locStringId, string text, Random random, HashSet<ulong> describedLocStrings)
         {
             if (string.IsNullOrEmpty(text))
             {
@@ -827,8 +832,7 @@ namespace WolvenKit.App.ViewModels.Documents
 
             // A locstring the scene already carries text for keeps the text it has: two descriptors
             // for one locstring and locale is what the game reads as a broken locStore.
-            if (_sceneData.LocStore.VdEntries.Any(entry =>
-                    entry.LocstringId != null && (ulong)entry.LocstringId.Ruid == locStringId))
+            if (!describedLocStrings.Add(locStringId))
             {
                 return false;
             }
@@ -986,7 +990,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created workspot instance
-                ExpandToNewEntry("workspotInstances", "", 0);
+                ExpandToNewEntry("workspotInstances", "");
 
                 _logger?.Info($"Created new workspot: path='{workspotPath}', dataId={dataId}, instanceId={instanceId}");
             }
@@ -1143,7 +1147,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 }
 
                 // Auto-expand to show the newly created effect instance
-                ExpandToNewEntry("effectInstances", "", 0);
+                ExpandToNewEntry("effectInstances", "");
 
                 _logger?.Info($"Created new effect: path='{effectPath}', effectId={effectId}, instanceId={instanceId}, compiledEvents={compiledEventInfos.Count}");
             }
@@ -1304,10 +1308,10 @@ namespace WolvenKit.App.ViewModels.Documents
                 switch (animationType.ToLower())
                 {
                     case "cinematic":
-                        ExpandToNewEntry("resouresReferences", "cinematicAnimNames", 0);
+                        ExpandToNewEntry("resouresReferences", "cinematicAnimNames");
                         break;
                     case "gameplay":
-                        ExpandToNewEntry("resouresReferences", "gameplayAnimNames", 0);
+                        ExpandToNewEntry("resouresReferences", "gameplayAnimNames");
                         break;
                 }
 
@@ -1324,8 +1328,7 @@ namespace WolvenKit.App.ViewModels.Documents
         /// </summary>
         /// <param name="parentPath">Parent path like "screenplayStore", "actors", or "props"</param>
         /// <param name="childPath">Child collection like "lines" or "options", or empty for direct arrays</param>
-        /// <param name="itemId">The itemId of the newly created entry</param>
-        private void ExpandToNewEntry(string parentPath, string childPath, uint itemId)
+        private void ExpandToNewEntry(string parentPath, string childPath)
         {
             try
             {

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -66,13 +66,15 @@ namespace WolvenKit.App.ViewModels.Documents
 
         public bool IsOptionCreationVisible => SelectedTab?.Header == "Dialogue";
 
+        public bool IsDialogueImportVisible => SelectedTab?.Header == "Dialogue";
+
         public bool IsWorkspotCreationVisible => SelectedTab?.Header == "Asset Library";
 
         public bool IsEffectCreationVisible => SelectedTab?.Header == "Asset Library";
 
         public bool IsAnimationCreationVisible => SelectedTab?.Header == "Asset Library";
 
-        public bool IsButtonBarVisible => IsActorCreationVisible || IsPropCreationVisible || IsDialogueCreationVisible || IsOptionCreationVisible || IsWorkspotCreationVisible || IsEffectCreationVisible || IsAnimationCreationVisible;
+        public bool IsButtonBarVisible => IsActorCreationVisible || IsPropCreationVisible || IsDialogueCreationVisible || IsOptionCreationVisible || IsDialogueImportVisible || IsWorkspotCreationVisible || IsEffectCreationVisible || IsAnimationCreationVisible;
 
         public override ERedDocumentItemType DocumentItemType => ERedDocumentItemType.MainFile;
 
@@ -247,6 +249,7 @@ namespace WolvenKit.App.ViewModels.Documents
             OnPropertyChanged(nameof(IsPropCreationVisible));
             OnPropertyChanged(nameof(IsDialogueCreationVisible));
             OnPropertyChanged(nameof(IsOptionCreationVisible));
+            OnPropertyChanged(nameof(IsDialogueImportVisible));
             OnPropertyChanged(nameof(IsWorkspotCreationVisible));
             OnPropertyChanged(nameof(IsEffectCreationVisible));
             OnPropertyChanged(nameof(IsAnimationCreationVisible));
@@ -582,6 +585,274 @@ namespace WolvenKit.App.ViewModels.Documents
             {
                 _logger?.Error($"Failed to create new choice option: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Takes a dialogue export written by another tool - the Dialogue Browser CET mod writes
+        /// one from its conversation panel - and adds its lines to the screenplay store, with
+        /// their embedded text and lipsync animations.
+        /// </summary>
+        [RelayCommand]
+        private void ImportDialogue()
+        {
+            try
+            {
+                var screenplayStore = _sceneData.ScreenplayStore;
+                if (screenplayStore == null)
+                {
+                    _logger?.Warning("Dialogue import: this scene has no screenplay store.");
+                    return;
+                }
+
+                var screenplayLines = screenplayStore.Lines;
+                var screenplayOptions = screenplayStore.Options;
+
+                var existingLineLocStrings = GetLocStringIds(screenplayLines.Select(line => line.LocstringId));
+                var existingOptionLocStrings = GetLocStringIds(screenplayOptions.Select(option => option.LocstringId));
+
+                var dialog = Interactions.ShowDialogueImport(new DialogueImportDialogOptions(
+                    FileName,
+                    existingLineLocStrings,
+                    existingOptionLocStrings,
+                    GetSceneActorOptions()));
+
+                // Cancelled.
+                if (dialog == null)
+                {
+                    return;
+                }
+
+                var importedLines = dialog.GetLinesToImport();
+                if (importedLines.Count == 0)
+                {
+                    return;
+                }
+
+                var createEmbeddedText = dialog.CreateEmbeddedText;
+                var random = new Random();
+
+                // Item ids run in steps of 256, as the game's own scenes do, and both halves of the
+                // screenplay store number themselves independently.
+                var nextLineItemId = (uint)1;
+                if (screenplayLines.Count > 0)
+                {
+                    nextLineItemId = screenplayLines[^1].ItemId.Id + 256;
+                }
+
+                var nextOptionItemId = (uint)2;
+                if (screenplayOptions.Count > 0)
+                {
+                    nextOptionItemId = screenplayOptions[^1].ItemId.Id + 256;
+                }
+
+                var addedLines = 0;
+                var addedOptions = 0;
+                var addedTexts = 0;
+                var addedActors = 0;
+                var skipped = 0;
+
+                foreach (var selection in importedLines)
+                {
+                    var line = selection.Line;
+
+                    // Checked again here rather than trusted from the dialog: its list was built
+                    // when it opened, and the same locstring must never end up with two screenplay
+                    // entries pointing at it.
+                    var known = line.IsChoiceOption ? existingOptionLocStrings : existingLineLocStrings;
+
+                    if (!known.Add(line.LocStringId))
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    if (line.IsChoiceOption)
+                    {
+                        screenplayOptions.Add(new scnscreenplayChoiceOption
+                        {
+                            ItemId = new scnscreenplayItemId { Id = nextOptionItemId },
+                            LocstringId = new scnlocLocstringId { Ruid = (CRUID)line.LocStringId },
+                            Usage = new scnscreenplayOptionUsage { PlayerGenderMask = new scnGenderMask { Mask = 3 } }
+                        });
+
+                        nextOptionItemId += 256;
+                        addedOptions++;
+                    }
+                    else
+                    {
+                        var dialogueLine = new scnscreenplayDialogLine
+                        {
+                            ItemId = new scnscreenplayItemId { Id = nextLineItemId },
+                            LocstringId = new scnlocLocstringId { Ruid = (CRUID)line.LocStringId },
+                            Usage = new scnscreenplayLineUsage { PlayerGenderMask = new scnGenderMask { Mask = 3 } }
+                        };
+
+                        // Who says the line and who it is said to, as the dialog left them: matched
+                        // against the scene's cast by name, then whatever the user picked instead.
+                        // A line they left unassigned keeps the default, which is the same "no
+                        // actor" a line added by hand starts out with.
+                        if (selection.SpeakerActorId is { } speakerActorId)
+                        {
+                            dialogueLine.Speaker = new scnActorId { Id = speakerActorId };
+                            addedActors++;
+                        }
+
+                        if (selection.AddresseeActorId is { } addresseeActorId)
+                        {
+                            dialogueLine.Addressee = new scnActorId { Id = addresseeActorId };
+                            addedActors++;
+                        }
+
+                        // The index knows a female animation for nearly every line and a male one
+                        // for only a few, so an empty name is left as the default rather than
+                        // written as one.
+                        if (!string.IsNullOrEmpty(line.FemaleLipsyncAnim))
+                        {
+                            dialogueLine.FemaleLipsyncAnimationName = line.FemaleLipsyncAnim;
+                        }
+
+                        if (!string.IsNullOrEmpty(line.MaleLipsyncAnim))
+                        {
+                            dialogueLine.MaleLipsyncAnimationName = line.MaleLipsyncAnim;
+                        }
+
+                        screenplayLines.Add(dialogueLine);
+
+                        nextLineItemId += 256;
+                        addedLines++;
+                    }
+
+                    if (createEmbeddedText && AddEmbeddedText(line.LocStringId, line.Text, random))
+                    {
+                        addedTexts++;
+                    }
+                }
+
+                if (addedLines == 0 && addedOptions == 0)
+                {
+                    _logger?.Warning("Dialogue import: every line was already in the scene.");
+                    return;
+                }
+
+                // Mark document as dirty
+                Parent?.SetIsDirty(true);
+
+                // Force recalculation of the root chunk properties to pick up the imported lines
+                var rootChunk = RDTViewModel.GetRootChunk();
+                if (rootChunk != null)
+                {
+                    rootChunk.RecalculateProperties();
+                }
+
+                // Refresh the current tab content
+                if (SelectedTab != null)
+                {
+                    UpdateTabContent(SelectedTab);
+                }
+
+                // Auto-expand to show what came in
+                ExpandToNewEntry("screenplayStore", addedLines > 0 ? "lines" : "options", 0);
+
+                // Update dialogue and choice counts in the UI
+                OnPropertyChanged(nameof(TotalDialogues));
+                OnPropertyChanged(nameof(TotalChoices));
+
+                _logger?.Success(
+                    $"Imported {addedLines} dialogue line(s)" +
+                    (addedOptions > 0 ? $" and {addedOptions} choice option(s)" : "") +
+                    (createEmbeddedText ? $", {addedTexts} with embedded text" : "") +
+                    (addedActors > 0 ? $", {addedActors} speaker/addressee assignment(s)" : "") +
+                    (skipped > 0 ? $". Skipped {skipped} already in the scene" : ""));
+            }
+            catch (Exception ex)
+            {
+                _logger?.Error($"Failed to import dialogue: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// The scene's cast, as the import dialog offers it: what speaker and addressee names are
+        /// matched against, and what the user picks from. Player actors are listed too, flagged as
+        /// such, because the first of them is what an export's "V" always means.
+        /// </summary>
+        private List<SceneActorOption> GetSceneActorOptions()
+        {
+            var actors = new List<SceneActorOption>();
+
+            foreach (var actor in _sceneData.Actors)
+            {
+                if (actor.ActorId is null)
+                {
+                    continue;
+                }
+
+                string actorName = actor.ActorName;
+                actors.Add(new SceneActorOption((uint)actor.ActorId.Id, actorName));
+            }
+
+            foreach (var playerActor in _sceneData.PlayerActors)
+            {
+                if (playerActor.ActorId is null)
+                {
+                    continue;
+                }
+
+                string playerName = playerActor.PlayerName;
+                actors.Add(new SceneActorOption((uint)playerActor.ActorId.Id, playerName, isPlayer: true));
+            }
+
+            return actors;
+        }
+
+        /// <summary>
+        /// Locstring ids of a screenplay collection, as something an import can be checked against.
+        /// </summary>
+        private static HashSet<ulong> GetLocStringIds(IEnumerable<scnlocLocstringId?>? locStringIds) =>
+            locStringIds?
+                .Where(locStringId => locStringId != null)
+                .Select(locStringId => (ulong)locStringId!.Ruid)
+                .ToHashSet() ?? [];
+
+        /// <summary>
+        /// Embeds a line's text into the scene's locStore, as a payload entry plus the descriptor
+        /// that points a locstring at it.
+        /// </summary>
+        /// <returns>False when there was nothing to embed, or the locStore already describes this locstring.</returns>
+        private bool AddEmbeddedText(ulong locStringId, string text, Random random)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return false;
+            }
+
+            // A locstring the scene already carries text for keeps the text it has: two descriptors
+            // for one locstring and locale is what the game reads as a broken locStore.
+            if (_sceneData.LocStore.VdEntries.Any(entry =>
+                    entry.LocstringId != null && (ulong)entry.LocstringId.Ruid == locStringId))
+            {
+                return false;
+            }
+
+            var variantCruid = (CRUID)random.NextCRUID();
+
+            // Create VpEntry (payload entry) with the embedded text
+            _sceneData.LocStore.VpEntries.Add(new scnlocLocStoreEmbeddedVariantPayloadEntry
+            {
+                Content = text,
+                VariantId = new scnlocVariantId { Ruid = variantCruid }
+            });
+
+            // Create VdEntry (descriptor entry) linking locStringId to the payload with en_us locale
+            _sceneData.LocStore.VdEntries.Add(new scnlocLocStoreEmbeddedVariantDescriptorEntry
+            {
+                LocstringId = new scnlocLocstringId { Ruid = (CRUID)locStringId },
+                VariantId = new scnlocVariantId { Ruid = variantCruid },
+                VpeIndex = (uint)(_sceneData.LocStore.VpEntries.Count - 1),
+                Signature = new scnlocSignature { Val = 3 }, // en_us locale signature
+                LocaleId = Enums.scnlocLocaleId.en_us
+            });
+
+            return true;
         }
 
         [RelayCommand]

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using WolvenKit.App.Helpers;
 using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.GraphEditor;
@@ -383,13 +384,7 @@ public class scnChoiceNodeWrapper : BaseSceneViewModel<scnChoiceNode>, IRefresha
         // VariantId is 4 higher then LocstringId, doesn't seem important
         var cruid = (CRUID)random.NextCRUID();
 
-        // first id is always 2, don't know why
-        var id = (CUInt32)2;
-        if (_sceneResource.ScreenplayStore.Options.Count > 0)
-        {
-            // needs to be 256 higher, if lower the previous text is used, if higher nothing is shown...
-            id = _sceneResource.ScreenplayStore.Options[^1].ItemId.Id + 256;
-        }
+        var id = (CUInt32)SceneEditingHelper.GetNextChoiceOptionItemId(_sceneResource.ScreenplayStore.Options);
 
         _sceneResource.LocStore.VpEntries.Add(new scnlocLocStoreEmbeddedVariantPayloadEntry
         {

--- a/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/Nodes/Scene/scnChoiceNodeWrapper.cs
@@ -408,7 +408,10 @@ public class scnChoiceNodeWrapper : BaseSceneViewModel<scnChoiceNode>, IRefresha
             VpeIndex = (uint)(_sceneResource.LocStore.VpEntries.Count - 1),
             Signature = new scnlocSignature
             {
-                Val = 3 // ???
+                // Gender mask, same 1 = male / 2 = female / 3 = both as scnGenderMask. Vanilla
+                // writes a second descriptor under 1 and 2 where the wording differs by player
+                // gender; one text authored here is the same for everyone, so it goes under 3.
+                Val = 3
             }
         });
 

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -134,13 +134,7 @@ public partial class RedGraph
             var random = new Random();
             var cruid = (CRUID)random.NextCRUID();
 
-            // first id is always 2, don't know why
-            var id = (CUInt32)2;
-            if (sceneResource.ScreenplayStore.Options.Count > 0)
-            {
-                // needs to be 256 higher, if lower the previous text is used, if higher nothing is shown...
-                id = sceneResource.ScreenplayStore.Options[^1].ItemId.Id + 256;
-            }
+            var id = (CUInt32)SceneEditingHelper.GetNextChoiceOptionItemId(sceneResource.ScreenplayStore.Options);
 
             sceneResource.LocStore.VpEntries.Add(new scnlocLocStoreEmbeddedVariantPayloadEntry
             {

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -158,6 +158,9 @@ public partial class RedGraph
                 VpeIndex = (uint)(sceneResource.LocStore.VpEntries.Count - 1),
                 Signature = new scnlocSignature
                 {
+                    // Gender mask, same 1 = male / 2 = female / 3 = both as scnGenderMask. Vanilla
+                    // writes a second descriptor under 1 and 2 where the wording differs by player
+                    // gender; one text authored here is the same for everyone, so it goes under 3.
                     Val = 3
                 }
             });

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
@@ -1,0 +1,478 @@
+<Window
+    x:Class="WolvenKit.Views.Dialogs.DialogueImportDialogView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:syncfusion="http://schemas.syncfusion.com/wpf"
+    xmlns:converters="clr-namespace:WolvenKit.Converters"
+    Title="{Binding Title}"
+    Width="1280"
+    Height="700"
+    MinWidth="{DynamicResource WolvenKitDialogWidth}"
+    MinHeight="{DynamicResource WolvenKitDialogHeightMedium}"
+    DataContext="{Binding RelativeSource={RelativeSource Self},
+                          Path=ViewModel}"
+    WindowStartupLocation="CenterScreen">
+
+    <Grid
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Stretch"
+        hc:ThemeManager.RequestedAccentColor="{DynamicResource MahApps.Brushes.Accent3}">
+        <Grid.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <hc:ThemeResources />
+                    <hc:Theme />
+                </ResourceDictionary.MergedDictionaries>
+
+                <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+                <converters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
+
+                <!-- Column headers, and the muted secondary columns of a row -->
+                <Style
+                    x:Key="ImportColumnHeaderStyle"
+                    TargetType="TextBlock">
+                    <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+                    <Setter Property="Foreground" Value="Gray" />
+                    <Setter Property="VerticalAlignment" Value="Center" />
+                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+                </Style>
+
+                <Style
+                    x:Key="ImportCellStyle"
+                    TargetType="TextBlock">
+                    <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+                    <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+                    <Setter Property="VerticalAlignment" Value="Center" />
+                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+                    <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+                </Style>
+
+                <!-- The rows of an open dropdown, as the Archive XL dialog dresses them: the
+                     window's own theme leaves them light, which is unreadable in this one -->
+                <Style TargetType="{x:Type ComboBoxItem}">
+                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor}" />
+                    <Setter Property="OverridesDefaultStyle" Value="true" />
+                    <Setter Property="SnapsToDevicePixels" Value="true" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                                <Border
+                                    x:Name="Border"
+                                    Padding="4,3"
+                                    Background="Transparent"
+                                    CornerRadius="4"
+                                    SnapsToDevicePixels="true">
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="SelectionStates">
+                                            <VisualState x:Name="Unselected" />
+                                            <VisualState x:Name="Selected">
+                                                <Storyboard>
+                                                    <ColorAnimationUsingKeyFrames
+                                                        Storyboard.TargetName="Border"
+                                                        Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
+                                                        <EasingColorKeyFrame
+                                                            KeyTime="0"
+                                                            Value="{StaticResource WolvenKitCyanColor}" />
+                                                    </ColorAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <ContentPresenter />
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+
+                <!-- Who a line is said by and said to: the same cast in every row, so the list
+                     comes off the row itself rather than being rebuilt per column -->
+                <Style
+                    x:Key="ImportActorSelectorStyle"
+                    BasedOn="{StaticResource {x:Type ComboBox}}"
+                    TargetType="ComboBox">
+                    <Setter Property="Background" Value="{StaticResource BackgroundColor_Control}" />
+                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor}" />
+                    <Setter Property="BorderThickness" Value="1" />
+                    <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+                    <Setter Property="VerticalAlignment" Value="Center" />
+                    <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+                    <Setter Property="Padding" Value="4,1" />
+                    <Setter Property="ItemsSource" Value="{Binding ActorOptions}" />
+                    <Setter Property="DisplayMemberPath" Value="DisplayName" />
+                    <Setter Property="IsEnabled" Value="{Binding CanSetActors}" />
+                </Style>
+            </ResourceDictionary>
+        </Grid.Resources>
+
+        <syncfusion:WizardControl
+            CancelButtonCancelsWindow="True"
+            FinishButtonClosesWindow="True">
+            <syncfusion:WizardPage
+                BackVisibility="Collapsed"
+                CancelVisibility="Visible"
+                FinishVisibility="Visible"
+                HelpVisibility="Collapsed"
+                NextVisibility="Collapsed"
+                PageType="Exterior"
+                FinishEnabled="{Binding CanImport,
+                                        UpdateSourceTrigger=PropertyChanged}">
+
+                <Grid
+                    Grid.IsSharedSizeScope="True"
+                    Margin="{DynamicResource WolvenKitMarginSmallHeader}">
+                    <Grid.RowDefinitions>
+                        <!-- Where the payload comes from -->
+                        <RowDefinition Height="Auto" />
+                        <!-- What was read of it -->
+                        <RowDefinition Height="Auto" />
+                        <!-- The payload itself, folded away -->
+                        <RowDefinition Height="Auto" />
+                        <!-- What the Dialogue Browser is, until there is an import to look at -->
+                        <RowDefinition Height="Auto" />
+                        <!-- Column headers -->
+                        <RowDefinition Height="Auto" />
+                        <!-- The lines -->
+                        <RowDefinition Height="*" />
+                        <!-- Selection and import options -->
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <!-- ============================================ source row -->
+                    <StackPanel
+                        Grid.Row="0"
+                        Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                        Orientation="Horizontal">
+                        <Button
+                            Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Content="Paste from clipboard"
+                            ToolTip="Read an export off the clipboard - the Dialogue Browser puts one there every time you export"
+                            Command="{Binding PasteFromClipboardCommand}" />
+
+                        <Button
+                            Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Content="Load file..."
+                            ToolTip="Open a .json export, e.g. from the mod's data/exports folder"
+                            Click="OnLoadFileClick" />
+
+                        <Button
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Content="Clear"
+                            Visibility="{Binding HasEntries,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Click="OnClearClick" />
+                    </StackPanel>
+
+                    <!-- ============================================ status line -->
+                    <TextBlock
+                        Grid.Row="1"
+                        Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        Text="{Binding StatusMessage}"
+                        TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="Gray" />
+                                <Style.Triggers>
+                                    <DataTrigger
+                                        Binding="{Binding IsStatusError}"
+                                        Value="True">
+                                        <Setter Property="Foreground" Value="{StaticResource WolvenKitRed}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- =========================================== raw payload -->
+                    <Expander
+                        Grid.Row="2"
+                        Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                        FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                        Foreground="Gray"
+                        Header="Payload (JSON)">
+                        <TextBox
+                            Height="90"
+                            Margin="{DynamicResource WolvenKitMarginTinyTop}"
+                            Padding="{DynamicResource WolvenKitMarginTiny}"
+                            FontFamily="Consolas"
+                            FontSize="{DynamicResource WolvenKitFontAltTitle}"
+                            AcceptsReturn="True"
+                            HorizontalScrollBarVisibility="Auto"
+                            VerticalScrollBarVisibility="Auto"
+                            Text="{Binding JsonText,
+                                           UpdateSourceTrigger=PropertyChanged}" />
+                    </Expander>
+
+                    <!-- ============================== what all this is, for a
+                                                        user meeting it for the first time. Gone as
+                                                        soon as there is an import to look at -->
+                    <Border
+                        Grid.Row="3"
+                        Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                        Padding="10,8"
+                        Background="#14FFFFFF"
+                        BorderBrush="#33FFFFFF"
+                        BorderThickness="1"
+                        Visibility="{Binding HasEntries,
+                                             Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                        <StackPanel>
+                            <TextBlock
+                                Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                FontWeight="Bold"
+                                Foreground="{StaticResource WolvenKitCyan}"
+                                Text="What is the Dialogue Browser?" />
+
+                            <TextBlock
+                                Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Foreground="{DynamicResource PrimaryTextBrush}"
+                                TextWrapping="Wrap"><Run Text="A Cyber Engine Tweaks mod that lets you browse the game's vanilla conversations while it runs, and export the lines you pick. Dialogue Browser is available on Nexus Mods and on GitHub : " /><Hyperlink
+                                    Foreground="{StaticResource WolvenKitCyan}"
+                                    NavigateUri="https://github.com/Akiway/Dialogue-Browser"
+                                    RequestNavigate="OnHyperlinkRequestNavigate"
+                                    ToolTip="Opens in your browser">https://github.com/Akiway/Dialogue-Browser</Hyperlink></TextBlock>
+
+                            <TextBlock
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Foreground="Gray"
+                                TextWrapping="Wrap"
+                                Text="Export from the mod: it puts the JSON on your clipboard, and writes a copy to the folder below." />
+
+                            <TextBlock
+                                Margin="{DynamicResource WolvenKitMarginTinyTop}"
+                                FontFamily="Consolas"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Foreground="Gray"
+                                TextWrapping="Wrap"
+                                Text="{Binding ExportFolderPath}"
+                                ToolTip="Where 'Load file...' opens" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- ======================================= column headers -->
+                    <Border
+                        Grid.Row="4"
+                        Margin="{DynamicResource WolvenKitMarginSmallTop}"
+                        Padding="4,2"
+                        BorderBrush="#33FFFFFF"
+                        BorderThickness="0,0,0,1">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Check" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="LocString" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Speaker" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Addressee" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Lipsync" />
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="Status" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                Grid.Column="0"
+                                Width="24"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Width="150"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="LocString" />
+                            <TextBlock
+                                Grid.Column="2"
+                                Width="180"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="Speaker" />
+                            <TextBlock
+                                Grid.Column="3"
+                                Width="180"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="Addressee" />
+                            <TextBlock
+                                Grid.Column="4"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="Text" />
+                            <TextBlock
+                                Grid.Column="5"
+                                Width="190"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="Lipsync animation" />
+                            <TextBlock
+                                Grid.Column="6"
+                                Width="110"
+                                Style="{StaticResource ImportColumnHeaderStyle}"
+                                Text="Status" />
+                        </Grid>
+                    </Border>
+
+                    <!-- ============================================== the lines -->
+                    <ListBox
+                        Grid.Row="5"
+                        Margin="{DynamicResource WolvenKitMarginTinyBottom}"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        ItemsSource="{Binding Entries}"
+                        HorizontalContentAlignment="Stretch"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                        ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="Focusable" Value="False" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="Padding" Value="0" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="4,3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Check" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="LocString" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Speaker" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Addressee" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Lipsync" />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Status" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- A duplicate cannot be taken, so its box is locked rather
+                                         than merely cleared -->
+                                    <CheckBox
+                                        Grid.Column="0"
+                                        Width="24"
+                                        VerticalAlignment="Center"
+                                        IsChecked="{Binding IsSelected,
+                                                            Mode=TwoWay,
+                                                            UpdateSourceTrigger=PropertyChanged}"
+                                        IsEnabled="{Binding CanImport}" />
+
+                                    <TextBlock
+                                        Grid.Column="1"
+                                        Width="150"
+                                        Style="{StaticResource ImportCellStyle}"
+                                        FontFamily="Consolas"
+                                        Text="{Binding LocStringId}"
+                                        ToolTip="{Binding LocStringId}" />
+
+                                    <!-- Matched from the export's own name, and the user's to
+                                         change. A choice option has neither, so both are locked -->
+                                    <ComboBox
+                                        Grid.Column="2"
+                                        Width="180"
+                                        Style="{StaticResource ImportActorSelectorStyle}"
+                                        SelectedItem="{Binding SpeakerActor,
+                                                               Mode=TwoWay,
+                                                               UpdateSourceTrigger=PropertyChanged}"
+                                        ToolTip="{Binding SpeakerToolTip}" />
+
+                                    <ComboBox
+                                        Grid.Column="3"
+                                        Width="180"
+                                        Style="{StaticResource ImportActorSelectorStyle}"
+                                        SelectedItem="{Binding AddresseeActor,
+                                                               Mode=TwoWay,
+                                                               UpdateSourceTrigger=PropertyChanged}"
+                                        ToolTip="{Binding AddresseeToolTip}" />
+
+                                    <TextBlock
+                                        Grid.Column="4"
+                                        Style="{StaticResource ImportCellStyle}"
+                                        Text="{Binding Text}"
+                                        ToolTip="{Binding Text}" />
+
+                                    <TextBlock
+                                        Grid.Column="5"
+                                        Width="190"
+                                        Style="{StaticResource ImportCellStyle}"
+                                        Foreground="Gray"
+                                        Text="{Binding LipsyncAnimNames}"
+                                        ToolTip="{Binding LipsyncAnimNames}" />
+
+                                    <TextBlock
+                                        Grid.Column="6"
+                                        Width="110"
+                                        Text="{Binding Status}">
+                                        <TextBlock.Style>
+                                            <Style
+                                                BasedOn="{StaticResource ImportCellStyle}"
+                                                TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{StaticResource WolvenKitGreen}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger
+                                                        Binding="{Binding IsDuplicate}"
+                                                        Value="True">
+                                                        <Setter Property="Foreground" Value="{StaticResource WolvenKitYellow}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <!-- ==================================== selection + options -->
+                    <Grid Grid.Row="6">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel
+                            Grid.Column="0"
+                            Orientation="Horizontal"
+                            Visibility="{Binding HasEntries,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Button
+                                Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                                Padding="{DynamicResource WolvenKitMarginTiny}"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Content="Select all"
+                                Command="{Binding SelectAllCommand}" />
+                            <Button
+                                Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                                Padding="{DynamicResource WolvenKitMarginTiny}"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Content="Select none"
+                                Command="{Binding SelectNoneCommand}" />
+                        </StackPanel>
+
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                            VerticalAlignment="Center"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Foreground="Gray"
+                            Visibility="{Binding HasEntries,
+                                                 Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Run Text="{Binding SelectedCount, Mode=OneWay}" />
+                            <Run Text="of" />
+                            <Run Text="{Binding EntryCount, Mode=OneWay}" />
+                            <Run Text="selected," />
+                            <Run Text="{Binding DuplicateCount, Mode=OneWay}" />
+                            <Run Text="already in the scene" />
+                        </TextBlock>
+
+                        <CheckBox
+                            Grid.Column="2"
+                            VerticalAlignment="Center"
+                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                            Content="Embed the text into the scene"
+                            ToolTip="Writes each line's subtitle into the scene's locStore, the way the Add Dialogue button does"
+                            IsChecked="{Binding CreateEmbeddedText}" />
+                    </Grid>
+                </Grid>
+            </syncfusion:WizardPage>
+        </syncfusion:WizardControl>
+    </Grid>
+</Window>

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
@@ -411,11 +411,25 @@
                                                                UpdateSourceTrigger=PropertyChanged}"
                                         ToolTip="{Binding AddresseeToolTip}" />
 
-                                    <TextBlock
+                                    <!-- A line worded for the player's gender is marked: only one
+                                         of its two wordings can be embedded, and the tooltip says
+                                         which and why -->
+                                    <StackPanel
                                         Grid.Column="4"
-                                        Style="{StaticResource ImportCellStyle}"
-                                        Text="{Binding Text}"
-                                        ToolTip="{Binding Text}" />
+                                        Orientation="Horizontal"
+                                        ToolTip="{Binding TextToolTip}">
+                                        <TextBlock
+                                            Style="{StaticResource ImportCellStyle}"
+                                            Margin="0,0,4,0"
+                                            FontWeight="Bold"
+                                            Foreground="{DynamicResource ForegroundColor_Yellow}"
+                                            Text="F/M"
+                                            Visibility="{Binding HasGenderedText,
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                        <TextBlock
+                                            Style="{StaticResource ImportCellStyle}"
+                                            Text="{Binding Text}" />
+                                    </StackPanel>
 
                                     <TextBlock
                                         Grid.Column="5"

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
@@ -33,9 +33,18 @@
                     x:Key="ImportColumnHeaderStyle"
                     TargetType="TextBlock">
                     <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
-                    <Setter Property="Foreground" Value="Gray" />
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundColor_Grey_Dark}" />
                     <Setter Property="VerticalAlignment" Value="Center" />
                     <Setter Property="Margin" Value="{DynamicResource WolvenKitMarginTinyRight}" />
+                </Style>
+
+                <!-- Everything the dialog says about itself rather than about a line -->
+                <Style
+                    x:Key="ImportHintStyle"
+                    TargetType="TextBlock">
+                    <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundColor_Grey_Dark}" />
+                    <Setter Property="TextWrapping" Value="Wrap" />
                 </Style>
 
                 <Style
@@ -51,7 +60,7 @@
                 <!-- The rows of an open dropdown, as the Archive XL dialog dresses them: the
                      window's own theme leaves them light, which is unreadable in this one -->
                 <Style TargetType="{x:Type ComboBoxItem}">
-                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor}" />
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
                     <Setter Property="OverridesDefaultStyle" Value="true" />
                     <Setter Property="SnapsToDevicePixels" Value="true" />
                     <Setter Property="Template">
@@ -92,8 +101,8 @@
                     x:Key="ImportActorSelectorStyle"
                     BasedOn="{StaticResource {x:Type ComboBox}}"
                     TargetType="ComboBox">
-                    <Setter Property="Background" Value="{StaticResource BackgroundColor_Control}" />
-                    <Setter Property="Foreground" Value="{StaticResource ForegroundColor}" />
+                    <Setter Property="Background" Value="{DynamicResource BackgroundColor_Control}" />
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
                     <Setter Property="BorderThickness" Value="1" />
                     <Setter Property="FontSize" Value="{DynamicResource WolvenKitFontSubTitle}" />
                     <Setter Property="VerticalAlignment" Value="Center" />
@@ -166,7 +175,7 @@
                             Content="Clear"
                             Visibility="{Binding HasEntries,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}"
-                            Click="OnClearClick" />
+                            Command="{Binding ClearCommand}" />
                     </StackPanel>
 
                     <!-- ============================================ status line -->
@@ -178,12 +187,12 @@
                         TextWrapping="Wrap">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="Gray" />
+                                <Setter Property="Foreground" Value="{DynamicResource ForegroundColor_Grey_Dark}" />
                                 <Style.Triggers>
                                     <DataTrigger
                                         Binding="{Binding IsStatusError}"
                                         Value="True">
-                                        <Setter Property="Foreground" Value="{StaticResource WolvenKitRed}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ForegroundColor_Red}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -195,19 +204,43 @@
                         Grid.Row="2"
                         Margin="{DynamicResource WolvenKitMarginTinyBottom}"
                         FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                        Foreground="Gray"
+                        Foreground="{DynamicResource ForegroundColor_Grey_Dark}"
                         Header="Payload (JSON)">
-                        <TextBox
-                            Height="90"
-                            Margin="{DynamicResource WolvenKitMarginTinyTop}"
-                            Padding="{DynamicResource WolvenKitMarginTiny}"
-                            FontFamily="Consolas"
-                            FontSize="{DynamicResource WolvenKitFontAltTitle}"
-                            AcceptsReturn="True"
-                            HorizontalScrollBarVisibility="Auto"
-                            VerticalScrollBarVisibility="Auto"
-                            Text="{Binding JsonText,
-                                           UpdateSourceTrigger=PropertyChanged}" />
+                        <StackPanel Margin="{DynamicResource WolvenKitMarginTinyTop}">
+                            <TextBox
+                                Height="90"
+                                Padding="{DynamicResource WolvenKitMarginTiny}"
+                                FontFamily="Consolas"
+                                FontSize="{DynamicResource WolvenKitFontAltTitle}"
+                                AcceptsReturn="True"
+                                HorizontalScrollBarVisibility="Auto"
+                                VerticalScrollBarVisibility="Auto"
+                                Text="{Binding JsonText,
+                                               UpdateSourceTrigger=PropertyChanged}" />
+
+                            <!-- Reading the box rebuilds the list from scratch, which throws away
+                                 every speaker and checkbox the user has set. That is theirs to ask
+                                 for rather than something an edit does out from under them -->
+                            <StackPanel
+                                Margin="{DynamicResource WolvenKitMarginTinyTop}"
+                                Orientation="Horizontal">
+                                <Button
+                                    Margin="{DynamicResource WolvenKitMarginTinyRight}"
+                                    Padding="{DynamicResource WolvenKitMarginTiny}"
+                                    FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                    Content="Read payload"
+                                    ToolTip="Rebuilds the list below from this text. Any speaker, addressee or selection you have set is lost"
+                                    Command="{Binding ReadPayloadCommand}" />
+
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Style="{StaticResource ImportHintStyle}"
+                                    Foreground="{DynamicResource ForegroundColor_Yellow}"
+                                    Text="Edited - press Read payload to rebuild the list below."
+                                    Visibility="{Binding IsPayloadStale,
+                                                         Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            </StackPanel>
+                        </StackPanel>
                     </Expander>
 
                     <!-- ============================== what all this is, for a
@@ -217,8 +250,8 @@
                         Grid.Row="3"
                         Margin="{DynamicResource WolvenKitMarginTinyBottom}"
                         Padding="10,8"
-                        Background="#14FFFFFF"
-                        BorderBrush="#33FFFFFF"
+                        Background="{DynamicResource BackgroundColor_Frame_Active}"
+                        BorderBrush="{DynamicResource ForegroundColor_Grey_Inactive}"
                         BorderThickness="1"
                         Visibility="{Binding HasEntries,
                                              Converter={StaticResource InverseBooleanToVisibilityConverter}}">
@@ -227,7 +260,7 @@
                                 Margin="{DynamicResource WolvenKitMarginTinyBottom}"
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
                                 FontWeight="Bold"
-                                Foreground="{StaticResource WolvenKitCyan}"
+                                Foreground="{DynamicResource ForegroundColor_Cyan}"
                                 Text="What is the Dialogue Browser?" />
 
                             <TextBlock
@@ -235,23 +268,19 @@
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
                                 Foreground="{DynamicResource PrimaryTextBrush}"
                                 TextWrapping="Wrap"><Run Text="A Cyber Engine Tweaks mod that lets you browse the game's vanilla conversations while it runs, and export the lines you pick. Dialogue Browser is available on Nexus Mods and on GitHub : " /><Hyperlink
-                                    Foreground="{StaticResource WolvenKitCyan}"
+                                    Foreground="{DynamicResource ForegroundColor_Cyan}"
                                     NavigateUri="https://github.com/Akiway/Dialogue-Browser"
                                     RequestNavigate="OnHyperlinkRequestNavigate"
                                     ToolTip="Opens in your browser">https://github.com/Akiway/Dialogue-Browser</Hyperlink></TextBlock>
 
                             <TextBlock
-                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                Foreground="Gray"
-                                TextWrapping="Wrap"
+                                Style="{StaticResource ImportHintStyle}"
                                 Text="Export from the mod: it puts the JSON on your clipboard, and writes a copy to the folder below." />
 
                             <TextBlock
                                 Margin="{DynamicResource WolvenKitMarginTinyTop}"
                                 FontFamily="Consolas"
-                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                                Foreground="Gray"
-                                TextWrapping="Wrap"
+                                Style="{StaticResource ImportHintStyle}"
                                 Text="{Binding ExportFolderPath}"
                                 ToolTip="Where 'Load file...' opens" />
                         </StackPanel>
@@ -262,7 +291,7 @@
                         Grid.Row="4"
                         Margin="{DynamicResource WolvenKitMarginSmallTop}"
                         Padding="4,2"
-                        BorderBrush="#33FFFFFF"
+                        BorderBrush="{DynamicResource ForegroundColor_Grey_Inactive}"
                         BorderThickness="0,0,0,1">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -392,7 +421,7 @@
                                         Grid.Column="5"
                                         Width="190"
                                         Style="{StaticResource ImportCellStyle}"
-                                        Foreground="Gray"
+                                        Foreground="{DynamicResource ForegroundColor_Grey_Dark}"
                                         Text="{Binding LipsyncAnimNames}"
                                         ToolTip="{Binding LipsyncAnimNames}" />
 
@@ -404,12 +433,12 @@
                                             <Style
                                                 BasedOn="{StaticResource ImportCellStyle}"
                                                 TargetType="TextBlock">
-                                                <Setter Property="Foreground" Value="{StaticResource WolvenKitGreen}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource WolvenKitGreen}" />
                                                 <Style.Triggers>
                                                     <DataTrigger
                                                         Binding="{Binding IsDuplicate}"
                                                         Value="True">
-                                                        <Setter Property="Foreground" Value="{StaticResource WolvenKitYellow}" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource WolvenKitYellow}" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
@@ -452,7 +481,7 @@
                             Margin="{DynamicResource WolvenKitMarginTinyRight}"
                             VerticalAlignment="Center"
                             FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                            Foreground="Gray"
+                            Foreground="{DynamicResource ForegroundColor_Grey_Dark}"
                             Visibility="{Binding HasEntries,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Run Text="{Binding SelectedCount, Mode=OneWay}" />

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml.cs
@@ -1,0 +1,134 @@
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Navigation;
+using Microsoft.Win32;
+using Splat;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Interaction.Options;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs;
+
+/// <summary>
+/// Takes a dialogue export written by another tool - the Dialogue Browser CET mod writes one from
+/// its conversation panel - and lets the user pick which of its lines go into the scene.
+/// </summary>
+public partial class DialogueImportDialogView : Window
+{
+    public DialogueImportDialogViewModel ViewModel { get; set; }
+
+    public DialogueImportDialogView(DialogueImportDialogOptions dialogOptions)
+    {
+        ViewModel = new DialogueImportDialogViewModel(dialogOptions);
+        DataContext = ViewModel;
+        InitializeComponent();
+
+        LoadClipboardIfItLooksLikeAnExport();
+    }
+
+    /// <summary>
+    /// The export puts itself on the clipboard, so in the common case the lines are already listed
+    /// when the dialog comes up. Only a payload that announces itself is taken: a user who has
+    /// something else entirely copied should not be met with a parse error.
+    /// </summary>
+    private void LoadClipboardIfItLooksLikeAnExport()
+    {
+        try
+        {
+            if (!Clipboard.ContainsText())
+            {
+                return;
+            }
+
+            var text = Clipboard.GetText();
+
+            if (DialogueImportHelper.LooksLikePayload(text))
+            {
+                ViewModel.SetPayload(text, "the clipboard");
+            }
+        }
+        catch (Exception)
+        {
+            // A clipboard another process has locked is not worth reporting: the user still has
+            // the paste button and the file picker.
+        }
+    }
+
+    private void OnLoadFileClick(object sender, RoutedEventArgs e)
+    {
+        var dialog = new OpenFileDialog
+        {
+            Title = "Select a dialogue export",
+            Multiselect = false,
+            Filter = "Dialogue export (*.json)|*.json|All files (*.*)|*.*"
+        };
+
+        // The exports are all in one place, so the picker opens there rather than wherever the last
+        // unrelated file was opened from.
+        var exportDirectory = GetDialogueBrowserExportDirectory();
+
+        if (exportDirectory is not null)
+        {
+            dialog.InitialDirectory = exportDirectory;
+        }
+
+        if (dialog.ShowDialog(this) != true || string.IsNullOrEmpty(dialog.FileName))
+        {
+            return;
+        }
+
+        ViewModel.LoadFile(dialog.FileName);
+    }
+
+    /// <summary>
+    /// The Dialogue Browser's export folder in the game install, when there is one to point at.
+    /// Null when the game path is unset or the mod has never written there: a folder that does not
+    /// exist is worse to open on than wherever the picker was last.
+    /// </summary>
+    private static string? GetDialogueBrowserExportDirectory()
+    {
+        try
+        {
+            if (Locator.Current.GetService<ISettingsManager>() is not { } settingsManager)
+            {
+                return null;
+            }
+
+            var directory = DialogueImportHelper.GetExportDirectory(settingsManager.GetRED4GameRootDir());
+
+            return Directory.Exists(directory) ? directory : null;
+        }
+        catch (Exception)
+        {
+            // No game executable set, or one pointing somewhere that is no longer there.
+            return null;
+        }
+    }
+
+    private void OnClearClick(object sender, RoutedEventArgs e) => ViewModel.JsonText = "";
+
+    /// <summary>Opens the mod's page in whatever the user browses with.</summary>
+    private void OnHyperlinkRequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        }
+        catch (Exception)
+        {
+            // No browser to hand it to. The url is on screen either way.
+        }
+
+        e.Handled = true;
+    }
+
+    public bool? ShowDialog(Window owner)
+    {
+        Owner = owner;
+        return ShowDialog();
+    }
+}

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml.cs
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml.cs
@@ -109,8 +109,6 @@ public partial class DialogueImportDialogView : Window
         }
     }
 
-    private void OnClearClick(object sender, RoutedEventArgs e) => ViewModel.JsonText = "";
-
     /// <summary>Opens the mod's page in whatever the user browses with.</summary>
     private void OnHyperlinkRequestNavigate(object sender, RequestNavigateEventArgs e)
     {

--- a/WolvenKit/Views/Documents/SceneGraphView.xaml
+++ b/WolvenKit/Views/Documents/SceneGraphView.xaml
@@ -325,6 +325,15 @@
                                                               RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
                                         <Button
                                             Style="{StaticResource SceneEditorButtonStyle}"
+                                            Visibility="{Binding DataContext.IsDialogueImportVisible,
+                                                                 RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
+                                                                 Converter={StaticResource BooleanToVisibilityConverter}}"
+                                            Content="Import Dialogue"
+                                            ToolTip="Import dialogue lines exported by another tool, e.g. the Dialogue Browser's conversation panel"
+                                            Command="{Binding DataContext.ImportDialogueCommand,
+                                                              RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}}}" />
+                                        <Button
+                                            Style="{StaticResource SceneEditorButtonStyle}"
                                             Visibility="{Binding DataContext.IsAnimationCreationVisible,
                                                                  RelativeSource={RelativeSource AncestorType={x:Type local:SceneGraphView}},
                                                                  Converter={StaticResource BooleanToVisibilityConverter}}"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -217,6 +217,13 @@ namespace WolvenKit.Views.Tools
                     return result == true ? (dialog.PrimaryInput, dialog.EnableSecondaryInput, dialog.SecondaryInput, dialog.DropdownValue) : (null, false, null, null);
                 };
 
+                Interactions.ShowDialogueImport = (parameters) =>
+                {
+                    var dialog = new DialogueImportDialogView(parameters);
+
+                    return dialog.ShowDialog(Application.Current.MainWindow) == true ? dialog.ViewModel : null;
+                };
+
                 Interactions.AskForFolderPathInput = (args) =>
                 {
                     var dialog = new FolderPathInputDialogView(args.Item2, args.Item1);

--- a/changelog/unreleased/3123.yaml
+++ b/changelog/unreleased/3123.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3123
+      author: "Akiway"
+      description: "Scene Editor has a new 'Import Dialogue' button and popup in the Dialogue tab. It reads a json from the clipboard or a .json file, to import lines with all their properties, matching each line's speaker and addressee to the scene's actors by name. For use with CET mod Dialogue Browser."


### PR DESCRIPTION
# Scene Editor: Import dialogue lines

**Implemented:**
Added an Import Dialogue button and popup. It allows the user to paste or select a file containing dialogues line data. The popup allows the user to change the speaker and adressee of each line before the validation. After that, dialogues lines are being added by filling the locStore (vdEntries and vpEntries) and the screenplayStore (lines) with all the relevent data (LocString, speaker, adressee, lypsincAnimName and embedded text).
___
<img width="796" height="130" alt="image" src="https://github.com/user-attachments/assets/07cf485e-75e9-4738-9492-e0546e9bd024" />

By default the popup shows a information box, explaining what is the Dialogue Browser, that disappears after pasting / selecting a file :
<img width="1274" height="701" alt="image" src="https://github.com/user-attachments/assets/e0c0e8b7-31b7-4b22-9a0c-554c1f70e2e7" />

The "load file..." button targets by default the export folder of Dialogue Browser :
<img width="1186" height="206" alt="image" src="https://github.com/user-attachments/assets/2c0c463c-3606-46b8-8e35-0cd460a2624e" />

The process prevent the player from adding LocString already in scene.
He can change the speaker and adressee to select actual actors of the scene.
<img width="1272" height="699" alt="image" src="https://github.com/user-attachments/assets/1219ab29-ceae-49db-b0ea-e23407686fd2" />

Result after validating :
<img width="830" height="607" alt="image" src="https://github.com/user-attachments/assets/41df5b85-aafa-4684-a84b-43a909c31712" />

___

Regarding the json format, it is the one generated by a new mod I'm finalizing : Dialogue Browser.
```json
{
  "format": "wolvenkit.scene.dialogue",
  "version": 1,
  "source": "DialogueBrowser 1.0.0",
  "conversation": "Ripperdoc",
  "lines": [
    {
      "order": 1,
      "kind": "line",
      "locStringId": "45896283497",
      "text": "Wakey wakey, choom.",
      "femaleText": "Wakey wakey, choom.",
      "maleText": "",
      "hasFemale": true,
      "hasMale": false,
      "speaker": "Viktor Vektor",
      "context": "Vo_Context_Quest",
      "expression": "Vo_Expression_Spoken",
      "femaleLipsyncAnim": "f_1A95FA94452C5000",
      "maleLipsyncAnim": "",
      "duration": 2.6
    }
  ]
}
```

**What is Dialogue Browser**
It is a CET mod that allows to preview vanilla dialogues lines and to create conversations. It is using the SoundDB API by zhincore. This tool is the first part of a larger project that will take time. Since this brick is ready and usable on its own, I decided to release it independantly.

Here is a preview of the mod : 
<img width="1668" height="1168" alt="image" src="https://github.com/user-attachments/assets/c503d4f5-e0b0-40ff-b393-56b21cf40954" />


**For the future**
- For Wolvenkit : it is possible to extend the supported json format, at the import, if other tools want to connect to the import process.
- For Dialogue Browser : it provides an API so other mods can connect to it to use dialogue lines for other things.


<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->