### PR TITLE
Restore behavior where new folders auto expand

### DIFF
--- a/WolvenKit.App/Models/FileSystemModel.cs
+++ b/WolvenKit.App/Models/FileSystemModel.cs
@@ -104,7 +104,8 @@ public class FileSystemModel : INotifyPropertyChanged
     /// <param name="name"></param><remark>Name of the file with extension but no paths.</remark>
     /// <param name="rawRelativePath"></param><remark>Path above 'source' to the file. E.g. archive/worlds/myfile.ent</remark>
     /// <param name="isDirectory"></param>
-    public FileSystemModel(FileSystemModel? parent, string name, string rawRelativePath, bool isDirectory, bool isExpanded = false)
+    /// <param name="isExpanded"></param>
+    public FileSystemModel(FileSystemModel? parent, string name, string rawRelativePath, bool isDirectory, bool isExpanded = true)
     {
         Parent = parent;
 

--- a/WolvenKit.App/Services/WatcherService.cs
+++ b/WolvenKit.App/Services/WatcherService.cs
@@ -282,7 +282,7 @@ public partial class WatcherService : ObservableObject, IWatcherService
                     isDirectory = attr.HasFlag(FileAttributes.Directory);
                 }
 
-                var isExpanded = GetExpansionStateOrNull(tmpPath) ?? false;
+                var isExpanded = GetExpansionStateOrNull(tmpPath) ?? true;
                 current = new FileSystemModel(parent, part, tmpPath, isDirectory, isExpanded);
 
                 if (!current.IsDirectory)

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -862,7 +862,7 @@ namespace WolvenKit.Views.Tools
                         continue;
                     }
 
-                    if (ViewModel.GetExpansionStateOrNull(fileSystemModel.RawRelativePath) is true or null)
+                    if (fileSystemModel.IsExpanded || ViewModel.GetExpansionStateOrNull(fileSystemModel.RawRelativePath) is true or null)
                     {
                         TreeGrid.ExpandNode(treeNode);
                     }


### PR DESCRIPTION
# Restore behavior where new folders auto expand

**Fixed:**
- Fixes a minor regression where folders imported to Project Explorer would not auto-expand in the tree view (which was the prior behavior before the merger of PR stack yesterday)

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->