### PR TITLE
show changelog after update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,6 +81,9 @@
     <PackageVersion Include="Syncfusion.SfTreeNavigator.WPF" Version="34.2.2" />
     <PackageVersion Include="Syncfusion.SfTreeView.WPF" Version="34.2.2" />
     <PackageVersion Include="Syncfusion.Themes.MaterialDark.WPF" Version="34.2.2" />
+    <PackageVersion Include="Syncfusion.SfMarkdownViewer.WPF" Version="34.2.2" />
+    <PackageVersion Include="Syncfusion.Markdown" Version="34.2.2" />
+    <PackageVersion Include="Syncfusion.Shared.WPF" Version="34.2.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.2" />

--- a/WolvenKit.App/Services/IUpdateService.cs
+++ b/WolvenKit.App/Services/IUpdateService.cs
@@ -10,4 +10,6 @@ public interface IUpdateService
     public Task UpdateToNewestVersion();
     public Task<string> GetLatestVersionTag();
     public SemVersion? GetLocalVersion();
+    public string? GetSavedChangelog();
+    public void ClearSavedChangelog();
 }

--- a/WolvenKit.App/Services/UpdateService.cs
+++ b/WolvenKit.App/Services/UpdateService.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Semver;
 using WolvenKit.App.Helpers;
@@ -21,6 +22,9 @@ public class UpdateService : IUpdateService
     private readonly ILoggerService _loggerService;
     private readonly ISettingsManager _settingsManager;
     private readonly HttpClient _httpClient;
+
+    private readonly string _localChangelogPath = Path.Join(ISettingsManager.GetAppData(), "changelog.md");
+    private const string s_remoteChangelogPath = "https://raw.githubusercontent.com/WolvenKit/WolvenKit/refs/heads/main/CHANGELOG.md";
 
     public UpdateService(ILoggerService loggerService, ISettingsManager settingsManager)
     {
@@ -121,6 +125,12 @@ public class UpdateService : IUpdateService
             File.Delete(unpackerZipPath);
         }
 
+        var relevantChangelog = await GetRemoteChangeLog(GetLocalVersion()?.ToString() ?? "", latestRelease.TagName);
+        if (!string.IsNullOrEmpty(relevantChangelog))
+        {
+            await File.WriteAllTextAsync(_localChangelogPath, relevantChangelog);
+        }
+
         var wolvenKitExePath = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "WolvenKit.exe");
         var startInfo = new ProcessStartInfo()
         {
@@ -164,6 +174,16 @@ public class UpdateService : IUpdateService
         return latestRelease?.TagName ?? "0.0.0";
     }
 
+    public string? GetSavedChangelog()
+    {
+        if (!File.Exists(_localChangelogPath))
+        {
+            return null;
+        }
+
+        return File.ReadAllText(_localChangelogPath);
+    }
+
     private bool IsLeftNewerThanRight(SemVersion left, SemVersion right) => right.CompareSortOrderTo(left) == -1;
 
     public SemVersion? GetLocalVersion() => Core.CommonFunctions.GetAssemblyVersion(Constants.AssemblyName);
@@ -198,5 +218,61 @@ public class UpdateService : IUpdateService
             return null;
         }
         return SemVersion.Parse(latestRelease.TagName, SemVersionStyles.OptionalMinorPatch);
+    }
+
+    private async Task<string?> GetRemoteChangeLog(string localVersion, string remoteVersion)
+    {
+        if (remoteVersion.Contains("nightly"))
+        {
+            // nightly doesn't have changelogs
+            return null;
+        }
+
+        var response =
+            await _httpClient.GetAsync(s_remoteChangelogPath);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        var remoteVersionStartIndex = -1;
+        var foundLocalVersion = false;
+        var localVersionEndIndex = -1;
+
+
+        var i = 0;
+        var contentByLine = content.Split("\n");
+        foreach (var line in contentByLine)
+        {
+            if (line.StartsWith($"## {remoteVersion}"))
+            {
+                remoteVersionStartIndex = i;
+            }
+
+            if (line.StartsWith($"## {localVersion}"))
+            {
+                foundLocalVersion = true;
+            }
+
+            if (foundLocalVersion && line.StartsWith("---"))
+            {
+                localVersionEndIndex = i;
+                break;
+            }
+
+            i++;
+        }
+
+        if (!foundLocalVersion)
+        {
+            localVersionEndIndex = contentByLine.Length - 1;
+        }
+
+        if (remoteVersionStartIndex == -1 || localVersionEndIndex == -1)
+        {
+            return null;
+        }
+
+        return string.Join("\n",
+            contentByLine.AsSpan(remoteVersionStartIndex, localVersionEndIndex - remoteVersionStartIndex));
     }
 }

--- a/WolvenKit.App/Services/UpdateService.cs
+++ b/WolvenKit.App/Services/UpdateService.cs
@@ -237,8 +237,7 @@ public class UpdateService : IUpdateService
         var content = await response.Content.ReadAsStringAsync();
 
         var remoteVersionStartIndex = -1;
-        var foundLocalVersion = false;
-        var localVersionEndIndex = -1;
+        var localVersionStartIndex = -1;
 
 
         var i = 0;
@@ -252,29 +251,28 @@ public class UpdateService : IUpdateService
 
             if (line.StartsWith($"## {localVersion}"))
             {
-                foundLocalVersion = true;
+                localVersionStartIndex = i;
             }
 
-            if (foundLocalVersion && line.StartsWith("---"))
+            if (remoteVersionStartIndex != -1 && localVersionStartIndex != -1)
             {
-                localVersionEndIndex = i;
                 break;
             }
 
             i++;
         }
 
-        if (!foundLocalVersion)
+        if (localVersionStartIndex == -1)
         {
-            localVersionEndIndex = contentByLine.Length - 1;
+            localVersionStartIndex = contentByLine.Length - 1;
         }
 
-        if (remoteVersionStartIndex == -1 || localVersionEndIndex == -1)
+        if (remoteVersionStartIndex == -1)
         {
             return null;
         }
 
         return string.Join("\n",
-            contentByLine.AsSpan(remoteVersionStartIndex, localVersionEndIndex - remoteVersionStartIndex));
+            contentByLine.AsSpan(remoteVersionStartIndex, localVersionStartIndex - remoteVersionStartIndex - 1));
     }
 }

--- a/WolvenKit.App/Services/UpdateService.cs
+++ b/WolvenKit.App/Services/UpdateService.cs
@@ -184,6 +184,8 @@ public class UpdateService : IUpdateService
         return File.ReadAllText(_localChangelogPath);
     }
 
+    public void ClearSavedChangelog() => File.Delete(_localChangelogPath);
+
     private bool IsLeftNewerThanRight(SemVersion left, SemVersion right) => right.CompareSortOrderTo(left) == -1;
 
     public SemVersion? GetLocalVersion() => Core.CommonFunctions.GetAssemblyVersion(Constants.AssemblyName);

--- a/WolvenKit.App/ViewModels/Dialogs/MarkdownInfoViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/MarkdownInfoViewModel.cs
@@ -1,0 +1,19 @@
+using WolvenKit.App.ViewModels.Shell;
+
+namespace WolvenKit.App.ViewModels.Dialogs;
+
+public partial class MarkdownInfoViewModel : DialogViewModel
+{
+    public AppViewModel AppViewModel { get; }
+
+    public string Title { get; set; }
+    public string Markdown { get; set; }
+
+    public MarkdownInfoViewModel(AppViewModel appViewModel, string title, string markdown)
+    {
+        AppViewModel = appViewModel;
+
+        Title = title;
+        Markdown = markdown;
+    }
+}

--- a/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
+++ b/WolvenKit.App/ViewModels/Shell/AppViewModel.cs
@@ -345,6 +345,8 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         }
 #endif
 
+        ShowChangeLogIfAvailableCommand.SafeExecute();
+
         CheckForScriptUpdatesCommand.SafeExecute();
         CheckForTemplateUpdatesCommand.SafeExecute();
         CheckForLongPathSupport();
@@ -698,6 +700,17 @@ public partial class AppViewModel : ObservableObject/*, IAppViewModel*/
         {
             _loggerService.Warning("Failed to update system templates");
             _loggerService.Warning(ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ShowChangeLogIfAvailable()
+    {
+        var changelog = _updateService.GetSavedChangelog();
+        if (changelog is not null)
+        {
+            await SetActiveDialog(new MarkdownInfoViewModel(this, "Changelog", changelog));
+            _updateService.ClearSavedChangelog();
         }
     }
 

--- a/WolvenKit/Views/Dialogs/MarkdownInfoDialog.xaml
+++ b/WolvenKit/Views/Dialogs/MarkdownInfoDialog.xaml
@@ -1,0 +1,59 @@
+<reactiveUi:ReactiveUserControl
+    x:Class="WolvenKit.Views.Dialogs.MarkdownInfoDialog"
+    x:TypeArguments="dialogs:MarkdownInfoViewModel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dialogs="clr-namespace:WolvenKit.App.ViewModels.Dialogs;assembly=WolvenKit.App"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactiveUi="http://reactiveui.net"
+    xmlns:templates="clr-namespace:WolvenKit.Views.Templates"
+    xmlns:markdown="clr-namespace:Syncfusion.UI.Xaml.Markdown;assembly=Syncfusion.SfMarkdownViewer.WPF"
+    mc:Ignorable="d"
+    d:DataContext="{d:DesignInstance Type=dialogs:MarkdownInfoViewModel}"
+    d:DesignWidth="800"
+    d:DesignHeight="450"
+    MinWidth="{DynamicResource WolvenKitDialogWidthSmall}"
+    MaxWidth="{DynamicResource WolvenKitDialogWidth}"
+    MinHeight="{DynamicResource WolvenKitDialogHeightSmall}"
+    MaxHeight="{DynamicResource WolvenKitDialogHeightLarge}"
+    Padding="{DynamicResource WolvenKitMargin}"
+    Background="{StaticResource ContentBackgroundAlt3}">
+ <Grid Margin="{DynamicResource WolvenKitMarginSmall}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Title -->
+        <TextBlock
+            Grid.Row="0"
+            Margin="{DynamicResource WolvenKitMarginSmall}"
+            FontSize="{DynamicResource WolvenKitFontHeader}"
+            FontWeight="Bold"
+            Text="{Binding Title}" />
+
+        <!-- Body -->
+        <markdown:SfMarkdownViewer
+            Grid.Row="1"
+            Margin="{DynamicResource WolvenKitMarginSmall}"
+            Padding="0"
+            Source="{Binding Markdown}"
+            FontSize="{DynamicResource WolvenKitFontBody}"
+            Background="{StaticResource ContentBackgroundAlt3}">
+        </markdown:SfMarkdownViewer>
+
+        <!-- Actions -->
+        <Button
+            Grid.Row="2"
+            Margin="{DynamicResource WolvenKitMarginSmall}"
+            HorizontalAlignment="Right"
+            Style="{StaticResource DialogPrimaryButtonStyle}"
+            Click="Ok_OnClick">
+            Ok
+        </Button>
+    </Grid>
+</reactiveUi:ReactiveUserControl>
+

--- a/WolvenKit/Views/Dialogs/MarkdownInfoDialog.xaml.cs
+++ b/WolvenKit/Views/Dialogs/MarkdownInfoDialog.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+using System.Windows.Controls;
+using ReactiveUI;
+using WolvenKit.App.ViewModels.Dialogs;
+
+namespace WolvenKit.Views.Dialogs;
+
+public partial class MarkdownInfoDialog : ReactiveUserControl<MarkdownInfoViewModel>
+{
+    public MarkdownInfoDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void Ok_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button || DataContext is not MarkdownInfoViewModel vm)
+        {
+            return;
+        }
+
+        vm.AppViewModel.CloseDialogCommand.Execute(null);
+    }
+}
+

--- a/WolvenKit/Views/Shell/MainView.xaml
+++ b/WolvenKit/Views/Shell/MainView.xaml
@@ -144,6 +144,9 @@
                     <DataTemplate DataType="{x:Type dialogVMs:UpdateDialogViewModel}">
                         <dialogs:UpdateDialog ViewModel="{Binding}" />
                     </DataTemplate>
+                    <DataTemplate DataType="{x:Type dialogVMs:MarkdownInfoViewModel}">
+                        <dialogs:MarkdownInfoDialog ViewModel="{Binding}" />
+                    </DataTemplate>
                     <DataTemplate DataType="{x:Type dialogVMs:ExtractEmbeddedFileDialogViewModel}">
                         <dialogs:ExtractEmbeddedFileDialog ViewModel="{Binding}" />
                     </DataTemplate>

--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -107,6 +107,9 @@
     <PackageReference Include="Syncfusion.SfTreeNavigator.WPF" />
     <PackageReference Include="Syncfusion.SfTreeView.WPF" />
     <PackageReference Include="Syncfusion.Themes.MaterialDark.WPF" />
+    <PackageReference Include="Syncfusion.SfMarkdownViewer.WPF"/>
+    <PackageReference Include="Syncfusion.Markdown" />
+    <PackageReference Include="Syncfusion.Shared.WPF"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/changelog/unreleased/3153.yaml
+++ b/changelog/unreleased/3153.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3153
+      author: "notaspirit"
+      description: "After a successful update of the app using the build in updater the changelog is now shown"


### PR DESCRIPTION
# show changelog after update

All changelogs between the version that was updated from upto and including the version updated to will be shown on startup (assuming they are present in CHANGELOG.md which contains changelogs since 8.18.0)

**Implemented:**
- added SyncFusions Markdown packages
- implemented showing changelog after an update
- MarkdownInfoDialog: dialog accepting a custom title and body accepting arbitrary markdown with an ok button

**Steps to Verify**
- for the showing of the changelog after an update:
- create a file under `%appdata%\REDmodding\WolvenKit\changelog.md` with some markdown content 
- build and run the branch
- see changelog info dialog
- observe file aforementioned file being deleted

- for the updater part:
- downgrade the version in WolvenKit.csproj to an older version like e.g. `8.18.1`
- build and run WolvenKit
- trigger an update
- observe `%appdata%\REDmodding\WolvenKit\changelog.md` being created with the changelog containing all changelogs available since last installed version

**Additional notes:**
closes #3028 

The inclusion of the new syncfusion packages should be checked with @rfuzzo to ensure they are covered under our existing license. 

<img width="679" height="790" alt="image" src="https://github.com/user-attachments/assets/da91a859-d1a8-4c09-b40a-8cb664a8156a" />

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->