### PR TITLE
Fix reopenProject issue

### DIFF
--- a/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
+++ b/WolvenKit/Views/Tools/ProjectExplorerView.xaml.cs
@@ -391,6 +391,10 @@ namespace WolvenKit.Views.Tools
             {
                 IndicateProjectLoading();
             }
+            else if (Ready())
+            {
+                IndicateProjectNotLoading();
+            }
 
             _loadingMode = mode;
         }


### PR DESCRIPTION
# Fix reopenProject issue

**Fixed:**
- A bizarre issue where if a project opened automatically at launch then the ProjectExplorer view would not show the files until after you pressed the refresh button. 

**Additional notes:**
- Resolves a complaint from discord.

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->