### PR TITLE
Restore the fix for the "ghost tree" issue

### DIFF
--- a/WolvenKit.App/Models/FileSystemModel.cs
+++ b/WolvenKit.App/Models/FileSystemModel.cs
@@ -86,18 +86,6 @@ public class FileSystemModel : INotifyPropertyChanged
     [Browsable(false)] public DispatchedObservableCollection<FileSystemModel> Children { get; } = new();
     [Browsable(false)] public bool IsDirectory { get; }
 
-    private bool _isExpanded;
-
-    /// <summary>
-    /// Indicates whether this directory node is expanded in the Project Explorer.
-    /// This is the source of truth for expansion state and survives tree rebuilds.
-    /// </summary>
-    public bool IsExpanded
-    {
-        get => _isExpanded;
-        set => SetField(ref _isExpanded, value);
-    }
-
     /// <summary>
     /// FileSystemModel represents a file or directory on-disk.
     /// </summary>
@@ -105,8 +93,7 @@ public class FileSystemModel : INotifyPropertyChanged
     /// <param name="name"></param><remark>Name of the file with extension but no paths.</remark>
     /// <param name="rawRelativePath"></param><remark>Path above 'source' to the file. E.g. archive/worlds/myfile.ent</remark>
     /// <param name="isDirectory"></param>
-    /// <param name="isExpanded"></param>
-    public FileSystemModel(FileSystemModel? parent, string name, string rawRelativePath, bool isDirectory, bool isExpanded = true)
+    public FileSystemModel(FileSystemModel? parent, string name, string rawRelativePath, bool isDirectory)
     {
         Parent = parent;
 
@@ -122,8 +109,6 @@ public class FileSystemModel : INotifyPropertyChanged
         _name = name;
         RawRelativePath = rawRelativePath;
         IsDirectory = isDirectory;
-        _isExpanded = isDirectory && isExpanded; // only directories can be expanded
-
         GetMetadata();
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
@@ -263,8 +263,7 @@ public partial class ProjectExplorerViewModel
                     isDirectory = attr.HasFlag(FileAttributes.Directory);
                 }
 
-                var isExpanded = GetExpansionStateOrNull(tmpPath) ?? true;
-                current = new FileSystemModel(parent, part, tmpPath, isDirectory, isExpanded);
+                current = new FileSystemModel(parent, part, tmpPath, isDirectory);
 
                 if (!current.IsDirectory)
                 {
@@ -528,8 +527,7 @@ public partial class ProjectExplorerViewModel
             parent,
             Path.GetFileName(entry.RawRelPath),
             entry.RawRelPath,
-            entry.IsDirectory,
-            GetExpansionStateOrNull(entry.RawRelPath) ?? false);
+            entry.IsDirectory);
 
         if (!_fileLookup.TryAdd(entry.RawRelPath, model))
         {
@@ -547,9 +545,7 @@ public partial class ProjectExplorerViewModel
         }
         else if (parent is { } parentModel)
         {
-            parentModel.Children.SuppressNotification = true;
             parentModel.Children.Add(model);
-            parentModel.Children.SuppressNotification = false;
         }
     }
 

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -291,6 +291,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
     [RelayCommand(CanExecute = nameof(CanRefresh))]
     private void Refresh()
     {
+        EnableLoadingMode(LoadingMode.ReloadingSameProject);
+
         if (IsWatcherStopped)
         {
             ResumeFileWatcher();
@@ -299,6 +301,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
         {
             RefreshWatcher();
         }
+
+        DisableLoadingMode();
     }
 
     private string GetActiveFolderPath() => SelectedTabIndex switch

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml
@@ -1121,7 +1121,6 @@
             AllowResizingColumns="False"
             AutoGenerateColumns="False"
             ChildPropertyName="Children"
-            ExpandStateMappingName="IsExpanded"
             ContextMenu="{StaticResource TreeGridContextMenu}"
             CurrentCellBorderBrush="White"
             CurrentCellBorderThickness="0"

--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -444,6 +444,11 @@ namespace WolvenKit.Views.Tools
             {
                 _disposables.ForEach(d => d.Dispose());
                 _disposables.Clear();
+
+                if (TreeGrid.View is { } treeView)
+                {
+                    RestoreExpansionRecursive(treeView.Nodes);
+                }
             });
 
         private void ResetCurrentFolderQuerySearchFilter()
@@ -789,13 +794,6 @@ namespace WolvenKit.Views.Tools
                     continue;
                 }
 
-                // Depth-first: fix children before this node so collapsing a parent
-                // does not leave child model/view state inconsistent.
-                if (node.ChildNodes is { Count: > 0 })
-                {
-                    RestoreExpansionRecursive(node.ChildNodes);
-                }
-
                 // Paths never recorded stay collapsed after search (search may have opened them).
                 var desired = ViewModel.GetExpansionStateOrNull(model.RawRelativePath) is true;
 
@@ -804,6 +802,11 @@ namespace WolvenKit.Views.Tools
                     if (!node.IsExpanded)
                     {
                         TreeGrid.ExpandNode(node);
+                    }
+
+                    if (node.ChildNodes is { Count: > 0 })
+                    {
+                        RestoreExpansionRecursive(node.ChildNodes);
                     }
                 }
                 else if (node.IsExpanded)
@@ -899,7 +902,7 @@ namespace WolvenKit.Views.Tools
                         continue;
                     }
 
-                    if (fileSystemModel.IsExpanded || ViewModel.GetExpansionStateOrNull(fileSystemModel.RawRelativePath) is true or null)
+                    if (ViewModel.GetExpansionStateOrNull(fileSystemModel.RawRelativePath) is true or null)
                     {
                         TreeGrid.ExpandNode(treeNode);
                     }


### PR DESCRIPTION
# Restore the fix for the "ghost tree" issue

PR #2945 introduced an "IsExpanded" property on FileSystemModel, as is the preferred method for tracking expansion state in SfTreeGrid. However, this caused the "ghost tree" bug in SyncFusion because SyncFusion are terrible programmers.

Today it was reported that the ghost tree issue is back, so I reverted that change and went back to simply handling tree expansion state through the JSON dictionary. For whatever reason, it seems to perform a bit better this way too.

**Fixed:**
- ghost tree issue

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->