### PR TITLE
Fix opus export skipping the last pak and mangling wav paths

### DIFF
--- a/Tests/WolvenKit.UnitTests/Modkit/OpusToolsTests.cs
+++ b/Tests/WolvenKit.UnitTests/Modkit/OpusToolsTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WolvenKit.Common;
+using WolvenKit.Modkit.RED4.Opus;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests
+{
+    [TestClass]
+    public class OpusToolsTests
+    {
+        /// <summary>
+        /// Builds a minimal in-memory .opusinfo holding one entry per given pack index.
+        /// </summary>
+        private static OpusInfo CreateOpusInfo(params ushort[] packIndices)
+        {
+            var ms = new MemoryStream();
+            var bw = new BinaryWriter(ms);
+
+            bw.Write(new byte[12]);             // Header
+            bw.Write((uint)packIndices.Length); // OpusCount
+            bw.Write(0u);                       // GroupingObjSize4x
+
+            for (var i = 0; i < packIndices.Length; i++)
+            {
+                bw.Write((uint)(1000 + i)); // OpusHashes
+            }
+            foreach (var packIndex in packIndices)
+            {
+                bw.Write(packIndex); // PackIndices
+            }
+            for (var i = 0; i < packIndices.Length; i++)
+            {
+                bw.Write(0u); // OpusOffsets
+            }
+            for (var i = 0; i < packIndices.Length; i++)
+            {
+                bw.Write((ushort)0); // RiffOpusOffsets
+            }
+            for (var i = 0; i < packIndices.Length; i++)
+            {
+                bw.Write(0u); // OpusStreamLengths
+            }
+            for (var i = 0; i < packIndices.Length; i++)
+            {
+                bw.Write(0u); // WavStreamLengths
+            }
+            // no grouping objects
+
+            ms.Position = 0;
+            return new OpusInfo(ms);
+        }
+
+        /// <summary>
+        /// An archive manager that finds no paks, but records every path it was asked for.
+        /// </summary>
+        private static (IArchiveManager, List<string>) CreateArchiveManager()
+        {
+            var requested = new List<string>();
+            var archiveManager = new Mock<IArchiveManager>();
+
+            archiveManager
+                .Setup(x => x.GetGameFile(It.IsAny<ResourcePath>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Callback((ResourcePath path, bool _, bool _) => requested.Add(path.GetResolvedText() ?? string.Empty))
+                .Returns((Core.Interfaces.IGameFile?)null);
+
+            return (archiveManager.Object, requested);
+        }
+
+        private static List<double> ExportAll(OpusInfo info, IArchiveManager archiveManager) =>
+            OpusTools.ExportAllOpus(info, archiveManager, false, false, new DirectoryInfo(Path.GetTempPath())).ToList();
+
+        [TestMethod]
+        public void ExportAllOpus_RequestsEveryPakIncludingTheLast()
+        {
+            var (archiveManager, requested) = CreateArchiveManager();
+
+            _ = ExportAll(CreateOpusInfo(0, 1, 2, 3), archiveManager);
+
+            CollectionAssert.AreEqual(
+                Enumerable.Range(0, 4)
+                    .Select(i => @$"base\sound\soundbanks\sfx_container_{i}.opuspak")
+                    .ToList(),
+                requested);
+        }
+
+        [TestMethod]
+        public void ExportAllOpus_UsesHighestPackIndexWhenNotSorted()
+        {
+            // PackIndices are not guaranteed to be ordered, the highest one still has to be exported
+            var (archiveManager, requested) = CreateArchiveManager();
+
+            _ = ExportAll(CreateOpusInfo(2, 0, 1), archiveManager);
+
+            CollectionAssert.Contains(requested, @"base\sound\soundbanks\sfx_container_2.opuspak");
+        }
+
+        [TestMethod]
+        public void ExportAllOpus_ReportsProgressUpToOne()
+        {
+            var (archiveManager, _) = CreateArchiveManager();
+
+            var progress = ExportAll(CreateOpusInfo(0, 1, 2, 3), archiveManager);
+
+            Assert.AreEqual(4, progress.Count);
+            Assert.AreEqual(1.0, progress.Last());
+        }
+    }
+}

--- a/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusInfo.cs
@@ -120,7 +120,7 @@ namespace WolvenKit.Modkit.RED4.Opus
             var proc = new ProcessStartInfo(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "opus-tools\\opusdec.exe"))
             {
                 WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
-                Arguments = $" \"{path}\" \"{path.Replace("opus", "wav")}\"",
+                Arguments = $" \"{path}\" \"{Path.ChangeExtension(path, ".wav")}\"",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 CreateNoWindow = true,

--- a/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
+++ b/WolvenKit.Modkit/RED4/Tools/OpusTools.cs
@@ -24,12 +24,13 @@ namespace WolvenKit.Modkit.RED4.Opus
 
         public static IEnumerable<double> ExportAllOpus(OpusInfo info, IArchiveManager archiveManager, bool useMod, bool useProject, DirectoryInfo rawOutDir)
         {
-            var maxPak = info.PackIndices.Last();
+            var maxPak = info.PackIndices.Max();
+            var pakCount = maxPak + 1;
             double progress;
 
-            for (var i = 0; i < maxPak; i++) // This could be parallel but it eats into RAM
+            for (var i = 0; i < pakCount; i++) // This could be parallel but it eats into RAM
             {
-                progress = (i + 1) / (double)maxPak;
+                progress = (i + 1) / (double)pakCount;
 
                 var opusPak = archiveManager.GetGameFile(@$"base\sound\soundbanks\sfx_container_{i}.opuspak", useMod, useProject);
                 if (opusPak != null)
@@ -102,10 +103,11 @@ namespace WolvenKit.Modkit.RED4.Opus
             foreach (var id in validIds)
             {
                 var name = Path.Combine(rawInDir.FullName, Convert.ToString(id) + ".opus");
+                var wavName = Path.ChangeExtension(name, ".wav");
                 var proc = new ProcessStartInfo(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "opus-tools\\opusenc.exe"))
                 {
                     WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
-                    Arguments = $" \"{name.Replace("opus", "wav")}\" \"{name}\" --serial 42 --quiet --padding 0 --vbr --comp 10 --framesize 20 ",
+                    Arguments = $" \"{wavName}\" \"{name}\" --serial 42 --quiet --padding 0 --vbr --comp 10 --framesize 20 ",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     CreateNoWindow = true,
@@ -118,7 +120,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                 var procNew = new ProcessStartInfo(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "opus-tools\\opusdec.exe"))
                 {
                     WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
-                    Arguments = $" \"{name}\" \"{name.Replace("opus", "wav")}\"",
+                    Arguments = $" \"{name}\" \"{wavName}\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     CreateNoWindow = true,
@@ -131,7 +133,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                 var procN = new ProcessStartInfo(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "opus-tools\\opusenc.exe"))
                 {
                     WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
-                    Arguments = $" \"{name.Replace("opus", "wav")}\" \"{name}\" --serial 42 --quiet --padding 0 --vbr --comp 10 --framesize 20 ",
+                    Arguments = $" \"{wavName}\" \"{name}\" --serial 42 --quiet --padding 0 --vbr --comp 10 --framesize 20 ",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     CreateNoWindow = true,
@@ -169,7 +171,7 @@ namespace WolvenKit.Modkit.RED4.Opus
                         modDictionary.Add(pakIdx, modStream);
                     }
 
-                    modDictionary[pakIdx] = info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(name.Replace("opus", "wav"))));
+                    modDictionary[pakIdx] = info.WriteOpusToPak(new MemoryStream(File.ReadAllBytes(name)), modDictionary[pakIdx], id, new MemoryStream(File.ReadAllBytes(wavName)));
                 }
             }
 

--- a/changelog/unreleased/0.yaml
+++ b/changelog/unreleased/0.yaml
@@ -1,0 +1,11 @@
+changes:
+    - type: "fixed"
+      packages: ["App", "CLI", "Nuget Packages"]
+      pr-number: 0
+      author: "Zhincore"
+      description: "Fixed exporting all sounds from OpusPaks skipping the last pak, leaving some sounds unexported."
+    - type: "fixed"
+      packages: ["App", "CLI", "Nuget Packages"]
+      pr-number: 0
+      author: "Zhincore"
+      description: "Fixed opus export and import writing .wav files to a wrong path when the used directory contains 'opus' in its name."

--- a/changelog/unreleased/3148.yaml
+++ b/changelog/unreleased/3148.yaml
@@ -1,11 +1,11 @@
 changes:
     - type: "fixed"
       packages: ["App", "CLI", "Nuget Packages"]
-      pr-number: 0
+      pr-number: 3148
       author: "Zhincore"
       description: "Fixed exporting all sounds from OpusPaks skipping the last pak, leaving some sounds unexported."
     - type: "fixed"
       packages: ["App", "CLI", "Nuget Packages"]
-      pr-number: 0
+      pr-number: 3148
       author: "Zhincore"
       description: "Fixed opus export and import writing .wav files to a wrong path when the used directory contains 'opus' in its name."


### PR DESCRIPTION
# Fixed opus export skipping the last pak and mangling wav paths

**Implemented:**
- Unit tests for `OpusTools.ExportAllOpus` covering pak enumeration, unsorted `PackIndices`, and progress reporting — no game install or fixture files needed

**Fixed:**
- Exporting all sounds from OpusPaks never opened the highest-numbered pak, so those sounds could not be extracted at all. On current game files that silently dropped the 27 sounds in `sfx_container_1878.opuspak`. The bound also no longer assumes `PackIndices` is sorted, and progress now reaches 1.0.
- Opus export and import built the `.wav` path with `Replace("opus", "wav")` on the full path, which rewrites the directory part too — output was lost whenever the directory contained "opus" in its name. Now uses `Path.ChangeExtension`.

**Additional notes:**
No API changes, both are behavioural fixes. Verified the new tests fail against the previous implementation and pass with the fix.

Full unit suite is 488/489; the one failure (`SceneDescriptorTests.AnimTargetDescribesStopAndStaticPosition`) is pre-existing on clean main and locale-dependent — it asserts on `1.25` but a comma-decimal locale renders `1,25`.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->
`