### PR TITLE
Fix dirs collapsing after rename

### DIFF
--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel+Watcher.cs
@@ -152,7 +152,7 @@ public partial class ProjectExplorerViewModel
             }
 
             var extension = Path.GetExtension(e.Name);
-            if (!string.IsNullOrEmpty(extension) && HasIgnoredExtension(e.Name))
+            if (!string.IsNullOrEmpty(extension) && (HasIgnoredExtension(e.Name) && e.ChangeType != WatcherChangeTypes.Renamed))
             {
                 continue;
             }
@@ -345,9 +345,22 @@ public partial class ProjectExplorerViewModel
                 return;
             }
 
+            if (!_fileLookup.TryGetValue(renamedEventArgs.OldName, out var renamedModel))
+            {
+                _loggerService?.Warning($"Renamed file was not in the database: {renamedEventArgs.OldName}. Recommend to restart WolvenKit.");
+                return;
+            }
+
+            if (!renamedModel.IsDirectory)
+            {
+                _fileChanges.Enqueue(new FileSystemEventArgsWrapper(
+                    new FileSystemEventArgs(WatcherChangeTypes.Deleted, _projectDirectory, renamedEventArgs.OldName)));
+                return;
+            }
+
             foreach (var key in _fileLookup.Keys)
             {
-                if (!key.StartsWith(renamedEventArgs.OldName))
+                if (!key.StartsWith(renamedEventArgs.OldName + Path.DirectorySeparatorChar))
                 {
                     continue;
                 }

--- a/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
+++ b/WolvenKit.App/ViewModels/Tools/ProjectExplorerViewModel.cs
@@ -891,12 +891,8 @@ public partial class ProjectExplorerViewModel : ToolViewModel
             return;
         }
 
-        StopWatcher();
-
         await _projectResourceTools.MoveAndRefactorAsync(relativePath, newRelativePath, prefixPath, refactor);
         _appViewModel.ReloadChangedFiles();
-
-        ResumeFileWatcher();
     }
 
 


### PR DESCRIPTION
# Fix dirs collapsing after rename

**Fixed:**
- an issue reported in discord where dirs would collapse in Project Explorer after a file rename

**Additional notes:**
A longstanding bug from old WatcherService had been papered over by refreshing the whole file tree after any file or directory was renamed. This has now been corrected and renamed events from the Windows file system are now properly handled. Also added a safety check to prevent directory renames from affecting other directories whose name has the renamed directory's name as an initial substring (previously, renaming a directory "foo/bar" could impact a directory "foo/bar2" because the trailing directory separator wasn't checked for in _fileLookup keys). 

<!-- If this is your first time contributing please read https://wolvenkit.github.io/WolvenKit/contributing/pull-requests.html -->