### PR TITLE
Add Clarifying Comments

### DIFF
--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -516,6 +516,15 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
         _ = ResourcesDirectory;
     }
 
+    /// <summary>
+    /// Splits the supplied `fullPath` into two paths divided after archive, raw, or resource.
+    /// E.g. for "C:\path\to\my\mod\source\archive\my\kleppiin\choom.ent":
+    /// returns ("C:\path\to\my\mod\source\archive", "my\kleppiin\choom.ent")
+    /// (An absolute path to the game-relative root folder and a game-relative path to the file.)
+    /// IMPORTANT: this does not give a "RawRelativePath".
+    /// </summary>
+    /// <param name="fullPath"></param>
+    /// <returns>(AbsolutePathToGameRelativeRoot, GameRelativePath)</returns>
     public (string, string) SplitFilePath(string fullPath) =>
         (GetAbsoluteSubDirPath(fullPath), GetRelativePath(fullPath));
 
@@ -564,7 +573,12 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
             _ => ResourceFiles.Contains(fileNameOrPath) || ResourceFiles.Any(f => f.EndsWith(fileNameOrPath)),
         };
 
-
+    /// <summary>
+    /// Resolves a path to its absolute form: an already-absolute path is returned unchanged;
+    /// a GAME-relative path is resolved under the appropriate source subdirectory.
+    /// </summary>
+    /// <param name="relativeOrAbsolutePath"></param>
+    /// <returns>The absolute path on disk.</returns>
     public string GetAbsolutePath(string relativeOrAbsolutePath)
     {
         if (Path.IsPathRooted(relativeOrAbsolutePath))
@@ -575,6 +589,7 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
         var (prefix, relativePath) = SplitFilePath(relativeOrAbsolutePath);
         prefix = prefix.Replace(ProjectDirectory, "");
 
+        // IMPORTANT: the relativePath here is a GameRelativePath.
         if (relativePath == relativeOrAbsolutePath)
         {
             return Path.Join(ModDirectory, prefix, relativePath);
@@ -618,6 +633,11 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
     private const string s_relativeRawDir = "wkitrawdir";
     private const string s_relativePackedDir = "wkitpackeddir";
 
+    /// <summary>
+    /// Get the game relative path from an absolute path.
+    /// </summary>
+    /// <param name="absolutePath"></param>
+    /// <returns>GameRelativePath</returns>
     public string GetRelativePath(string absolutePath)
     {
         if (absolutePath.Equals(FileDirectory, StringComparison.Ordinal))


### PR DESCRIPTION
# Add Clarifying Comments

This PR just adds doc comments to some methods to clarify where GameRelativePath vs. AbsolutePath is used, etc.

It's made a separate PR simply to de-clutter the ProjectEvents integration PR, so that one is easier to review.
