### PR TITLE
Add ProjectEvents Messaging Service & ProjectEventsTests

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Services/ProjectEventsTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Services/ProjectEventsTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using WolvenKit.App.Services;
+using WolvenKit.Common;
+using WolvenKit.Core.Interfaces;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Services;
+
+/// <summary>
+/// Tests for the new IProjectEvents pub/sub used by the large-project performance bypass path.
+/// These protect the contract between bulk file add operations (Asset Browser, JSON export, RED4 AddToModAsync)
+/// and the WatcherService's OnFilesImported handler.
+/// </summary>
+public class ProjectEventsTests
+{
+    [Fact]
+    public void PublishFilesImported_WithGameFiles_NotifiesSubscribers()
+    {
+        var events = new ProjectEvents();
+        var received = new List<FilesImportedMessage>();
+
+        using var sub = events.FilesImported.Subscribe(received.Add);
+
+        var fakeFiles = new List<IGameFile> { new FakeGameFile("archive\\test\\file.mesh") };
+        events.PublishFilesImported(new FilesImportedMessage.GameFiles(fakeFiles));
+
+        Assert.Single(received);
+
+        if (received[0] is not FilesImportedMessage.GameFiles gameFilesMsg)
+        {
+            Assert.Fail("FilesImportedMessage received was not a GameFiles.");
+            return;
+        }
+
+        Assert.Single(gameFilesMsg.Files);
+        Assert.Equal("archive\\test\\file.mesh", gameFilesMsg.Files.First().FileName);
+    }
+
+    [Fact]
+    public void PublishFilesImported_WithRawFiles_NotifiesSubscribers()
+    {
+        var events = new ProjectEvents();
+        var received = new List<FilesImportedMessage>();
+
+        using var sub = events.FilesImported.Subscribe(received.Add);
+
+        var raw = new FileInfo(Path.GetTempFileName());
+        try
+        {
+            events.PublishFilesImported(new FilesImportedMessage.RawFiles(new[] { raw }));
+
+            Assert.Single(received);
+
+            if (received[0] is not FilesImportedMessage.RawFiles rawFilesMsg)
+            {
+                Assert.Fail("FilesImportedMessage received was not a GameFiles.");
+                return;
+            }
+            Assert.Single(rawFilesMsg.Files);
+        }
+        finally
+        {
+            if (raw.Exists) raw.Delete();
+        }
+    }
+
+    [Fact]
+    public void MultipleSubscribers_AllReceiveMessages()
+    {
+        var events = new ProjectEvents();
+        var count1 = 0;
+        var count2 = 0;
+
+        using var s1 = events.FilesImported.Subscribe(_ => count1++);
+        using var s2 = events.FilesImported.Subscribe(_ => count2++);
+
+        events.PublishFilesImported(new FilesImportedMessage.RawFiles(Array.Empty<FileInfo>()));
+
+        Assert.Equal(1, count1);
+        Assert.Equal(1, count2);
+    }
+
+    private sealed class FakeGameFile : IGameFile
+    {
+        public FakeGameFile(string fileName)
+        {
+            FileName = fileName;
+            Name = Path.GetFileName(fileName);
+            Extension = Path.GetExtension(fileName).TrimStart('.');
+        }
+
+        public ulong Key { get; set; }
+        public string Name { get; }
+        public uint Size { get; set; }
+        public uint ZSize { get; set; }
+        public string Extension { get; }
+        public string? GuessedExtension { get; set; }
+        public string FileName { get; }
+        public ArchiveManagerScope Scope { get; set; }
+
+        public void Extract(Stream output) => throw new NotImplementedException();
+        public Task ExtractAsync(Stream output) => Task.CompletedTask;
+
+        public T GetArchive<T>() where T : IGameArchive => throw new NotImplementedException();
+        public IGameArchive GetArchive() => throw new NotImplementedException();
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Services/ProjectEventsTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Services/ProjectEventsTests.cs
@@ -10,11 +10,6 @@ using Xunit;
 
 namespace Wolvenkit.Test.App.Services;
 
-/// <summary>
-/// Tests for the new IProjectEvents pub/sub used by the large-project performance bypass path.
-/// These protect the contract between bulk file add operations (Asset Browser, JSON export, RED4 AddToModAsync)
-/// and the WatcherService's OnFilesImported handler.
-/// </summary>
 public class ProjectEventsTests
 {
     [Fact]

--- a/WolvenKit.App/Services/IProjectEvents.cs
+++ b/WolvenKit.App/Services/IProjectEvents.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using WolvenKit.App.ViewModels.Documents;
+using WolvenKit.Core.Interfaces;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// Service for published events related to file operations.
+/// Provides an alternative to monitoring of file system events.
+/// </summary>
+public interface IProjectEvents
+{
+    /// <summary>
+    /// Consumers of the published events should subscribe here.
+    /// </summary>
+    IObservable<FilesImportedMessage> FilesImported { get; }
+
+    /// <summary>
+    /// Consumers of completed-move events should subscribe here.
+    /// </summary>
+    IObservable<FilesMovedMessage> FilesMoved { get; }
+
+    /// <summary>
+    /// Consumers of completed-deletion events should subscribe here.
+    /// </summary>
+    IObservable<FilesDeletedMessage> FilesDeleted { get; }
+
+    /// <summary>
+    /// Consumers of completed change events should subscribe here.
+    /// </summary>
+    IObservable<FileChangedMessage> FileChanged { get; }
+
+    /// <summary>
+    /// To be called when a known batch of files are being added to the project.
+    /// E.g.: when adding files from AssetBrowser or exporting JSON, etc.
+    /// NOTE: Be sure to disable monitoring of file system events before use.
+    /// </summary>
+    /// <param name="message"></param>
+    void PublishFilesImported(FilesImportedMessage message);
+
+    /// <summary>
+    /// Publish that a single file was added to the project at <paramref name="absolutePath"/> (e.g.
+    /// copied in from outside the project). Call this AFTER the file exists on disk. The project
+    /// explorer materializes the node and any missing parent directories. Idempotent.
+    /// </summary>
+    /// <param name="absolutePath">Absolute path of the added file.</param>
+    void PublishFileImported(string absolutePath);
+
+    /// <summary>
+    /// Publish an authoritative set of file moves that have <b>already happened on disk</b>.
+    /// Call this AFTER the move completes and after any overwrite/confirmation prompts have been
+    /// resolved, so the project explorer reflects what actually happened rather than what was
+    /// intended. The apply is idempotent, so it is safe to publish whether or not the OS file
+    /// system watcher is suspended (a live watcher's own events simply become no-ops).
+    /// </summary>
+    /// <param name="message"></param>
+    void PublishFilesMoved(FilesMovedMessage message);
+
+    /// <summary>
+    /// Publish that a single file was deleted on disk (e.g. an overwrite target removed just before a
+    /// move takes its place). Call this AFTER the delete has happened. The project explorer removes the
+    /// matching node. Idempotent: a path the tree doesn't know is a no-op.
+    /// </summary>
+    /// <param name="absolutePath">Absolute path of the deleted file.</param>
+    void PublishFileDeleted(string absolutePath);
+
+    /// <summary>
+    /// Publish that a directory (and everything under it) was deleted on disk. Call this AFTER the
+    /// delete has happened. The project explorer removes the matching node and its whole subtree.
+    /// Idempotent: a path the tree doesn't know is a no-op.
+    /// </summary>
+    /// <param name="absoluteDirectoryPath">Absolute path of the deleted directory.</param>
+    void PublishDirectoryDeleted(string absoluteDirectoryPath);
+
+    /// <summary>
+    /// Publish that a file has been modified but not renamed.
+    /// </summary>
+    /// <param name="message"></param>
+    void PublishFileChanged(FileChangedMessage message);
+}
+
+/// <summary>
+/// A list of files published. If other formats of file lists are needed to be used,
+/// this record could be expanded upon.
+/// </summary>
+public abstract record FilesImportedMessage
+{
+    /// <summary>
+    /// A published list of IGameFiles that has been added to `archive/`.
+    /// </summary>
+    /// <param name="Files"></param>
+    public sealed record GameFiles(IReadOnlyList<IGameFile> Files): FilesImportedMessage;
+
+    /// <summary>
+    /// A published list of FileInfo that have been added to `raw/`
+    /// </summary>
+    /// <param name="Files"></param>
+    public sealed record RawFiles(IReadOnlyList<FileInfo> Files): FilesImportedMessage;
+
+    /// <summary>
+    /// A published list of FileInfo that have been added to `archive/`
+    /// </summary>
+    /// <param name="Files"></param>
+    public sealed record ArchiveFiles(IReadOnlyList<FileInfo> Files) : FilesImportedMessage;
+}
+
+/// <summary>
+/// A message published when a file has changed, i.e. when it has been saved or modified
+/// without the filename changing.
+/// </summary>
+public abstract record FileChangedMessage
+{
+    /// <summary>
+    /// A published IFileSystemViewModel that has been changed without being renamed.
+    /// </summary>
+    /// <param name="File"></param>
+    public sealed record Document(IDocumentViewModel File): FileChangedMessage;
+}
+
+/// <summary>
+/// An authoritative list of completed moves, each an absolute source path that was moved to an
+/// absolute target path. Renames are moves too. Covers whole-directory moves as a flat list of the
+/// files that were actually relocated (empty source directories left behind are reconciled by the
+/// consumer). Emitted only for moves that succeeded, so declining an overwrite prompt simply omits
+/// those files from the set. An entry with an empty <c>From</c> is a pure addition (e.g. a copy
+/// target): the consumer just materializes <c>To</c> and performs no removal.
+/// </summary>
+/// <param name="Moves"></param>
+public sealed record FilesMovedMessage(
+    IReadOnlyList<(string From, string To)> Moves
+);
+
+/// <summary>
+/// An authoritative list of absolute paths that were deleted on disk. A directory path implies its
+/// entire subtree was removed; the consumer removes the matching node (recursing for directories).
+/// </summary>
+/// <param name="AbsolutePaths"></param>
+public sealed record FilesDeletedMessage(
+    IReadOnlyList<string> AbsolutePaths
+);

--- a/WolvenKit.App/Services/MainThreadInlineScheduler.cs
+++ b/WolvenKit.App/Services/MainThreadInlineScheduler.cs
@@ -13,7 +13,7 @@ namespace WolvenKit.App.Services;
 /// Why this exists: <c>ObserveOn(RxApp.MainThreadScheduler)</c> ALWAYS re-posts each notification to a
 /// later dispatcher turn — even for a publisher that is already on the UI thread. For the project-event
 /// pipeline that means a UI-thread flow which publishes and then <i>immediately</i> releases a Syncfusion
-/// deferred-refresh (e.g. renaming a file) can redraw the grid from domain models the WatcherService
+/// deferred-refresh (e.g. renaming a file) can redraw the grid from domain models the ProjectExplorerViewModel
 /// handler hasn't updated yet — a race. Delivering inline when we're on the UI thread closes it: by the
 /// time <c>PublishXxx(...)</c> returns, the handler has already applied the change to FileList/FileTree,
 /// so the subsequent refresh reflects reality.

--- a/WolvenKit.App/Services/MainThreadInlineScheduler.cs
+++ b/WolvenKit.App/Services/MainThreadInlineScheduler.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Reactive.Concurrency;
+using System.Windows.Threading;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// An <see cref="IScheduler"/> that runs work <b>inline</b> (synchronously) when the caller is already on
+/// the WPF UI thread, and otherwise defers to a <paramref name="fallback"/> scheduler (normally
+/// <c>RxApp.MainThreadScheduler</c>, which posts onto the dispatcher).
+///
+/// <para>
+/// Why this exists: <c>ObserveOn(RxApp.MainThreadScheduler)</c> ALWAYS re-posts each notification to a
+/// later dispatcher turn — even for a publisher that is already on the UI thread. For the project-event
+/// pipeline that means a UI-thread flow which publishes and then <i>immediately</i> releases a Syncfusion
+/// deferred-refresh (e.g. renaming a file) can redraw the grid from domain models the WatcherService
+/// handler hasn't updated yet — a race. Delivering inline when we're on the UI thread closes it: by the
+/// time <c>PublishXxx(...)</c> returns, the handler has already applied the change to FileList/FileTree,
+/// so the subsequent refresh reflects reality.
+/// </para>
+///
+/// <para>
+/// Off-thread publishers (scripts, background imports/exports) are unaffected: they aren't on the UI
+/// thread, so they take the fallback (posting) path exactly as before, and any flow that waits on those
+/// still needs its own dispatcher pump.
+/// </para>
+/// </summary>
+public sealed class MainThreadInlineScheduler : IScheduler
+{
+    private readonly IScheduler _fallback;
+    private readonly Dispatcher _uiDispatcher;
+
+    /// <param name="fallback">Scheduler used when the caller is not on the UI thread (e.g. RxApp.MainThreadScheduler).</param>
+    /// <param name="uiDispatcher">The UI-thread dispatcher; <see cref="Dispatcher.CheckAccess"/> decides "are we on it?".</param>
+    public MainThreadInlineScheduler(IScheduler fallback, Dispatcher uiDispatcher)
+    {
+        _fallback = fallback ?? throw new ArgumentNullException(nameof(fallback));
+        _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
+    }
+
+    public DateTimeOffset Now => _fallback.Now;
+
+    public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+        => _uiDispatcher.CheckAccess() ? action(this, state) : _fallback.Schedule(state, action);
+
+    /// <summary>
+    /// If the <param name="action"/> is supposed to happen immediately,
+    /// AND we're already on the UI thread, execute it directly.
+    ///
+    /// Otherwise, schedule it through <see cref="_fallback"/> scheduler.
+    /// </summary>
+    /// <param name="state"></param>
+    /// <param name="dueTime"></param>
+    /// <param name="action"></param>
+    /// <typeparam name="TState"></typeparam>
+    /// <returns>an <see cref="IDisposable" />s
+    /// </returns>
+    public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
+        => Scheduler.Normalize(dueTime) == TimeSpan.Zero && _uiDispatcher.CheckAccess()
+            ? action(this, state)
+            : _fallback.Schedule(state, dueTime, action);
+
+    public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
+        => _fallback.Schedule(state, dueTime, action);
+}

--- a/WolvenKit.App/Services/ProjectEvents.cs
+++ b/WolvenKit.App/Services/ProjectEvents.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace WolvenKit.App.Services;
+
+public class ProjectEvents : IProjectEvents
+{
+    private readonly Subject<FilesImportedMessage> _filesImported = new();
+    private readonly Subject<FilesMovedMessage> _filesMoved = new();
+    private readonly Subject<FilesDeletedMessage> _filesDeleted = new();
+    private readonly Subject<FileChangedMessage> _fileChanged = new();
+
+    public IObservable<FilesImportedMessage> FilesImported =>
+        _filesImported.AsObservable();
+
+    public IObservable<FilesMovedMessage> FilesMoved =>
+        _filesMoved.AsObservable();
+
+    public IObservable<FilesDeletedMessage> FilesDeleted =>
+        _filesDeleted.AsObservable();
+
+    public IObservable<FileChangedMessage> FileChanged =>
+        _fileChanged.AsObservable();
+
+    public void PublishFilesImported(FilesImportedMessage message)
+    {
+        _filesImported.OnNext(message);
+    }
+
+    public void PublishFilesMoved(FilesMovedMessage message)
+    {
+        _filesMoved.OnNext(message);
+    }
+
+    public void PublishFileChanged(FileChangedMessage message)
+    {
+        _fileChanged.OnNext(message);
+    }
+
+    // A single-file add is modelled as a move with an empty source: the consumer materializes the
+    // destination (and any missing parent dirs) and removes nothing. Reusing FilesMoved keeps the add
+    // path side-effect-free (unlike OnFilesImported, which also Resumes the watcher for the bulk flow).
+    public void PublishFileImported(string absolutePath)
+    {
+        if (!string.IsNullOrEmpty(absolutePath))
+        {
+            _filesMoved.OnNext(new FilesMovedMessage([(string.Empty, absolutePath)]));
+        }
+    }
+
+    public void PublishFileDeleted(string absolutePath) => PublishDeleted(absolutePath);
+
+    public void PublishDirectoryDeleted(string absoluteDirectoryPath) => PublishDeleted(absoluteDirectoryPath);
+
+    // File and directory deletions apply identically (the consumer removes the node, recursing for
+    // directories); the two public methods just document intent at the call site.
+    private void PublishDeleted(string absolutePath)
+    {
+        if (!string.IsNullOrEmpty(absolutePath))
+        {
+            _filesDeleted.OnNext(new FilesDeletedMessage([absolutePath]));
+        }
+    }
+}


### PR DESCRIPTION
# Add ProjectEvents Messaging Service

This PR adds the ProjectEvents messaging service and associated unit tests but does not wire up ProjectEvents into anything in the live app yet. (That will be a subsequent PR that will be stacked on this one.)

We also add a MainThreadInlineScheduler that avoids race conditions with SyncFusion model updates by ensuring that data model mutations happen before SyncFusion refresh events and not during them.

At this stage, ProjectEvents is not wired up to anything in the app yet, so this PR should be an easy approve. 

ProjectEvents was on dev for a couple of weeks and was previously reviewed, so I'm confident this is solid.

**Implemented:**
- Adds the ProjectEvents messaging service from PR #2945.

**Additional notes:**
Part of the work for implementing better testability for file and project operations #3139. This is a prerequisite for a lot of tests to come.
and breaking apart PR #2945 into chunks

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->