### PR TITLE
Make drag-and-drop work properly without exceptions

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Helpers/ProjectExplorerDropHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/ProjectExplorerDropHelperTests.cs
@@ -1,0 +1,797 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models;
+using Xunit;
+using static WolvenKit.App.Helpers.ProjectExplorerDropHelper;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+public sealed class ProjectExplorerDropHelperTests : IDisposable
+{
+    private readonly string _projectDirectory;
+
+    public ProjectExplorerDropHelperTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), "wk-drophelper-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_projectDirectory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_projectDirectory, true);
+        }
+        catch (IOException)
+        {
+            // a leaked temp directory must never fail a test run
+        }
+    }
+
+    #region helpers
+
+    private FileSystemModel NewRoot() =>
+        new(null, FileSystemModel.ProjectDirName, _projectDirectory, true);
+
+    private FileSystemModel NewDirectory(FileSystemModel parent, string name)
+    {
+        var relativePath = RelativePathOf(parent, name);
+        Directory.CreateDirectory(Path.Combine(_projectDirectory, relativePath));
+
+        var model = new FileSystemModel(parent, name, relativePath, true);
+        AddChild(parent, model);
+        return model;
+    }
+
+    private FileSystemModel NewFile(FileSystemModel parent, string name)
+    {
+        var relativePath = RelativePathOf(parent, name);
+        File.WriteAllBytes(Path.Combine(_projectDirectory, relativePath), []);
+
+        var model = new FileSystemModel(parent, name, relativePath, false);
+        AddChild(parent, model);
+        return model;
+    }
+
+    private static string RelativePathOf(FileSystemModel parent, string name) =>
+        parent.Parent == null ? name : Path.Combine(parent.RawRelativePath, name);
+
+    private static void AddChild(FileSystemModel parent, FileSystemModel child) =>
+        ((ObservableCollection<FileSystemModel>)parent.Children).Add(child);
+
+    private static string[] PathsOf(params FileSystemModel[] models) =>
+        models.Select(model => model.FullName).ToArray();
+
+    private static DropPayload TreeDrag(params FileSystemModel[] models) =>
+        new(DropSource.TreeRows, PathsOf(models));
+
+    private static DropPayload ExternalDrop(params string[] paths) =>
+        new(DropSource.ExternalFiles, paths);
+
+    private static string OutsidePath(string name) =>
+        Path.Combine(Path.GetTempPath(), "wk-drophelper-elsewhere", name);
+
+    private static DropPlan Plan(
+        FileSystemModel? targetItem,
+        DropPayload payload,
+        IReadOnlyList<FileSystemModel> selectedModels,
+        bool isCopy = false) =>
+        PlanDrop(targetItem, payload, selectedModels, isCopy);
+
+    private sealed record Node(object? Item);
+
+    private static object? ItemOf(Node node) => node.Item;
+
+    private static DataObject NodeDrag(params FileSystemModel?[] items) =>
+        new(TreeNodeDataFormat, new ObservableCollection<Node>(items.Select(item => new Node(item))));
+
+    #endregion
+
+    #region unpacking the payload
+
+    [Fact]
+    public void GetDroppedPayload_FromAnInTreeDrag_ReturnsTheFullNameOfEveryDraggedRow()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+        var file = NewFile(archive, "foo.mesh");
+
+        var payload = GetDroppedPayload<Node>(NodeDrag(directory, file), ItemOf);
+
+        Assert.Equal(DropSource.TreeRows, payload.Source);
+        Assert.Equal(PathsOf(directory, file), payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_FromAnExternalFileDrop_ReturnsThePathsAsGiven()
+    {
+        var external = OutsidePath("external.mesh");
+
+        var payload = GetDroppedPayload<Node>(new DataObject(DataFormats.FileDrop, new[] { external }), ItemOf);
+
+        // nothing here has a model behind it, so the paths are passed through untouched
+        Assert.Equal(DropSource.ExternalFiles, payload.Source);
+        Assert.Equal(new[] { external }, payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_WhenThePayloadCarriesBothFormats_PrefersTheExternalFiles()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var file = NewFile(archive, "foo.mesh");
+        var external = OutsidePath("external.mesh");
+
+        var dropData = NodeDrag(file);
+        dropData.SetData(DataFormats.FileDrop, new[] { external });
+
+        var payload = GetDroppedPayload<Node>(dropData, ItemOf);
+
+        Assert.Equal(DropSource.ExternalFiles, payload.Source);
+        Assert.Equal(new[] { external }, payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_SkipsDraggedRowsThatAreNotBoundToAFileSystemModel()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var file = NewFile(archive, "foo.mesh");
+
+        var payload = GetDroppedPayload<Node>(NodeDrag(null, file), ItemOf);
+
+        Assert.Equal(PathsOf(file), payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_FromAnEmptyDrag_IsAnEmptyTreeDrag()
+    {
+        var payload = GetDroppedPayload<Node>(NodeDrag(), ItemOf);
+
+        Assert.Equal(DropSource.TreeRows, payload.Source);
+        Assert.Empty(payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_FromAPayloadInNeitherFormat_HasNoSource()
+    {
+        var payload = GetDroppedPayload<Node>(new DataObject(DataFormats.UnicodeText, "not a drag"), ItemOf);
+
+        Assert.Equal(DropSource.None, payload.Source);
+        Assert.Empty(payload.Paths);
+    }
+
+    [Fact]
+    public void GetDroppedPayload_FromRowsOfSomeOtherGrid_HasNoSource()
+    {
+        // the format is right but the rows are not ours, so the typed cast declines them
+        var dropData = new DataObject(TreeNodeDataFormat, new ObservableCollection<string> { "surprise" });
+
+        var payload = GetDroppedPayload<Node>(dropData, ItemOf);
+
+        Assert.Equal(DropSource.None, payload.Source);
+        Assert.Empty(payload.Paths);
+    }
+
+    #endregion
+
+    #region no target
+
+    [Fact]
+    public void PlanDrop_WithoutATarget_IsRejected()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var file = NewFile(archive, "foo.mesh");
+
+        var plan = Plan(null, TreeDrag(file), [file]);
+
+        Assert.False(plan.IsActionable);
+        Assert.Equal(DropRejection.NoTarget, plan.Rejection);
+        Assert.Empty(plan.Files);
+        Assert.Null(plan.TargetDirectory);
+    }
+
+    [Fact]
+    public void PlanDrop_OntoAParentlessFile_IsRejectedRatherThanThrowing()
+    {
+        // a file node with no parent has no directory to drop into. FileSystemModel.TargetDir
+        // throws for this; planning is also driven from DragOver, where an exception per mouse
+        // move would be a very bad way to find out.
+        var orphanPath = Path.Combine(_projectDirectory, "orphan.mesh");
+        File.WriteAllBytes(orphanPath, []);
+        var orphan = new FileSystemModel(null, "orphan.mesh", orphanPath, false);
+
+        var plan = Plan(orphan, ExternalDrop(orphanPath), []);
+
+        Assert.Equal(DropRejection.NoTarget, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_RejectedPlan_StillReportsWhereTheDropLanded()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        var plan = Plan(directory, TreeDrag(directory), [directory]);
+
+        Assert.False(plan.IsActionable);
+        Assert.Equal(directory.FullName, plan.TargetDirectory);
+    }
+
+    #endregion
+
+    #region the project root is not a drop target
+
+    [Fact]
+    public void PlanDrop_OntoAFileInTheProjectRoot_IsRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var projectFile = NewFile(root, "mymod.cdproj");
+        var file = NewFile(archive, "foo.mesh");
+
+        var plan = Plan(projectFile, TreeDrag(file), [file]);
+
+        // the target would be <ProjectDir>, which is outside archive/raw/resources - a file moved
+        // there drops out of the mod with nothing to show for it
+        Assert.False(plan.IsActionable);
+        Assert.Equal(DropRejection.ProjectRoot, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_OntoATopLevelDirectory_IsFine()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var raw = NewDirectory(root, "raw");
+        var file = NewFile(raw, "foo.mesh");
+
+        var plan = Plan(archive, TreeDrag(file), [file]);
+
+        Assert.True(plan.IsActionable);
+        Assert.Equal(archive.FullName, plan.TargetDirectory);
+    }
+
+    #endregion
+
+    #region target directory resolution
+
+    [Fact]
+    public void PlanDrop_OntoADirectory_TargetsThatDirectory()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(destination, TreeDrag(file), [file]);
+
+        Assert.True(plan.IsActionable);
+        Assert.Equal(destination.FullName, plan.TargetDirectory);
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_OntoAFile_TargetsTheDirectoryThatHoldsIt()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var file = NewFile(source, "foo.mesh");
+        var neighbour = NewFile(destination, "bar.mesh");
+
+        var plan = Plan(neighbour, TreeDrag(file), [file]);
+
+        Assert.True(plan.IsActionable);
+        Assert.Equal(destination.FullName, plan.TargetDirectory);
+    }
+
+    #endregion
+
+    #region narrowing an in-tree drag to the selection
+
+    [Fact]
+    public void PlanDrop_InTreeDrag_DropsPayloadEntriesThatAreNotSelected()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var selected = NewFile(source, "selected.mesh");
+        var alsoDragged = NewFile(source, "stowaway.mesh");
+
+        // the grid can hand over more than the user last clicked; only the selection counts
+        var plan = Plan(destination, TreeDrag(selected, alsoDragged), [selected]);
+
+        Assert.Equal(PathsOf(selected), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_InTreeDrag_MatchesPayloadPathsCaseInsensitively()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(destination, new DropPayload(DropSource.TreeRows, [file.FullName.ToUpperInvariant()]), [file]);
+
+        // Windows paths are case insensitive, so an upper-cased payload is the same file
+        Assert.True(plan.IsActionable);
+        Assert.Equal(new[] { file.FullName.ToUpperInvariant() }, plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_InTreeDragWithNothingSelected_KeepsThePayloadAsItIs()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(destination, TreeDrag(file), []);
+
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_ExternalFiles_AreNotNarrowedByTheTreeSelection()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var stillSelected = NewFile(source, "foo.mesh");
+
+        var external = OutsidePath("external.mesh");
+
+        var plan = Plan(destination, ExternalDrop(external), [stillSelected]);
+
+        // a file dragged in from Explorer can never be in the tree selection, so narrowing to it
+        // would silently import nothing whenever any row happened to be selected
+        Assert.True(plan.IsActionable);
+        Assert.Equal(new[] { external }, plan.Files);
+    }
+
+    #endregion
+
+    #region dropping onto where the files already are
+
+    [Fact]
+    public void PlanDrop_DirectoryOntoItself_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        var plan = Plan(directory, TreeDrag(directory), [directory]);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+        Assert.Empty(plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryOntoItself_IsRefusedEvenWithNothingSelected()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        // the rules are decided on the payload; the selection only ever narrows it
+        var plan = Plan(directory, TreeDrag(directory), []);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryOntoItsOwnParent_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        var plan = Plan(archive, TreeDrag(directory), [directory]);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_FileOntoTheDirectoryItAlreadyLivesIn_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(source, TreeDrag(file), [file]);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_FileOntoItself_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(file, TreeDrag(file), [file]);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_FileOntoASiblingFile_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var file = NewFile(source, "foo.mesh");
+        var sibling = NewFile(source, "bar.mesh");
+
+        // the sibling resolves to the same directory the file is already in
+        var plan = Plan(sibling, TreeDrag(file), [file]);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_MixedDrop_KeepsTheEntriesThatAreNotAlreadyInTheTarget()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var moving = NewFile(source, "moving.mesh");
+        var alreadyThere = NewFile(destination, "resident.mesh");
+
+        var plan = Plan(destination, TreeDrag(moving, alreadyThere), [moving, alreadyThere]);
+
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(moving), plan.Files);
+    }
+
+    #endregion
+
+    #region ctrl-drag duplicates in place
+
+    [Fact]
+    public void PlanDrop_CopyingAFileOntoItsOwnDirectory_IsKept()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(source, TreeDrag(file), [file], isCopy: true);
+
+        // this is how a file is duplicated: ProcessFileAction sees the collision and offers a
+        // rename, or falls back to a "_copy" suffix. Pruning it as a no-op move kills the feature.
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_CopyingADirectoryOntoItsOwnParent_IsKept()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        var plan = Plan(archive, TreeDrag(directory), [directory], isCopy: true);
+
+        // same thing one level up: the folder is duplicated as "directory_copy"
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(directory), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_CopyingADirectoryOntoItself_IsStillRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+
+        var plan = Plan(directory, TreeDrag(directory), [directory], isCopy: true);
+
+        // there is no sensible reading of copying a directory into itself
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_CopyingADirectoryIntoItsOwnDescendant_IsStillRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+
+        var plan = Plan(child, TreeDrag(parent), [parent], isCopy: true);
+
+        // worse than the move: the copy would be walking a tree it is writing into
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+    }
+
+    #endregion
+
+    #region entries that travel with an ancestor
+
+    [Fact]
+    public void PlanDrop_SelectedDirectoryAndItsContents_ListsOnlyTheDirectory()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var nested = NewDirectory(source, "nested");
+        var file = NewFile(nested, "foo.mesh");
+
+        var plan = Plan(destination, TreeDrag(source, nested, file), [source, nested, file]);
+
+        // the children move inside their parent, so naming them separately would move them twice
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(source), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_WholeSelectedSubtreeOntoItsContainer_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var nested = NewDirectory(archive, "nested");
+        var deeper = NewDirectory(nested, "deeper");
+        var file = NewFile(deeper, "foo.mesh");
+
+        var plan = Plan(archive, TreeDrag(nested, deeper, file), [nested, deeper, file]);
+
+        // "deeper" and the file travel with "nested", and "nested" is already in "archive"
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_ItemUnderAnUnselectedDirectory_IsStillMovedOnItsOwn()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var nested = NewDirectory(archive, "nested");
+        var file = NewFile(nested, "foo.mesh");
+
+        var plan = Plan(archive, TreeDrag(file), [file]);
+
+        // "nested" is not being dragged, so it stays put - which makes moving the file up to
+        // "archive" a real move, not a no-op
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    #endregion
+
+    #region a directory may not move into its own descendant
+
+    [Fact]
+    public void PlanDrop_DirectoryIntoItsOwnChild_IsRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+
+        var plan = Plan(child, TreeDrag(parent), [parent]);
+
+        Assert.False(plan.IsActionable);
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+        Assert.Empty(plan.Files);
+        Assert.Equal(PathsOf(parent), plan.RefusedDirectories);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryIntoADeepDescendant_IsRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+        var grandChild = NewDirectory(child, "grandchild");
+
+        var plan = Plan(grandChild, TreeDrag(parent), [parent]);
+
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryOntoAFileInsideItself_IsRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+        var file = NewFile(child, "foo.mesh");
+
+        // dropping on the file resolves to "child", which is still inside "parent"
+        var plan = Plan(file, TreeDrag(parent), [parent]);
+
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_OneIllegalDirectory_StillMakesTheLegalMoves()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+        var elsewhere = NewDirectory(archive, "elsewhere");
+        var innocent = NewFile(elsewhere, "foo.mesh");
+
+        var plan = Plan(child, TreeDrag(parent, innocent), [parent, innocent]);
+
+        // only the offending directory is dropped; refusing the whole gesture would make a
+        // multi-select drag all-or-nothing for a reason the user cannot see
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(innocent), plan.Files);
+        Assert.Equal(PathsOf(parent), plan.RefusedDirectories);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryIntoItsOwnDescendant_IsRefusedWithNothingSelected()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+
+        var plan = Plan(child, TreeDrag(parent), []);
+
+        // the rule is evaluated on the payload, so an empty or stale selection cannot smuggle a
+        // directory into its own child
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_ExternalDirectoryContainingTheTarget_IsRefused()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+
+        // the same folder dragged in from an Explorer window: no model, only a path
+        var plan = Plan(child, ExternalDrop(parent.FullName), []);
+
+        Assert.Equal(DropRejection.DirectoryIntoOwnDescendant, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_FileWhoseDirectoryIsAnAncestorOfTheTarget_IsFine()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var parent = NewDirectory(archive, "parent");
+        var child = NewDirectory(parent, "child");
+        var file = NewFile(parent, "foo.mesh");
+
+        var plan = Plan(child, TreeDrag(file), [file]);
+
+        // only a directory can contain its destination; a file moving down is a normal move
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_DirectoryWhoseNameIsAPrefixOfTheTargets_IsFine()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var baseDir = NewDirectory(archive, "base");
+        var baseTwo = NewDirectory(archive, "base2");
+        var destination = NewDirectory(baseTwo, "sub");
+
+        var plan = Plan(destination, TreeDrag(baseDir), [baseDir]);
+
+        // "...\archive\base2\sub" starts with "...\archive\base" without being inside it - the
+        // containment check has to land on a separator, not just on a prefix
+        Assert.True(plan.IsActionable);
+        Assert.Equal(PathsOf(baseDir), plan.Files);
+    }
+
+    #endregion
+
+    #region payload edge cases
+
+    [Fact]
+    public void PlanDrop_EmptyPayload_HasNothingToMove()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var destination = NewDirectory(archive, "destination");
+
+        var plan = Plan(destination, new DropPayload(DropSource.None, []), []);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_PayloadListedTwice_KeepsOneCopyOfIt()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var source = NewDirectory(archive, "source");
+        var destination = NewDirectory(archive, "destination");
+        var file = NewFile(source, "foo.mesh");
+
+        var plan = Plan(destination, ExternalDrop(file.FullName, file.FullName.ToUpperInvariant()), []);
+
+        Assert.Equal(PathsOf(file), plan.Files);
+    }
+
+    [Fact]
+    public void PlanDrop_TargetPathListedTwice_IsStillRecognisedAsASelfDrop()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var destination = NewDirectory(archive, "destination");
+
+        var plan = Plan(destination, ExternalDrop(destination.FullName, destination.FullName), []);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_TargetPathSpelledInADifferentCase_IsStillRecognisedAsASelfDrop()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var destination = NewDirectory(archive, "destination");
+
+        var plan = Plan(destination, ExternalDrop(destination.FullName.ToUpperInvariant()), []);
+
+        // an Explorer drop can spell a path differently than the tree does, and NTFS does not care
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_PathWithATrailingSeparator_IsStillRecognisedAsASelfDrop()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var destination = NewDirectory(archive, "destination");
+
+        var plan = Plan(destination, ExternalDrop(destination.FullName + Path.DirectorySeparatorChar), []);
+
+        Assert.Equal(DropRejection.NothingToMove, plan.Rejection);
+    }
+
+    [Fact]
+    public void PlanDrop_DoesNotMutateItsInputs()
+    {
+        var root = NewRoot();
+        var archive = NewDirectory(root, "archive");
+        var directory = NewDirectory(archive, "directory");
+        var file = NewFile(directory, "foo.mesh");
+
+        var payload = new DropPayload(DropSource.TreeRows, PathsOf(directory, file));
+        var selection = new List<FileSystemModel> { directory, file };
+
+        Plan(directory, payload, selection);
+
+        // the caller's selection is live grid state; the helper works on copies
+        Assert.Equal(PathsOf(directory, file), payload.Paths);
+        Assert.Equal(new[] { directory, file }, selection);
+    }
+
+    #endregion
+}

--- a/WolvenKit.App/Helpers/ProjectExplorerDropHelper.cs
+++ b/WolvenKit.App/Helpers/ProjectExplorerDropHelper.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using WolvenKit.App.Models;
+
+namespace WolvenKit.App.Helpers;
+
+/// <summary>
+/// Determinds what drag-and-drop should actually allow to happen, given the drop payload,
+/// the current tree selection, and the node under the cursor.
+/// </summary>
+public static class ProjectExplorerDropHelper
+{
+    /// <summary>The format Syncfusion's row drag-and-drop files the dragged rows under.</summary>
+    public const string TreeNodeDataFormat = "Nodes";
+
+    /// <summary>Where the dropped paths came from. The two are not interchangeable.</summary>
+    public enum DropSource
+    {
+        /// <summary>The payload carried neither format we understand.</summary>
+        None,
+
+        /// <summary>Rows dragged inside the Project Explorer, each backed by a <see cref="FileSystemModel"/>.</summary>
+        TreeRows,
+
+        /// <summary>Files dragged in from outside the application. (I.e. Windows Explorer).</summary>
+        ExternalFiles
+    }
+
+    /// <summary>The dropped paths, plus where they came from.</summary>
+    public sealed record DropPayload(DropSource Source, IReadOnlyList<string> Paths);
+
+    /// <summary>Why a drop produced no file operation.</summary>
+    public enum DropRejection
+    {
+        /// <summary>The drop is actionable.</summary>
+        None,
+
+        /// <summary>Nothing droppable was under the cursor.</summary>
+        NoTarget,
+
+        /// <summary>The drop would have landed in the project root, outside archive/raw/resources.</summary>
+        ProjectRoot,
+
+        /// <summary>Everything in the payload was filtered out - typically a drop onto where the files already are.</summary>
+        NothingToMove,
+
+        /// <summary>Every dragged directory would have been moved inside one of its own descendants.</summary>
+        DirectoryIntoOwnDescendant
+    }
+
+    /// <summary>
+    /// The outcome of PlanDrop: either a list of source paths plus the directory they
+    /// should end up in, or the reason there is nothing to do.
+    /// </summary>
+    /// <param name="Rejection">Why nothing will happen, or DropRejection.None.</param>
+    /// <param name="Files">Source paths to hand to ProjectExplorerViewModel.ProcessFileAction.</param>
+    /// <param name="TargetDirectory">
+    /// Absolute path of the directory to drop into. Null only when there was no target at all;
+    /// it is populated even for a rejected plan, so a caller can log where the drop landed.
+    /// </param>
+    /// <param name="RefusedDirectories">
+    /// Payload entries left out because they would have swallowed their own destination. The rest
+    /// of the drop still goes ahead, so these are worth telling the user about.
+    /// </param>
+    public sealed record DropPlan(
+        DropRejection Rejection,
+        IReadOnlyList<string> Files,
+        string? TargetDirectory,
+        IReadOnlyList<string> RefusedDirectories)
+    {
+        /// <summary>True when the drop should be carried out. Implies TargetDirectory is not null.</summary>
+        public bool IsActionable => Rejection == DropRejection.None;
+
+        internal static DropPlan Rejected(
+            DropRejection rejection,
+            string? targetDirectory = null,
+            IReadOnlyList<string>? refusedDirectories = null) =>
+            new(rejection, [], targetDirectory, refusedDirectories ?? []);
+    }
+
+    /// <summary>
+    /// Unpacks a drop payload into absolute paths.
+    /// </summary>
+    /// <typeparam name="TNode">The grid's row type - Syncfusion's <c>TreeNode</c> in practice.</typeparam>
+    /// <param name="dropData">The dropped IDataObject.</param>
+    /// <param name="itemOfNode">Reads the bound item off a dragged row.</param>
+    /// <returns>
+    /// The dropped paths in payload order, tagged with their source. Empty and
+    /// "None" when the payload carries neither format.
+    /// </returns>
+    public static DropPayload GetDroppedPayload<TNode>(IDataObject dropData, Func<TNode, object?> itemOfNode)
+    {
+        if (dropData.GetDataPresent(DataFormats.FileDrop) && dropData.GetData(DataFormats.FileDrop) is string[] fileDropData)
+        {
+            return new DropPayload(DropSource.ExternalFiles, [.. fileDropData]);
+        }
+
+        if (dropData.GetDataPresent(TreeNodeDataFormat) && dropData.GetData(TreeNodeDataFormat) is IEnumerable<TNode> treeNodes)
+        {
+            return new DropPayload(
+                DropSource.TreeRows,
+                [.. treeNodes.Select(itemOfNode).OfType<FileSystemModel>().Select(model => model.FullName)]);
+        }
+
+        return new DropPayload(DropSource.None, []);
+    }
+
+    /// <summary>
+    /// Decides which of the dropped paths may be moved into the directory implied by targetItem
+    ///
+    /// The rules, in the order they are applied:
+    /// 1. A drop onto a file means a drop into the directory that holds it.
+    /// 2. The project root is not a drop target: everything belongs under one of the top-level
+    /// directories.
+    /// 3. An in-tree drag is narrowed to the selection, because the grid hands over whatever it
+    /// put on the clipboard. An external file drop is left alone - nothing in the tree stands
+    /// behind those paths, so the selection says nothing about them.
+    /// 4. A directory that contains the target is refused: it cannot be moved inside itself.
+    /// Only that entry is dropped, so the rest of the drop still goes through.
+    /// 5. The target directory itself is never moved into itself.
+    /// 6. An entry that lives inside another entry is redundant - it travels with its
+    /// ancestor.
+    /// 7. Anything already sitting directly in the target directory is dropped, because moving
+    /// it would be a no-op. When isCopy is set it is kept instead: copying onto
+    /// its own location is how a file or folder is duplicated in place.
+    /// </summary>
+    /// <param name="targetItem">The node under the cursor. A file resolves to its parent directory.</param>
+    /// <param name="payload">The dropped paths, from GetDroppedPayload.</param>
+    /// <param name="selectedModels">The current Project Explorer selection.</param>
+    /// <param name="isCopy">True when the drop will copy rather than move - i.e. ctrl is held.</param>
+    public static DropPlan PlanDrop(
+        FileSystemModel? targetItem,
+        DropPayload payload,
+        IReadOnlyList<FileSystemModel> selectedModels,
+        bool isCopy)
+    {
+        // a file with no parent has no directory to drop into
+        if (targetItem is null || (!targetItem.IsDirectory && targetItem.Parent is null))
+        {
+            return DropPlan.Rejected(DropRejection.NoTarget);
+        }
+
+        var targetDirModel = targetItem.TargetDir;
+        var targetDirPath = targetDirModel.FullName;
+
+        // only <ProjectDir> has no parent, and dropping there would take files out of the mod
+        if (targetDirModel.Parent is null)
+        {
+            return DropPlan.Rejected(DropRejection.ProjectRoot, targetDirPath);
+        }
+
+        var paths = payload.Paths.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (payload.Source == DropSource.TreeRows && selectedModels.Count > 0)
+        {
+            var selectedPaths = selectedModels.Select(model => model.FullName).ToList();
+            paths = paths.Where(path => selectedPaths.Any(selected => IsSamePath(selected, path))).ToList();
+        }
+
+        // A directory cannot be moved inside itself. Refuse just that entry: a drop that also
+        // carries legal items should still make the legal moves.
+        var refusedDirectories = paths.Where(path => IsInsideDirectory(targetDirPath, path)).ToList();
+
+        var candidates = paths
+            .Where(path => !IsInsideDirectory(targetDirPath, path))
+            .Where(path => !IsSamePath(path, targetDirPath))
+            .ToList();
+
+        // Keep children with their parent: an entry inside another entry moves along with it, so
+        // listing it separately would move it twice.
+        var files = candidates
+            .Where(path => !candidates.Any(other => IsInsideDirectory(path, other)))
+            .ToList();
+
+        // Dropping something back where it already is does nothing - unless this is a copy, in
+        // which case it is how the file or folder gets duplicated in place.
+        if (!isCopy)
+        {
+            files = files.Where(path => !IsSamePath(ParentDirectoryOf(path), targetDirPath)).ToList();
+        }
+
+        if (files.Count == 0)
+        {
+            return DropPlan.Rejected(
+                refusedDirectories.Count > 0 ? DropRejection.DirectoryIntoOwnDescendant : DropRejection.NothingToMove,
+                targetDirPath,
+                refusedDirectories);
+        }
+
+        return new DropPlan(DropRejection.None, files, targetDirPath, refusedDirectories);
+    }
+
+    #region path comparison
+
+    private static string ParentDirectoryOf(string path) =>
+        Path.GetDirectoryName(TrimSeparator(path)) ?? "";
+
+    private static bool IsSamePath(string left, string right) =>
+        left.Length > 0
+        && right.Length > 0
+        && string.Equals(TrimSeparator(left), TrimSeparator(right), StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsInsideDirectory(string path, string directory)
+    {
+        var parent = TrimSeparator(directory);
+        var candidate = TrimSeparator(path);
+
+        if (parent.Length == 0
+            || candidate.Length <= parent.Length
+            || !candidate.StartsWith(parent, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // a prefix match is only a containment if it ends on a directory boundary, or the parent is
+        // a root like "C:\" and already carries one
+        return IsSeparator(parent[^1]) || IsSeparator(candidate[parent.Length]);
+    }
+
+    private static string TrimSeparator(string path) => Path.TrimEndingDirectorySeparator(path);
+
+    private static bool IsSeparator(char character) =>
+        character == Path.DirectorySeparatorChar || character == Path.AltDirectorySeparatorChar;
+
+    #endregion
+}

--- a/WolvenKit.App/Models/FileSystemModel.cs
+++ b/WolvenKit.App/Models/FileSystemModel.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using WolvenKit.Common;
+using WolvenKit.Core.Exceptions;
 using WolvenKit.Core.Extensions;
 using WolvenKit.RED4.Types;
 
@@ -213,6 +214,50 @@ public class FileSystemModel : INotifyPropertyChanged
         }
 
         return string.Format(CultureInfo.InvariantCulture, "{0:0.##} {1}", len, sizes[order]);
+    }
+
+    /// <summary>
+    /// Returns true if the supplied model is an ancestor of this model.
+    /// </summary>
+    /// <param name="ancestorDir"></param>
+    /// <returns></returns>
+    public bool HasAncestorDir(FileSystemModel ancestorDir)
+    {
+        if (Parent == null)
+        {
+            return false;
+        }
+
+        if (Parent.FullName == ancestorDir.FullName)
+        {
+            return true;
+        }
+
+        return Parent.HasAncestorDir(ancestorDir);
+    }
+
+    /// <summary>
+    /// Returns its parent if it's a file, otherwise returns itself.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="WolvenKitException"></exception>
+    public FileSystemModel TargetDir
+    {
+        get
+        {
+            if (IsDirectory)
+            {
+                return this;
+            }
+
+            if (Parent is { } parent)
+            {
+                return parent;
+            }
+
+            throw new WolvenKitException(0x4025a73,
+                $"No directory model exists for drag and drop operation. Target file path: ${FullName}.");
+        }
     }
 
     #region INotifyPropertyChanged

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -232,9 +232,40 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     [NotifyCanExecuteChangedFor(nameof(ConvertRawFileCommand))]
     [NotifyCanExecuteChangedFor(nameof(ExportArchiveFileCommand))]
     [NotifyCanExecuteChangedFor(nameof(ImportRawFileCommand))]
-    private ObservableCollection<object>? _selectedItems = new();
+    private ObservableCollection<object>? _treeSelectedItems = new();
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(DeleteFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ConvertArchiveFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ConvertRawFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ExportArchiveFileCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ImportRawFileCommand))]
+    private ObservableCollection<object>? _flatSelectedItems = new();
+
+    /// <summary>
+    /// The selection of whichever grid is on screen.
+    /// </summary>
+    public ObservableCollection<object>? SelectedItems => IsFlatModeEnabled ? FlatSelectedItems : TreeSelectedItems;
+
+    partial void OnTreeSelectedItemsChanged(ObservableCollection<object>? value) =>
+        OnPropertyChanged(nameof(SelectedItems));
+
+    partial void OnFlatSelectedItemsChanged(ObservableCollection<object>? value) =>
+        OnPropertyChanged(nameof(SelectedItems));
 
     [ObservableProperty] private bool _isFlatModeEnabled;
+
+    partial void OnIsFlatModeEnabledChanged(bool value)
+    {
+        // SelectedItems resolves to the other grid's collection
+        OnPropertyChanged(nameof(SelectedItems));
+
+        DeleteFileCommand.NotifyCanExecuteChanged();
+        ConvertArchiveFileCommand.NotifyCanExecuteChanged();
+        ConvertRawFileCommand.NotifyCanExecuteChanged();
+        ExportArchiveFileCommand.NotifyCanExecuteChanged();
+        ImportRawFileCommand.NotifyCanExecuteChanged();
+    }
 
     [ObservableProperty] private int _selectedTabIndex;
 
@@ -2191,7 +2222,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     ///  Since the previous implementation would sometimes fail silently and claim that perfectly viable files weren't found,
     /// here's an attempt at implementing everything in a more robust way that's also more in line with windows move/copy behaviour.
     /// </summary>
-    public async Task ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory)
+    public void ProcessFileAction(IReadOnlyList<string> sourceFiles, string targetDirectory)
     {
         var isCopy = ModifierViewStateService.IsCtrlBeingHeld;
 
@@ -2279,7 +2310,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         // 1 - 10 files: Show a single dialogue that asks for confirmation
         if (existingFiles.Count is < 10 and > 0)
         {
-            var messageBoxResult = await Interactions.ShowMessageBoxAsync(
+            var messageBoxResult = Interactions.ShowMessageBox(
                 $"Overwrite the following files? \n\n  {string.Join("\n  ", existingFiles)}",
                 "File Overwrite Confirmation", WMessageBoxButtons.YesNoCancel);
 
@@ -2298,7 +2329,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             var canWriteToTargetFile =
                 !File.Exists(targetFile)
                 || isOverwrite
-                || (!skipDialogue && isAskIndividually && await Interactions.ShowMessageBoxAsync(
+                || (!skipDialogue && isAskIndividually && Interactions.ShowMessageBox(
                     $"Overwrite the following file? {targetFile}",
                     "File Overwrite Confirmation",
                     WMessageBoxButtons.YesNo) == WMessageBoxResult.Yes);

--- a/WolvenKit/Views/Others/CancellableRowDragDropController.cs
+++ b/WolvenKit/Views/Others/CancellableRowDragDropController.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using Syncfusion.UI.Xaml.TreeGrid;
+
+namespace WolvenKit.Views.Others;
+
+public class CancellableRowDragDropController : TreeGridRowDragDropController
+{
+    public void CancelPendingAutoExpand()
+    {
+        timer?.Stop();
+        autoExpandNode = null;
+    }
+}

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -1134,7 +1134,7 @@
             RowDragDropTemplate="{StaticResource DragDropTemplate}"
             RowDropIndicatorMode="Line"
             SelectedItem="{Binding SelectedItem}"
-            SelectedItems="{Binding SelectedItems,
+            SelectedItems="{Binding TreeSelectedItems,
                                     UpdateSourceTrigger=PropertyChanged,
                                     Mode=TwoWay}"
             SelectionMode="Extended"
@@ -1198,7 +1198,7 @@
             CurrentCellBorderThickness="0"
             IsReadOnly="True"
             SelectedItem="{Binding SelectedItem}"
-            SelectedItems="{Binding SelectedItems,
+            SelectedItems="{Binding FlatSelectedItems,
                                     UpdateSourceTrigger=PropertyChanged,
                                     Mode=TwoWay}"
             SelectionMode="Extended"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -1,3 +1,4 @@
+using DynamicData;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -19,6 +20,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using HandyControl.Data;
 using MahApps.Metro.Controls;
 using ReactiveUI;
+using Splat;
 using Syncfusion.Data;
 using Syncfusion.UI.Xaml.Grid;
 using Syncfusion.UI.Xaml.TreeGrid;
@@ -31,10 +33,14 @@ using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Dialogs;
 using WolvenKit.App.ViewModels.Documents;
 using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Core.Exceptions;
+using WolvenKit.Core.Interfaces;
 using WolvenKit.Services;
 using WolvenKit.Views.Dialogs;
 using WolvenKit.Views.Dialogs.Windows;
 using WolvenKit.Helpers;
+using WolvenKit.RED4.Types;
+using WolvenKit.Views.Others;
 using WolvenKit.Views.Templates;
 using RowColumnIndex = Syncfusion.UI.Xaml.ScrollAxis.RowColumnIndex;
 
@@ -50,6 +56,8 @@ namespace WolvenKit.Views.Tools
         #region fields
 
         private readonly IMessenger _messenger;
+
+        private readonly ILoggerService _loggerService;
 
         private List<IDisposable> _disposables = [];
 
@@ -81,6 +89,7 @@ namespace WolvenKit.Views.Tools
         private readonly DispatcherTimer _searchDebounceTimer;
         private bool _isDragging;
         private CancellationTokenSource _deferRefreshTokenSource = new();
+        private readonly CancellableRowDragDropController _rowDragDropController;
 
         /// <summary>
         /// When true, NodeExpanded/NodeCollapsed must not persist expansion state or write
@@ -110,6 +119,8 @@ namespace WolvenKit.Views.Tools
             _messenger = WeakReferenceMessenger.Default;
             _messenger.RegisterAll(this);
 
+            _loggerService = Locator.Current.GetService<ILoggerService>();
+
             // Debounce for live search
             _searchDebounceTimer = new DispatcherTimer
             {
@@ -118,9 +129,12 @@ namespace WolvenKit.Views.Tools
 
             _searchDebounceTimer.Tick += SearchDebounceTimer_Tick;
 
+            _rowDragDropController = new CancellableRowDragDropController();
+
             TreeGrid.ItemsSourceChanged += TreeGrid_ItemsSourceChanged;
             TreeGridFlat.ItemsSourceChanged += TreeGridFlat_ItemsSourceChanged;
-            TreeGridFlat.SizeChanged += TreeGridFlat_SizeChanged;
+
+            TreeGrid.RowDragDropController = _rowDragDropController;
             TreeGrid.RowDragDropController.DragStart += RowDragDropController_DragStart;
             TreeGrid.RowDragDropController.DragOver += RowDragDropController_DragOver;
             TreeGrid.RowDragDropController.Drop += RowDragDropController_Drop;
@@ -819,6 +833,7 @@ namespace WolvenKit.Views.Tools
         {
             if (ViewModel?.GetActiveEditorFile() is not IDocumentViewModel activeFile)
             {
+                e.Handled = true;
                 return;
             }
 
@@ -828,6 +843,7 @@ namespace WolvenKit.Views.Tools
 
             if (activeFileNode is null)
             {
+                e.Handled = true;
                 return;
             }
 
@@ -1278,106 +1294,110 @@ namespace WolvenKit.Views.Tools
 
             vm.IsDragging = true;
 
-            var draggingItems = e.DraggingNodes.Select(x => x.Item as FileSystemModel).ToList();
+            var draggingItems = e.DraggingNodes.Select(node => node.Item).OfType<FileSystemModel>().ToList();
 
-            if (vm.SelectedItems is { } selectedItems
-                && draggingItems.Select(x => !selectedItems.Contains(x)).ToList().Count > 0)
+            if (draggingItems.Count == 0)
             {
-                vm.SelectedItems.Clear();
-                vm.SelectedItems.AddRange(draggingItems);
-
-                if (draggingItems.Count == 1)
-                {
-                    vm.SelectedItem = draggingItems[0];
-                }
-
                 return;
             }
 
-            if (vm.SelectedItem is { } selectedItem && draggingItems.FirstOrDefault() is { } draggingItem)
+            // Whatever is dragged becomes the selection.
+            vm.TreeSelectedItems ??= [];
+
+            if (!IsSameSelection(vm.TreeSelectedItems, draggingItems))
             {
-                if (selectedItem.RawRelativePath != draggingItem.RawRelativePath)
-                {
-                    vm.SelectedItem = draggingItem;
-                }
+                vm.TreeSelectedItems.Clear();
+                vm.TreeSelectedItems.AddRange(draggingItems);
+            }
+
+            // keep the current item as the primary one if it is part of the drag
+            if (vm.SelectedItem is not { } selectedItem || !draggingItems.Contains(selectedItem))
+            {
+                vm.SelectedItem = draggingItems[0];
             }
         }
 
+        private static bool IsSameSelection(ICollection<object> selection, List<FileSystemModel> draggingItems) =>
+            selection.Count == draggingItems.Count && draggingItems.All(selection.Contains);
+
+        /// <summary>
+        /// Shows the drop indicator only where the drop would actually do something.
+        /// </summary>
         private void RowDragDropController_DragOver(object sender, TreeGridRowDragOverEventArgs e)
         {
-            if (!e.Data.GetDataPresent("Nodes") ||
-                e.Data.GetData("Nodes") is not ObservableCollection<TreeNode> treeNodes ||
-                treeNodes[0].Item is not FileSystemModel sourceFile ||
-                e.TargetNode.Item is not FileSystemModel targetFile)
+            if (ViewModel is not { } vm || e.TargetNode?.Item is not FileSystemModel targetItem)
             {
+                e.Handled = true;
                 return;
             }
 
-            if (targetFile == sourceFile)
-            {
-                e.ShowDragUI = false;
-                e.Handled = true;
-            }
-            else
-            {
-                e.ShowDragUI = true;
-                e.Handled = false;
-            }
+            var plan = PlanDrop(vm, e.Data, targetItem);
+
+            e.ShowDragUI = plan.IsActionable;
+
+            // A drop that does nothing  has to stay unhandled,
+            // or CanAutoExpand never gets to open that folder up.
+            e.Handled = plan.Rejection is ProjectExplorerDropHelper.DropRejection.ProjectRoot
+                or ProjectExplorerDropHelper.DropRejection.DirectoryIntoOwnDescendant;
         }
+
+        /// <summary>
+        /// Drag and drop only exists on the tree grid, so always read that grid's selection.
+        /// </summary>
+        private static ProjectExplorerDropHelper.DropPlan PlanDrop(
+            ProjectExplorerViewModel vm, IDataObject dropData, FileSystemModel targetItem) =>
+            ProjectExplorerDropHelper.PlanDrop(
+                targetItem,
+                ProjectExplorerDropHelper.GetDroppedPayload<TreeNode>(dropData, node => node.Item),
+                vm.TreeSelectedItems?.OfType<FileSystemModel>().ToList() ?? [],
+                ModifierViewStateService.IsCtrlBeingHeld);
 
         private async void RowDragDropController_Drop(object sender, TreeGridRowDropEventArgs e)
         {
-            // this should all be somewhere else, right?
             try
             {
-                e.Handled = _isDragging; // which should be true at this point
-                if (e.TargetNode.Item is not FileSystemModel targetFile || ViewModel is not ProjectExplorerViewModel vm)
+                _rowDragDropController.CancelPendingAutoExpand();
+                e.Handled = _isDragging;
+
+                if (e.TargetNode?.Item is not FileSystemModel targetItem || ViewModel is not { } vm)
                 {
                     e.Handled = true;
                     return;
                 }
 
-                var selectedFilePaths =
-                    vm.SelectedItems?.OfType<FileSystemModel>().Select(fsm => fsm.FullName).ToList() ?? [];
+                var plan = PlanDrop(vm, e.Data, targetItem);
 
-                var files = new List<string>();
+                ReportRefusals(plan);
 
-                if (e.Data.GetDataPresent(DataFormats.FileDrop) &&
-                    e.Data.GetData(DataFormats.FileDrop) is string[] fileDropData
-                   )
-                {
-                    files.AddRange(fileDropData);
-                }
-                else if (e.Data.GetDataPresent("Nodes") &&
-                         e.Data.GetData("Nodes") is ObservableCollection<TreeNode> treeNodes)
-                {
-                    files.AddRange(treeNodes.Select(n => n.Item).OfType<FileSystemModel>().Select(fsm => fsm.FullName));
-                }
-
-                // If items are selected: ignore anything that isn't
-                if (selectedFilePaths.Count > 0)
-                {
-                    files = files.Where(p => selectedFilePaths.Contains(p, StringComparer.OrdinalIgnoreCase)).ToList();
-                }
-
-                // if dragged on file, use file's parent directory as target dir
-                var targetDirectory = Directory.Exists(targetFile.FullName)
-                    ? targetFile.FullName
-                    : Path.GetDirectoryName(targetFile.FullName);
-
-                // 1146: addresses "prevent self-drag-and-drop"
-                if (files.Count == 0 || files[0] == targetDirectory)
+                if (plan is not { IsActionable: true, TargetDirectory: { } targetDirectory })
                 {
                     e.Handled = true;
                     return;
                 }
 
-                await vm.ProcessFileAction(files, targetDirectory);
+                DispatcherHelper.PostOnMainThread(() => vm.ProcessFileAction(plan.Files, targetDirectory));
             }
             catch (Exception error)
             {
                 e.Handled = true;
-                Console.WriteLine(error.Message);
+                _loggerService?.Error($"Drag and drop failed: {error.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Tell the user in logs about any attempted drag-and-drop that got refused.
+        /// </summary>
+        private void ReportRefusals(ProjectExplorerDropHelper.DropPlan plan)
+        {
+            foreach (var refused in plan.RefusedDirectories)
+            {
+                _loggerService?.Warning($"Can't move {refused} inside itself - skipped.");
+            }
+
+            if (plan.Rejection == ProjectExplorerDropHelper.DropRejection.ProjectRoot)
+            {
+                _loggerService?.Warning(
+                    "Can't drop files in the project root, choombatta. Use the archive, raw, or resources folder.");
             }
         }
 

--- a/changelog/unreleased/3137.yaml
+++ b/changelog/unreleased/3137.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "fixed"
+      packages: ["App"]
+      pr-number: 3137
+      author: "gistya"
+      description: "Fixed numerous bugs with drag-and-drop within WolvenKit's ProjectExplorer file tree."


### PR DESCRIPTION
# Make drag-and-drop work properly without exceptions

**Implemented:**
- User now receives warnings if an item they tried to drag-and-drop can't be moved for some reason
- Relocates drag-and-drop business logic to its own class for testability
- Adds tests for drag-and-drop business logic
- Separates the selected items for Tree and Flat views to resolve data race in SyncFusion (see below)
 
**Fixed:**
- a SyncFusion exception that was uncovered due to fixing other issues. See #3136 for details.
- Dragging a directory into a child directory of itself makes a horrible tree of pain #3135
- Dragging a group of files onto their parent folder asks to replace them #3129
- Creating a new folder breaks drag and drop #2749
- Fixes an issue where users could drag-and-drop items to the base level outside of Archive/Raw/Resources
- Fixes an issue where a user could drag the project directory into the project via Windows Explorer (don't even ask what happens. I'm pretty sure it's worse than dividing by zero)
- and several other issues
