### PR TITLE
Add Unit and Integration tests enabled by ProjectEvents integration

### DIFF
--- a/Tests/WolvenKit.IntegrationTests/App/Helpers/EmptyFolderCleanupIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/Helpers/EmptyFolderCleanupIntegrationTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using Moq;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.IntegrationTests.Helpers;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace WolvenKit.IntegrationTests.App.Helpers;
+
+/// <summary>
+/// Filesystem-backed tests for the two shared empty-folder cleanup helpers
+/// (<see cref="Cp77Project.DeleteEmptyFolders(ILoggerService, IProjectEvents?)"/> and
+/// <see cref="ProjectResourceTools.DeleteEmptyParents(string?, Cp77Project, IProjectEvents?)"/>).
+///
+/// Both delete directories inside the project on disk; these tests assert they announce every removed
+/// directory to <see cref="IProjectEvents"/> so the project explorer prunes the matching nodes rather
+/// than leaving them stale — while still honouring their existing safety rules (non-empty folders and
+/// folders directly under the project root are never touched).
+/// </summary>
+public sealed class EmptyFolderCleanupIntegrationTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Cp77Project _project;
+    private readonly Mock<IProjectEvents> _events = new();
+    private readonly ILoggerService _logger = new Mock<ILoggerService>().Object;
+
+    public EmptyFolderCleanupIntegrationTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "WolvenKit_EmptyFolderTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+
+        // Location points at a (non-existent) .cpmodproj file; ProjectDirectory resolves to its folder,
+        // and FileDirectory (/source) + ModDirectory (/source/archive) are materialized on demand under it.
+        _project = new Cp77Project(Path.Combine(_tempRoot, "TestMod.cpmodproj"), "TestMod", "TestMod");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            RecentProjectsTestCleanup.RemoveProjectsUnder(_tempRoot);
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch { /* best effort */ }
+    }
+
+    // ---------- Cp77Project.DeleteEmptyFolders ----------
+
+    [Fact]
+    public void DeleteEmptyFolders_RemovesAndAnnouncesEveryEmptyFolder_KeepsNonEmpty()
+    {
+        var archive = _project.ModDirectory;
+        var emptyA = Path.Combine(archive, "emptyA");
+        var emptyB = Path.Combine(archive, "emptyB");
+        var emptyBNested = Path.Combine(emptyB, "nested");
+        var full = Path.Combine(archive, "full");
+        Directory.CreateDirectory(emptyA);
+        Directory.CreateDirectory(emptyBNested);
+        Directory.CreateDirectory(full);
+        File.WriteAllText(Path.Combine(full, "keep.txt"), "x");
+
+        _project.DeleteEmptyFolders(_logger, _events.Object);
+
+        // emptyB becomes empty once its only child (nested) is removed, so the whole chain goes.
+        Assert.False(Directory.Exists(emptyA));
+        Assert.False(Directory.Exists(emptyBNested));
+        Assert.False(Directory.Exists(emptyB));
+        Assert.True(Directory.Exists(full)); // has a file, preserved
+
+        _events.Verify(e => e.PublishDirectoryDeleted(emptyA), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(emptyBNested), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(emptyB), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(It.IsAny<string>()), Times.Exactly(3));
+        _events.Verify(e => e.PublishDirectoryDeleted(full), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteEmptyFolders_NothingEmpty_PublishesNothing()
+    {
+        var archive = _project.ModDirectory;
+        var full = Path.Combine(archive, "keepme");
+        Directory.CreateDirectory(full);
+        File.WriteAllText(Path.Combine(full, "a.txt"), "x");
+
+        _project.DeleteEmptyFolders(_logger, _events.Object);
+
+        Assert.True(Directory.Exists(full));
+        _events.Verify(e => e.PublishDirectoryDeleted(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteEmptyFolders_NullProjectEvents_StillDeletesWithoutThrowing()
+    {
+        var archive = _project.ModDirectory;
+        var empty = Path.Combine(archive, "empty");
+        Directory.CreateDirectory(empty);
+
+        // Backwards-compatible overload: existing callers passing only the logger must keep working.
+        _project.DeleteEmptyFolders(_logger);
+
+        Assert.False(Directory.Exists(empty));
+    }
+
+    // ---------- ProjectResourceTools.DeleteEmptyParents ----------
+
+    [Fact]
+    public void DeleteEmptyParents_RemovesAndAnnouncesEmptyChain_StopsAtProjectRoot()
+    {
+        // source/archive/a/b/c, all empty. 'archive' sits directly under FileDirectory (source) and must survive.
+        var archive = _project.ModDirectory;
+        var a = Path.Combine(archive, "a");
+        var b = Path.Combine(a, "b");
+        var c = Path.Combine(b, "c");
+        Directory.CreateDirectory(c);
+
+        // Simulate cleanup after deleting a file that lived in c.
+        var deletedFile = Path.Combine(c, "gone.mesh");
+        ProjectResourceTools.DeleteEmptyParents(deletedFile, _project, _events.Object);
+
+        Assert.False(Directory.Exists(c));
+        Assert.False(Directory.Exists(b));
+        Assert.False(Directory.Exists(a));
+        Assert.True(Directory.Exists(archive)); // directly under source: never removed
+
+        _events.Verify(e => e.PublishDirectoryDeleted(c), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(b), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(a), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(It.IsAny<string>()), Times.Exactly(3));
+        _events.Verify(e => e.PublishDirectoryDeleted(archive), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteEmptyParents_FolderDirectlyUnderProjectRoot_IsNeverDeleted()
+    {
+        // A folder one level under FileDirectory (source) is protected even when empty.
+        var fileDir = _project.FileDirectory;
+        var directChild = Path.Combine(fileDir, "loosefolder");
+        Directory.CreateDirectory(directChild);
+
+        ProjectResourceTools.DeleteEmptyParents(Path.Combine(directChild, "x.txt"), _project, _events.Object);
+
+        Assert.True(Directory.Exists(directChild));
+        _events.Verify(e => e.PublishDirectoryDeleted(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteEmptyParents_NonEmptyParent_HaltsAndAnnouncesOnlyWhatWasRemoved()
+    {
+        var archive = _project.ModDirectory;
+        var a = Path.Combine(archive, "a");
+        var b = Path.Combine(a, "b");
+        Directory.CreateDirectory(b);
+        File.WriteAllText(Path.Combine(a, "sibling.txt"), "x"); // makes 'a' non-empty
+
+        // b is empty → removed; a still holds sibling.txt → kept, recursion stops there.
+        ProjectResourceTools.DeleteEmptyParents(Path.Combine(b, "gone.mesh"), _project, _events.Object);
+
+        Assert.False(Directory.Exists(b));
+        Assert.True(Directory.Exists(a));
+
+        _events.Verify(e => e.PublishDirectoryDeleted(b), Times.Once);
+        _events.Verify(e => e.PublishDirectoryDeleted(It.IsAny<string>()), Times.Once);
+    }
+}

--- a/Tests/WolvenKit.IntegrationTests/App/Helpers/MeshMovePathHandlingIntegrationTests.cs
+++ b/Tests/WolvenKit.IntegrationTests/App/Helpers/MeshMovePathHandlingIntegrationTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.Common;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.IntegrationTests.Helpers;
+using WolvenKit.RED4.CR2W;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace WolvenKit.IntegrationTests.App.Helpers;
+
+/// <summary>
+/// Guards the path handling that <c>TemplateFileTools.MoveMesh</c> (GeneratePropItem's
+/// "move meshes to folder") relies on: a mesh under <c>archive</c> is relocated into a sibling
+/// folder by deriving <c>(root, sourceRawRel, destRawRel)</c> exactly the way MoveMesh does,
+/// then calling <see cref="ProjectResourceTools.MoveAndRefactorAsync"/>.
+///
+/// Raw-relative paths include the <c>archive\</c> segment and must be joined with
+/// <see cref="Cp77Project.FileDirectory"/> (<c>source/</c>). Feeding them with the archive
+/// subdir as prefix produces a double-prefixed <c>archive\archive\...</c> path — the bug this
+/// test guards against. Filesystem-backed (real move) but needs no game install: the archive
+/// manager is mocked and <c>refactor: false</c> skips Cr2W/reference rewriting.
+/// </summary>
+public sealed class MeshMovePathHandlingIntegrationTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Cp77Project _project;
+    private readonly ProjectResourceTools _tools;
+    private readonly Mock<IProjectEvents> _events = new();
+
+    public MeshMovePathHandlingIntegrationTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "WolvenKit_MeshMoveTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+
+        _project = new Cp77Project(Path.Combine(_tempRoot, "TestMod.cpmodproj"), "TestMod", "TestMod");
+        _ = _project.ModDirectory; // materialize source/archive on disk
+
+        var logger = new Mock<ILoggerService>().Object;
+        var hash = new Mock<IHashService>().Object;
+        var hook = new Mock<IHookService>().Object;
+
+        var projectManager = new Mock<IProjectManager>();
+        projectManager.Setup(m => m.ActiveProject).Returns(_project);
+
+        // Cr2WTools is unused on the refactor:false move path, but the ctor needs a non-null instance.
+        var cr2wTools = new Cr2WTools(logger, hash, new Red4ParserService(hash, logger, hook));
+
+        _tools = new ProjectResourceTools(
+            projectManager.Object,
+            new Mock<IArchiveManager>().Object,
+            logger,
+            new Mock<ISettingsManager>().Object,
+            cr2wTools,
+            _events.Object);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            RecentProjectsTestCleanup.RemoveProjectsUnder(_tempRoot);
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task MoveMesh_DerivesGameRelativePaths_MovesFileToTargetFolder_NoDoubleArchivePrefix()
+    {
+        // prop.MeshFileN / ParentFolder are game-relative (depot paths under archive/).
+        const string meshFile = @"base\props\old\mymesh.mesh";
+        const string parentFolder = @"base\props\new"; // prop.ParentFolder
+        var meshFileName = Path.GetFileName(meshFile);
+
+        var sourceAbsPath = _project.GetAbsolutePath(meshFile);
+        Directory.CreateDirectory(Path.GetDirectoryName(sourceAbsPath)!);
+        File.WriteAllText(sourceAbsPath, "dummy mesh");
+
+        // ---- exactly what TemplateFileTools.MoveMesh does ----
+        var meshFilePath = Path.Combine(parentFolder, meshFileName);
+        var destAbsPath = _project.GetAbsolutePath(meshFilePath);
+        await _tools.MoveAndRefactorAsync(sourceAbsPath, destAbsPath, "", false);
+        // -------------------------------------------------------
+
+        // Landed at the intended target, gone from the source.
+        Assert.True(File.Exists(destAbsPath), $"Expected mesh at {destAbsPath}");
+        Assert.False(File.Exists(sourceAbsPath), $"Source {sourceAbsPath} should have been moved away");
+
+        // The double-prefix bug (raw-relative joined with archive subdir as root) would have
+        // produced ...\source\archive\archive\... — assert that nested archive folder does not exist.
+        Assert.False(Directory.Exists(Path.Combine(_project.ModDirectory, "archive")),
+            "A nested archive\\archive folder indicates a raw-vs-game path double-prefix regression.");
+
+        // Exactly one mesh under the archive dir, and it is the target file.
+        var filesUnderArchive = Directory
+            .EnumerateFiles(_project.ModDirectory, "*", SearchOption.AllDirectories)
+            .ToList();
+        Assert.Single(filesUnderArchive);
+        Assert.Equal(destAbsPath, filesUnderArchive[0]);
+
+        // The move was announced authoritatively as absolute source -> absolute dest.
+        _events.Verify(e => e.PublishFilesMoved(
+                It.Is<FilesMovedMessage>(m => m.Moves.Any(mv =>
+                    string.Equals(mv.From, sourceAbsPath, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(mv.To, destAbsPath, StringComparison.OrdinalIgnoreCase)))),
+            Times.Once);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/TempProjectDirectory.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/TempProjectDirectory.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// Deletes a temp tree that a real <c>FileSystemWatcher</c> and its background polling tasks may
+/// still hold handles on.
+///
+/// The previous teardown swallowed every exception, which turned the (frequent) race with the
+/// watcher into unbounded temp-directory growth on CI agents. Retrying briefly lets the watcher
+/// release its handles; if it still fails we say so rather than pretending it worked.
+/// </summary>
+public static class TempProjectDirectory
+{
+    public static void Delete(string path, Action<string>? onFailure = null)
+    {
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        const int attempts = 5;
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                if (attempt == attempts)
+                {
+                    onFailure?.Invoke($"Could not delete temp dir '{path}' after {attempts} attempts: {e.Message}");
+                    return;
+                }
+
+                Thread.Sleep(20 * attempt);
+            }
+        }
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Helpers/TestProjectExplorer.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/TestProjectExplorer.cs
@@ -1,0 +1,49 @@
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Common;
+using WolvenKit.Common.Interfaces;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.Modkit.RED4;
+
+namespace Wolvenkit.Test.App.Helpers;
+
+/// <summary>
+/// Builds a <see cref="ProjectExplorerViewModel"/> backed by mocks.
+///
+/// The file watching logic lives on the view model itself, so tests that exercise it have to
+/// construct one. Everything the watcher needs is created here; the heavy collaborators that it
+/// never touches are uninitialized instances, which keeps the DI graph out of unit tests.
+/// </summary>
+public static class TestProjectExplorer
+{
+    public static ProjectExplorerViewModel Create(
+        IProjectEvents projectEvents,
+        ILoggerService? logger = null,
+        IProjectManager? projectManager = null,
+        IProgressService<double>? progress = null,
+        AppViewModel? appViewModel = null)
+    {
+        return new ProjectExplorerViewModel(
+            appViewModel ?? (AppViewModel)RuntimeHelpers.GetUninitializedObject(typeof(AppViewModel)),
+            projectManager ?? new Mock<IProjectManager>().Object,
+            logger ?? new Mock<ILoggerService>().Object,
+            new Mock<INotificationService>().Object,
+            progress ?? new Mock<IProgressService<double>>().Object,
+            new Mock<IModTools>().Object,
+            new Mock<IGameControllerFactory>().Object,
+            new Mock<IPluginService>().Object,
+            new Mock<ISettingsManager>().Object,
+            new Mock<IModifierViewStateService>().Object,
+            new Mock<IArchiveManager>().Object,
+            (ProjectResourceTools)RuntimeHelpers.GetUninitializedObject(typeof(ProjectResourceTools)),
+            (ImportExportHelper)RuntimeHelpers.GetUninitializedObject(typeof(ImportExportHelper)),
+            projectEvents);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Models/DispatchedObservableCollectionTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Models/DispatchedObservableCollectionTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows;
+using WolvenKit.App.Models;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Models;
+
+/// <summary>
+/// Tests for the batch-update collection introduced for large-project performance.
+/// The AddRange/ReplaceAll paths are critical — they must produce exactly one Reset notification
+/// instead of N individual notifications, which was the source of the original UI thrashing.
+///
+/// Note: These tests are best-effort in a pure unit test context because DispatcherHelper
+/// ultimately requires Application.Current. Full verification of marshaling happens in
+/// integration tests that run with a real WPF application context.
+/// </summary>
+public class DispatchedObservableCollectionTests
+{
+    [Fact]
+    public void AddRange_Empty_DoesNothing_AndProducesNoEvents()
+    {
+        var collection = new DispatchedObservableCollection<string>();
+        var changeCount = 0;
+        collection.CollectionChanged += (_, __) => changeCount++;
+
+        collection.AddRange(Enumerable.Empty<string>());
+
+        Assert.Equal(0, changeCount);
+        Assert.Empty(collection);
+    }
+
+    [Fact]
+    public void AddRange_MultipleItems_AddsAll_AndFiresSingleReset()
+    {
+        var collection = new DispatchedObservableCollection<int>();
+        NotifyCollectionChangedEventArgs? lastEvent = null;
+        collection.CollectionChanged += (_, e) => lastEvent = e;
+
+        var items = new[] { 1, 2, 3, 4, 5 };
+        collection.AddRange(items);
+
+        // After marshaling, items should be present.
+        // In a pure unit test without STA/WPF app, the action may not have run yet.
+        // We at least verify the API shape and that no per-item events were the intent.
+        Assert.NotNull(lastEvent); // If the dispatcher ran synchronously in this context, we see it
+        // The important contract: when it does run, it uses Reset, not Add for each.
+        if (lastEvent != null)
+        {
+            Assert.Equal(NotifyCollectionChangedAction.Reset, lastEvent.Action);
+        }
+    }
+
+    [Fact]
+    public void AddRange_LargeNumber_DoesNotThrow()
+    {
+        var collection = new DispatchedObservableCollection<int>();
+        var large = Enumerable.Range(0, 10_000).ToList();
+
+        var ex = Record.Exception(() => collection.AddRange(large));
+        Assert.Null(ex);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/Services/ProjectFileDiffTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Services/ProjectFileDiffTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using WolvenKit.App.Services;
+using Xunit;
+
+namespace Wolvenkit.Test.App.Services;
+
+/// <summary>
+/// Tests the snapshot-diff reconciliation used to announce derived, multi-file outputs (e.g. a script
+/// export producing a .glb + textures) to the project explorer without knowing the paths up front.
+/// </summary>
+public class ProjectFileDiffTests
+{
+    // Mirrors ProjectFileDiff.Snapshot's comparer so Contains() behaves the same as in production.
+    private static IReadOnlySet<string> Set(params string[] paths) =>
+        new HashSet<string>(paths, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Publish_NewFiles_AreAnnouncedAsImports()
+    {
+        var events = new Mock<IProjectEvents>();
+        var before = Set(@"C:\proj\raw\a.glb");
+        var after = Set(@"C:\proj\raw\a.glb", @"C:\proj\raw\b.glb", @"C:\proj\raw\tex\b.png");
+
+        ProjectFileDiff.Publish(before, after, events.Object);
+
+        events.Verify(e => e.PublishFileImported(@"C:\proj\raw\b.glb"), Times.Once);
+        events.Verify(e => e.PublishFileImported(@"C:\proj\raw\tex\b.png"), Times.Once);
+        events.Verify(e => e.PublishFileImported(It.IsAny<string>()), Times.Exactly(2));
+        events.Verify(e => e.PublishFileDeleted(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Publish_RemovedFiles_AreAnnouncedAsDeletes()
+    {
+        var events = new Mock<IProjectEvents>();
+        var before = Set(@"C:\proj\raw\a.glb", @"C:\proj\raw\old.glb");
+        var after = Set(@"C:\proj\raw\a.glb");
+
+        ProjectFileDiff.Publish(before, after, events.Object);
+
+        events.Verify(e => e.PublishFileDeleted(@"C:\proj\raw\old.glb"), Times.Once);
+        events.Verify(e => e.PublishFileDeleted(It.IsAny<string>()), Times.Exactly(1));
+        events.Verify(e => e.PublishFileImported(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Publish_UnchangedOrOverwrittenInPlace_PublishNothing()
+    {
+        var events = new Mock<IProjectEvents>();
+        var same = Set(@"C:\proj\raw\a.glb", @"C:\proj\raw\b.glb");
+
+        ProjectFileDiff.Publish(same, same, events.Object);
+
+        events.Verify(e => e.PublishFileImported(It.IsAny<string>()), Times.Never);
+        events.Verify(e => e.PublishFileDeleted(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Publish_Mixed_PublishesBothAddsAndDeletes()
+    {
+        var events = new Mock<IProjectEvents>();
+        var before = Set(@"C:\proj\raw\keep.glb", @"C:\proj\raw\gone.glb");
+        var after = Set(@"C:\proj\raw\keep.glb", @"C:\proj\raw\new.glb");
+
+        ProjectFileDiff.Publish(before, after, events.Object);
+
+        events.Verify(e => e.PublishFileImported(@"C:\proj\raw\new.glb"), Times.Once);
+        events.Verify(e => e.PublishFileDeleted(@"C:\proj\raw\gone.glb"), Times.Once);
+        events.Verify(e => e.PublishFileImported(It.IsAny<string>()), Times.Exactly(1));
+        events.Verify(e => e.PublishFileDeleted(It.IsAny<string>()), Times.Exactly(1));
+    }
+
+    [Fact]
+    public void Publish_CaseInsensitive_TreatsSamePathAsUnchanged()
+    {
+        var events = new Mock<IProjectEvents>();
+        var before = Set(@"C:\proj\raw\Model.glb");
+        var after = Set(@"C:\proj\raw\model.GLB");
+
+        ProjectFileDiff.Publish(before, after, events.Object);
+
+        events.Verify(e => e.PublishFileImported(It.IsAny<string>()), Times.Never);
+        events.Verify(e => e.PublishFileDeleted(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Snapshot_NullOrMissingDirectory_ReturnsEmpty()
+    {
+        Assert.Empty(ProjectFileDiff.Snapshot(null));
+        Assert.Empty(ProjectFileDiff.Snapshot(@"C:\does\not\exist\" + Guid.NewGuid().ToString("N")));
+    }
+
+    [Fact]
+    public void Snapshot_ExistingDirectory_ReturnsAllFilesRecursively()
+    {
+        var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ProjectFileDiffTests_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var nested = System.IO.Path.Combine(root, "sub");
+            System.IO.Directory.CreateDirectory(nested);
+            var f1 = System.IO.Path.Combine(root, "a.glb");
+            var f2 = System.IO.Path.Combine(nested, "b.png");
+            System.IO.File.WriteAllText(f1, "x");
+            System.IO.File.WriteAllText(f2, "y");
+
+            var snap = ProjectFileDiff.Snapshot(root);
+
+            Assert.Equal(2, snap.Count);
+            Assert.Contains(f1, snap);
+            Assert.Contains(f2, snap);
+        }
+        finally
+        {
+            if (System.IO.Directory.Exists(root))
+            {
+                System.IO.Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Shell/AppViewModelProjectLoadTests.cs
@@ -1,0 +1,330 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.Docking;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Common;
+using WolvenKit.Common.Interfaces;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.Modkit.RED4;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.ViewModels.Shell;
+
+/// <summary>
+/// Covers AppViewModel.LoadProjectFromPathAsync lifecycle: failed loads cancel PE chrome;
+/// location mismatch vs ProjectManager previous project cancels loading; a successful load
+/// eventually raises OnInitialProjectLoaded.
+///
+/// Note that the success path finishes on a delayed dispatcher callback
+/// (DispatcherHelper.DelayOnMainThread), so awaiting LoadProjectFromPathAsync won't
+/// work... the tests would have to "pump" (see PumpUntil).
+/// </summary>
+[Collection(ProjectLoadHeartbeatCollection.Name)]
+public class AppViewModelProjectLoadTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<ILoggerService> _logger = new();
+    private readonly Mock<INotificationService> _notifications = new();
+    private readonly Mock<IProgressService<double>> _progress = new();
+    private readonly Mock<IModTools> _modTools = new();
+    private readonly Mock<IGameControllerFactory> _gameControllerFactory = new();
+    private readonly Mock<IGameController> _gameController = new();
+    private readonly Mock<IPluginService> _plugins = new();
+    private readonly Mock<ISettingsManager> _settings = new();
+    private readonly Mock<IModifierViewStateService> _modifiers = new();
+    private readonly Mock<IArchiveManager> _archives = new();
+    private readonly Mock<IArchiveManagerLoader> _archiveLoader = new();
+    private readonly ProjectEvents _projectEvents = new();
+    private readonly AppViewModel _app;
+    private readonly ProjectExplorerViewModel _pe;
+    private readonly string _fakeExePath;
+
+    public AppViewModelProjectLoadTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "AppVmProjectLoad_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+        _fakeExePath = Path.Combine(_tempRoot, "Cyberpunk2077.exe");
+        File.WriteAllText(_fakeExePath, "exe");
+
+        _settings.SetupGet(s => s.CP77ExecutablePath).Returns(_fakeExePath);
+        _gameControllerFactory.Setup(f => f.GetController()).Returns(_gameController.Object);
+
+        _app = (AppViewModel)RuntimeHelpers.GetUninitializedObject(typeof(AppViewModel));
+        SetField(_app, "_projectManager", _projectManager.Object);
+        SetField(_app, "_loggerService", _logger.Object);
+        SetField(_app, "_notificationService", _notifications.Object);
+        SetField(_app, "_gameControllerFactory", _gameControllerFactory.Object);
+        SetField(_app, "_archiveManagerLoader", _archiveLoader.Object);
+        SetProperty(_app, nameof(AppViewModel.SettingsManager), _settings.Object);
+
+        // DockedViews is initialized by the field initializer; with GetUninitializedObject it is null.
+        SetField(_app, "_dockedViews", new ObservableCollection<IDockElement>());
+
+        var projectResourceTools = (ProjectResourceTools)RuntimeHelpers.GetUninitializedObject(typeof(ProjectResourceTools));
+        var importExportHelper = (ImportExportHelper)RuntimeHelpers.GetUninitializedObject(typeof(ImportExportHelper));
+
+        _pe = new ProjectExplorerViewModel(
+            _app,
+            _projectManager.Object,
+            _logger.Object,
+            _notifications.Object,
+            _progress.Object,
+            _modTools.Object,
+            _gameControllerFactory.Object,
+            _plugins.Object,
+            _settings.Object,
+            _modifiers.Object,
+            _archives.Object,
+            projectResourceTools,
+            importExportHelper,
+            _projectEvents);
+
+        _app.DockedViews.Add(_pe);
+    }
+
+    public void Dispose()
+    {
+        _pe.CancelProjectLoad();
+
+        try
+        {
+            _pe.UnwatchProject(_pe.ActiveProject);
+        }
+        catch (Exception)
+        {
+            // The watcher may never have been started for a given test.
+        }
+
+        TempProjectDirectory.Delete(_tempRoot);
+    }
+
+    /// <summary>
+    /// A failing archive load must not escape startup. ArchiveManagerLoader logs and rethrows, and
+    /// HandleActivation is reached from the Status setter, so an unguarded fault would propagate
+    /// out of OnStatusChanged and take the launch down. Before archive loading moved to
+    /// HandleActivation this was guarded inside LoadProjectFromPathAsync; these two pin the
+    /// replacement guard.
+    /// </summary>
+    [Fact]
+    public async Task LoadArchivesSafely_LoaderFaults_IsLoggedAndSwallowed()
+    {
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync())
+            .ThrowsAsync(new InvalidOperationException("archive boom"));
+
+        await InvokeLoadArchivesSafely();
+
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Once);
+        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadArchivesSafely_LoaderSucceeds_LogsNoError()
+    {
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
+
+        await InvokeLoadArchivesSafely();
+
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Once);
+        _logger.Verify(l => l.Error(It.IsAny<Exception>()), Times.Never);
+    }
+
+    /// <summary>
+    /// HandleActivation itself is not reachable from these tests - it also inits plugins, opens
+    /// the home page and fires update commands, none of which exist on a
+    /// GetUninitializedObject AppViewModel - so the guard is exercised directly.
+    /// </summary>
+    private Task InvokeLoadArchivesSafely()
+    {
+        var method = typeof(AppViewModel).GetMethod(
+            "LoadArchivesSafelyAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        return (Task)method!.Invoke(_app, null)!;
+    }
+
+    /// <summary>
+    /// Drains the dispatcher queue until <paramref name="condition"/> holds or we time out.
+    /// Nothing runs a dispatcher frame in a unit test, so callbacks posted by
+    /// DispatcherHelper.DelayOnMainThread would otherwise never execute.
+    /// </summary>
+    private static void PumpUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var dispatcher = Dispatcher.CurrentDispatcher;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (!condition() && stopwatch.Elapsed < timeout)
+        {
+            dispatcher.Invoke(() => { }, DispatcherPriority.Background);
+            Thread.Sleep(1);
+        }
+    }
+
+    private Cp77Project CreateProject(string name)
+    {
+        var dir = Path.Combine(_tempRoot, name);
+        Directory.CreateDirectory(dir);
+        var projectFile = Path.Combine(dir, name + Cp77Project.ProjectFileExtension);
+        File.WriteAllText(projectFile, "<!-- test -->");
+        var project = new Cp77Project(projectFile, name, name);
+        project.CreateDefaultDirectories();
+        return project;
+    }
+
+    /// <summary>
+    /// Archive loading moved out of the project-load path and into AppViewModel.HandleActivation,
+    /// so a broken archive load can no longer affect opening a project. This test checks
+    /// that these are now decoupled: the archive loader is not consulted here at all,
+    /// and the project still loads.
+    /// </summary>
+    [Fact]
+    public async Task LoadProjectFromPathAsync_DoesNotLoadArchives()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).ThrowsAsync(new InvalidOperationException("archive boom"));
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) => raised = true;
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
+
+        PumpUntil(() => raised, TimeSpan.FromSeconds(10));
+        Assert.True(raised);
+        _notifications.Verify(n => n.Success(It.Is<string>(s => s.Contains("loaded", StringComparison.OrdinalIgnoreCase))), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_MissingExe_RaisesOnInitialProjectLoadedWithoutHandleStartup()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _settings.SetupGet(s => s.CP77ExecutablePath).Returns(Path.Combine(_tempRoot, "missing.exe"));
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) => raised = true;
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        Assert.True(raised);
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_NullProject_CancelsPeLoading()
+    {
+        var path = Path.Combine(_tempRoot, "ghost", "ghost.cpmodproj");
+        _projectManager.Setup(m => m.LoadAsync(path)).ReturnsAsync((Cp77Project?)null);
+        _pe.ProjectWillLoad(path);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        await _app.LoadProjectFromPathAsync(path);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_LocationMismatch_CancelsPeLoading()
+    {
+        var existing = CreateProject("Existing");
+        var requested = Path.Combine(_tempRoot, "Other", "Other.cpmodproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(requested)!);
+
+        // Simulates ProjectManager returning previous ActiveProject when new path fails.
+        _projectManager.Setup(m => m.LoadAsync(requested)).ReturnsAsync(existing);
+        _pe.ProjectWillLoad(requested);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        await _app.LoadProjectFromPathAsync(requested);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        _archiveLoader.Verify(c => c.LoadArchiveManagerAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_Success_ArmsProjectWillLoadThenRaisesEvent()
+    {
+        var project = CreateProject("ModA");
+        _projectManager.Setup(m => m.LoadAsync(project.Location)).ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+
+        var raised = false;
+        _app.OnInitialProjectLoaded += (_, _) => raised = true;
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        // ActiveProject is set synchronously; the event is not. The success lane runs on a
+        // DelayOnMainThread callback, so it needs a dispatcher frame and more than that delay.
+        Assert.Equal(project, _app.ActiveProject);
+
+        PumpUntil(() => raised, TimeSpan.FromSeconds(10));
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_AnnouncesPendingLoadBeforeProjectManagerSwapsActiveProject()
+    {
+        var project = CreateProject("ModA");
+        var modeWhenLoadAsyncRan = ProjectExplorerViewModel.LoadingMode.Ready;
+
+        _projectManager.Setup(m => m.LoadAsync(project.Location))
+            .Callback(() => modeWhenLoadAsyncRan = _pe.CurrentLoadingMode)
+            .ReturnsAsync(project);
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+        _archiveLoader.Setup(c => c.LoadArchiveManagerAsync()).Returns(Task.CompletedTask);
+
+        await _app.LoadProjectFromPathAsync(project.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, modeWhenLoadAsyncRan);
+    }
+
+    [Fact]
+    public async Task LoadProjectFromPathAsync_FailedLoad_DoesNotReportProjectLoaded()
+    {
+        var path = Path.Combine(_tempRoot, "ghost", "ghost.cpmodproj");
+        _projectManager.Setup(m => m.LoadAsync(path)).ReturnsAsync((Cp77Project?)null);
+
+        await _app.LoadProjectFromPathAsync(path);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        _logger.Verify(
+            l => l.Success(It.Is<string>(s => s.Contains("Loaded project", StringComparison.Ordinal))),
+            Times.Never);
+    }
+
+    private static void SetField(object target, string name, object? value)
+    {
+        var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static void SetProperty(object target, string name, object? value)
+    {
+        var prop = target.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(prop);
+        prop!.SetValue(target, value);
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerLoadingModeTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Tools/ProjectExplorerLoadingModeTests.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Moq;
+using WolvenKit.App.Controllers;
+using WolvenKit.App.Helpers;
+using WolvenKit.App.Models.ProjectManagement.Project;
+using WolvenKit.App.Services;
+using WolvenKit.App.ViewModels.Shell;
+using WolvenKit.App.ViewModels.Tools;
+using WolvenKit.Common;
+using WolvenKit.Common.Interfaces;
+using WolvenKit.Common.Services;
+using WolvenKit.Core.Interfaces;
+using WolvenKit.Core.Services;
+using WolvenKit.Modkit.RED4;
+using Wolvenkit.Test.App.Helpers;
+using Xunit;
+
+namespace Wolvenkit.Test.App.ViewModels.Tools;
+
+/// <summary>
+/// Covers PE loading chrome lifecycle (review issues 3, 4-related CancelProjectLoad, DisableLoadingMode).
+/// Uses an uninitialized AppViewModel so we avoid the heavy DI graph while still exercising PEVM.
+/// </summary>
+[Collection(ProjectLoadHeartbeatCollection.Name)]
+public class ProjectExplorerLoadingModeTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<ILoggerService> _logger = new();
+    private readonly Mock<INotificationService> _notifications = new();
+    private readonly Mock<IProgressService<double>> _progress = new();
+    private readonly Mock<IModTools> _modTools = new();
+    private readonly Mock<IGameControllerFactory> _gameController = new();
+    private readonly Mock<IPluginService> _plugins = new();
+    private readonly Mock<ISettingsManager> _settings = new();
+    private readonly Mock<IModifierViewStateService> _modifiers = new();
+    private readonly Mock<IArchiveManager> _archives = new();
+    private readonly ProjectEvents _projectEvents = new();
+    private readonly ProjectExplorerViewModel _pe;
+    private readonly AppViewModel _appViewModel;
+
+    public ProjectExplorerLoadingModeTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "PELoadingModeTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+
+        _appViewModel = (AppViewModel)RuntimeHelpers.GetUninitializedObject(typeof(AppViewModel));
+        _pe = CreateProjectExplorer();
+    }
+
+    private ProjectExplorerViewModel CreateProjectExplorer()
+    {
+        var projectResourceTools = (ProjectResourceTools)RuntimeHelpers.GetUninitializedObject(typeof(ProjectResourceTools));
+        var importExportHelper = (ImportExportHelper)RuntimeHelpers.GetUninitializedObject(typeof(ImportExportHelper));
+
+        return new ProjectExplorerViewModel(
+            _appViewModel,
+            _projectManager.Object,
+            _logger.Object,
+            _notifications.Object,
+            _progress.Object,
+            _modTools.Object,
+            _gameController.Object,
+            _plugins.Object,
+            _settings.Object,
+            _modifiers.Object,
+            _archives.Object,
+            projectResourceTools,
+            importExportHelper,
+            _projectEvents);
+    }
+
+    public void Dispose()
+    {
+        _pe.CancelProjectLoad();
+
+        try
+        {
+            _pe.UnwatchProject(_pe.ActiveProject);
+        }
+        catch (Exception)
+        {
+            // The watcher may never have been started for a given test.
+        }
+
+        TempProjectDirectory.Delete(_tempRoot);
+    }
+
+    private Cp77Project CreateProject(string name)
+    {
+        var dir = Path.Combine(_tempRoot, name);
+        Directory.CreateDirectory(dir);
+        var projectFile = Path.Combine(dir, name + Cp77Project.ProjectFileExtension);
+        File.WriteAllText(projectFile, "<!-- test -->");
+        var project = new Cp77Project(projectFile, name, name);
+        project.CreateDefaultDirectories();
+        return project;
+    }
+
+    [Fact]
+    public void ProjectWillLoad_ArmsLoadingNewProject()
+    {
+        var project = CreateProject("ModA");
+
+        _pe.ProjectWillLoad(project.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void ProjectWillLoad_SameProjectPath_DoesNotRearm()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+
+        _pe.ProjectWillLoad(project.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void CancelProjectLoad_ClearsLoadingModeWithoutSuccessLog()
+    {
+        var project = CreateProject("ModA");
+        _pe.ProjectWillLoad(project.Location);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        _pe.CancelProjectLoad();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+        _logger.Verify(l => l.Success(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void DisableLoadingMode_StopsHeartbeatAndReportsSuccessWhenProjectActive()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+        _pe.ProjectWillLoad(CreateProject("ModB").Location);
+
+        _pe.DisableLoadingMode();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+        _logger.Verify(l => l.Success(It.Is<string>(s => s.Contains("Loaded project", StringComparison.Ordinal))), Times.Once);
+    }
+
+    [Fact]
+    public void OnInitialProjectLoaded_EqualsBail_DisarmsLoadingChrome()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+        _projectManager.SetupGet(m => m.ActiveProject).Returns(project);
+
+        // Arm for a different path so chrome is loading, then simulate event for same project.
+        _pe.ProjectWillLoad(CreateProject("ModB").Location);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+
+        InvokeOnInitialProjectLoaded();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void OnInitialProjectLoaded_NullProjectManager_DisarmsLoadingChrome()
+    {
+        _projectManager.SetupGet(m => m.ActiveProject).Returns((Cp77Project?)null);
+        _pe.ProjectWillLoad(CreateProject("ModA").Location);
+
+        InvokeOnInitialProjectLoaded();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+    }
+
+    [Fact]
+    public void EnableLoadingMode_SecondCall_DoesNotThrow()
+    {
+        var a = CreateProject("ModA");
+        var b = CreateProject("ModB");
+
+        _pe.ProjectWillLoad(a.Location);
+        // Second arm for another project while first heartbeat still running (token non-empty).
+        _pe.ProjectWillLoad(b.Location);
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.LoadingNewProject, _pe.CurrentLoadingMode);
+        Assert.True(DispatcherHelper.IsRepeatingActionRunning("ProjectExplorer load project"));
+    }
+
+    [Fact]
+    public void DisableLoadingMode_AfterOperationLoading_DoesNotReportProjectLoaded()
+    {
+        var project = CreateProject("ModA");
+        _pe.ActiveProject = project;
+
+        InvokeEnableLoadingMode(ProjectExplorerViewModel.LoadingMode.ShowLoadingDuringOperation);
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.ShowLoadingDuringOperation, _pe.CurrentLoadingMode);
+
+        _pe.DisableLoadingMode();
+
+        Assert.Equal(ProjectExplorerViewModel.LoadingMode.Ready, _pe.CurrentLoadingMode);
+        Assert.False(DispatcherHelper.IsRepeatingActionRunning(ProjectExplorerViewModel.LoadProjectPurpose));
+        _logger.Verify(
+            l => l.Success(It.Is<string>(s => s.Contains("Loaded project", StringComparison.Ordinal))),
+            Times.Never);
+    }
+
+    // [Fact]
+    // public void TwoProjectExplorerInstances_LoadingProjects_DoNotCollideOnAutosave()
+    // {
+    //     var project = CreateProject("ModA");
+    //     var second = CreateProjectExplorer();
+    //
+    //     try
+    //     {
+    //         _pe.StartWatcher_AndLoadProject(project, false);
+    //         second.StartWatcher_AndLoadProject(project, false);
+    //
+    //         _logger.Verify(
+    //             l => l.Error(It.Is<string>(s => s.Contains("Error refreshing project", StringComparison.Ordinal))),
+    //             Times.Never);
+    //     }
+    //     finally
+    //     {
+    //         second.CancelProjectLoad();
+    //         try
+    //         {
+    //             second.UnwatchProject();
+    //         }
+    //         catch (Exception)
+    //         {
+    //             // Nothing to unwatch if the load bailed early.
+    //         }
+    //     }
+    // }
+
+    private void InvokeEnableLoadingMode(ProjectExplorerViewModel.LoadingMode mode)
+    {
+        var method = typeof(ProjectExplorerViewModel).GetMethod(
+            "EnableLoadingMode",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(_pe, new object?[] { mode });
+    }
+
+    private void InvokeOnInitialProjectLoaded()
+    {
+        var method = typeof(ProjectExplorerViewModel).GetMethod(
+            "AppViewModel_OnInitialProjectLoaded",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(_pe, new object?[] { _appViewModel, EventArgs.Empty });
+    }
+}

--- a/Tests/WolvenKit.UnitTests/WolvenKit.UnitTests.csproj
+++ b/Tests/WolvenKit.UnitTests/WolvenKit.UnitTests.csproj
@@ -100,6 +100,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
@@ -120,6 +121,7 @@
     <ProjectReference Include="..\..\WolvenKit.App\WolvenKit.App.csproj" />
     <ProjectReference Include="..\..\WolvenKit.Core\WolvenKit.Core.csproj" />
       <ProjectReference Include="..\..\WolvenKit.Common\WolvenKit.Common.csproj" />
+    <ProjectReference Include="..\..\WolvenKit.Modkit\WolvenKit.Modkit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WolvenKit.App/Services/ProjectFileDiff.cs
+++ b/WolvenKit.App/Services/ProjectFileDiff.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace WolvenKit.App.Services;
+
+/// <summary>
+/// Reconciles a before/after snapshot of an on-disk file set with the project explorer by publishing
+/// the adds and removals to <see cref="IProjectEvents"/>.
+///
+/// Use this where the exact mutations aren't knowable up front — e.g. a script export that produces
+/// derived, possibly multi-file outputs (a mesh yields a .glb plus textures) — but the operation can
+/// be bracketed deterministically (snapshot, run + await, snapshot again). It's much cheaper than a
+/// full project reload: an on-disk enumeration plus publishing the (usually small) diff, with no tree
+/// rebuild.
+/// </summary>
+public static class ProjectFileDiff
+{
+    /// <summary>
+    /// Absolute paths of every file under <paramref name="directory"/> (recursively), case-insensitive.
+    /// Returns an empty set if the directory is null or missing.
+    /// </summary>
+    public static IReadOnlySet<string> Snapshot(string? directory) =>
+        !string.IsNullOrEmpty(directory) && Directory.Exists(directory)
+            ? Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Publishes the difference between two snapshots: paths present only in <paramref name="after"/>
+    /// are announced as adds, paths present only in <paramref name="before"/> as deletes. Paths in both
+    /// (unchanged, or overwritten in place) produce nothing.
+    /// </summary>
+    public static void Publish(IReadOnlySet<string> before, IReadOnlySet<string> after, IProjectEvents projectEvents)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+        ArgumentNullException.ThrowIfNull(projectEvents);
+
+        foreach (var added in after)
+        {
+            if (!before.Contains(added))
+            {
+                projectEvents.PublishFileImported(added);
+            }
+        }
+
+        foreach (var removed in before)
+        {
+            if (!after.Contains(removed))
+            {
+                projectEvents.PublishFileDeleted(removed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Add Unit & Integration tests for various file & project operations

This is the first batch of new tests that are now possible due to being able to hook into published ProjectEvents messages from various methods in the app. 

These tests help guard against regressions.

**Implemented:**

Tests around:
- deletion of empty folders from the project
- adding meshes to the project via handling their paths
- functionality of DispatchedObservableCollection
- project loading flow (some tests disabled until the next round)
- ProjectExplorer loading mode functionality
- ProjectFileDiff functionality (ability to take snapshots of the file system and produce diffs between them for validation of file system operations)

Note: the integration tests require a live game directory at this time and do not run on CI. But they are passing locally for me with this branch.

**Additional notes:**
- Changes are pulled from PR #2945 
- Part of a refactor for issue #3139

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->