### PR TITLE
Add UI Queue Drain Helper + Tests

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DispatcherHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -233,4 +234,140 @@ public class DispatcherHelperTests
         using var restarted = DispatcherHelper.StartRepeatingAction(purpose, () => { }, TimeSpan.FromHours(1));
         Assert.True(DispatcherHelper.IsRepeatingActionRunning(purpose));
     }
+
+    #region DrainTheQueue
+
+    // The drain semantics are covered by passing a dispatcher the test owns.
+
+    [Fact]
+    public void DrainTheQueue_WithoutAnApplication_DoesNotThrow()
+    {
+        Assert.Null(Record.Exception(() =>
+        {
+            DispatcherHelper.DrainTheQueue();
+            DispatcherHelper.DrainTheQueue();
+        }));
+    }
+
+    [Fact]
+    public void DrainTheQueue_WithoutAnApplication_DrainsNothing()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var ran = false;
+
+        dispatcher.BeginInvoke(() => ran = true, DispatcherPriority.Normal);
+
+        DispatcherHelper.DrainTheQueue();
+
+        // no Application.Current means no dispatcher to invoke on, so the queue is untouched
+        Assert.False(ran);
+
+        // ...and the operation really was pending - it runs the moment anything does pump
+        PumpUntil(() => ran, TimeSpan.FromSeconds(10));
+        Assert.True(ran);
+    }
+
+    [Fact]
+    public void DrainTheQueue_OnAThreadWithNoDispatcher_ReturnsWithoutCreatingOne()
+    {
+        Exception? thrown = null;
+        var createdADispatcher = true;
+
+        // a fresh thread, so this cannot see a dispatcher some earlier test left on a pool thread
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                DispatcherHelper.DrainTheQueue();
+                createdADispatcher = Dispatcher.FromThread(Thread.CurrentThread) is not null;
+            }
+            catch (Exception exception)
+            {
+                thrown = exception;
+            }
+        });
+
+        thread.Start();
+
+        // the Join bound is the real assertion: reaching for Dispatcher.CurrentDispatcher here
+        // instead of Application.Current would spin up a dispatcher nobody pumps and block forever
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "DrainTheQueue did not return");
+        Assert.Null(thrown);
+        Assert.False(createdADispatcher);
+    }
+
+    [Fact]
+    public void DrainTheQueue_RunsEverythingQueuedAboveContextIdle_HighestPriorityFirst()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var order = new List<string>();
+
+        // queued lowest-first, so an implementation that merely drained in insertion order would
+        // still pass the ordering assertion by accident
+        var background = dispatcher.BeginInvoke(() => order.Add("background"), DispatcherPriority.Background);
+        var input = dispatcher.BeginInvoke(() => order.Add("input"), DispatcherPriority.Input);
+        var normal = dispatcher.BeginInvoke(() => order.Add("normal"), DispatcherPriority.Normal);
+
+        DispatcherHelper.DrainTheQueue(dispatcher);
+
+        Assert.Equal(new[] { "normal", "input", "background" }, order);
+        Assert.Equal(DispatcherOperationStatus.Completed, normal.Status);
+        Assert.Equal(DispatcherOperationStatus.Completed, input.Status);
+        Assert.Equal(DispatcherOperationStatus.Completed, background.Status);
+    }
+
+    [Fact]
+    public void DrainTheQueue_LeavesWorkQueuedBelowContextIdle()
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var ran = false;
+
+        var operation = dispatcher.BeginInvoke(() => ran = true, DispatcherPriority.ApplicationIdle);
+
+        DispatcherHelper.DrainTheQueue(dispatcher);
+
+        // ContextIdle is the floor: idle-priority work is deliberately left for a real idle moment
+        Assert.False(ran);
+        Assert.Equal(DispatcherOperationStatus.Pending, operation.Status);
+
+        // this dispatcher outlives the test - don't leave the operation to fire during another one
+        operation.Abort();
+    }
+
+    [Fact]
+    public void DrainTheQueue_OnAShutDownDispatcher_DoesNotThrow()
+    {
+        var dispatcher = DispatcherOnItsOwnShutDownThread();
+
+        // the only path that reaches the catch: Invoke on a dead dispatcher. "Best effort" in the
+        // doc comment means the caller never sees this.
+        Assert.Null(Record.Exception(() => DispatcherHelper.DrainTheQueue(dispatcher)));
+    }
+
+    /// <summary>Spins up a dispatcher on its own thread, shuts it down, and hands back the corpse.</summary>
+    private static Dispatcher DispatcherOnItsOwnShutDownThread()
+    {
+        Dispatcher? dispatcher = null;
+        using var ready = new ManualResetEventSlim();
+
+        var thread = new Thread(() =>
+        {
+            dispatcher = Dispatcher.CurrentDispatcher;
+            ready.Set();
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true
+        };
+
+        thread.Start();
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(10)), "the dispatcher thread never started");
+
+        dispatcher!.InvokeShutdown();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "the dispatcher thread never stopped");
+
+        return dispatcher;
+    }
+
+    #endregion DrainTheQueue
 }

--- a/WolvenKit.App/Helpers/DispatcherHelper.cs
+++ b/WolvenKit.App/Helpers/DispatcherHelper.cs
@@ -16,6 +16,8 @@ public static class DispatcherHelper
 
     private static readonly object s_repeatingActionsLock = new();
 
+    #region main thread helpers
+
     public static void RunOnMainThread(Action action, DispatcherPriority priority = DispatcherPriority.Normal) => Application.Current.RunOnUIThread(action, priority);
 
     private static void RunOnUIThread(this DispatcherObject? d, Action action, DispatcherPriority priority = DispatcherPriority.Normal)
@@ -116,6 +118,33 @@ public static class DispatcherHelper
             .ContinueWith(_ => RunOnMainThread(action), TaskScheduler.Default);
     }
 
+    #endregion main thread helpers
+
+    #region scheduling helpers
+
+    /// <summary>
+    /// Synchronously drains the current WPF dispatcher queue through
+    /// <see cref="System.Windows.Threading.DispatcherPriority.ContextIdle"/>,
+    /// ensuring that previously queued work at higher priorities is processed
+    /// before this method returns. This is a best-effort operation and is a no-op
+    /// when no application dispatcher is available or dispatcher invocation fails.
+    /// </summary>
+    /// <param name="dispatcher">
+    /// Dispatcher to drain. Defaults to the application's (WPF UI dispatcher), which
+    /// is null in a headless or unit-test context. So for tests, pass one explicitly
+    /// to drain a dispatcher the caller owns.
+    /// </param>
+    public static void DrainTheQueue(Dispatcher? dispatcher = null)
+    {
+        try
+        {
+            (dispatcher ?? System.Windows.Application.Current?.Dispatcher)?.Invoke(
+                () => { },
+                System.Windows.Threading.DispatcherPriority.ContextIdle);
+        }
+        catch { /* test/headless/no dispatcher or cross-thread invoke not available; best effort */ }
+    }
+
     public static void WaitUntilCancelled(CancellationToken token, Action onCancelled)
     {
         if (token.IsCancellationRequested)
@@ -143,6 +172,8 @@ public static class DispatcherHelper
         // Start the polling loop
         dispatcher.BeginInvoke(CheckCancellation, DispatcherPriority.Background);
     }
+
+    #endregion
 
     #region repeating actions
 


### PR DESCRIPTION
# Add UI Queue Drain Helper + Tests

In order to avoid issues with race conditions between SyncFusion grids and side-effects from published events from ProjectEvents, it can be necessary to enforce a particular ordering of events. The UI Queue drain method added in this PR allows you to ensure that any UI-dispatched actions/tasks will execute before returning from the method in which DrainTheQueue is called. 

We have also added tests to ensure that this indeed works as expected.

**Implemented:**
- A helper method on DispatcherHelper that, when called, pauses the current execution context until all scheduled tasks and waiting work of higher priority than "context idle" has competed.

**Additional notes:**
This is preliminary work in preparation for implementation of ProjectEvents from #2945 and resolving #3139

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->