### PR TITLE
Integrate ProjectEvents publishers in lieu of tests

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Models/ProjectManagement/Project/Cp77ProjectTest.cs
+++ b/Tests/WolvenKit.UnitTests/App/Models/ProjectManagement/Project/Cp77ProjectTest.cs
@@ -35,15 +35,16 @@ public class Cp77ProjectTest
     [InlineData(@"raw\base\file.xbm", @"base\file.xbm", @"raw")]
     [InlineData(@"resources\file.yaml", @"file.yaml", "resources")]
     [InlineData(@"invalid\file.yaml", @"invalid\file.yaml", "")]
-    public void SplitPathTest(string relativePath, string expectedRelativePath, string expectedPrefix)
+    public void SplitGameRelativePathTest(string relativePath, string expectedGameRelativePath, string expectedPrefix)
     {
         var absolutePath = Path.Join(testProject.FileDirectory, relativePath);
         var absolutePrefix = Path.Join(testProject.FileDirectory, expectedPrefix);
 
         var (prefix, rel) = testProject.SplitFilePath(absolutePath);
-        Assert.Equal(expectedRelativePath, rel);
+        Assert.Equal(expectedGameRelativePath, rel);
+        Assert.Equal(absolutePrefix, prefix);
 
-        Assert.Equal(expectedRelativePath, testProject.GetRelativePath(absolutePath));
+        Assert.Equal(expectedGameRelativePath, testProject.GetRelativePath(absolutePath));
         Assert.Equal(absolutePrefix, testProject.GetAbsoluteSubDirPath(absolutePath));
     }
 }

--- a/WolvenKit.App/Controllers/IGameController.cs
+++ b/WolvenKit.App/Controllers/IGameController.cs
@@ -34,8 +34,10 @@ public interface IGameController
     /// </summary>
     /// <param name="file">the file in question</param>
     /// <param name="searchScope">Search scope. Defaults to ArchiveManagerScope.Basegame</param>
+    /// <param name="publish">Announce the add to the project explorer. Pass false for bulk callers
+    /// that publish a single batch afterwards (e.g. AddToModAsync).</param>
     /// <returns>bool success</returns>
-    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope);
+    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope, bool publish = true);
 
     /// <summary>
     /// Adds file to the mod's directory, creating the necessary folders. Will pass the currently active scope.

--- a/WolvenKit.App/Controllers/MockGameController.cs
+++ b/WolvenKit.App/Controllers/MockGameController.cs
@@ -22,7 +22,7 @@ public class MockGameController : IGameController
 
     public bool AddToMod(ulong hash, ArchiveManagerScope searchScope) => throw new NotImplementedException();
 
-    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope) => throw new NotImplementedException();
+    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope, bool publish = true) => throw new NotImplementedException();
     public Task AddToModAsync(IList<IGameFile> files) => throw new NotImplementedException();
 
     public bool AddToMod(ulong hash) => throw new NotImplementedException();

--- a/WolvenKit.App/Controllers/RED4Controller.cs
+++ b/WolvenKit.App/Controllers/RED4Controller.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 using System.Xml.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using WolvenKit.App.Helpers;
@@ -45,6 +46,7 @@ public class RED4Controller : ObservableObject, IGameController
     private readonly IProgressService<double> _progressService;
     private readonly IPluginService _pluginService;
     private readonly IModifierViewStateService _modifierService;
+    private readonly IProjectEvents _projectEvents;
 
     #endregion
 
@@ -58,7 +60,8 @@ public class RED4Controller : ObservableObject, IGameController
         IAppArchiveManager gameArchiveManager,
         IProgressService<double> progressService,
         IPluginService pluginService,
-        IModifierViewStateService modifierService)
+        IModifierViewStateService modifierService,
+        IProjectEvents projectEvents)
     {
         _notificationService = notificationService;
         _loggerService = loggerService;
@@ -70,6 +73,7 @@ public class RED4Controller : ObservableObject, IGameController
         _progressService = progressService;
         _pluginService = pluginService;
         _modifierService = modifierService;
+        _projectEvents = projectEvents;
     }
 
     #region Packing
@@ -922,13 +926,17 @@ public class RED4Controller : ObservableObject, IGameController
             // often saturates the disk and ends up slower + spams the UI thread.
             var dop = Math.Min(8, Math.Max(1, Environment.ProcessorCount / 2));
 
+            var bulkScope = _archiveManager.IsModBrowserActive ? ArchiveManagerScope.Mods : ArchiveManagerScope.Basegame;
+
             await Parallel.ForEachAsync(
                 files,
                 new ParallelOptions { MaxDegreeOfParallelism = dop },
                 (file, token) =>
                 {
                     token.ThrowIfCancellationRequested();
-                    AddToMod(file);
+                    // publish:false — we emit ONE FilesImported batch after the loop (below) instead
+                    // of thousands of per-file events, which is the whole point of the bulk path.
+                    AddToMod(file, bulkScope, publish: false);
                     var current = Interlocked.Increment(ref progress);
                     var reportInterval = Math.Max(1, total / 50);
 
@@ -951,6 +959,10 @@ public class RED4Controller : ObservableObject, IGameController
         }
 
         _progressService.Completed();
+        _projectEvents.PublishFilesImported(new FilesImportedMessage.GameFiles([.. files]));
+        DispatcherHelper.DrainTheQueue();
+        // Note: draining the queue here to ensure that any side effects of publishing, such
+        // as updating of data models, completes synchronously before returning from this method.
     }
 
 
@@ -976,7 +988,7 @@ public class RED4Controller : ObservableObject, IGameController
     }
 
     /// <Inheritdoc />
-    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope)
+    public bool AddToMod(IGameFile file, ArchiveManagerScope searchScope, bool publish = true)
     {
         if (_projectManager.ActiveProject is null)
         {
@@ -1020,6 +1032,13 @@ public class RED4Controller : ObservableObject, IGameController
                 _loggerService.Error(ex);
             }
 
+        }
+
+        // Announce the single add to the project explorer (only if the write actually landed). Bulk
+        // callers pass publish:false and emit one FilesImported batch instead — see AddToModAsync.
+        if (publish && File.Exists(diskPathInfo.FullName))
+        {
+            _projectEvents.PublishFileImported(diskPathInfo.FullName);
         }
 
         return true;

--- a/WolvenKit.App/Factories/PaneViewModelFactory.cs
+++ b/WolvenKit.App/Factories/PaneViewModelFactory.cs
@@ -34,6 +34,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
     private readonly PropertiesViewModel _propertiesViewModel;
     private readonly IModifierViewStateService _modifierSvc;
     private readonly ProjectResourceTools _projectResourceTools;
+    private readonly IProjectEvents _projectEvents;
     private readonly IArchiveManagerLoader _archiveManagerLoader;
 
     public PaneViewModelFactory(
@@ -55,6 +56,7 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         AppScriptService appScriptService,
         ProjectResourceTools projectResourceTools,
         IModifierViewStateService modifierSvc,
+        IProjectEvents projectEvents,
         IArchiveManagerLoader archiveManagerLoader
         )
     {
@@ -76,13 +78,14 @@ public class PaneViewModelFactory : IPaneViewModelFactory
         _appScriptService = appScriptService;
         _modifierSvc = modifierSvc;
         _projectResourceTools = projectResourceTools;
+        _projectEvents = projectEvents;
         _archiveManagerLoader = archiveManagerLoader;
     }
 
     public LogViewModel LogViewModel() => new(_loggerService, _appScriptService, _settingsManager);
     public ProjectExplorerViewModel ProjectExplorerViewModel(AppViewModel appViewModel)
         => new(appViewModel, _projectManager, _loggerService, _notificationService, _progressService, _modTools,
-            _gameController, _pluginService, _settingsManager, _modifierSvc, _archiveManager, _projectResourceTools, _importExportHelper);
+            _gameController, _pluginService, _settingsManager, _modifierSvc, _archiveManager, _projectResourceTools, _importExportHelper, _projectEvents);
     public PropertiesViewModel PropertiesViewModel()
         => _propertiesViewModel;
     public AssetBrowserViewModel AssetBrowserViewModel(AppViewModel appViewModel)

--- a/WolvenKit.App/Helpers/ProjectResourceTools.cs
+++ b/WolvenKit.App/Helpers/ProjectResourceTools.cs
@@ -39,6 +39,7 @@ public partial class ProjectResourceTools
 
     private readonly Cr2WTools _crwWTools;
 
+    private readonly IProjectEvents _projectEvents;
 
     private static readonly List<string> s_ignoredDependencyPartials =
     [
@@ -107,13 +108,15 @@ public partial class ProjectResourceTools
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
     public ProjectResourceTools(IProjectManager projectManager, IArchiveManager archiveManager,
-        ILoggerService loggerService, ISettingsManager settingsServiceManager, Cr2WTools cr2WTools)
+        ILoggerService loggerService, ISettingsManager settingsServiceManager, Cr2WTools cr2WTools,
+        IProjectEvents projectEvents)
     {
         _projectManager = projectManager;
         _archiveManager = archiveManager;
         _loggerService = loggerService;
         _settingsService = settingsServiceManager;
         _crwWTools = cr2WTools;
+        _projectEvents = projectEvents;
     }
 
     private RED4Controller? _red4Controller = null;
@@ -277,7 +280,7 @@ public partial class ProjectResourceTools
         }
         finally
         {
-            currentProject.DeleteEmptyFolders(_loggerService);
+            currentProject.DeleteEmptyFolders(_loggerService, _projectEvents);
             _semaphore.Release();
         }
     }
@@ -399,13 +402,24 @@ public partial class ProjectResourceTools
 
         File.Move(sourceAbsolutePath, targetAbsoluteFile, true);
 
+        // AddToMod published the file at its extracted (source) path; it has now been relocated into the
+        // target folder. Announce the move so the tree can update if needed. (No-op if the file already existed.)
+        _projectEvents.PublishFilesMoved(new FilesMovedMessage([(sourceAbsolutePath, targetAbsoluteFile)]));
+
         // pop it into our map
         pathReplacements.TryAdd(sourceRelativePath, Path.Combine(targetRelativePath, fileName));
     }
 
     private const string s_tempDirSuffix = "_wolvenkit_tempdir";
 
-    // TODO: Remove stupid AbsoluteFolderPrefix
+    /// <summary>
+    /// Carries out the action of moving the file from the source to the destination.
+    /// </summary>
+    /// <param name="sourcePath">IMPORTANT: sourcePath can be a "GameRelativePath" or an "AbsolutePath". The behavior of this method differs depending upon which of the two is passed in. Beware that "RawRelativePath" cannot be passed in here.</param>
+    /// <param name="destPath"></param>
+    /// <param name="absoluteFolderPrefix"></param>
+    /// <param name="refactor"></param>
+    /// <exception cref="InvalidDataException"></exception>
     public async Task MoveAndRefactorAsync(string sourcePath, string destPath, string absoluteFolderPrefix,
         bool refactor)
     {
@@ -415,7 +429,7 @@ public partial class ProjectResourceTools
         }
 
         var originalSourcePath = sourcePath;
-
+        // IMPORTANT: Here, "Rel" means "GameRelative".
         var sourceRelPath = sourcePath;
         var destRelPath = destPath;
 
@@ -472,9 +486,26 @@ public partial class ProjectResourceTools
         // the user is moving an empty directory
         if (files.Count == 0 && sourceIsDirectory)
         {
+            // This move will fail if a file or directory already exists at the destination...
             Directory.Move(sourceFileOrDirAbsPath, destAbsPath);
+
+            var didMoveSucceed = Directory.Exists(destAbsPath) // a dir exists at the destination
+                                 && !destAbsPath.Contains(s_tempDirSuffix) // it's not the temp dir
+                                 && !Directory.Exists(sourceFileOrDirAbsPath); // and the source dir got deleted/moved
+
+            // ... so, only notify subscribers that the move succeeded if the directory we were trying to move
+            // no longer exists and there does exist a directory at the path we were moving it to.
+            // (If the move failed then the one we were trying to move will still be there.)
+            if (didMoveSucceed)
+            {
+                _projectEvents.PublishFilesMoved(
+                    new FilesMovedMessage([(sourceFileOrDirAbsPath, destAbsPath)]));
+            }
+
             return;
         }
+
+        // Below we prepare to merge the files being moved with any files at the destination.
 
         files = files.Distinct().ToList();
 
@@ -505,6 +536,10 @@ public partial class ProjectResourceTools
 
         var fileReplacements = new Dictionary<string, string>();
 
+        // Authoritative (from -> to) pairs to announce to the project explorer once the move has
+        // actually completed on disk. Absolute paths, keyed by the path the tree currently knows.
+        var publishedMoves = new List<(string From, string To)>();
+
         foreach (var sourceAbsPath in files)
         {
             // If the file is not a folder, this is just the dest path
@@ -522,6 +557,18 @@ public partial class ProjectResourceTools
             {
                 continue;
             }
+
+            // The absolute path the project explorer currently knows this file by. Normally that is
+            // just the source; for the case-only-rename three-way move we relocated via a temp dir,
+            // so map the temp source back onto the original (rooted) path the tree still holds.
+            var fromAbsPath = sourceAbsPath;
+
+            if (originalSourcePath != sourceFileOrDirAbsPath && Path.IsPathRooted(originalSourcePath))
+            {
+                fromAbsPath = sourceAbsPath.Replace(sourceFileOrDirAbsPath, originalSourcePath);
+            }
+
+            publishedMoves.Add((fromAbsPath, targetAbsPath));
 
             var relativeSourcePath = activeProject.GetRelativePath(sourceAbsPath);
 
@@ -550,6 +597,13 @@ public partial class ProjectResourceTools
         if (successfulReplacements.Count > 0)
         {
             DeleteEmptyDirectoriesRecursive(sourceFileOrDirAbsPath);
+        }
+
+        var confirmedMoves = publishedMoves.Where(m => File.Exists(m.To)).ToList();
+
+        if (confirmedMoves.Count > 0)
+        {
+            _projectEvents.PublishFilesMoved(new FilesMovedMessage(confirmedMoves));
         }
 
         if (!refactor)
@@ -996,7 +1050,8 @@ public partial class ProjectResourceTools
     /// </summary>
     /// <param name="absolutePath">Absolute path to file or folder</param>
     /// <param name="activeProject">Current Wolvenkit project (so we don't delete too many folders)</param>
-    public static void DeleteEmptyParents(string? absolutePath, Cp77Project activeProject)
+    /// <param name="projectEvents">Optional: when supplied, each deleted folder is announced to subscribers.</param>
+    public static void DeleteEmptyParents(string? absolutePath, Cp77Project activeProject, IProjectEvents? projectEvents = null)
     {
         var absoluteFolderPath = absolutePath;
 
@@ -1026,7 +1081,8 @@ public partial class ProjectResourceTools
         }
 
         Directory.Delete(absoluteFolderPath);
-        DeleteEmptyParents(absoluteFolderPath, activeProject);
+        projectEvents?.PublishDirectoryDeleted(absoluteFolderPath);
+        DeleteEmptyParents(absoluteFolderPath, activeProject, projectEvents);
     }
 
     public void ScanModArchives(bool? executeScan = null, string? archiveName = null)
@@ -1372,6 +1428,7 @@ public partial class ProjectResourceTools
             try
             {
                 File.Delete(absolutePath);
+                _projectEvents.PublishFileDeleted(absolutePath);
             }
             catch
             {
@@ -1379,7 +1436,7 @@ public partial class ProjectResourceTools
             }
         }
 
-        activeProject.DeleteEmptyFolders(_loggerService);
+        activeProject.DeleteEmptyFolders(_loggerService, _projectEvents);
     }
 
     # region meshFiles

--- a/WolvenKit.App/Models/DispatchedObservableCollection.cs
+++ b/WolvenKit.App/Models/DispatchedObservableCollection.cs
@@ -1,12 +1,13 @@
 ﻿#nullable enable
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.App.Helpers;
 
 namespace WolvenKit.App.Models;
 
-public class DispatchedObservableCollection<T> : ObservableCollectionEx<T> where T : FileSystemModel
+public class DispatchedObservableCollection<T> : ObservableCollectionEx<T>
 {
     private sealed record Batch
     {
@@ -72,4 +73,14 @@ public class DispatchedObservableCollection<T> : ObservableCollectionEx<T> where
         _batch.Clear();
         base.Clear();
     });
+
+    public void AddRange(IEnumerable<T> items)
+    {
+        SuppressNotification = true;
+        foreach (var item in items)
+        {
+            Add(item);
+        }
+        SuppressNotification = false;
+    }
 }

--- a/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
+++ b/WolvenKit.App/Models/ProjectManagement/Project/Cp77Project.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WolvenKit.App.Extensions;
 using WolvenKit.App.Helpers;
+using WolvenKit.App.Services;
 using WolvenKit.App.ViewModels.Shell;
 using WolvenKit.Common;
 using WolvenKit.Core.Extensions;
@@ -997,32 +998,36 @@ public sealed partial class Cp77Project : IEquatable<Cp77Project>, ICloneable
     [GeneratedRegex(@"(((\w+\/)|(\w+\\\\?))+\w+\.\w+)")]
     private static partial Regex ResourceFilePathsRegex();
 
-    public void DeleteEmptyFolders(ILoggerService loggerService)
+    // TODO: Move to ProjectResourceTools or ProjectExplorerVM
+    public void DeleteEmptyFolders(ILoggerService loggerService, IProjectEvents? projectEvents = null)
     {
-        var numEmptyFolders = DeleteEmptyFolders(ModDirectory);
-        if (numEmptyFolders > 0)
+        var deletedFolders = new List<string>();
+        DeleteEmptyFolders(ModDirectory, deletedFolders);
+        if (deletedFolders.Count > 0)
         {
-            loggerService.Success($"Deleted {numEmptyFolders} empty folders");
+            loggerService.Success($"Deleted {deletedFolders.Count} empty folders");
+
+            foreach (var folder in deletedFolders)
+            {
+                projectEvents?.PublishDirectoryDeleted(folder);
+            }
         }
     }
 
-    private static int DeleteEmptyFolders(string directory)
+    private static void DeleteEmptyFolders(string directory, List<string> deletedFolders)
     {
-        var numEmptyFolders = 0;
         foreach (var subdirectory in Directory.GetDirectories(directory))
         {
-            DeleteEmptyFolders(subdirectory);
+            DeleteEmptyFolders(subdirectory, deletedFolders);
 
             if (Directory.GetFiles(subdirectory).Length != 0 || Directory.GetDirectories(subdirectory).Length != 0)
             {
                 continue;
             }
 
-            numEmptyFolders += 1;
             Directory.Delete(subdirectory);
+            deletedFolders.Add(subdirectory);
         }
-
-        return numEmptyFolders;
     }
 
     /// <summary>

--- a/WolvenKit.App/Scripting/AppScriptFunctions.cs
+++ b/WolvenKit.App/Scripting/AppScriptFunctions.cs
@@ -47,6 +47,7 @@ public class AppScriptFunctions : ScriptFunctions
     private readonly IGameControllerFactory _gameController;
     private readonly GeometryCacheService _geometryCacheService;
     private readonly ISettingsManager _settingsManager;
+    private readonly IProjectEvents _projectEvents;
 
     public AppViewModel? AppViewModel;
 
@@ -60,7 +61,8 @@ public class AppScriptFunctions : ScriptFunctions
         IGameControllerFactory gameController,
         GeometryCacheService geometryCacheService,
         ISettingsManager settingsManager,
-        RedTypeTemplateService templateService)
+        RedTypeTemplateService templateService,
+        IProjectEvents projectEvents)
         : base(loggerService, archiveManager, parserService, templateService)
     {
         _projectManager = projectManager;
@@ -69,7 +71,7 @@ public class AppScriptFunctions : ScriptFunctions
         _gameController = gameController;
         _geometryCacheService = geometryCacheService;
         _settingsManager = settingsManager;
-
+        _projectEvents = projectEvents;
     }
 
     /// <summary>
@@ -159,6 +161,9 @@ public class AppScriptFunctions : ScriptFunctions
         try
         {
             action(diskPathInfo.FullName);
+            // Announce the add to the project explorer (covers SaveToProject/SaveToRaw/SaveToResources).
+            // For an overwrite the tree add is a no-op, but the publish still reloads an open editor tab.
+            _projectEvents.PublishFileImported(diskPathInfo.FullName);
         }
         catch (Exception ex)
         {
@@ -745,6 +750,7 @@ public class AppScriptFunctions : ScriptFunctions
         }
 
         File.Delete(absoluteFilePath);
+        _projectEvents.PublishFileDeleted(absoluteFilePath);
         return !File.Exists(baseFolder);
     }
 

--- a/WolvenKit.App/Services/AppScriptService.cs
+++ b/WolvenKit.App/Services/AppScriptService.cs
@@ -40,12 +40,13 @@ public partial class AppScriptService : ScriptService
         IHookService hookService,
         IGameControllerFactory gameController,
         GeometryCacheService geometryCacheService,
-        RedTypeTemplateService templateService) : base(loggerService)
+        RedTypeTemplateService templateService,
+        IProjectEvents projectEvents) : base(loggerService)
     {
         _settingsManager = settingsManager;
         _hookService = hookService;
 
-        _wkit = new AppScriptFunctions(_loggerService, projectManager, archiveManager, red4ParserService, modTools, importExportHelper, gameController, geometryCacheService, settingsManager, templateService);
+        _wkit = new AppScriptFunctions(_loggerService, projectManager, archiveManager, red4ParserService, modTools, importExportHelper, gameController, geometryCacheService, settingsManager, templateService, projectEvents);
         _ui = new UiScriptFunctions(this);
 
         DefaultHostObject = new() { { "wkit", _wkit } };

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.WScript.cs
@@ -315,9 +315,11 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
                 }
 
                 File.Delete(destPath);
+                _projectEvents.PublishFileDeleted(destPath);
             }
 
             File.Copy(filePath, destPath);
+            _projectEvents.PublishFileImported(destPath);
         }
 
         try
@@ -341,7 +343,8 @@ public partial class AppViewModel : ObservableObject /*, IAppViewModel*/
         try
         {
             File.Delete(destPath);
-            ProjectResourceTools.DeleteEmptyParents(destPath, ActiveProject);
+            _projectEvents.PublishFileDeleted(destPath);
+            ProjectResourceTools.DeleteEmptyParents(destPath, ActiveProject, _projectEvents);
         }
         catch
         {

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -71,6 +71,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
 
     private readonly ILoggerService _loggerService;
     private readonly IProjectManager _projectManager;
+    private readonly IProjectEvents _projectEvents;
     private readonly IGameControllerFactory _gameControllerFactory;
     private readonly INotificationService _notificationService;
     private readonly IRecentlyUsedItemsService _recentlyUsedItemsService;
@@ -122,6 +123,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         ProjectResourceTools projectResourceTools,
         IUpdateService updateService,
         RedTypeTemplateService redTypeTemplateService,
+        IProjectEvents projectEvents,
         IArchiveManagerLoader archiveManagerLoader
     )
     {
@@ -148,6 +150,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         ProjectResourceTools = projectResourceTools;
         _updateService = updateService;
         _redTypeTemplateService = redTypeTemplateService;
+        _projectEvents = projectEvents;
         _archiveManagerLoader = archiveManagerLoader;
 
         _fileValidationScript = _scriptService.GetScripts().ToList()
@@ -1136,7 +1139,7 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
     }
 
     [RelayCommand(CanExecute = nameof(CanShowProjectActions))]
-    private void DeleteEmptyFolders() => _projectManager.ActiveProject?.DeleteEmptyFolders(_loggerService);
+    private void DeleteEmptyFolders() => _projectManager.ActiveProject?.DeleteEmptyFolders(_loggerService, _projectEvents);
 
     [RelayCommand(CanExecute = nameof(CanShowProjectActions))]
     private void DeleteEmptyMeshes()

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
@@ -110,7 +110,7 @@ public partial class ProjectExplorerViewModel
 
     public void Resume() => _modsWatcher.EnableRaisingEvents = true;
 
-    private void UnwatchProject(Cp77Project? project)
+    internal void UnwatchProject(Cp77Project? project)
     {
         _isWatcherStopped = true;
         UnwatchLocation();

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -76,6 +76,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     private readonly IGameControllerFactory _gameController;
     private readonly AppViewModel _appViewModel;
     public readonly IModifierViewStateService ModifierStateService;
+    private readonly IProjectEvents _projectEvents;
 
     private DispatcherHelper.RepeatingActionHandle? _autoSaveCancelToken;
 
@@ -126,7 +127,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         IModifierViewStateService modifierSvc,
         IArchiveManager archiveManager,
         ProjectResourceTools projectResourceTools,
-        ImportExportHelper importExportHelper
+        ImportExportHelper importExportHelper,
+        IProjectEvents projectEvents
     ) : base(s_toolTitle)
     {
         _projectManager = projectManager;
@@ -141,6 +143,7 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         _projectResourceTools = projectResourceTools;
         _importExportHelper = importExportHelper;
         ModifierStateService = modifierSvc;
+        _projectEvents = projectEvents;
 
         _appViewModel = appViewModel;
 

--- a/WolvenKit/GenericHost.cs
+++ b/WolvenKit/GenericHost.cs
@@ -101,6 +101,7 @@ namespace WolvenKit
                     services.AddSingleton<IPluginService, PluginService>();
                     services.AddSingleton<IModifierViewStateService, ModifierViewStateService>();
                     services.AddSingleton<INodeSelectionService, NodeSelectionService>();
+                    services.AddSingleton<IProjectEvents, ProjectEvents>();
                     services.AddTransient<IArchiveManagerLoader, ArchiveManagerLoader>();
 
                     // factories


### PR DESCRIPTION
# Integrate ProjectEvents publishers in lieu of tests

These changes are broken out from "The big PR" #2945. 

This PR is part of the refactor described in issue #3139. The goal is to add publishers that can be subscribed to by integration and unit tests around file operations such as deletion of folders, moving files, adding meshes to the project, etc. 

The changes in this PR do not actually change the behavior in the live app. (We are simply publishing events that do not at this time have any subscribers in the live app.)

I have to do this PR before the tests because the tests won't compile without this. I could include the tests in the same PR if it makes people feel better, but it's going to be harder to review all as one piece. (If it's an issue I'll just merge the stacked tests into here. Integration tests don't run on CI yet though.)

**Implemented:**
- Adds ProjectEvents publishers around various file operations in the app to provide hooks for integration and unit tests to be added in the next PR.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->