### PR TITLE
Scene Editor: Import dialogue creates section node

### DIFF
--- a/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
@@ -217,7 +217,7 @@ public class DialogueImportHelperTests
     {
         var line = DialogueImportHelper.Parse(LegacyConversationExport).Lines[0];
 
-        Assert.AreEqual(45896283497UL, line.LocStringId);
+        Assert.AreEqual(45896283497UL, (ulong)line.LocStringId);
         Assert.AreEqual("Wakey wakey, choom.", line.EmbeddedText);
         Assert.AreEqual("Viktor Vektor", line.Speaker);
         Assert.AreEqual("V", line.Addressee);
@@ -293,7 +293,7 @@ public class DialogueImportHelperTests
             payload.Lines
                 .Select((line, index) => new SectionDialogueLine
                 {
-                    ScreenplayLineId = (uint)(1 + index * 256),
+                    ScreenplayLineId = new scnscreenplayItemId { Id = (uint)(1 + index * 256) },
                     DurationMs = line.DurationMs,
                     StartTimeMs = line.StartTimeMs,
                     Text = line.EmbeddedText
@@ -424,11 +424,77 @@ public class DialogueImportHelperTests
     {
         var payload = DialogueImportHelper.Parse(LegacyConversationExport);
 
-        Assert.AreEqual("Vo_Context_Quest", payload.Lines[0].VoContext);
-        Assert.AreEqual("Vo_Expression_Spoken", payload.Lines[0].VoExpression);
+        Assert.AreEqual(
+            Enums.locVoiceoverContext.Vo_Context_Quest,
+            (Enums.locVoiceoverContext)payload.Lines[0].VoContext!.Value);
+        Assert.AreEqual(
+            Enums.locVoiceoverExpression.Vo_Expression_Spoken,
+            (Enums.locVoiceoverExpression)payload.Lines[0].VoExpression!.Value);
 
-        Assert.AreEqual("", payload.Lines[1].VoContext);
-        Assert.AreEqual("", payload.Lines[1].VoExpression);
+        Assert.IsNull(payload.Lines[1].VoContext, "the export named none");
+        Assert.IsNull(payload.Lines[1].VoExpression);
+    }
+
+    [TestMethod]
+    public void ReadsAroundAFieldWrittenAsSomethingElseEntirely()
+    {
+        // Invalid field shapes should not prevent other fields from being parsed.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "version": { "major": 2 },
+              "lines": [
+                {
+                  "locStringId": "1",
+                  "text": "Still readable.",
+                  "duration": { "ms": 1988 },
+                  "startTime": [ 1500 ],
+                  "order": { },
+                  "context": [ "Vo_Context_Quest" ]
+                }
+              ]
+            }
+            """);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual(0, payload.Version);
+        Assert.AreEqual("Still readable.", payload.Lines[0].EmbeddedText);
+        Assert.AreEqual(0U, payload.Lines[0].DurationMs);
+        Assert.IsNull(payload.Lines[0].StartTimeMs);
+        Assert.AreEqual(0, payload.Lines[0].Order);
+        Assert.IsNull(payload.Lines[0].VoContext);
+    }
+
+    [TestMethod]
+    public void RefusesAVoiceoverParameterThatIsNotAnEnumName()
+    {
+        // Only supported voiceover parameter names are accepted.
+        // Numeric strings are refused even where they would map to a declared enum value.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                { "locStringId": "1", "context": "Vo_Context_Whatever" },
+                { "locStringId": "2", "context": "1" },
+                { "locStringId": "3", "expression": "7" },
+                { "locStringId": "4", "context": "" },
+                { "locStringId": "5", "context": 1 },
+                { "locStringId": "6", "context": "vo_context_community", "expression": "vo_expression_globaltv" }
+              ]
+            }
+            """);
+
+        Assert.IsNull(payload.Lines[0].VoContext, "not a context the game knows");
+        Assert.IsNull(payload.Lines[1].VoContext, "numeric strings are not names");
+        Assert.IsNull(payload.Lines[2].VoExpression, "numeric strings are not names");
+        Assert.IsNull(payload.Lines[3].VoContext);
+        Assert.IsNull(payload.Lines[4].VoContext, "a context is named, not numbered");
+
+        // Voiceover parameter names are matched case-insensitively.
+        Assert.AreEqual(
+            Enums.locVoiceoverContext.Vo_Context_Community,
+            (Enums.locVoiceoverContext)payload.Lines[5].VoContext!.Value);
+        Assert.AreEqual(
+            Enums.locVoiceoverExpression.Vo_Expression_GlobalTV,
+            (Enums.locVoiceoverExpression)payload.Lines[5].VoExpression!.Value);
     }
 
     [TestMethod]
@@ -446,7 +512,7 @@ public class DialogueImportHelperTests
 
         CollectionAssert.AreEqual(
             new ulong[] { 1, 2, 3 },
-            payload.Lines.Select(line => line.LocStringId).ToArray());
+            payload.Lines.Select(line => (ulong)line.LocStringId).ToArray());
     }
 
     [TestMethod]
@@ -466,7 +532,7 @@ public class DialogueImportHelperTests
 
         CollectionAssert.AreEqual(
             new ulong[] { 3, 1, 2 },
-            payload.Lines.Select(line => line.LocStringId).ToArray());
+            payload.Lines.Select(line => (ulong)line.LocStringId).ToArray());
 
         Assert.AreEqual(0, payload.Lines[1].Order);
     }
@@ -505,7 +571,7 @@ public class DialogueImportHelperTests
             """);
 
         Assert.IsTrue(payload.IsValid);
-        Assert.AreEqual(45896283497UL, payload.Lines[0].LocStringId);
+        Assert.AreEqual(45896283497UL, (ulong)payload.Lines[0].LocStringId);
     }
 
     [TestMethod]
@@ -563,7 +629,7 @@ public class DialogueImportHelperTests
 
         Assert.IsTrue(payload.IsValid);
         Assert.AreEqual(1, payload.Lines.Count);
-        Assert.AreEqual(77UL, payload.Lines.Single().LocStringId);
+        Assert.AreEqual(77UL, (ulong)payload.Lines.Single().LocStringId);
         Assert.AreEqual(3, payload.SkippedCount);
     }
 

--- a/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/DialogueImportHelperTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WolvenKit.App.Helpers;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.UnitTests.App.Helpers;
 
@@ -9,10 +10,151 @@ namespace WolvenKit.UnitTests.App.Helpers;
 /// the Dialogue Browser CET mod writes one from its conversation panel. The JSON in these tests is
 /// shaped exactly as that exporter writes it: keys sorted, locstring ids as strings.
 /// </summary>
+/// <remarks>
+/// Two versions of the format are read. Version 2 times its lines in milliseconds and lays the
+/// conversation out itself, giving every line a start time; version 1 wrote seconds and left the
+/// layout to whoever read it. The unit cannot be told from the number - 2 is either two seconds or
+/// a fifth of a frame - so the version is what decides, and both are covered here.
+/// </remarks>
 [TestClass]
 public class DialogueImportHelperTests
 {
+    /// <summary>
+    /// A version 2 export, as the exporter writes one: durations in milliseconds, every line placed
+    /// on the conversation's own timeline, and a <c>duration</c> that is already the longer of the
+    /// two recorded takes. Its orders skip 3 and 5, and the gaps in its start times are where those
+    /// lines were passed over.
+    /// </summary>
     private const string ConversationExport = """
+        {
+          "conversation": "Showcase",
+          "conversationId": "conv1787238496_1",
+          "exportedAt": 1787748046,
+          "format": "wolvenkit.scene.dialogue",
+          "lines": [
+            {
+              "addressee": "Judy",
+              "context": "Vo_Context_Quest",
+              "duration": 1988,
+              "expression": "Vo_Expression_Spoken",
+              "femaleDuration": 1800,
+              "femaleLipsyncAnim": "f_18BBDCE3DF2FC000",
+              "femaleText": "Welcome to Night City.",
+              "hasFemale": true,
+              "hasMale": true,
+              "kind": "line",
+              "locStringId": "1782260948815298560",
+              "maleDuration": 1988,
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 1,
+              "quest": "base\\quest\\side_quests\\sq026\\phases\\sq026_judys_suicide.questphase",
+              "scene": "base/quest/side_quests/sq026/scenes/sq026_01a_suicide.scene",
+              "speaker": "V",
+              "startTime": 0,
+              "subtitlePath": "base/localization/en-us/subtitles/quest/sq026/sq026_01a_suicide.json",
+              "text": "Welcome to Night City."
+            },
+            {
+              "addressee": "V",
+              "context": "Vo_Context_Quest",
+              "duration": 1186,
+              "expression": "Vo_Expression_Spoken",
+              "femaleDuration": 1186,
+              "femaleLipsyncAnim": "f_172460154E29F000",
+              "femaleText": "Thanks, V.",
+              "hasFemale": true,
+              "hasMale": false,
+              "kind": "line",
+              "locStringId": "1667563406655877120",
+              "maleDuration": 0,
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 2,
+              "quest": "base\\quest\\main_quests\\part1\\q103\\phases\\q103_03_ghost_town.questphase",
+              "scene": "base/quest/main_quests/part1/q103/scenes/q103_11_tunnel_drive.scene",
+              "speaker": "Panam",
+              "startTime": 1988,
+              "subtitlePath": "base/localization/en-us/subtitles/quest/q103/q103_11_tunnel_drive.json",
+              "text": "Thanks, V."
+            },
+            {
+              "addressee": "V",
+              "context": "Vo_Context_Quest",
+              "duration": 2438,
+              "expression": "Vo_Expression_Spoken",
+              "femaleDuration": 2438,
+              "femaleLipsyncAnim": "",
+              "femaleText": "Jesus, you really do look terrible.",
+              "hasFemale": true,
+              "hasMale": false,
+              "kind": "line",
+              "locStringId": "1853019730599550976",
+              "maleDuration": 0,
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 4,
+              "quest": "base\\quest\\main_quests\\part1\\q115\\phases\\q115_02_ripperdoc.questphase",
+              "scene": "base/quest/main_quests/part1/q115/scenes/q115_02d_misty.scene",
+              "speaker": "Panam",
+              "startTime": 4174,
+              "subtitlePath": "base/localization/en-us/subtitles/quest/q115/q115_02d_misty.json",
+              "text": "Jesus, you really do look terrible."
+            },
+            {
+              "addressee": "Judy",
+              "context": "Vo_Context_Quest",
+              "duration": 2880,
+              "expression": "Vo_Expression_Spoken",
+              "femaleDuration": 2602,
+              "femaleLipsyncAnim": "f_14AABCC86A29F000",
+              "femaleText": "Just tired, is all...",
+              "hasFemale": true,
+              "hasMale": true,
+              "kind": "line",
+              "locStringId": "1489210195759984640",
+              "maleDuration": 2880,
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 6,
+              "quest": "base\\quest\\main_quests\\epilogue\\q203\\phase\\q203_penthouse.questphase",
+              "scene": "base/quest/main_quests/epilogue/q203/scenes/q203_02c_judy.scene",
+              "speaker": "V",
+              "startTime": 7112,
+              "subtitlePath": "base/localization/en-us/subtitles/quest/q203/q203_02c_judy.json",
+              "text": "Just tired, is all..."
+            },
+            {
+              "addressee": "Delamain",
+              "context": "Vo_Context_Quest",
+              "duration": 2052,
+              "expression": "Vo_Expression_Phone",
+              "femaleDuration": 2034,
+              "femaleLipsyncAnim": "f_1BDEF0F12E29F008",
+              "femaleText": "Difficult few weeks.",
+              "hasFemale": true,
+              "hasMale": true,
+              "kind": "line",
+              "locStringId": "2008307402506104840",
+              "maleDuration": 2052,
+              "maleLipsyncAnim": "",
+              "maleText": "",
+              "order": 7,
+              "quest": "base\\quest\\main_quests\\epilogue\\q203\\phase\\q203_av_ride.questphase",
+              "scene": "base/quest/main_quests/epilogue/q203/scenes/q203_04_delamain.scene",
+              "speaker": "V",
+              "startTime": 9992,
+              "subtitlePath": "base/localization/en-us/subtitles/quest/q203/q203_04_delamain.json",
+              "text": "Difficult few weeks."
+            }
+          ],
+          "source": "DialogueBrowser 1.1.0",
+          "version": 2
+        }
+        """;
+
+    /// <summary>A version 1 export: durations in seconds, no start times.</summary>
+    private const string LegacyConversationExport = """
         {
           "conversation": "Ripperdoc",
           "conversationId": "conv1755043200_1",
@@ -60,7 +202,7 @@ public class DialogueImportHelperTests
     [TestMethod]
     public void ParsesAConversationExport()
     {
-        var payload = DialogueImportHelper.Parse(ConversationExport);
+        var payload = DialogueImportHelper.Parse(LegacyConversationExport);
 
         Assert.IsTrue(payload.IsValid);
         Assert.IsNull(payload.Error);
@@ -73,7 +215,7 @@ public class DialogueImportHelperTests
     [TestMethod]
     public void CarriesEverythingAScreenplayLineNeeds()
     {
-        var line = DialogueImportHelper.Parse(ConversationExport).Lines[0];
+        var line = DialogueImportHelper.Parse(LegacyConversationExport).Lines[0];
 
         Assert.AreEqual(45896283497UL, line.LocStringId);
         Assert.AreEqual("Wakey wakey, choom.", line.EmbeddedText);
@@ -117,15 +259,228 @@ public class DialogueImportHelperTests
     }
 
     [TestMethod]
+    public void ReadsTheConversationTheExporterLaidOut()
+    {
+        var payload = DialogueImportHelper.Parse(ConversationExport);
+
+        Assert.IsTrue(payload.IsValid);
+        Assert.AreEqual(2, payload.Version);
+        Assert.AreEqual("Showcase", payload.ConversationName);
+        Assert.AreEqual("DialogueBrowser 1.1.0", payload.Source);
+        Assert.AreEqual(5, payload.Lines.Count);
+
+        // Milliseconds as written, no conversion: from version 2 the export times its lines the way
+        // a scene's events are timed.
+        CollectionAssert.AreEqual(
+            new uint[] { 1_988, 1_186, 2_438, 2_880, 2_052 },
+            payload.Lines.Select(line => line.DurationMs).ToArray());
+
+        // Where each line comes in, gaps and all - the 1000ms before the third is where a line of
+        // the original conversation was passed over.
+        CollectionAssert.AreEqual(
+            new uint?[] { 0, 1_988, 4_174, 7_112, 9_992 },
+            payload.Lines.Select(line => line.StartTimeMs).ToArray());
+    }
+
+    [TestMethod]
+    public void LaysARealExportOutAsTheConversationRan()
+    {
+        // The whole way through: the export as the mod writes it, out the other end as a section
+        // whose events sit where the original conversation put them.
+        var payload = DialogueImportHelper.Parse(ConversationExport);
+
+        var section = SceneSectionBuilder.Build(
+            payload.Lines
+                .Select((line, index) => new SectionDialogueLine
+                {
+                    ScreenplayLineId = (uint)(1 + index * 256),
+                    DurationMs = line.DurationMs,
+                    StartTimeMs = line.StartTimeMs,
+                    Text = line.EmbeddedText
+                })
+                .ToList());
+
+        var events = section.Node.Events
+            .Select(handle => (scnDialogLineEvent)handle.Chunk!)
+            .ToList();
+
+        CollectionAssert.AreEqual(
+            new uint[] { 0, 1_988, 4_174, 7_112, 9_992 },
+            events.Select(sceneEvent => (uint)sceneEvent.StartTime).ToArray());
+
+        CollectionAssert.AreEqual(
+            new uint[] { 1, 257, 513, 769, 1_025 },
+            events.Select(sceneEvent => (uint)sceneEvent.ScreenplayLineId.Id).ToArray());
+
+        // The last line starts at 9992 and runs 2052, so the section has to reach 12044 to play it
+        // through - a shorter one would cut Delamain off mid-sentence.
+        Assert.AreEqual(12_044U, section.DurationMs);
+
+        Assert.AreEqual(5, section.PlacedByExportCount, "a version 2 export places every line itself");
+        Assert.AreEqual(0, section.EstimatedDurationCount, "and times every line itself");
+    }
+
+    [TestMethod]
+    public void ReadsAVersionOneLengthAsSeconds()
+    {
+        var payload = DialogueImportHelper.Parse(LegacyConversationExport);
+
+        Assert.AreEqual(1, payload.Version);
+
+        // 2.6 in a version 1 payload is two and a half seconds. The same number in a version 2 one
+        // is a fifth of a frame, so only the version can say which was meant.
+        Assert.AreEqual(2_600U, payload.Lines[0].DurationMs);
+
+        Assert.AreEqual(0U, payload.Lines[1].DurationMs, "an export that gave no length gives 0");
+    }
+
+    [TestMethod]
+    public void LeavesAVersionOneLineUnplaced()
+    {
+        // Version 1 timed its lines but did not lay them out, so there is nothing to place them by
+        // and whoever builds a section has to decide when each one comes in.
+        var payload = DialogueImportHelper.Parse(LegacyConversationExport);
+
+        Assert.IsTrue(payload.Lines.TrueForAll(line => line.StartTimeMs is null));
+    }
+
+    [TestMethod]
+    public void TellsAnUnstatedStartTimeFromAZeroOne()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "version": 2,
+              "lines": [
+                { "locStringId": "1", "startTime": 0 },
+                { "locStringId": "2" }
+              ]
+            }
+            """);
+
+        // The first line of a conversation starts at 0, so 0 cannot stand in for "not said".
+        Assert.AreEqual(0U, payload.Lines[0].StartTimeMs);
+        Assert.IsNull(payload.Lines[1].StartTimeMs);
+    }
+
+    [TestMethod]
+    public void ReadsATimingWrittenAsAString()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "version": 2,
+              "lines": [ { "locStringId": "1", "duration": "1750", "startTime": "500" } ]
+            }
+            """);
+
+        Assert.AreEqual(1_750U, payload.Lines[0].DurationMs);
+        Assert.AreEqual(500U, payload.Lines[0].StartTimeMs);
+    }
+
+    [TestMethod]
+    public void RefusesALengthNoRecordingCouldHave()
+    {
+        // Anything unusable reads as "not said", which leaves the section to estimate rather than
+        // stretching it to whatever the payload claimed.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "version": 2,
+              "lines": [
+                { "locStringId": "1", "duration": -3 },
+                { "locStringId": "2", "duration": 0 },
+                { "locStringId": "3", "duration": 600000 },
+                { "locStringId": "4", "duration": "not a number" },
+                { "locStringId": "5" }
+              ]
+            }
+            """);
+
+        foreach (var line in payload.Lines)
+        {
+            Assert.AreEqual(0U, line.DurationMs, $"locstring {line.LocStringId}");
+        }
+    }
+
+    [TestMethod]
+    public void RefusesAStartTimeNoSectionCouldReach()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "version": 2,
+              "lines": [
+                { "locStringId": "1", "startTime": -1 },
+                { "locStringId": "2", "startTime": 7200000 },
+                { "locStringId": "3", "startTime": "sometime" }
+              ]
+            }
+            """);
+
+        // A section is a scene beat, not an afternoon; an unusable start time leaves the line to be
+        // placed rather than stretching the section to reach it.
+        Assert.IsTrue(payload.Lines.TrueForAll(line => line.StartTimeMs is null));
+    }
+
+    [TestMethod]
+    public void ReadsTheVoiceoverContextAndExpression()
+    {
+        var payload = DialogueImportHelper.Parse(LegacyConversationExport);
+
+        Assert.AreEqual("Vo_Context_Quest", payload.Lines[0].VoContext);
+        Assert.AreEqual("Vo_Expression_Spoken", payload.Lines[0].VoExpression);
+
+        Assert.AreEqual("", payload.Lines[1].VoContext);
+        Assert.AreEqual("", payload.Lines[1].VoExpression);
+    }
+
+    [TestMethod]
+    public void PutsTheLinesInTheOrderTheConversationSaysThem()
+    {
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                { "locStringId": "3", "order": 3 },
+                { "locStringId": "1", "order": 1 },
+                { "locStringId": "2", "order": 2 }
+              ]
+            }
+            """);
+
+        CollectionAssert.AreEqual(
+            new ulong[] { 1, 2, 3 },
+            payload.Lines.Select(line => line.LocStringId).ToArray());
+    }
+
+    [TestMethod]
+    public void LeavesTheLinesAloneWhenNotAllOfThemSayWhereTheyFall()
+    {
+        // Half an ordering would move the lines that have one past the lines that do not, which is
+        // worse than the order the export wrote them in.
+        var payload = DialogueImportHelper.Parse("""
+            {
+              "lines": [
+                { "locStringId": "3", "order": 3 },
+                { "locStringId": "1" },
+                { "locStringId": "2", "order": 2 }
+              ]
+            }
+            """);
+
+        CollectionAssert.AreEqual(
+            new ulong[] { 3, 1, 2 },
+            payload.Lines.Select(line => line.LocStringId).ToArray());
+
+        Assert.AreEqual(0, payload.Lines[1].Order);
+    }
+
+    [TestMethod]
     public void LeavesTheAddresseeEmptyWhenTheExportDoesNotNameOne()
     {
-        Assert.AreEqual("", DialogueImportHelper.Parse(ConversationExport).Lines[1].Addressee);
+        Assert.AreEqual("", DialogueImportHelper.Parse(LegacyConversationExport).Lines[1].Addressee);
     }
 
     [TestMethod]
     public void ReadsTheLipsyncNameOfEitherRecordedVariant()
     {
-        var line = DialogueImportHelper.Parse(ConversationExport).Lines[1];
+        var line = DialogueImportHelper.Parse(LegacyConversationExport).Lines[1];
 
         Assert.AreEqual("", line.FemaleLipsyncAnim);
         Assert.AreEqual("m_2B95FA94452C5001", line.MaleLipsyncAnim);

--- a/Tests/WolvenKit.UnitTests/App/Helpers/SceneSectionBuilderTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/SceneSectionBuilderTests.cs
@@ -22,15 +22,15 @@ public class SceneSectionBuilderTests
         uint? speaker = null,
         uint? addressee = null,
         string text = "",
-        string voContext = "",
-        string voExpression = "") =>
+        Enums.locVoiceoverContext? voContext = null,
+        Enums.locVoiceoverExpression? voExpression = null) =>
         new()
         {
-            ScreenplayLineId = screenplayLineId,
+            ScreenplayLineId = new scnscreenplayItemId { Id = screenplayLineId },
             DurationMs = durationMs,
             StartTimeMs = startTimeMs,
-            SpeakerActorId = speaker,
-            AddresseeActorId = addressee,
+            Speaker = speaker is { } speakerId ? new scnActorId { Id = speakerId } : null,
+            Addressee = addressee is { } addresseeId ? new scnActorId { Id = addresseeId } : null,
             Text = text,
             VoContext = voContext,
             VoExpression = voExpression
@@ -202,8 +202,9 @@ public class SceneSectionBuilderTests
     {
         var section = SceneSectionBuilder.Build(
             [
-                Line(voContext: "Vo_Context_Community", voExpression: "Vo_Expression_Phone"),
-                Line(voContext: "Vo_Context_Whatever", voExpression: "")
+                Line(voContext: Enums.locVoiceoverContext.Vo_Context_Community,
+                     voExpression: Enums.locVoiceoverExpression.Vo_Expression_Phone),
+                Line(voContext: null, voExpression: null)
             ]);
 
         var events = EventsOf(section.Node);
@@ -215,8 +216,7 @@ public class SceneSectionBuilderTests
             Enums.locVoiceoverExpression.Vo_Expression_Phone,
             (Enums.locVoiceoverExpression)events[0].VoParams.VoExpression);
 
-        // A name the game does not know is left off rather than guessed at, which leaves the same
-        // default the scene editor's own Add Dialogue writes.
+        // Missing or invalid voiceover parameters keep the event defaults.
         Assert.AreEqual(
             Enums.locVoiceoverContext.Vo_Context_Quest,
             (Enums.locVoiceoverContext)events[1].VoParams.VoContext);
@@ -301,11 +301,11 @@ public class SceneSectionBuilderTests
     [TestMethod]
     public void NamesTheSectionAfterTheConversationItCameFrom()
     {
-        Assert.AreEqual("showcase", SceneSectionBuilder.GetNotablePointName("Showcase"));
-        Assert.AreEqual("ripperdoc_intro", SceneSectionBuilder.GetNotablePointName("Ripperdoc Intro"));
-        Assert.AreEqual("q000_wakeup", SceneSectionBuilder.GetNotablePointName(" q000 - wakeup! "));
-        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName(""));
-        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName(null));
-        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName("---"));
+        Assert.AreEqual("showcase", SceneSectionBuilder.SanitizeNotablePointName("Showcase"));
+        Assert.AreEqual("ripperdoc_intro", SceneSectionBuilder.SanitizeNotablePointName("Ripperdoc Intro"));
+        Assert.AreEqual("q000_wakeup", SceneSectionBuilder.SanitizeNotablePointName(" q000 - wakeup! "));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.SanitizeNotablePointName(""));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.SanitizeNotablePointName(null));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.SanitizeNotablePointName("---"));
     }
 }

--- a/Tests/WolvenKit.UnitTests/App/Helpers/SceneSectionBuilderTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/Helpers/SceneSectionBuilderTests.cs
@@ -1,0 +1,311 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WolvenKit.App.Helpers;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.UnitTests.App.Helpers;
+
+/// <summary>
+/// Laying an imported conversation out as a section node. The timing is what these are about: the
+/// game plays a section for exactly as long as its sectionDuration says and cuts whatever is still
+/// running, and it plays every event whose start time has come - so lines that all start at 0 are
+/// everybody talking at once.
+/// </summary>
+[TestClass]
+public class SceneSectionBuilderTests
+{
+    private static SectionDialogueLine Line(
+        uint screenplayLineId = 1,
+        uint durationMs = 2_000,
+        uint? startTimeMs = null,
+        uint? speaker = null,
+        uint? addressee = null,
+        string text = "",
+        string voContext = "",
+        string voExpression = "") =>
+        new()
+        {
+            ScreenplayLineId = screenplayLineId,
+            DurationMs = durationMs,
+            StartTimeMs = startTimeMs,
+            SpeakerActorId = speaker,
+            AddresseeActorId = addressee,
+            Text = text,
+            VoContext = voContext,
+            VoExpression = voExpression
+        };
+
+    private static List<scnDialogLineEvent> EventsOf(scnSectionNode node) =>
+        node.Events.Select(handle => (scnDialogLineEvent)handle.Chunk!).ToList();
+
+    private static uint[] StartTimesOf(scnSectionNode node) =>
+        EventsOf(node).Select(sceneEvent => (uint)sceneEvent.StartTime).ToArray();
+
+    [TestMethod]
+    public void BringsEachLineInWhenTheExportSaysItDoes()
+    {
+        // The gaps are the export's own: the 1000ms before the third line is where a line of the
+        // original conversation was passed over, and putting the lines back end to end would close
+        // it up and lose the pacing.
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(screenplayLineId: 1, startTimeMs: 0, durationMs: 1_988),
+                Line(screenplayLineId: 257, startTimeMs: 1_988, durationMs: 1_186),
+                Line(screenplayLineId: 513, startTimeMs: 4_174, durationMs: 2_438)
+            ]);
+
+        CollectionAssert.AreEqual(new uint[] { 0, 1_988, 4_174 }, StartTimesOf(section.Node));
+
+        CollectionAssert.AreEqual(
+            new uint[] { 1_988, 1_186, 2_438 },
+            EventsOf(section.Node).Select(sceneEvent => (uint)sceneEvent.Duration).ToArray());
+
+        Assert.AreEqual(3, section.PlacedByExportCount);
+    }
+
+    [TestMethod]
+    public void EndsTheSectionWhereItsLastLineDoes()
+    {
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(startTimeMs: 0, durationMs: 1_988),
+                Line(startTimeMs: 9_992, durationMs: 2_052)
+            ]);
+
+        // A section that ends before its last event truncates that line, which is what the editor's
+        // own timeline flags as "section duration too short".
+        Assert.AreEqual(12_044U, (uint)section.Node.SectionDuration.Stu);
+        Assert.AreEqual((uint)section.Node.SectionDuration.Stu, section.DurationMs);
+    }
+
+    [TestMethod]
+    public void ReachesPastALineThatStartsEarlierButRunsLonger()
+    {
+        // Lines are free to overlap - one character talking over another - so the last one to start
+        // is not always the last one to finish.
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(startTimeMs: 0, durationMs: 10_000),
+                Line(startTimeMs: 1_000, durationMs: 1_000)
+            ]);
+
+        Assert.AreEqual(10_000U, section.DurationMs);
+    }
+
+    [TestMethod]
+    public void BringsAnUnplacedLineInAsTheOneBeforeItEnds()
+    {
+        // What an export written before the exporter timed its own conversations gives: lengths but
+        // no layout, so the section makes one.
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(durationMs: 2_000),
+                Line(durationMs: 1_500),
+                Line(durationMs: 3_000)
+            ]);
+
+        CollectionAssert.AreEqual(new uint[] { 0, 2_000, 3_500 }, StartTimesOf(section.Node));
+        Assert.AreEqual(6_500U, section.DurationMs);
+        Assert.AreEqual(0, section.PlacedByExportCount);
+    }
+
+    [TestMethod]
+    public void CarriesOnFromAPlacedLineWhenTheNextOneIsNotPlaced()
+    {
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(startTimeMs: 5_000, durationMs: 1_000),
+                Line(durationMs: 2_000),
+                Line(startTimeMs: 20_000, durationMs: 1_000)
+            ]);
+
+        CollectionAssert.AreEqual(new uint[] { 5_000, 6_000, 20_000 }, StartTimesOf(section.Node));
+        Assert.AreEqual(2, section.PlacedByExportCount);
+    }
+
+    [TestMethod]
+    public void BindsEachEventToTheScreenplayLineItPlays()
+    {
+        var section = SceneSectionBuilder.Build([Line(screenplayLineId: 1), Line(screenplayLineId: 257)]);
+
+        CollectionAssert.AreEqual(
+            new uint[] { 1, 257 },
+            EventsOf(section.Node).Select(sceneEvent => (uint)sceneEvent.ScreenplayLineId.Id).ToArray());
+    }
+
+    [TestMethod]
+    public void GivesEveryEventAnIdOfItsOwn()
+    {
+        var section = SceneSectionBuilder.Build(
+            [Line(screenplayLineId: 1), Line(screenplayLineId: 257), Line(screenplayLineId: 513)]);
+
+        var ids = EventsOf(section.Node).Select(sceneEvent => (ulong)sceneEvent.Id.Id).ToList();
+
+        Assert.AreEqual(3, ids.Distinct().Count());
+        CollectionAssert.DoesNotContain(ids, (ulong)long.MaxValue, "the unassigned default is not an id");
+    }
+
+    [TestMethod]
+    public void NamesEveryActorInTheSectionOnce()
+    {
+        // V talking to Judy, then Judy back to V: two actors, however many lines they trade.
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(speaker: 0, addressee: 2),
+                Line(speaker: 2, addressee: 0),
+                Line(speaker: 1, addressee: 2)
+            ]);
+
+        CollectionAssert.AreEqual(
+            new uint[] { 0, 2, 1 },
+            section.Node.ActorBehaviors.Select(behavior => (uint)behavior.ActorId.Id).ToArray());
+
+        Assert.AreEqual(3, section.ActorCount);
+
+        Assert.IsTrue(section.Node.ActorBehaviors.All(behavior =>
+            (Enums.scnSectionInternalsActorBehaviorMode)behavior.BehaviorMode ==
+            Enums.scnSectionInternalsActorBehaviorMode.OnlyIfAlive));
+    }
+
+    [TestMethod]
+    public void LeavesUnassignedLinesOutOfTheCast()
+    {
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(speaker: null, addressee: null),
+                Line(speaker: SceneActorOption.NoActorId, addressee: SceneActorOption.NoActorId),
+                Line(speaker: 4)
+            ]);
+
+        // uint.MaxValue is what an unassigned line carries, not an actor to tell the section about.
+        CollectionAssert.AreEqual(
+            new uint[] { 4 },
+            section.Node.ActorBehaviors.Select(behavior => (uint)behavior.ActorId.Id).ToArray());
+    }
+
+    [TestMethod]
+    public void GivesTheSectionItsStandardOutputs()
+    {
+        var section = SceneSectionBuilder.Build([Line()]);
+
+        // OnEnd first, OnCancel second: the node wrapper labels its outputs by position.
+        CollectionAssert.AreEqual(
+            new ushort[] { 0, 1 },
+            section.Node.OutputSockets.Select(socket => (ushort)socket.Stamp.Name).ToArray());
+
+        Assert.IsTrue(section.Node.OutputSockets.All(socket => socket.Stamp.Ordinal == 0));
+    }
+
+    [TestMethod]
+    public void TakesTheVoiceoverParametersTheExportNamed()
+    {
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(voContext: "Vo_Context_Community", voExpression: "Vo_Expression_Phone"),
+                Line(voContext: "Vo_Context_Whatever", voExpression: "")
+            ]);
+
+        var events = EventsOf(section.Node);
+
+        Assert.AreEqual(
+            Enums.locVoiceoverContext.Vo_Context_Community,
+            (Enums.locVoiceoverContext)events[0].VoParams.VoContext);
+        Assert.AreEqual(
+            Enums.locVoiceoverExpression.Vo_Expression_Phone,
+            (Enums.locVoiceoverExpression)events[0].VoParams.VoExpression);
+
+        // A name the game does not know is left off rather than guessed at, which leaves the same
+        // default the scene editor's own Add Dialogue writes.
+        Assert.AreEqual(
+            Enums.locVoiceoverContext.Vo_Context_Quest,
+            (Enums.locVoiceoverContext)events[1].VoParams.VoContext);
+        Assert.AreEqual(
+            Enums.locVoiceoverExpression.Vo_Expression_Spoken,
+            (Enums.locVoiceoverExpression)events[1].VoParams.VoExpression);
+    }
+
+    [TestMethod]
+    public void EstimatesTheLengthOfALineTheExportDidNotTime()
+    {
+        var section = SceneSectionBuilder.Build(
+            [
+                Line(durationMs: 0, text: "Welcome to Night City."),
+                Line(durationMs: 2_000, text: "Timed already.")
+            ]);
+
+        var events = EventsOf(section.Node);
+
+        Assert.AreEqual(1, section.EstimatedDurationCount);
+        Assert.AreEqual(2_000U, (uint)events[1].Duration, "a timed line is left as timed");
+
+        Assert.AreEqual(SceneSectionBuilder.EstimateDuration("Welcome to Night City."), (uint)events[0].Duration);
+        Assert.IsTrue((uint)events[0].Duration >= SceneSectionBuilder.MinLineDurationMs);
+    }
+
+    [TestMethod]
+    public void KeepsEveryLineOnScreenLongEnoughToRead()
+    {
+        var section = SceneSectionBuilder.Build([Line(durationMs: 1), Line(durationMs: 0, text: "Hm.")]);
+
+        Assert.IsTrue(EventsOf(section.Node).All(sceneEvent =>
+            sceneEvent.Duration >= SceneSectionBuilder.MinLineDurationMs));
+    }
+
+    [TestMethod]
+    public void CapsAGuessMadeFromAWallOfText()
+    {
+        var wall = new string('x', 100_000);
+
+        var section = SceneSectionBuilder.Build([Line(durationMs: 0, text: wall)]);
+
+        Assert.AreEqual(
+            SceneSectionBuilder.MaxEstimatedDurationMs, (uint)EventsOf(section.Node)[0].Duration);
+    }
+
+    [TestMethod]
+    public void BelievesALengthTheExportStatedPastWhatAGuessIsCappedAt()
+    {
+        // A monologue the export actually timed at 90 seconds is 90 seconds. Cutting it to the cap
+        // a guess is held to would truncate it, and quietly - it is not an estimated line, so
+        // nothing would tell the user to go and check it.
+        const uint ninetySeconds = 90_000;
+
+        var section = SceneSectionBuilder.Build([Line(durationMs: ninetySeconds)]);
+
+        Assert.AreEqual(ninetySeconds, (uint)EventsOf(section.Node)[0].Duration);
+        Assert.AreEqual(ninetySeconds, section.DurationMs);
+        Assert.AreEqual(0, section.EstimatedDurationCount);
+    }
+
+    [TestMethod]
+    public void CapsALengthNoRecordingWouldRunTo()
+    {
+        var section = SceneSectionBuilder.Build([Line(durationMs: 10 * 60_000)]);
+
+        Assert.AreEqual(SceneSectionBuilder.MaxLineDurationMs, (uint)EventsOf(section.Node)[0].Duration);
+    }
+
+    [TestMethod]
+    public void BuildsAnEmptySectionFromNoLines()
+    {
+        var section = SceneSectionBuilder.Build([]);
+
+        Assert.AreEqual(0, section.EventCount);
+        Assert.AreEqual(0, section.ActorCount);
+        Assert.AreEqual(0U, section.DurationMs);
+        Assert.AreEqual(0U, (uint)section.Node.SectionDuration.Stu);
+        Assert.AreEqual(2, section.Node.OutputSockets.Count);
+    }
+
+    [TestMethod]
+    public void NamesTheSectionAfterTheConversationItCameFrom()
+    {
+        Assert.AreEqual("showcase", SceneSectionBuilder.GetNotablePointName("Showcase"));
+        Assert.AreEqual("ripperdoc_intro", SceneSectionBuilder.GetNotablePointName("Ripperdoc Intro"));
+        Assert.AreEqual("q000_wakeup", SceneSectionBuilder.GetNotablePointName(" q000 - wakeup! "));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName(""));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName(null));
+        Assert.AreEqual("imported_dialogue", SceneSectionBuilder.GetNotablePointName("---"));
+    }
+}

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction.Options;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.UnitTests.App.ViewModels.Dialogs;
 
@@ -68,8 +69,8 @@ public class DialogueImportDialogViewModelTests
 
     /// <summary>The scene these tests import into: two cast members and a player actor.</summary>
     private static DialogueImportDialogViewModel ViewModel(
-        IEnumerable<ExistingSceneLine>? existingLines = null,
-        IEnumerable<ulong>? existingOptions = null) =>
+        IEnumerable<scnscreenplayDialogLine>? existingLines = null,
+        IEnumerable<scnscreenplayChoiceOption>? existingOptions = null) =>
         new(new DialogueImportDialogOptions(
             "q000_ripperdoc",
             existingLines ?? [],
@@ -80,19 +81,27 @@ public class DialogueImportDialogViewModelTests
                 new SceneActorOption(2, "Player", isPlayer: true)
             ]));
 
-    /// <summary>A line the scene already carries, as the screenplay store would report it.</summary>
-    private static ExistingSceneLine InScene(
+    /// <summary>Creates an existing screenplay line.</summary>
+    private static scnscreenplayDialogLine InScene(
         ulong locStringId,
         uint? screenplayLineId = 4_097,
         uint? speaker = null,
         uint? addressee = null) =>
         new()
         {
-            LocStringId = locStringId,
-            ScreenplayLineId = screenplayLineId,
-            SpeakerActorId = speaker,
-            AddresseeActorId = addressee
+            LocstringId = new scnlocLocstringId { Ruid = locStringId },
+            // Defaults represent an unset actor and an unassigned item id.
+            ItemId = new scnscreenplayItemId
+            {
+                Id = screenplayLineId ?? SceneEditingHelper.UnassignedScreenplayItemId
+            },
+            Speaker = new scnActorId { Id = speaker ?? SceneActorOption.NoActorId },
+            Addressee = new scnActorId { Id = addressee ?? SceneActorOption.NoActorId }
         };
+
+    /// <summary>Creates an existing screenplay choice option.</summary>
+    private static scnscreenplayChoiceOption OptionInScene(ulong locStringId) =>
+        new() { LocstringId = new scnlocLocstringId { Ruid = locStringId } };
 
     [TestMethod]
     public void NamesTheSceneItIsImportingInto()
@@ -211,7 +220,7 @@ public class DialogueImportDialogViewModelTests
     {
         // Nothing plays an option - the player picks it - so there is nothing a section could do
         // with one the scene already has.
-        var viewModel = ViewModel(existingOptions: [1003UL]);
+        var viewModel = ViewModel(existingOptions: [OptionInScene(1003)]);
 
         viewModel.LoadPayload(ThreeLines);
 
@@ -261,7 +270,7 @@ public class DialogueImportDialogViewModelTests
     {
         // The two halves of the screenplay store number and key themselves independently, so a
         // locstring in one says nothing about the other.
-        var viewModel = ViewModel(existingLines: [InScene(1003)], existingOptions: [1001UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1003)], existingOptions: [OptionInScene(1001)]);
 
         viewModel.LoadPayload(ThreeLines);
 
@@ -283,16 +292,16 @@ public class DialogueImportDialogViewModelTests
         // new lines first and the old ones after.
         CollectionAssert.AreEqual(
             new ulong[] { 1001, 1002, 1003 },
-            selections.Select(selection => selection.Line.LocStringId).ToArray());
+            selections.Select(selection => (ulong)selection.Line.LocStringId).ToArray());
 
         var reused = selections[1];
 
         Assert.IsTrue(reused.IsAlreadyInScene);
-        Assert.AreEqual(4_097U, reused.ExistingScreenplayLineId);
-        Assert.AreEqual(1U, reused.SpeakerActorId, "the scene's speaker, not the export's");
+        Assert.AreEqual(4_097U, (uint)reused.ExistingLine!.ItemId.Id);
+        Assert.AreEqual(1U, (uint)reused.Speaker!.Id, "the scene's speaker, not the export's");
 
         Assert.IsFalse(selections[0].IsAlreadyInScene);
-        Assert.IsNull(selections[0].ExistingScreenplayLineId);
+        Assert.IsNull(selections[0].ExistingLine);
     }
 
     [TestMethod]
@@ -318,7 +327,7 @@ public class DialogueImportDialogViewModelTests
     {
         // Every line already in the scene: taking them writes nothing, and the section is the only
         // thing that makes taking them worth anything.
-        var viewModel = ViewModel(existingLines: [InScene(1001), InScene(1002)], existingOptions: [1003UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1001), InScene(1002)], existingOptions: [OptionInScene(1003)]);
         viewModel.LoadPayload(ThreeLines);
 
         viewModel.SelectAllCommand.Execute(null);
@@ -368,10 +377,10 @@ public class DialogueImportDialogViewModelTests
         var imported = viewModel.GetLinesToImport();
 
         Assert.AreEqual(2, imported.Count);
-        Assert.AreEqual(1001UL, imported[0].Line.LocStringId);
-        Assert.AreEqual<uint?>(0u, imported[0].SpeakerActorId);
-        Assert.AreEqual<uint?>(1u, imported[0].AddresseeActorId, "the user's pick beats the matched name");
-        Assert.AreEqual(1003UL, imported[1].Line.LocStringId);
+        Assert.AreEqual(1001UL, (ulong)imported[0].Line.LocStringId);
+        Assert.AreEqual(0u, (uint)imported[0].Speaker!.Id);
+        Assert.AreEqual(1u, (uint)imported[0].Addressee!.Id, "the user's pick beats the matched name");
+        Assert.AreEqual(1003UL, (ulong)imported[1].Line.LocStringId);
     }
 
     [TestMethod]
@@ -384,14 +393,14 @@ public class DialogueImportDialogViewModelTests
 
         var imported = viewModel.GetLinesToImport();
 
-        Assert.IsNull(imported[0].SpeakerActorId);
-        Assert.AreEqual<uint?>(2u, imported[0].AddresseeActorId);
+        Assert.IsNull(imported[0].Speaker);
+        Assert.AreEqual(2u, (uint)imported[0].Addressee!.Id);
     }
 
     [TestMethod]
     public void NeverHandsBackALineTheSceneAlreadyCarriesAsOneToWrite()
     {
-        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [1003UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [OptionInScene(1003)]);
         viewModel.LoadPayload(ThreeLines);
 
         // Asked for outright, both of them. The line comes back marked as the scene's own, so the
@@ -415,7 +424,7 @@ public class DialogueImportDialogViewModelTests
     [TestMethod]
     public void SelectsAndDeselectsEverythingItIsAllowedTo()
     {
-        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [1003UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [OptionInScene(1003)]);
         viewModel.LoadPayload(ThreeLines);
 
         viewModel.SelectNoneCommand.Execute(null);
@@ -576,12 +585,11 @@ public class DialogueImportDialogViewModelTests
         Assert.AreEqual(1, viewModel.SelectedExistingCount);
         Assert.IsTrue(viewModel.HasSectionOnlySelection);
 
-        // Handed back saying the scene has it but naming no id, which is what tells the import to
-        // give the entry one.
+        // Existing entries with unassigned item ids are returned for repair.
         var selection = viewModel.GetLinesToImport().Single(line => line.Line.LocStringId == 1001);
 
         Assert.IsTrue(selection.IsAlreadyInScene);
-        Assert.IsNull(selection.ExistingScreenplayLineId);
+        Assert.IsFalse(SceneEditingHelper.HasAssignedItemId(selection.ExistingLine!.ItemId));
     }
 
     [TestMethod]
@@ -611,15 +619,17 @@ public class DialogueImportDialogViewModelTests
         viewModel.LoadPayload(TimedLines);
 
         var selection = viewModel.GetLinesToImport()[0];
-        var sectionLine = selection.ToSectionLine(257);
+        var sectionLine = selection.ToSectionLine(new scnscreenplayItemId { Id = 257 });
 
-        Assert.AreEqual(257U, sectionLine.ScreenplayLineId);
+        Assert.AreEqual(257U, (uint)sectionLine.ScreenplayLineId.Id);
         Assert.AreEqual(1_988U, sectionLine.DurationMs);
         Assert.AreEqual(1_500U, sectionLine.StartTimeMs, "where the export placed it in the conversation");
-        Assert.AreEqual(0U, sectionLine.SpeakerActorId, "Viktor Vektor, matched against the cast");
-        Assert.AreEqual(2U, sectionLine.AddresseeActorId, "V, which is always the first player actor");
-        Assert.AreEqual("Vo_Context_Quest", sectionLine.VoContext);
-        Assert.AreEqual("Vo_Expression_Spoken", sectionLine.VoExpression);
+        Assert.AreEqual(0U, (uint)sectionLine.Speaker!.Id, "Viktor Vektor, matched against the cast");
+        Assert.AreEqual(2U, (uint)sectionLine.Addressee!.Id, "V, which is always the first player actor");
+        Assert.AreEqual(Enums.locVoiceoverContext.Vo_Context_Quest, (Enums.locVoiceoverContext)sectionLine.VoContext!.Value);
+        Assert.AreEqual(
+            Enums.locVoiceoverExpression.Vo_Expression_Spoken,
+            (Enums.locVoiceoverExpression)sectionLine.VoExpression!.Value);
         Assert.AreEqual("Welcome to Night City.", sectionLine.Text);
     }
 

--- a/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
+++ b/Tests/WolvenKit.UnitTests/App/ViewModels/Dialogs/DialogueImportDialogViewModelTests.cs
@@ -44,9 +44,31 @@ public class DialogueImportDialogViewModelTests
         }
         """;
 
+    /// <summary>One line with everything a version 2 export says about how it is played.</summary>
+    private const string TimedLines = """
+        {
+          "format": "wolvenkit.scene.dialogue",
+          "version": 2,
+          "conversation": "Ripperdoc",
+          "lines": [
+            {
+              "locStringId": "1001",
+              "text": "Welcome to Night City.",
+              "speaker": "Viktor Vektor",
+              "addressee": "V",
+              "context": "Vo_Context_Quest",
+              "expression": "Vo_Expression_Spoken",
+              "duration": 1988,
+              "startTime": 1500,
+              "kind": "line"
+            }
+          ]
+        }
+        """;
+
     /// <summary>The scene these tests import into: two cast members and a player actor.</summary>
     private static DialogueImportDialogViewModel ViewModel(
-        IEnumerable<ulong>? existingLines = null,
+        IEnumerable<ExistingSceneLine>? existingLines = null,
         IEnumerable<ulong>? existingOptions = null) =>
         new(new DialogueImportDialogOptions(
             "q000_ripperdoc",
@@ -57,6 +79,20 @@ public class DialogueImportDialogViewModelTests
                 new SceneActorOption(1, "Jackie Welles"),
                 new SceneActorOption(2, "Player", isPlayer: true)
             ]));
+
+    /// <summary>A line the scene already carries, as the screenplay store would report it.</summary>
+    private static ExistingSceneLine InScene(
+        ulong locStringId,
+        uint? screenplayLineId = 4_097,
+        uint? speaker = null,
+        uint? addressee = null) =>
+        new()
+        {
+            LocStringId = locStringId,
+            ScreenplayLineId = screenplayLineId,
+            SpeakerActorId = speaker,
+            AddresseeActorId = addressee
+        };
 
     [TestMethod]
     public void NamesTheSceneItIsImportingInto()
@@ -148,18 +184,76 @@ public class DialogueImportDialogViewModelTests
     }
 
     [TestMethod]
-    public void LocksALineTheSceneAlreadyCarries()
+    public void OffersALineTheSceneAlreadyCarriesForTheSectionOnly()
     {
-        var viewModel = ViewModel(existingLines: [1002UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1002)]);
 
         viewModel.LoadPayload(ThreeLines);
 
-        Assert.IsTrue(viewModel.Entries[1].IsDuplicate);
-        Assert.IsFalse(viewModel.Entries[1].CanImport);
-        Assert.IsFalse(viewModel.Entries[1].IsSelected);
-        Assert.AreEqual("Already in scene", viewModel.Entries[1].Status);
+        var duplicate = viewModel.Entries[1];
+
+        // Takeable, but unticked to begin with: taking it writes nothing, and it is only worth
+        // anything to someone laying the whole conversation out as a section.
+        Assert.IsTrue(duplicate.IsDuplicate);
+        Assert.IsTrue(duplicate.IsSectionOnly);
+        Assert.IsTrue(duplicate.CanImport);
+        Assert.IsFalse(duplicate.IsSelected);
+        Assert.AreEqual("In scene - section only", duplicate.Status);
+
         Assert.AreEqual(1, viewModel.DuplicateCount);
         Assert.AreEqual(2, viewModel.SelectedCount);
+        Assert.AreEqual(2, viewModel.SelectedNewCount);
+        Assert.AreEqual(0, viewModel.SelectedExistingCount);
+    }
+
+    [TestMethod]
+    public void LocksAChoiceOptionTheSceneAlreadyCarries()
+    {
+        // Nothing plays an option - the player picks it - so there is nothing a section could do
+        // with one the scene already has.
+        var viewModel = ViewModel(existingOptions: [1003UL]);
+
+        viewModel.LoadPayload(ThreeLines);
+
+        var duplicate = viewModel.Entries[2];
+
+        Assert.IsTrue(duplicate.IsDuplicate);
+        Assert.IsFalse(duplicate.IsSectionOnly);
+        Assert.IsFalse(duplicate.CanImport);
+        Assert.IsFalse(duplicate.IsSelected);
+        Assert.AreEqual("Already in scene", duplicate.Status);
+    }
+
+    [TestMethod]
+    public void ShowsTheScenesOwnActorsOnALineItAlreadyCarries()
+    {
+        // The export says Viktor speaking to V. The scene says otherwise, and the scene wins: the
+        // entry is not being rewritten, so what it says is what will be played.
+        var viewModel = ViewModel(existingLines: [InScene(1001, speaker: 1, addressee: 0)]);
+
+        viewModel.LoadPayload(ThreeLines);
+
+        var duplicate = viewModel.Entries[0];
+
+        Assert.AreEqual(1u, duplicate.SpeakerActor.ActorId);
+        Assert.AreEqual(0u, duplicate.AddresseeActor.ActorId);
+        Assert.IsFalse(duplicate.CanSetActors, "not the import's to change");
+        Assert.IsTrue(duplicate.SpeakerToolTip.Contains("does not change"));
+    }
+
+    [TestMethod]
+    public void ShowsNoActorWhereTheSceneNamesNoneOrOneItNoLongerHas()
+    {
+        var viewModel = ViewModel(existingLines:
+        [
+            InScene(1001),
+            InScene(1002, speaker: 99)
+        ]);
+
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.IsTrue(viewModel.Entries[0].SpeakerActor.IsNone, "the entry names nobody");
+        Assert.IsTrue(viewModel.Entries[1].SpeakerActor.IsNone, "actor 99 is not in this cast");
     }
 
     [TestMethod]
@@ -167,12 +261,99 @@ public class DialogueImportDialogViewModelTests
     {
         // The two halves of the screenplay store number and key themselves independently, so a
         // locstring in one says nothing about the other.
-        var viewModel = ViewModel(existingLines: [1003UL], existingOptions: [1001UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1003)], existingOptions: [1001UL]);
 
         viewModel.LoadPayload(ThreeLines);
 
         Assert.IsFalse(viewModel.Entries[0].IsDuplicate, "a line is not an option");
         Assert.IsFalse(viewModel.Entries[2].IsDuplicate, "an option is not a line");
+    }
+
+    [TestMethod]
+    public void HandsBackTheEntryTheSceneAlreadyHasForALineTakenForTheSection()
+    {
+        var viewModel = ViewModel(existingLines: [InScene(1002, screenplayLineId: 4_097, speaker: 1)]);
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.Entries[1].IsSelected = true;
+
+        var selections = viewModel.GetLinesToImport();
+
+        // In payload order, so a section plays the conversation as it runs rather than putting the
+        // new lines first and the old ones after.
+        CollectionAssert.AreEqual(
+            new ulong[] { 1001, 1002, 1003 },
+            selections.Select(selection => selection.Line.LocStringId).ToArray());
+
+        var reused = selections[1];
+
+        Assert.IsTrue(reused.IsAlreadyInScene);
+        Assert.AreEqual(4_097U, reused.ExistingScreenplayLineId);
+        Assert.AreEqual(1U, reused.SpeakerActorId, "the scene's speaker, not the export's");
+
+        Assert.IsFalse(selections[0].IsAlreadyInScene);
+        Assert.IsNull(selections[0].ExistingScreenplayLineId);
+    }
+
+    [TestMethod]
+    public void CountsWhatWouldBeWrittenApartFromWhatWouldOnlyBePlayed()
+    {
+        var viewModel = ViewModel(existingLines: [InScene(1001), InScene(1002)]);
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.AreEqual(1, viewModel.SelectedNewCount, "the choice option is all that is new");
+        Assert.AreEqual(0, viewModel.SelectedExistingCount);
+        Assert.IsFalse(viewModel.HasSectionOnlySelection);
+
+        viewModel.SelectAllCommand.Execute(null);
+
+        Assert.AreEqual(3, viewModel.SelectedCount);
+        Assert.AreEqual(1, viewModel.SelectedNewCount);
+        Assert.AreEqual(2, viewModel.SelectedExistingCount);
+        Assert.IsTrue(viewModel.HasSectionOnlySelection);
+    }
+
+    [TestMethod]
+    public void RefusesARunThatWouldLeaveTheSceneExactlyAsItWas()
+    {
+        // Every line already in the scene: taking them writes nothing, and the section is the only
+        // thing that makes taking them worth anything.
+        var viewModel = ViewModel(existingLines: [InScene(1001), InScene(1002)], existingOptions: [1003UL]);
+        viewModel.LoadPayload(ThreeLines);
+
+        viewModel.SelectAllCommand.Execute(null);
+
+        Assert.AreEqual(2, viewModel.SelectedCount);
+        Assert.AreEqual(0, viewModel.SelectedNewCount);
+        Assert.IsTrue(viewModel.CanImport, "the section is asked for by default");
+
+        // Turned off, ticking them would write nothing and build nothing, so there is nothing to
+        // finish.
+        viewModel.CreateSectionNode = false;
+        Assert.IsFalse(viewModel.CanImport);
+
+        viewModel.CreateSectionNode = true;
+        Assert.IsTrue(viewModel.CanImport);
+    }
+
+    [TestMethod]
+    public void CountsALineTheSceneAlreadyHasAsTheUserTicksIt()
+    {
+        // Ticking one row rather than using Select All, which is the other way the counts are
+        // reached: the row raises its own change and the totals are taken again.
+        var viewModel = ViewModel(existingLines: [InScene(1002)]);
+        viewModel.LoadPayload(ThreeLines);
+
+        Assert.AreEqual(0, viewModel.SelectedExistingCount, "it starts unticked");
+        Assert.IsFalse(viewModel.HasSectionOnlySelection);
+        Assert.AreEqual(2, viewModel.SelectedNewCount, "the other line and the choice option");
+
+        viewModel.Entries[1].IsSelected = true;
+
+        Assert.AreEqual(1, viewModel.SelectedExistingCount);
+        Assert.IsTrue(viewModel.HasSectionOnlySelection);
+        Assert.AreEqual(2, viewModel.SelectedNewCount, "unchanged - it writes nothing to the store");
+        Assert.AreEqual(3, viewModel.SelectedCount);
     }
 
     [TestMethod]
@@ -208,22 +389,33 @@ public class DialogueImportDialogViewModelTests
     }
 
     [TestMethod]
-    public void NeverHandsBackALineTheSceneAlreadyCarries()
+    public void NeverHandsBackALineTheSceneAlreadyCarriesAsOneToWrite()
     {
-        var viewModel = ViewModel(existingLines: [1001UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [1003UL]);
         viewModel.LoadPayload(ThreeLines);
 
-        // Even asked for outright: a duplicate is filtered on the way out as well as locked in the
-        // list, so a payload swapped out from under the selection cannot smuggle one in.
+        // Asked for outright, both of them. The line comes back marked as the scene's own, so the
+        // import plays it rather than writing it; the option does not come back at all.
         viewModel.Entries[0].IsSelected = true;
+        viewModel.Entries[2].IsSelected = true;
 
-        Assert.IsFalse(viewModel.GetLinesToImport().Any(selection => selection.Line.LocStringId == 1001UL));
+        var selections = viewModel.GetLinesToImport();
+
+        var line = selections.Single(selection => selection.Line.LocStringId == 1001UL);
+        Assert.IsTrue(line.IsAlreadyInScene);
+
+        Assert.IsFalse(
+            selections.Any(selection => selection.Line.LocStringId == 1003UL),
+            "a duplicate option is filtered on the way out as well as locked in the list");
+
+        // Nothing that would be written to the store is one the scene already has.
+        Assert.IsFalse(selections.Any(selection => !selection.IsAlreadyInScene && selection.Line.LocStringId == 1001UL));
     }
 
     [TestMethod]
     public void SelectsAndDeselectsEverythingItIsAllowedTo()
     {
-        var viewModel = ViewModel(existingLines: [1001UL]);
+        var viewModel = ViewModel(existingLines: [InScene(1001)], existingOptions: [1003UL]);
         viewModel.LoadPayload(ThreeLines);
 
         viewModel.SelectNoneCommand.Execute(null);
@@ -233,8 +425,10 @@ public class DialogueImportDialogViewModelTests
 
         viewModel.SelectAllCommand.Execute(null);
 
-        Assert.AreEqual(2, viewModel.SelectedCount, "the duplicate stays out of it");
-        Assert.IsFalse(viewModel.Entries[0].IsSelected);
+        // The duplicate line comes along, for a section's sake; the duplicate option cannot.
+        Assert.AreEqual(2, viewModel.SelectedCount);
+        Assert.IsTrue(viewModel.Entries[0].IsSelected);
+        Assert.IsFalse(viewModel.Entries[2].IsSelected, "no section plays a choice option");
         Assert.IsTrue(viewModel.CanImport);
     }
 
@@ -358,4 +552,75 @@ public class DialogueImportDialogViewModelTests
         Assert.IsFalse(viewModel.HasEntries);
         Assert.IsFalse(viewModel.CanImport);
     }
+
+    [TestMethod]
+    public void TakesAnEntryThatCarriesNoItemIdSoTheImportCanGiveItOne()
+    {
+        // A line added through the raw chunk editor and never given an item id. The scene has it, so
+        // it is not imported again, but it can still be taken: the import gives the entry an id and
+        // the section plays it.
+        var viewModel = ViewModel(existingLines: [InScene(1001, screenplayLineId: null)]);
+        viewModel.LoadPayload(ThreeLines);
+
+        var entry = viewModel.Entries[0];
+
+        Assert.IsTrue(entry.IsDuplicate, "the scene has this locstring");
+        Assert.IsTrue(entry.IsSectionOnly, "nothing is written to the store for it");
+        Assert.IsTrue(entry.NeedsItemId);
+        Assert.IsTrue(entry.CanImport, "so the row is the user's to tick");
+        Assert.IsFalse(entry.CanSetActors, "the entry is not being rewritten");
+        Assert.AreEqual("In scene - needs item id", entry.Status);
+
+        viewModel.SelectAllCommand.Execute(null);
+
+        Assert.AreEqual(1, viewModel.SelectedExistingCount);
+        Assert.IsTrue(viewModel.HasSectionOnlySelection);
+
+        // Handed back saying the scene has it but naming no id, which is what tells the import to
+        // give the entry one.
+        var selection = viewModel.GetLinesToImport().Single(line => line.Line.LocStringId == 1001);
+
+        Assert.IsTrue(selection.IsAlreadyInScene);
+        Assert.IsNull(selection.ExistingScreenplayLineId);
+    }
+
+    [TestMethod]
+    public void LaysTheConversationOutUnlessTheUserSaysOtherwise()
+    {
+        // Lines in the store with nothing playing them is half an import, so the section is on and
+        // the user unticks it.
+        Assert.IsTrue(ViewModel().CreateSectionNode);
+    }
+
+    [TestMethod]
+    public void HandsBackTheConversationTheExportNamed()
+    {
+        var viewModel = ViewModel();
+
+        viewModel.LoadPayload(ThreeLines);
+        Assert.AreEqual("Ripperdoc", viewModel.ConversationName);
+
+        viewModel.LoadPayload("not json at all");
+        Assert.AreEqual("", viewModel.ConversationName, "a payload that would not read names nothing");
+    }
+
+    [TestMethod]
+    public void CarriesALinesTimingAndActorsThroughToTheSection()
+    {
+        var viewModel = ViewModel();
+        viewModel.LoadPayload(TimedLines);
+
+        var selection = viewModel.GetLinesToImport()[0];
+        var sectionLine = selection.ToSectionLine(257);
+
+        Assert.AreEqual(257U, sectionLine.ScreenplayLineId);
+        Assert.AreEqual(1_988U, sectionLine.DurationMs);
+        Assert.AreEqual(1_500U, sectionLine.StartTimeMs, "where the export placed it in the conversation");
+        Assert.AreEqual(0U, sectionLine.SpeakerActorId, "Viktor Vektor, matched against the cast");
+        Assert.AreEqual(2U, sectionLine.AddresseeActorId, "V, which is always the first player actor");
+        Assert.AreEqual("Vo_Context_Quest", sectionLine.VoContext);
+        Assert.AreEqual("Vo_Expression_Spoken", sectionLine.VoExpression);
+        Assert.AreEqual("Welcome to Night City.", sectionLine.Text);
+    }
+
 }

--- a/WolvenKit.App/Helpers/DialogueImportHelper.cs
+++ b/WolvenKit.App/Helpers/DialogueImportHelper.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using WolvenKit.RED4.Types;
+using static WolvenKit.RED4.Types.Enums;
 
 namespace WolvenKit.App.Helpers;
 
@@ -17,7 +19,7 @@ namespace WolvenKit.App.Helpers;
 public sealed class ImportedDialogueLine
 {
     /// <summary>Locstring id the recording is registered under.</summary>
-    public ulong LocStringId { get; init; }
+    public CRUID LocStringId { get; init; }
 
     /// <summary>
     /// The one subtitle the scene's locstore gets for this line, picked from the variants below.
@@ -69,14 +71,11 @@ public sealed class ImportedDialogueLine
     /// </summary>
     public uint? StartTimeMs { get; init; }
 
-    /// <summary>
-    /// The <c>locVoiceoverContext</c> the line is recorded under, by name - "Vo_Context_Quest" and
-    /// the like. Kept as the export wrote it; whether the game knows the name is checked later.
-    /// </summary>
-    public string VoContext { get; init; } = "";
+    /// <summary>Voiceover context for the line.</summary>
+    public CEnum<locVoiceoverContext>? VoContext { get; init; }
 
-    /// <inheritdoc cref="VoContext"/>
-    public string VoExpression { get; init; } = "";
+    /// <summary>Voiceover expression for the line.</summary>
+    public CEnum<locVoiceoverExpression>? VoExpression { get; init; }
 
     /// <summary>
     /// Where the line falls in the conversation, counting from 1, or 0 where the export did not say.
@@ -118,33 +117,6 @@ public sealed class DialogueImportPayload
     public bool IsValid => Error is null && Lines.Count > 0;
 
     public static DialogueImportPayload Failed(string error) => new() { Error = error };
-}
-
-/// <summary>
-/// A screenplay line the scene already carries. An import never writes one of these a second time -
-/// two entries on one recording cannot be told apart afterwards - but a section can still play the
-/// entry that is there, which is how a conversation imported in pieces gets a section.
-/// </summary>
-public sealed class ExistingSceneLine
-{
-    /// <summary>Locstring id the entry is keyed on, which an import is matched against.</summary>
-    public required ulong LocStringId { get; init; }
-
-    /// <summary>
-    /// The entry's item id, which a section's dialogue event points at to play it. Null where the
-    /// entry was left on <see cref="SceneEditingHelper.UnassignedScreenplayItemId"/> - the id an
-    /// event means "points at nothing" by - in which case the import gives it one.
-    /// </summary>
-    public required uint? ScreenplayLineId { get; init; }
-
-    /// <summary>
-    /// Who the scene has saying it, or null where the entry names nobody. Read off the entry, not
-    /// the export: the entry is not being rewritten, so the scene's answer holds.
-    /// </summary>
-    public uint? SpeakerActorId { get; init; }
-
-    /// <inheritdoc cref="SpeakerActorId"/>
-    public uint? AddresseeActorId { get; init; }
 }
 
 /// <summary>
@@ -301,7 +273,7 @@ public static class DialogueImportHelper
     /// <c>startTime</c>. Version 1 wrote seconds, and the unit cannot be told from the number - 2 is
     /// either two seconds or a fifth of a frame - so only the version says which.
     /// </summary>
-    private const int MillisecondTimingVersion = 2;
+    private const int millisecondTimingVersion = 2;
 
     /// <summary>
     /// The longest a line's stated length can be and still be believed. No single recording runs
@@ -312,13 +284,13 @@ public static class DialogueImportHelper
     /// The same ceiling as <see cref="SceneSectionBuilder.MaxLineDurationMs"/>, so a length believed
     /// here is one a section plays in full. Move the two together.
     /// </remarks>
-    private const double MaxLineDurationMs = 300_000;
+    private const double maxLineDurationMs = 300_000;
 
     /// <summary>
     /// The latest a line can be said to start. A start time past this would leave a section running
     /// for hours with nothing in it.
     /// </summary>
-    private const double MaxStartTimeMs = 3_600_000;
+    private const double maxStartTimeMs = 3_600_000;
 
     /// <summary>
     /// Where the Dialogue Browser writes its exports, relative to a Cyberpunk install. Named here
@@ -331,11 +303,20 @@ public static class DialogueImportHelper
     public static string GetExportDirectory(string gameRootDir) =>
         Path.Combine(gameRootDir, ExportDirectoryRelativePath);
 
+    /// <summary>JSON parser settings for import payloads.</summary>
     private static readonly JsonSerializerOptions s_options = new()
     {
         PropertyNameCaseInsensitive = true,
         AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        Converters =
+        {
+            new LocStringIdConverter(),
+            new LenientDoubleConverter(),
+            new LenientInt32Converter(),
+            new RedEnumNameConverter<locVoiceoverContext>(),
+            new RedEnumNameConverter<locVoiceoverExpression>()
+        }
     };
 
     /// <summary>
@@ -408,16 +389,18 @@ public static class DialogueImportHelper
         }
 
         // How to read the lines' timings. Taken once: every line in a payload shares the version.
-        var version = ReadVersion(payload.Version);
-        var isMillisecondTiming = version >= MillisecondTimingVersion;
+        // Missing or invalid versions use the oldest payload format.
+        var version = Math.Max(payload.Version ?? 0, 0);
+        var isMillisecondTiming = version >= millisecondTimingVersion;
 
         var lines = new List<ImportedDialogueLine>(payload.Lines.Count);
         var skipped = 0;
-        var seen = new HashSet<ulong>();
+        var seen = new HashSet<CRUID>();
 
         foreach (var dto in payload.Lines)
         {
-            if (dto is null || !TryReadLocStringId(dto.LocStringId, out var locStringId) || locStringId == 0)
+            // Lines without a usable locstring id cannot be imported.
+            if (dto is null || dto.LocStringId is not { } locStringId || locStringId == 0)
             {
                 skipped++;
                 continue;
@@ -445,9 +428,9 @@ public static class DialogueImportHelper
                 MaleLipsyncAnim = dto.MaleLipsyncAnim?.Trim() ?? "",
                 DurationMs = ReadDurationMs(dto.Duration, isMillisecondTiming),
                 StartTimeMs = ReadStartTimeMs(dto.StartTime),
-                VoContext = dto.Context?.Trim() ?? "",
-                VoExpression = dto.Expression?.Trim() ?? "",
-                Order = ReadOrder(dto.Order),
+                VoContext = dto.Context,
+                VoExpression = dto.Expression,
+                Order = dto.Order is > 0 ? dto.Order.Value : 0,
                 IsChoiceOption = string.Equals(dto.Kind, "option", StringComparison.OrdinalIgnoreCase)
             });
         }
@@ -468,43 +451,20 @@ public static class DialogueImportHelper
     }
 
     /// <summary>
-    /// Locstring ids are 64 bit, so an exporter is free to write one as a string to keep it out of
-    /// a language's float; both forms are read here.
+    /// Converts a stated line duration to milliseconds and rejects unusable values.
     /// </summary>
-    private static bool TryReadLocStringId(JsonElement element, out ulong value)
+    /// <param name="duration">The stated duration in the payload unit.</param>
+    /// <param name="isMilliseconds">Whether the payload unit is milliseconds.</param>
+    private static uint ReadDurationMs(double? duration, bool isMilliseconds)
     {
-        value = 0;
-
-        if (element.ValueKind == JsonValueKind.String)
-        {
-            return ulong.TryParse(element.GetString()?.Trim(), NumberStyles.Integer,
-                CultureInfo.InvariantCulture, out value);
-        }
-
-        if (element.ValueKind == JsonValueKind.Number)
-        {
-            return element.TryGetUInt64(out value);
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// A line's length in milliseconds. Written in milliseconds from
-    /// <see cref="MillisecondTimingVersion"/> on and in seconds before it, so the same number means
-    /// different things by version. Anything that is not a length a line could run - a negative, a
-    /// NaN, an hour - reads as "not said".
-    /// </summary>
-    private static uint ReadDurationMs(JsonElement element, bool isMilliseconds)
-    {
-        if (!TryReadNumber(element, out var duration))
+        if (duration is not { } stated)
         {
             return 0;
         }
 
-        var milliseconds = isMilliseconds ? duration : duration * 1000;
+        var milliseconds = isMilliseconds ? stated : stated * 1000;
 
-        if (milliseconds <= 0 || milliseconds > MaxLineDurationMs)
+        if (milliseconds <= 0 || milliseconds > maxLineDurationMs)
         {
             return 0;
         }
@@ -516,74 +476,15 @@ public static class DialogueImportHelper
     /// Where a line starts, in milliseconds from the beginning of the conversation, or null where
     /// the export said nothing. 0 is a start time in its own right, so it cannot mean "not said".
     /// </summary>
-    private static uint? ReadStartTimeMs(JsonElement element)
+    /// <param name="startTime">The stated start time in milliseconds.</param>
+    private static uint? ReadStartTimeMs(double? startTime)
     {
-        if (!TryReadNumber(element, out var startTime))
+        if (startTime is not { } stated || double.IsNegative(stated) || stated > maxStartTimeMs)
         {
             return null;
         }
 
-        if (double.IsNegative(startTime) || startTime > MaxStartTimeMs)
-        {
-            return null;
-        }
-
-        return (uint)Math.Round(startTime);
-    }
-
-    /// <summary>
-    /// A number an export may have written as a number or as a string, as it may with a locstring
-    /// id. False for anything that is not a number, NaN and infinity among them.
-    /// </summary>
-    private static bool TryReadNumber(JsonElement element, out double value)
-    {
-        value = 0;
-
-        bool read;
-
-        if (element.ValueKind == JsonValueKind.Number)
-        {
-            read = element.TryGetDouble(out value);
-        }
-        else if (element.ValueKind == JsonValueKind.String)
-        {
-            read = double.TryParse(element.GetString()?.Trim(), NumberStyles.Float,
-                CultureInfo.InvariantCulture, out value);
-        }
-        else
-        {
-            return false;
-        }
-
-        return read && !double.IsNaN(value) && !double.IsInfinity(value);
-    }
-
-    /// <summary>
-    /// The format version the payload declared, or 0 where it declared none, which reads as the
-    /// oldest.
-    /// </summary>
-    private static int ReadVersion(JsonElement element) =>
-        TryReadNumber(element, out var version) && version > 0 && version < int.MaxValue
-            ? (int)version
-            : 0;
-
-    /// <summary>Where the export puts the line in its conversation, or 0 where it does not say.</summary>
-    private static int ReadOrder(JsonElement element)
-    {
-        if (element.ValueKind == JsonValueKind.Number)
-        {
-            return element.TryGetInt32(out var order) && order > 0 ? order : 0;
-        }
-
-        if (element.ValueKind == JsonValueKind.String)
-        {
-            return int.TryParse(element.GetString()?.Trim(), NumberStyles.Integer,
-                CultureInfo.InvariantCulture, out var order) && order > 0
-                ? order
-                : 0;
-        }
-
-        return 0;
+        return (uint)Math.Round(stated);
     }
 
     /// <summary>
@@ -614,13 +515,13 @@ public static class DialogueImportHelper
         public string? Format { get; set; }
         public string? Conversation { get; set; }
         public string? Source { get; set; }
-        public JsonElement Version { get; set; }
+        public int? Version { get; set; }
         public List<LineDto>? Lines { get; set; }
     }
 
     private sealed class LineDto
     {
-        [JsonPropertyName("locStringId")] public JsonElement LocStringId { get; set; }
+        [JsonPropertyName("locStringId")] public CRUID? LocStringId { get; set; }
         public string? Text { get; set; }
         public string? FemaleText { get; set; }
         public string? MaleText { get; set; }
@@ -629,15 +530,195 @@ public static class DialogueImportHelper
         public string? FemaleLipsyncAnim { get; set; }
         public string? MaleLipsyncAnim { get; set; }
         public string? Kind { get; set; }
+        public double? Duration { get; set; }
+        public double? StartTime { get; set; }
+        public CEnum<locVoiceoverContext>? Context { get; set; }
+        public CEnum<locVoiceoverExpression>? Expression { get; set; }
+        public int? Order { get; set; }
+    }
 
-        /// <summary>A <see cref="JsonElement"/> for the same reason the locstring id is.</summary>
-        public JsonElement Duration { get; set; }
+    /// <summary>
+    /// Reads a locstring id from a JSON number or string.
+    /// Invalid values return 0 so callers can skip the line.
+    /// </summary>
+    private sealed class LocStringIdConverter : JsonConverter<CRUID?>
+    {
+        public override CRUID? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Number:
+                    // Avoid double conversion so large ids are not rounded.
+                    return reader.TryGetUInt64(out var number) ? number : 0;
 
-        /// <inheritdoc cref="Duration"/>
-        public JsonElement StartTime { get; set; }
+                case JsonTokenType.String:
+                    return ulong.TryParse(reader.GetString()?.Trim(), NumberStyles.Integer,
+                        CultureInfo.InvariantCulture, out var text)
+                        ? text
+                        : 0;
 
-        public string? Context { get; set; }
-        public string? Expression { get; set; }
-        public JsonElement Order { get; set; }
+                default:
+                    SkipValue(ref reader);
+                    return 0;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, CRUID? value, JsonSerializerOptions options)
+        {
+            // Write as a string so readers that parse numbers as doubles do not round large ids.
+            if (value is { } locStringId)
+            {
+                writer.WriteStringValue(((ulong)locStringId).ToString(CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads a nullable number from a JSON number or string.
+    /// Invalid or non-finite values return null.
+    /// </summary>
+    private sealed class LenientDoubleConverter : JsonConverter<double?>
+    {
+        public override double? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            double value;
+
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Number:
+                    if (!reader.TryGetDouble(out value))
+                    {
+                        return null;
+                    }
+
+                    break;
+
+                case JsonTokenType.String:
+                    if (!double.TryParse(reader.GetString()?.Trim(), NumberStyles.Float,
+                            CultureInfo.InvariantCulture, out value))
+                    {
+                        return null;
+                    }
+
+                    break;
+
+                default:
+                    SkipValue(ref reader);
+                    return null;
+            }
+
+            // String parsing can produce NaN or Infinity, which are not valid timings.
+            return double.IsFinite(value) ? value : null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, double? value, JsonSerializerOptions options)
+        {
+            if (value is { } number)
+            {
+                writer.WriteNumberValue(number);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+        }
+    }
+
+    /// <inheritdoc cref="LenientDoubleConverter"/>
+    private sealed class LenientInt32Converter : JsonConverter<int?>
+    {
+        public override int? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Number:
+                    return reader.TryGetInt32(out var number) ? number : null;
+
+                case JsonTokenType.String:
+                    return int.TryParse(reader.GetString()?.Trim(), NumberStyles.Integer,
+                        CultureInfo.InvariantCulture, out var text)
+                        ? text
+                        : null;
+
+                default:
+                    SkipValue(ref reader);
+                    return null;
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, int? value, JsonSerializerOptions options)
+        {
+            if (value is { } number)
+            {
+                writer.WriteNumberValue(number);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads a RED enum from a JSON string and returns null for unknown values or numeric strings.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Enum.TryParse{T}(string, bool, out T)"/> accepts numeric strings, so accepted
+    /// values are looked up by declared name instead.
+    /// </remarks>
+    /// <typeparam name="T">The RED enum type.</typeparam>
+    private sealed class RedEnumNameConverter<T> : JsonConverter<CEnum<T>?> where T : struct, Enum
+    {
+        private static readonly IReadOnlyDictionary<string, T> s_valuesByName =
+            Enum.GetNames<T>().ToDictionary(
+                name => name,
+                name => Enum.Parse<T>(name),
+                StringComparer.OrdinalIgnoreCase);
+
+        public override CEnum<T>? Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                SkipValue(ref reader);
+                return null;
+            }
+
+            var name = reader.GetString()?.Trim();
+
+            return !string.IsNullOrEmpty(name) && s_valuesByName.TryGetValue(name, out var value)
+                ? value
+                : null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, CEnum<T>? value, JsonSerializerOptions options)
+        {
+            if (value is { } redEnum)
+            {
+                writer.WriteStringValue(redEnum.ToEnumString());
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Skips object or array values that a converter does not handle.
+    /// </summary>
+    private static void SkipValue(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+        {
+            reader.Skip();
+        }
     }
 }

--- a/WolvenKit.App/Helpers/DialogueImportHelper.cs
+++ b/WolvenKit.App/Helpers/DialogueImportHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -52,6 +53,37 @@ public sealed class ImportedDialogueLine
     public string MaleLipsyncAnim { get; init; } = "";
 
     /// <summary>
+    /// How long the recording runs, in milliseconds, or 0 where the export gave no length and a
+    /// section has to estimate one.
+    /// </summary>
+    /// <remarks>
+    /// Where an export times each recorded variant, this is the longer of the two: one event plays
+    /// whichever V is speaking, and the shorter take would cut the other off.
+    /// </remarks>
+    public uint DurationMs { get; init; }
+
+    /// <summary>
+    /// Where the line starts, in milliseconds from the beginning of the conversation. Null where the
+    /// export did not say - an older payload, or a hand-written one - leaving it to whoever lays the
+    /// lines out.
+    /// </summary>
+    public uint? StartTimeMs { get; init; }
+
+    /// <summary>
+    /// The <c>locVoiceoverContext</c> the line is recorded under, by name - "Vo_Context_Quest" and
+    /// the like. Kept as the export wrote it; whether the game knows the name is checked later.
+    /// </summary>
+    public string VoContext { get; init; } = "";
+
+    /// <inheritdoc cref="VoContext"/>
+    public string VoExpression { get; init; } = "";
+
+    /// <summary>
+    /// Where the line falls in the conversation, counting from 1, or 0 where the export did not say.
+    /// </summary>
+    public int Order { get; init; }
+
+    /// <summary>
     /// Whether the line belongs in the screenplay store's options rather than its lines. A choice
     /// option has no recording behind it, so exports from a conversation are never one.
     /// </summary>
@@ -71,6 +103,12 @@ public sealed class DialogueImportPayload
     /// <summary>Tool and version that wrote the payload, when it said.</summary>
     public string Source { get; init; } = "";
 
+    /// <summary>
+    /// The payload format's version, or 0 where the export declared none. See
+    /// <see cref="DialogueImportHelper.PayloadVersion"/> for what the versions mean.
+    /// </summary>
+    public int Version { get; init; }
+
     /// <summary>Entries that carried no usable locstring id and were dropped.</summary>
     public int SkippedCount { get; init; }
 
@@ -80,6 +118,33 @@ public sealed class DialogueImportPayload
     public bool IsValid => Error is null && Lines.Count > 0;
 
     public static DialogueImportPayload Failed(string error) => new() { Error = error };
+}
+
+/// <summary>
+/// A screenplay line the scene already carries. An import never writes one of these a second time -
+/// two entries on one recording cannot be told apart afterwards - but a section can still play the
+/// entry that is there, which is how a conversation imported in pieces gets a section.
+/// </summary>
+public sealed class ExistingSceneLine
+{
+    /// <summary>Locstring id the entry is keyed on, which an import is matched against.</summary>
+    public required ulong LocStringId { get; init; }
+
+    /// <summary>
+    /// The entry's item id, which a section's dialogue event points at to play it. Null where the
+    /// entry was left on <see cref="SceneEditingHelper.UnassignedScreenplayItemId"/> - the id an
+    /// event means "points at nothing" by - in which case the import gives it one.
+    /// </summary>
+    public required uint? ScreenplayLineId { get; init; }
+
+    /// <summary>
+    /// Who the scene has saying it, or null where the entry names nobody. Read off the entry, not
+    /// the export: the entry is not being rewritten, so the scene's answer holds.
+    /// </summary>
+    public uint? SpeakerActorId { get; init; }
+
+    /// <inheritdoc cref="SpeakerActorId"/>
+    public uint? AddresseeActorId { get; init; }
 }
 
 /// <summary>
@@ -228,6 +293,33 @@ public static class DialogueImportHelper
 {
     public const string PayloadFormat = "wolvenkit.scene.dialogue";
 
+    /// <summary>The payload version this was written against, and what the exporter writes now.</summary>
+    public const int PayloadVersion = 2;
+
+    /// <summary>
+    /// The version from which <c>duration</c> is milliseconds and a line carries its own
+    /// <c>startTime</c>. Version 1 wrote seconds, and the unit cannot be told from the number - 2 is
+    /// either two seconds or a fifth of a frame - so only the version says which.
+    /// </summary>
+    private const int MillisecondTimingVersion = 2;
+
+    /// <summary>
+    /// The longest a line's stated length can be and still be believed. No single recording runs
+    /// five minutes, so a payload saying it does is writing something other than what it declared.
+    /// A length past this reads as "not said" and is estimated from the text instead.
+    /// </summary>
+    /// <remarks>
+    /// The same ceiling as <see cref="SceneSectionBuilder.MaxLineDurationMs"/>, so a length believed
+    /// here is one a section plays in full. Move the two together.
+    /// </remarks>
+    private const double MaxLineDurationMs = 300_000;
+
+    /// <summary>
+    /// The latest a line can be said to start. A start time past this would leave a section running
+    /// for hours with nothing in it.
+    /// </summary>
+    private const double MaxStartTimeMs = 3_600_000;
+
     /// <summary>
     /// Where the Dialogue Browser writes its exports, relative to a Cyberpunk install. Named here
     /// rather than in the file picker so the dialog can tell the user the same path it opens.
@@ -315,6 +407,10 @@ public static class DialogueImportHelper
             return DialogueImportPayload.Failed("No dialogue lines in that import.");
         }
 
+        // How to read the lines' timings. Taken once: every line in a payload shares the version.
+        var version = ReadVersion(payload.Version);
+        var isMillisecondTiming = version >= MillisecondTimingVersion;
+
         var lines = new List<ImportedDialogueLine>(payload.Lines.Count);
         var skipped = 0;
         var seen = new HashSet<ulong>();
@@ -347,6 +443,11 @@ public static class DialogueImportHelper
                 Addressee = dto.Addressee?.Trim() ?? "",
                 FemaleLipsyncAnim = dto.FemaleLipsyncAnim?.Trim() ?? "",
                 MaleLipsyncAnim = dto.MaleLipsyncAnim?.Trim() ?? "",
+                DurationMs = ReadDurationMs(dto.Duration, isMillisecondTiming),
+                StartTimeMs = ReadStartTimeMs(dto.StartTime),
+                VoContext = dto.Context?.Trim() ?? "",
+                VoExpression = dto.Expression?.Trim() ?? "",
+                Order = ReadOrder(dto.Order),
                 IsChoiceOption = string.Equals(dto.Kind, "option", StringComparison.OrdinalIgnoreCase)
             });
         }
@@ -358,9 +459,10 @@ public static class DialogueImportHelper
 
         return new DialogueImportPayload
         {
-            Lines = lines,
+            Lines = SortByConversationOrder(lines),
             ConversationName = payload.Conversation?.Trim() ?? "",
             Source = payload.Source?.Trim() ?? "",
+            Version = version,
             SkippedCount = skipped
         };
     }
@@ -387,6 +489,113 @@ public static class DialogueImportHelper
         return false;
     }
 
+    /// <summary>
+    /// A line's length in milliseconds. Written in milliseconds from
+    /// <see cref="MillisecondTimingVersion"/> on and in seconds before it, so the same number means
+    /// different things by version. Anything that is not a length a line could run - a negative, a
+    /// NaN, an hour - reads as "not said".
+    /// </summary>
+    private static uint ReadDurationMs(JsonElement element, bool isMilliseconds)
+    {
+        if (!TryReadNumber(element, out var duration))
+        {
+            return 0;
+        }
+
+        var milliseconds = isMilliseconds ? duration : duration * 1000;
+
+        if (milliseconds <= 0 || milliseconds > MaxLineDurationMs)
+        {
+            return 0;
+        }
+
+        return (uint)Math.Round(milliseconds);
+    }
+
+    /// <summary>
+    /// Where a line starts, in milliseconds from the beginning of the conversation, or null where
+    /// the export said nothing. 0 is a start time in its own right, so it cannot mean "not said".
+    /// </summary>
+    private static uint? ReadStartTimeMs(JsonElement element)
+    {
+        if (!TryReadNumber(element, out var startTime))
+        {
+            return null;
+        }
+
+        if (double.IsNegative(startTime) || startTime > MaxStartTimeMs)
+        {
+            return null;
+        }
+
+        return (uint)Math.Round(startTime);
+    }
+
+    /// <summary>
+    /// A number an export may have written as a number or as a string, as it may with a locstring
+    /// id. False for anything that is not a number, NaN and infinity among them.
+    /// </summary>
+    private static bool TryReadNumber(JsonElement element, out double value)
+    {
+        value = 0;
+
+        bool read;
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            read = element.TryGetDouble(out value);
+        }
+        else if (element.ValueKind == JsonValueKind.String)
+        {
+            read = double.TryParse(element.GetString()?.Trim(), NumberStyles.Float,
+                CultureInfo.InvariantCulture, out value);
+        }
+        else
+        {
+            return false;
+        }
+
+        return read && !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    /// <summary>
+    /// The format version the payload declared, or 0 where it declared none, which reads as the
+    /// oldest.
+    /// </summary>
+    private static int ReadVersion(JsonElement element) =>
+        TryReadNumber(element, out var version) && version > 0 && version < int.MaxValue
+            ? (int)version
+            : 0;
+
+    /// <summary>Where the export puts the line in its conversation, or 0 where it does not say.</summary>
+    private static int ReadOrder(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out var order) && order > 0 ? order : 0;
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return int.TryParse(element.GetString()?.Trim(), NumberStyles.Integer,
+                CultureInfo.InvariantCulture, out var order) && order > 0
+                ? order
+                : 0;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// The lines in conversation order, where every one of them says where it falls. A payload
+    /// missing even one order is left as written: a partial ordering would move the lines that have
+    /// one past the lines that do not.
+    /// </summary>
+    private static List<ImportedDialogueLine> SortByConversationOrder(List<ImportedDialogueLine> lines) =>
+        lines.TrueForAll(line => line.Order > 0)
+            ? lines.OrderBy(line => line.Order).ToList()
+            : lines;
+
     private static string FirstNonEmpty(params string?[] values)
     {
         foreach (var value in values)
@@ -405,6 +614,7 @@ public static class DialogueImportHelper
         public string? Format { get; set; }
         public string? Conversation { get; set; }
         public string? Source { get; set; }
+        public JsonElement Version { get; set; }
         public List<LineDto>? Lines { get; set; }
     }
 
@@ -419,5 +629,15 @@ public static class DialogueImportHelper
         public string? FemaleLipsyncAnim { get; set; }
         public string? MaleLipsyncAnim { get; set; }
         public string? Kind { get; set; }
+
+        /// <summary>A <see cref="JsonElement"/> for the same reason the locstring id is.</summary>
+        public JsonElement Duration { get; set; }
+
+        /// <inheritdoc cref="Duration"/>
+        public JsonElement StartTime { get; set; }
+
+        public string? Context { get; set; }
+        public string? Expression { get; set; }
+        public JsonElement Order { get; set; }
     }
 }

--- a/WolvenKit.App/Helpers/SceneEditingHelper.cs
+++ b/WolvenKit.App/Helpers/SceneEditingHelper.cs
@@ -291,6 +291,13 @@ namespace WolvenKit.App.Helpers
                 options?.Select(option => ItemIdOf(option?.ItemId)) ?? [],
                 FirstChoiceOptionItemId);
 
+        /// <summary>
+        /// Whether an item id is present and not the unassigned sentinel.
+        /// </summary>
+        /// <param name="itemId">The item id to check.</param>
+        public static bool HasAssignedItemId(scnscreenplayItemId? itemId) =>
+            itemId is not null && itemId.Id != UnassignedScreenplayItemId;
+
         /// <summary>An entry's id, or the unassigned one where the raw editor left it without.</summary>
         private static uint ItemIdOf(scnscreenplayItemId? itemId) =>
             itemId is null ? UnassignedScreenplayItemId : itemId.Id;

--- a/WolvenKit.App/Helpers/SceneSectionBuilder.cs
+++ b/WolvenKit.App/Helpers/SceneSectionBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using WolvenKit.Core.Extensions;
 using WolvenKit.RED4.Types;
+using static WolvenKit.RED4.Types.Enums;
 
 namespace WolvenKit.App.Helpers;
 
@@ -13,13 +14,13 @@ namespace WolvenKit.App.Helpers;
 public sealed class SectionDialogueLine
 {
     /// <summary>The screenplay entry the event plays.</summary>
-    public required uint ScreenplayLineId { get; init; }
+    public required scnscreenplayItemId ScreenplayLineId { get; init; }
 
     /// <summary>Who says it, or null if unassigned.</summary>
-    public uint? SpeakerActorId { get; init; }
+    public scnActorId? Speaker { get; init; }
 
-    /// <inheritdoc cref="SpeakerActorId"/>
-    public uint? AddresseeActorId { get; init; }
+    /// <inheritdoc cref="Speaker"/>
+    public scnActorId? Addressee { get; init; }
 
     /// <summary>
     /// How long the recording runs, in milliseconds, or 0 to estimate it from <see cref="Text"/>.
@@ -35,11 +36,15 @@ public sealed class SectionDialogueLine
     /// <summary>Used only to estimate a duration the export did not give.</summary>
     public string Text { get; init; } = "";
 
-    /// <summary>A <c>locVoiceoverContext</c> by name, e.g. "Vo_Context_Quest". Empty for the default.</summary>
-    public string VoContext { get; init; } = "";
+    /// <summary>
+    /// Voiceover context to write, or null to keep the default.
+    /// </summary>
+    public CEnum<locVoiceoverContext>? VoContext { get; init; }
 
-    /// <summary>A <c>locVoiceoverExpression</c> by name, e.g. "Vo_Expression_Spoken".</summary>
-    public string VoExpression { get; init; } = "";
+    /// <summary>
+    /// Voiceover expression to write, or null to keep the default.
+    /// </summary>
+    public CEnum<locVoiceoverExpression>? VoExpression { get; init; }
 }
 
 /// <summary>What a section came out as, so the caller need not walk the node again.</summary>
@@ -60,8 +65,7 @@ public sealed class BuiltDialogueSection
     public required int EstimatedDurationCount { get; init; }
 
     /// <summary>
-    /// Lines the export gave a start time for, as against ones laid end to end. An older export
-    /// places none of them.
+    /// Lines with explicit start times from the export.
     /// </summary>
     public required int PlacedByExportCount { get; init; }
 }
@@ -105,7 +109,7 @@ public static class SceneSectionBuilder
     /// Characters a second to read an untimed line at. Near Cyberpunk's own delivery, and a guess
     /// the user can drag on the timeline afterwards.
     /// </summary>
-    private const double EstimatedCharactersPerSecond = 14;
+    private const double estimatedCharactersPerSecond = 14;
 
     /// <summary>
     /// Builds the section. The node comes back without a node id - the graph hands one out when it
@@ -161,15 +165,15 @@ public static class SceneSectionBuilder
                 Id = new scnSceneEventId { Id = random.NextCRUID() },
                 StartTime = startTime,
                 Duration = duration,
-                ScreenplayLineId = new scnscreenplayItemId { Id = line.ScreenplayLineId },
+                ScreenplayLineId = new scnscreenplayItemId { Id = line.ScreenplayLineId.Id },
                 VoParams = BuildVoParams(line)
             }));
 
             cursor = startTime + duration;
             end = Math.Max(end, cursor);
 
-            AddActor(line.SpeakerActorId, actorIds, seenActorIds);
-            AddActor(line.AddresseeActorId, actorIds, seenActorIds);
+            AddActor(line.Speaker, actorIds, seenActorIds);
+            AddActor(line.Addressee, actorIds, seenActorIds);
         }
 
         foreach (var actorId in actorIds)
@@ -177,7 +181,7 @@ public static class SceneSectionBuilder
             section.ActorBehaviors.Add(new scnSectionInternalsActorBehavior
             {
                 ActorId = new scnActorId { Id = actorId },
-                BehaviorMode = Enums.scnSectionInternalsActorBehaviorMode.OnlyIfAlive
+                BehaviorMode = scnSectionInternalsActorBehaviorMode.OnlyIfAlive
             });
         }
 
@@ -198,6 +202,8 @@ public static class SceneSectionBuilder
     /// <summary>
     /// How long to play a line for: what the export timed it at, or an estimate from its text.
     /// </summary>
+    /// <param name="line">The line whose duration is being calculated.</param>
+    /// <param name="wasEstimated">Whether the duration was estimated from text.</param>
     public static uint GetLineDuration(SectionDialogueLine line, out bool wasEstimated)
     {
         ArgumentNullException.ThrowIfNull(line);
@@ -211,11 +217,9 @@ public static class SceneSectionBuilder
             : Math.Clamp(line.DurationMs, MinLineDurationMs, MaxLineDurationMs);
     }
 
-    /// <summary>
-    /// What to list the section under in the scene's notable points, which is what the canvas puts
-    /// on the node's marker bar. The conversation name, cut down to an identifier.
-    /// </summary>
-    public static string GetNotablePointName(string? conversationName)
+    /// <summary>Returns a valid notable point name for a conversation.</summary>
+    /// <param name="conversationName">The source name.</param>
+    public static string SanitizeNotablePointName(string? conversationName)
     {
         const string fallback = "imported_dialogue";
 
@@ -244,6 +248,7 @@ public static class SceneSectionBuilder
     }
 
     /// <summary>How long text of this length takes to say, in milliseconds.</summary>
+    /// <param name="text">The text to estimate from.</param>
     public static uint EstimateDuration(string? text)
     {
         if (string.IsNullOrWhiteSpace(text))
@@ -251,27 +256,24 @@ public static class SceneSectionBuilder
             return MinLineDurationMs;
         }
 
-        var seconds = text.Trim().Length / EstimatedCharactersPerSecond;
+        var seconds = text.Trim().Length / estimatedCharactersPerSecond;
 
         return (uint)Math.Clamp(Math.Round(seconds * 1000), MinLineDurationMs, MaxEstimatedDurationMs);
     }
 
     /// <summary>
-    /// The line's voiceover parameters, as far as the export named them. A name the game does not
-    /// know is left off, which leaves the field on the same default Add Dialogue writes.
+    /// Builds voiceover parameters, preserving defaults for missing values.
     /// </summary>
     private static scnDialogLineVoParams BuildVoParams(SectionDialogueLine line)
     {
         var voParams = new scnDialogLineVoParams();
 
-        if (Enum.TryParse<Enums.locVoiceoverContext>(line.VoContext, ignoreCase: true, out var context) &&
-            Enum.IsDefined(context))
+        if (line.VoContext is { } context)
         {
             voParams.VoContext = context;
         }
 
-        if (Enum.TryParse<Enums.locVoiceoverExpression>(line.VoExpression, ignoreCase: true, out var expression) &&
-            Enum.IsDefined(expression))
+        if (line.VoExpression is { } expression)
         {
             voParams.VoExpression = expression;
         }
@@ -283,16 +285,19 @@ public static class SceneSectionBuilder
     /// Notes an actor as being in the section, once. <see cref="SceneActorOption.NoActorId"/> is
     /// the id an unassigned line carries, not an actor, so it is skipped.
     /// </summary>
-    private static void AddActor(uint? actorId, List<uint> actorIds, HashSet<uint> seenActorIds)
+    /// <param name="actorId">The actor id to add, or null to skip.</param>
+    /// <param name="actorIds">The destination list in insertion order.</param>
+    /// <param name="seenActorIds">Set used to avoid duplicates.</param>
+    private static void AddActor(scnActorId? actorId, List<uint> actorIds, HashSet<uint> seenActorIds)
     {
-        if (actorId is not { } id || id == SceneActorOption.NoActorId)
+        if (actorId is null || actorId.Id == SceneActorOption.NoActorId)
         {
             return;
         }
 
-        if (seenActorIds.Add(id))
+        if (seenActorIds.Add(actorId.Id))
         {
-            actorIds.Add(id);
+            actorIds.Add(actorId.Id);
         }
     }
 }

--- a/WolvenKit.App/Helpers/SceneSectionBuilder.cs
+++ b/WolvenKit.App/Helpers/SceneSectionBuilder.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using WolvenKit.Core.Extensions;
+using WolvenKit.RED4.Types;
+
+namespace WolvenKit.App.Helpers;
+
+/// <summary>
+/// One line as a section plays it. Built after the line is in the screenplay store, since that is
+/// where its item id comes from.
+/// </summary>
+public sealed class SectionDialogueLine
+{
+    /// <summary>The screenplay entry the event plays.</summary>
+    public required uint ScreenplayLineId { get; init; }
+
+    /// <summary>Who says it, or null if unassigned.</summary>
+    public uint? SpeakerActorId { get; init; }
+
+    /// <inheritdoc cref="SpeakerActorId"/>
+    public uint? AddresseeActorId { get; init; }
+
+    /// <summary>
+    /// How long the recording runs, in milliseconds, or 0 to estimate it from <see cref="Text"/>.
+    /// </summary>
+    public uint DurationMs { get; init; }
+
+    /// <summary>
+    /// When the line starts, in milliseconds from the start of the section, as the export laid the
+    /// conversation out. Null to start it as the line before it ends.
+    /// </summary>
+    public uint? StartTimeMs { get; init; }
+
+    /// <summary>Used only to estimate a duration the export did not give.</summary>
+    public string Text { get; init; } = "";
+
+    /// <summary>A <c>locVoiceoverContext</c> by name, e.g. "Vo_Context_Quest". Empty for the default.</summary>
+    public string VoContext { get; init; } = "";
+
+    /// <summary>A <c>locVoiceoverExpression</c> by name, e.g. "Vo_Expression_Spoken".</summary>
+    public string VoExpression { get; init; } = "";
+}
+
+/// <summary>What a section came out as, so the caller need not walk the node again.</summary>
+public sealed class BuiltDialogueSection
+{
+    public required scnSectionNode Node { get; init; }
+
+    /// <summary>Dialogue events written, one per line.</summary>
+    public required int EventCount { get; init; }
+
+    /// <summary>Actors the section carries a behavior for, speakers and addressees.</summary>
+    public required int ActorCount { get; init; }
+
+    /// <summary>How long the section runs, in milliseconds.</summary>
+    public required uint DurationMs { get; init; }
+
+    /// <summary>Lines whose length had to be estimated.</summary>
+    public required int EstimatedDurationCount { get; init; }
+
+    /// <summary>
+    /// Lines the export gave a start time for, as against ones laid end to end. An older export
+    /// places none of them.
+    /// </summary>
+    public required int PlacedByExportCount { get; init; }
+}
+
+/// <summary>
+/// Lays a run of dialogue out as a section node: one <c>scnDialogLineEvent</c> per line, over a
+/// section long enough to hold them all.
+/// </summary>
+/// <remarks>
+/// The game plays a section for exactly as long as its <c>sectionDuration</c> says and cuts whatever
+/// is still running, so a section shorter than its last event truncates that line - the timeline
+/// flags this as "section duration too short". Start times come off the export, which keeps the
+/// original conversation's pacing. A line the export did not place starts as the one before it ends.
+/// <para>
+/// Start times are never rebased onto the earliest line the user took, so a section built from the
+/// back half of a conversation opens with the lead-in the first half occupied. That is deliberate:
+/// closing the gap would move every line against a start nobody chose.
+/// </para>
+/// </remarks>
+public static class SceneSectionBuilder
+{
+    /// <summary>
+    /// The shortest a line is played for, so a one-word line is still on screen long enough to read.
+    /// </summary>
+    public const uint MinLineDurationMs = 500;
+
+    /// <summary>
+    /// The longest an estimate may run. Caps a guess made from a wall of text, which a
+    /// subtitle-per-line export occasionally carries.
+    /// </summary>
+    public const uint MaxEstimatedDurationMs = 60_000;
+
+    /// <summary>
+    /// The longest a line is played for at all. A length the export stated is believed up to here
+    /// rather than cut to the estimate cap, so a timed monologue is not truncated. Matches the
+    /// ceiling <see cref="DialogueImportHelper"/> accepts a stated length at; move the two together.
+    /// </summary>
+    public const uint MaxLineDurationMs = 300_000;
+
+    /// <summary>
+    /// Characters a second to read an untimed line at. Near Cyberpunk's own delivery, and a guess
+    /// the user can drag on the timeline afterwards.
+    /// </summary>
+    private const double EstimatedCharactersPerSecond = 14;
+
+    /// <summary>
+    /// Builds the section. The node comes back without a node id - the graph hands one out when it
+    /// takes the node.
+    /// </summary>
+    /// <param name="lines">The lines, in the order the section is to play them.</param>
+    public static BuiltDialogueSection Build(IReadOnlyList<SectionDialogueLine> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        var random = new Random();
+
+        var section = new scnSectionNode
+        {
+            // OnEnd first, OnCancel second: the section wrapper reads them by position.
+            OutputSockets =
+            [
+                new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 0, Ordinal = 0 } },
+                new scnOutputSocket { Stamp = new scnOutputSocketStamp { Name = 1, Ordinal = 0 } }
+            ]
+        };
+
+        // Speakers and addressees both: the game has no instruction for an actor the section does
+        // not name.
+        var actorIds = new List<uint>();
+        var seenActorIds = new HashSet<uint>();
+
+        // Where an unplaced line starts, and how far the section has to reach. Kept apart because
+        // lines may overlap, so the last to start is not always the last to finish.
+        uint cursor = 0;
+        uint end = 0;
+        var estimated = 0;
+        var placed = 0;
+
+        foreach (var line in lines)
+        {
+            var duration = GetLineDuration(line, out var wasEstimated);
+
+            if (wasEstimated)
+            {
+                estimated++;
+            }
+
+            if (line.StartTimeMs is not null)
+            {
+                placed++;
+            }
+
+            var startTime = line.StartTimeMs ?? cursor;
+
+            section.Events.Add(new CHandle<scnSceneEvent>(new scnDialogLineEvent
+            {
+                Id = new scnSceneEventId { Id = random.NextCRUID() },
+                StartTime = startTime,
+                Duration = duration,
+                ScreenplayLineId = new scnscreenplayItemId { Id = line.ScreenplayLineId },
+                VoParams = BuildVoParams(line)
+            }));
+
+            cursor = startTime + duration;
+            end = Math.Max(end, cursor);
+
+            AddActor(line.SpeakerActorId, actorIds, seenActorIds);
+            AddActor(line.AddresseeActorId, actorIds, seenActorIds);
+        }
+
+        foreach (var actorId in actorIds)
+        {
+            section.ActorBehaviors.Add(new scnSectionInternalsActorBehavior
+            {
+                ActorId = new scnActorId { Id = actorId },
+                BehaviorMode = Enums.scnSectionInternalsActorBehaviorMode.OnlyIfAlive
+            });
+        }
+
+        // Long enough to reach whatever finishes last, which is not always the last line to start.
+        section.SectionDuration = new scnSceneTime { Stu = end };
+
+        return new BuiltDialogueSection
+        {
+            Node = section,
+            EventCount = section.Events.Count,
+            ActorCount = actorIds.Count,
+            DurationMs = end,
+            EstimatedDurationCount = estimated,
+            PlacedByExportCount = placed
+        };
+    }
+
+    /// <summary>
+    /// How long to play a line for: what the export timed it at, or an estimate from its text.
+    /// </summary>
+    public static uint GetLineDuration(SectionDialogueLine line, out bool wasEstimated)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        wasEstimated = line.DurationMs == 0;
+
+        // Capped separately: clamping a stated length to the estimate cap would silently truncate a
+        // long line the export timed correctly, and a clamped line is not reported as estimated.
+        return wasEstimated
+            ? EstimateDuration(line.Text)
+            : Math.Clamp(line.DurationMs, MinLineDurationMs, MaxLineDurationMs);
+    }
+
+    /// <summary>
+    /// What to list the section under in the scene's notable points, which is what the canvas puts
+    /// on the node's marker bar. The conversation name, cut down to an identifier.
+    /// </summary>
+    public static string GetNotablePointName(string? conversationName)
+    {
+        const string fallback = "imported_dialogue";
+
+        if (string.IsNullOrWhiteSpace(conversationName))
+        {
+            return fallback;
+        }
+
+        var name = new StringBuilder(conversationName.Length);
+
+        foreach (var character in conversationName.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                name.Append(character);
+            }
+            else if (name.Length > 0 && name[^1] != '_')
+            {
+                name.Append('_');
+            }
+        }
+
+        var trimmed = name.ToString().TrimEnd('_');
+
+        return trimmed.Length > 0 ? trimmed : fallback;
+    }
+
+    /// <summary>How long text of this length takes to say, in milliseconds.</summary>
+    public static uint EstimateDuration(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return MinLineDurationMs;
+        }
+
+        var seconds = text.Trim().Length / EstimatedCharactersPerSecond;
+
+        return (uint)Math.Clamp(Math.Round(seconds * 1000), MinLineDurationMs, MaxEstimatedDurationMs);
+    }
+
+    /// <summary>
+    /// The line's voiceover parameters, as far as the export named them. A name the game does not
+    /// know is left off, which leaves the field on the same default Add Dialogue writes.
+    /// </summary>
+    private static scnDialogLineVoParams BuildVoParams(SectionDialogueLine line)
+    {
+        var voParams = new scnDialogLineVoParams();
+
+        if (Enum.TryParse<Enums.locVoiceoverContext>(line.VoContext, ignoreCase: true, out var context) &&
+            Enum.IsDefined(context))
+        {
+            voParams.VoContext = context;
+        }
+
+        if (Enum.TryParse<Enums.locVoiceoverExpression>(line.VoExpression, ignoreCase: true, out var expression) &&
+            Enum.IsDefined(expression))
+        {
+            voParams.VoExpression = expression;
+        }
+
+        return voParams;
+    }
+
+    /// <summary>
+    /// Notes an actor as being in the section, once. <see cref="SceneActorOption.NoActorId"/> is
+    /// the id an unassigned line carries, not an actor, so it is skipped.
+    /// </summary>
+    private static void AddActor(uint? actorId, List<uint> actorIds, HashSet<uint> seenActorIds)
+    {
+        if (actorId is not { } id || id == SceneActorOption.NoActorId)
+        {
+            return;
+        }
+
+        if (seenActorIds.Add(id))
+        {
+            actorIds.Add(id);
+        }
+    }
+}

--- a/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
+++ b/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
@@ -12,23 +12,40 @@ public class DialogueImportDialogOptions
 {
     public DialogueImportDialogOptions(
         string sceneName,
-        IEnumerable<ulong> existingLineLocStrings,
+        IEnumerable<ExistingSceneLine> existingLines,
         IEnumerable<ulong> existingOptionLocStrings,
         IEnumerable<SceneActorOption> actors)
     {
         SceneName = sceneName;
-        ExistingLineLocStrings = existingLineLocStrings.ToHashSet();
         ExistingOptionLocStrings = existingOptionLocStrings.ToHashSet();
         Actors = actors.ToList();
+
+        var lines = new Dictionary<ulong, ExistingSceneLine>();
+
+        // The first entry of a locstring keeps it. A store with two is already broken in the way
+        // this dialog exists to prevent, and nothing says which was meant.
+        foreach (var line in existingLines)
+        {
+            lines.TryAdd(line.LocStringId, line);
+        }
+
+        ExistingLines = lines;
     }
 
     /// <summary>Named in the dialog title, so it is clear which scene is being imported into.</summary>
     public string SceneName { get; init; }
 
-    /// <summary>Locstring ids already in the screenplay store's lines. Imports matching one are refused.</summary>
-    public HashSet<ulong> ExistingLineLocStrings { get; init; }
+    /// <summary>
+    /// The screenplay lines the scene already carries, by locstring id. An import matching one is
+    /// never written again, but the user may still take it for a section to play - hence the item
+    /// id and actors.
+    /// </summary>
+    public IReadOnlyDictionary<ulong, ExistingSceneLine> ExistingLines { get; init; }
 
-    /// <inheritdoc cref="ExistingLineLocStrings"/>
+    /// <summary>
+    /// Locstring ids already among the screenplay store's choice options. Imports matching one are
+    /// refused outright: an option is picked rather than played, so no section can use it either.
+    /// </summary>
     public HashSet<ulong> ExistingOptionLocStrings { get; init; }
 
     /// <summary>

--- a/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
+++ b/WolvenKit.App/Interaction/Options/DialogueImportDialogOptions.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.ViewModels.Dialogs;
+using WolvenKit.RED4.Types;
 
 namespace WolvenKit.App.Interaction.Options;
 
@@ -10,23 +11,37 @@ namespace WolvenKit.App.Interaction.Options;
 /// </summary>
 public class DialogueImportDialogOptions
 {
+    /// <param name="sceneName">Scene name displayed in the dialog title.</param>
+    /// <param name="existingLines">Existing screenplay dialogue lines.</param>
+    /// <param name="existingOptions">Existing screenplay choice options.</param>
+    /// <param name="actors">Scene actor choices.</param>
     public DialogueImportDialogOptions(
         string sceneName,
-        IEnumerable<ExistingSceneLine> existingLines,
-        IEnumerable<ulong> existingOptionLocStrings,
+        IEnumerable<scnscreenplayDialogLine> existingLines,
+        IEnumerable<scnscreenplayChoiceOption> existingOptions,
         IEnumerable<SceneActorOption> actors)
     {
         SceneName = sceneName;
-        ExistingOptionLocStrings = existingOptionLocStrings.ToHashSet();
         Actors = actors.ToList();
 
-        var lines = new Dictionary<ulong, ExistingSceneLine>();
+        ExistingOptionLocStrings = existingOptions
+            .Where(option => option?.LocstringId is not null)
+            .Select(option => option.LocstringId.Ruid)
+            .ToHashSet();
+
+        var lines = new Dictionary<CRUID, scnscreenplayDialogLine>();
 
         // The first entry of a locstring keeps it. A store with two is already broken in the way
         // this dialog exists to prevent, and nothing says which was meant.
         foreach (var line in existingLines)
         {
-            lines.TryAdd(line.LocStringId, line);
+            // Lines without locstring ids cannot be matched to imports.
+            if (line?.LocstringId is null)
+            {
+                continue;
+            }
+
+            lines.TryAdd(line.LocstringId.Ruid, line);
         }
 
         ExistingLines = lines;
@@ -36,17 +51,16 @@ public class DialogueImportDialogOptions
     public string SceneName { get; init; }
 
     /// <summary>
-    /// The screenplay lines the scene already carries, by locstring id. An import matching one is
-    /// never written again, but the user may still take it for a section to play - hence the item
-    /// id and actors.
+    /// Existing screenplay dialogue lines keyed by locstring id.
+    /// Matching imports reuse the stored entry.
     /// </summary>
-    public IReadOnlyDictionary<ulong, ExistingSceneLine> ExistingLines { get; init; }
+    public IReadOnlyDictionary<CRUID, scnscreenplayDialogLine> ExistingLines { get; init; }
 
     /// <summary>
     /// Locstring ids already among the screenplay store's choice options. Imports matching one are
     /// refused outright: an option is picked rather than played, so no section can use it either.
     /// </summary>
-    public HashSet<ulong> ExistingOptionLocStrings { get; init; }
+    public HashSet<CRUID> ExistingOptionLocStrings { get; init; }
 
     /// <summary>
     /// The scene's cast, in the order it lists them: what each line's speaker and addressee are

--- a/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
@@ -27,6 +27,35 @@ public sealed class DialogueImportSelection
 
     /// <inheritdoc cref="SpeakerActorId"/>
     public uint? AddresseeActorId { get; init; }
+
+    /// <summary>Whether the scene already carries a screenplay entry for this line.</summary>
+    public bool IsAlreadyInScene { get; init; }
+
+    /// <summary>
+    /// The item id of the entry the scene already has, or null where that entry carries none yet
+    /// and the import is to give it one.
+    /// </summary>
+    public uint? ExistingScreenplayLineId { get; init; }
+
+    /// <summary>
+    /// The line as a section plays it. Length and voiceover parameters come off the export; the
+    /// actors are the user's answer above.
+    /// </summary>
+    /// <param name="screenplayLineId">
+    /// The item id the line is in the screenplay store under. A section binds to its lines by item
+    /// id alone, so this must be the id actually written.
+    /// </param>
+    public SectionDialogueLine ToSectionLine(uint screenplayLineId) => new()
+    {
+        ScreenplayLineId = screenplayLineId,
+        SpeakerActorId = SpeakerActorId,
+        AddresseeActorId = AddresseeActorId,
+        DurationMs = Line.DurationMs,
+        StartTimeMs = Line.StartTimeMs,
+        Text = Line.EmbeddedText,
+        VoContext = Line.VoContext,
+        VoExpression = Line.VoExpression
+    };
 }
 
 /// <summary>
@@ -40,18 +69,31 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     public DialogueImportEntryViewModel(
         ImportedDialogueLine line,
         bool isDuplicate,
+        ExistingSceneLine? existingLine,
         IReadOnlyList<SceneActorOption> actorOptions,
         DialogueSpeakerResolver resolver)
     {
         Line = line;
         IsDuplicate = isDuplicate;
-        IsSelected = !isDuplicate;
+        ExistingLine = existingLine;
         ActorOptions = actorOptions;
 
-        // What the export says, matched against the scene's cast. Whatever it did not match is left
-        // unset for the user to pick, which is the same "no actor" a line added by hand starts with.
-        _speakerActor = resolver.Resolve(line.Speaker) ?? SceneActorOption.None;
-        _addresseeActor = resolver.Resolve(line.Addressee) ?? SceneActorOption.None;
+        // A line already in the scene starts unticked: it is only worth taking for a section.
+        IsSelected = !isDuplicate;
+
+        if (existingLine is not null)
+        {
+            // The scene's answer, not the export's: the entry is not being rewritten.
+            _speakerActor = FindActor(existingLine.SpeakerActorId, actorOptions);
+            _addresseeActor = FindActor(existingLine.AddresseeActorId, actorOptions);
+        }
+        else
+        {
+            // What the export says, matched against the scene's cast. Anything unmatched is left on
+            // "no actor", the same as a line added by hand.
+            _speakerActor = resolver.Resolve(line.Speaker) ?? SceneActorOption.None;
+            _addresseeActor = resolver.Resolve(line.Addressee) ?? SceneActorOption.None;
+        }
     }
 
     public ImportedDialogueLine Line { get; }
@@ -59,8 +101,29 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     /// <summary>Whether the scene already carries a screenplay entry for this locstring id.</summary>
     public bool IsDuplicate { get; }
 
-    /// <summary>Whether the line is the user's to take. Duplicates never are.</summary>
-    public bool CanImport => !IsDuplicate;
+    /// <summary>
+    /// The entry the scene already carries for this line. Null for a new line, and for a choice
+    /// option - nothing plays an option, so there is nothing to do with one the scene has.
+    /// </summary>
+    public ExistingSceneLine? ExistingLine { get; }
+
+    /// <summary>
+    /// Whether taking this line only feeds a section, leaving the screenplay store alone. The scene
+    /// already has the entry, and writing it again would put two entries on one recording.
+    /// </summary>
+    public bool IsSectionOnly => ExistingLine is not null;
+
+    /// <summary>
+    /// Whether the entry the scene has carries no item id yet. Taking the line gives it one, since
+    /// a section's event has to have something to point at.
+    /// </summary>
+    public bool NeedsItemId => ExistingLine is { ScreenplayLineId: null };
+
+    /// <summary>
+    /// Whether the line is the user's to take. A duplicate line is, for a section's sake; a
+    /// duplicate choice option is not, since no section plays one.
+    /// </summary>
+    public bool CanImport => !IsDuplicate || IsSectionOnly;
 
     [ObservableProperty] private bool _isSelected;
 
@@ -72,17 +135,17 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     [ObservableProperty] private SceneActorOption _addresseeActor;
 
     /// <summary>
-    /// Whether this line has actors to assign at all. A choice option is something the player says
-    /// by picking it, and the screenplay store keeps no speaker for one.
+    /// Whether this line's actors are the user's to set. The store keeps no speaker for a choice
+    /// option, and a line the scene already has is shown as the scene has it, not rewritten.
     /// </summary>
-    public bool CanSetActors => !Line.IsChoiceOption;
+    public bool CanSetActors => !Line.IsChoiceOption && !IsSectionOnly;
 
     public string LocStringId => Line.LocStringId.ToString();
 
     /// <summary>What the export called the speaker, kept where the user can check the match.</summary>
-    public string SpeakerToolTip => DescribeExportedName("speaker", Line.Speaker);
+    public string SpeakerToolTip => DescribeActor("speaker", Line.Speaker);
 
-    public string AddresseeToolTip => DescribeExportedName("addressee", Line.Addressee);
+    public string AddresseeToolTip => DescribeActor("addressee", Line.Addressee);
 
     public string Text => string.IsNullOrEmpty(Line.EmbeddedText) ? "(no text)" : Line.EmbeddedText;
 
@@ -140,16 +203,56 @@ public partial class DialogueImportEntryViewModel : ObservableObject
         }
     }
 
-    public string Status => IsDuplicate
-        ? "Already in scene"
-        : Line.IsChoiceOption
-            ? "New choice option"
-            : "New line";
+    public string Status => NeedsItemId
+        ? "In scene - needs item id"
+        : IsSectionOnly
+            ? "In scene - section only"
+            : IsDuplicate
+                ? "Already in scene"
+                : Line.IsChoiceOption
+                    ? "New choice option"
+                    : "New line";
 
-    private static string DescribeExportedName(string role, string name) =>
-        string.IsNullOrEmpty(name)
+    /// <summary>
+    /// What taking this line would do, where the row has no room to say it. Worth explaining for a
+    /// line the scene already has, since ticking it looks like an import and is not.
+    /// </summary>
+    public string StatusToolTip => NeedsItemId
+        ? "This line is already in the scene, but its screenplay entry carries no item id. Select it to give the entry an item id."
+        : IsSectionOnly
+            ? "This line is already in the scene. Select it to append it to a new section."
+            : IsDuplicate
+                ? "The scene already has this choice option. An option is picked rather than " +
+                  "played, so there is nothing a section could do with it either."
+                : "This line is not in the scene yet and will be added to the screenplay store.";
+
+    /// <summary>
+    /// Where a row's actor came from: the entry the scene has, or the name the export gave.
+    /// </summary>
+    private string DescribeActor(string role, string exportedName)
+    {
+        if (IsSectionOnly)
+        {
+            return $"The scene's own {role} for this line, which the import does not change";
+        }
+
+        return string.IsNullOrEmpty(exportedName)
             ? $"The export names no {role} for this line"
-            : $"The export names \"{name}\" as the {role}";
+            : $"The export names \"{exportedName}\" as the {role}";
+    }
+
+    /// <summary>The dropdown entry for an actor id, or "no actor" where there is none.</summary>
+    private static SceneActorOption FindActor(uint? actorId, IReadOnlyList<SceneActorOption> actorOptions)
+    {
+        if (actorId is not { } id || id == SceneActorOption.NoActorId)
+        {
+            return SceneActorOption.None;
+        }
+
+        // An id the scene's cast no longer runs to shows as unset: the dropdown can only offer
+        // actors the scene has.
+        return actorOptions.FirstOrDefault(option => option.ActorId == id) ?? SceneActorOption.None;
+    }
 }
 
 /// <summary>
@@ -159,7 +262,7 @@ public partial class DialogueImportEntryViewModel : ObservableObject
 /// </summary>
 public partial class DialogueImportDialogViewModel : DialogViewModel
 {
-    private readonly HashSet<ulong> _existingLineLocStrings;
+    private readonly IReadOnlyDictionary<ulong, ExistingSceneLine> _existingLines;
     private readonly HashSet<ulong> _existingOptionLocStrings;
     private readonly DialogueSpeakerResolver _speakerResolver;
 
@@ -178,7 +281,7 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
     public DialogueImportDialogViewModel(DialogueImportDialogOptions dialogOptions)
     {
-        _existingLineLocStrings = dialogOptions.ExistingLineLocStrings;
+        _existingLines = dialogOptions.ExistingLines;
         _existingOptionLocStrings = dialogOptions.ExistingOptionLocStrings;
         _speakerResolver = new DialogueSpeakerResolver(dialogOptions.Actors);
 
@@ -223,25 +326,59 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
     [ObservableProperty] private bool _isStatusError;
 
     /// <summary>
+    /// What the export called the conversation. Names the section node, so it can be found in the
+    /// graph afterwards.
+    /// </summary>
+    [ObservableProperty] private string _conversationName = "";
+
+    /// <summary>
     /// Whether the lines' text is embedded into the scene's locstore. Without it the scene points
     /// at recordings whose subtitles live in the game's own string tables, which is what a scene
     /// referencing existing dialogue wants; with it the text travels with the scene.
     /// </summary>
     [ObservableProperty] private bool _createEmbeddedText = true;
 
+    /// <summary>
+    /// Whether the conversation is laid out as a section node as well as written to the screenplay
+    /// store. On by default: lines in the store with nothing playing them is half an import. A user
+    /// who wants only the store entries unticks it.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanImport))]
+    private bool _createSectionNode = true;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasEntries))]
     private int _entryCount;
 
+    /// <summary>Rows the user has ticked, of either kind.</summary>
+    [ObservableProperty] private int _selectedCount;
+
+    /// <summary>Ticked rows that will be written to the screenplay store.</summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanImport))]
-    private int _selectedCount;
+    private int _selectedNewCount;
+
+    /// <summary>
+    /// Ticked rows the scene already has, which are worth taking only for a section to play.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanImport))]
+    [NotifyPropertyChangedFor(nameof(HasSectionOnlySelection))]
+    private int _selectedExistingCount;
 
     [ObservableProperty] private int _duplicateCount;
 
     public bool HasEntries => EntryCount > 0;
 
-    public bool CanImport => SelectedCount > 0;
+    /// <summary>Whether the user has taken a line that only a section could use.</summary>
+    public bool HasSectionOnlySelection => SelectedExistingCount > 0;
+
+    /// <summary>
+    /// Whether there is anything for the import to do. Lines the scene already has count only when a
+    /// section is being built.
+    /// </summary>
+    public bool CanImport => SelectedNewCount > 0 || (CreateSectionNode && SelectedExistingCount > 0);
 
     partial void OnJsonTextChanged(string value) => IsPayloadStale = value != _readJson;
 
@@ -300,6 +437,8 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
         Entries.Clear();
 
+        ConversationName = "";
+
         if (string.IsNullOrWhiteSpace(json))
         {
             SetStatus("Paste an export from the Dialogue Browser, or load one from a file.", false);
@@ -314,11 +453,20 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
             return;
         }
 
+        ConversationName = payload.ConversationName;
+
         foreach (var line in payload.Lines)
         {
-            var existing = line.IsChoiceOption ? _existingOptionLocStrings : _existingLineLocStrings;
+            // Options are looked up among options and lines among lines: the two halves of the
+            // store number themselves apart.
+            var existingLine = line.IsChoiceOption ? null : FindExistingLine(line.LocStringId);
+
+            var isDuplicate = line.IsChoiceOption
+                ? _existingOptionLocStrings.Contains(line.LocStringId)
+                : existingLine is not null;
+
             var entry = new DialogueImportEntryViewModel(
-                line, existing.Contains(line.LocStringId), ActorOptions, _speakerResolver);
+                line, isDuplicate, existingLine, ActorOptions, _speakerResolver);
 
             entry.PropertyChanged += OnEntryPropertyChanged;
             Entries.Add(entry);
@@ -378,10 +526,14 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
     private void SelectNone() => SetSelection(false);
 
     /// <summary>
-    /// The lines the user settled on, each with the actors they left it pointing at. Duplicates are
-    /// filtered out here as well as being locked in the list, so nothing gets in by way of a payload
-    /// swapped out from under the selection.
+    /// The lines the user settled on, in conversation order, each with the actors they left it
+    /// pointing at. A line the scene already has comes back flagged, which tells the import to play
+    /// it rather than write it again.
     /// </summary>
+    /// <remarks>
+    /// A duplicate choice option is filtered out here as well as locked in the list, so nothing gets
+    /// in by way of a payload swapped out from under the selection.
+    /// </remarks>
     public List<DialogueImportSelection> GetLinesToImport() =>
         Entries
             .Where(entry => entry.IsSelected && entry.CanImport)
@@ -389,9 +541,15 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
             {
                 Line = entry.Line,
                 SpeakerActorId = ActorIdOf(entry.SpeakerActor),
-                AddresseeActorId = ActorIdOf(entry.AddresseeActor)
+                AddresseeActorId = ActorIdOf(entry.AddresseeActor),
+                IsAlreadyInScene = entry.IsSectionOnly,
+                ExistingScreenplayLineId = entry.ExistingLine?.ScreenplayLineId
             })
             .ToList();
+
+    /// <summary>The entry the scene has for a locstring, or null where it has none.</summary>
+    private ExistingSceneLine? FindExistingLine(ulong locStringId) =>
+        _existingLines.TryGetValue(locStringId, out var existingLine) ? existingLine : null;
 
     /// <summary>An actor id to write, or null where the user left the line unassigned.</summary>
     private static uint? ActorIdOf(SceneActorOption? option) =>
@@ -399,8 +557,7 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
 
     private void SetSelection(bool isSelected)
     {
-        // Each row raising its own change would have the counts recomputed once per row; they are
-        // the same counts either way, so they are taken once at the end.
+        // Recomputing per row would give the same counts, so take them once at the end.
         _isUpdatingEntries = true;
 
         try
@@ -460,7 +617,8 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
         }
 
         var duplicates = 0;
-        var selected = 0;
+        var selectedNew = 0;
+        var selectedExisting = 0;
 
         foreach (var entry in Entries)
         {
@@ -468,15 +626,27 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
             {
                 duplicates++;
             }
-            else if (entry.IsSelected)
+
+            if (!entry.IsSelected || !entry.CanImport)
             {
-                selected++;
+                continue;
+            }
+
+            if (entry.IsSectionOnly)
+            {
+                selectedExisting++;
+            }
+            else
+            {
+                selectedNew++;
             }
         }
 
         EntryCount = Entries.Count;
         DuplicateCount = duplicates;
-        SelectedCount = selected;
+        SelectedNewCount = selectedNew;
+        SelectedExistingCount = selectedExisting;
+        SelectedCount = selectedNew + selectedExisting;
     }
 
     private void OnEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RefreshCounts();

--- a/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
+++ b/WolvenKit.App/ViewModels/Dialogs/DialogueImportDialogViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WolvenKit.App.Helpers;
 using WolvenKit.App.Interaction.Options;
+using WolvenKit.RED4.Types;
 using Clipboard = System.Windows.Clipboard;
 
 namespace WolvenKit.App.ViewModels.Dialogs;
@@ -23,19 +24,19 @@ public sealed class DialogueImportSelection
     public required ImportedDialogueLine Line { get; init; }
 
     /// <summary>Actor to write as the line's speaker, or null to leave it unset.</summary>
-    public uint? SpeakerActorId { get; init; }
+    public scnActorId? Speaker { get; init; }
 
-    /// <inheritdoc cref="SpeakerActorId"/>
-    public uint? AddresseeActorId { get; init; }
-
-    /// <summary>Whether the scene already carries a screenplay entry for this line.</summary>
-    public bool IsAlreadyInScene { get; init; }
+    /// <inheritdoc cref="Speaker"/>
+    public scnActorId? Addressee { get; init; }
 
     /// <summary>
-    /// The item id of the entry the scene already has, or null where that entry carries none yet
-    /// and the import is to give it one.
+    /// Existing screenplay entry for this line, or null for a new line.
+    /// Section events reuse this entry instead of creating a duplicate.
     /// </summary>
-    public uint? ExistingScreenplayLineId { get; init; }
+    public scnscreenplayDialogLine? ExistingLine { get; init; }
+
+    /// <summary>Whether an existing screenplay entry was matched.</summary>
+    public bool IsAlreadyInScene => ExistingLine is not null;
 
     /// <summary>
     /// The line as a section plays it. Length and voiceover parameters come off the export; the
@@ -45,11 +46,11 @@ public sealed class DialogueImportSelection
     /// The item id the line is in the screenplay store under. A section binds to its lines by item
     /// id alone, so this must be the id actually written.
     /// </param>
-    public SectionDialogueLine ToSectionLine(uint screenplayLineId) => new()
+    public SectionDialogueLine ToSectionLine(scnscreenplayItemId screenplayLineId) => new()
     {
         ScreenplayLineId = screenplayLineId,
-        SpeakerActorId = SpeakerActorId,
-        AddresseeActorId = AddresseeActorId,
+        Speaker = Speaker,
+        Addressee = Addressee,
         DurationMs = Line.DurationMs,
         StartTimeMs = Line.StartTimeMs,
         Text = Line.EmbeddedText,
@@ -66,10 +67,15 @@ public sealed class DialogueImportSelection
 /// </summary>
 public partial class DialogueImportEntryViewModel : ObservableObject
 {
+    /// <param name="line">Imported line data.</param>
+    /// <param name="isDuplicate">Whether the locstring id already exists.</param>
+    /// <param name="existingLine">Existing screenplay entry, when matched.</param>
+    /// <param name="actorOptions">Available actor choices.</param>
+    /// <param name="resolver">Speaker-name resolver.</param>
     public DialogueImportEntryViewModel(
         ImportedDialogueLine line,
         bool isDuplicate,
-        ExistingSceneLine? existingLine,
+        scnscreenplayDialogLine? existingLine,
         IReadOnlyList<SceneActorOption> actorOptions,
         DialogueSpeakerResolver resolver)
     {
@@ -84,8 +90,8 @@ public partial class DialogueImportEntryViewModel : ObservableObject
         if (existingLine is not null)
         {
             // The scene's answer, not the export's: the entry is not being rewritten.
-            _speakerActor = FindActor(existingLine.SpeakerActorId, actorOptions);
-            _addresseeActor = FindActor(existingLine.AddresseeActorId, actorOptions);
+            _speakerActor = FindActor(existingLine.Speaker, actorOptions);
+            _addresseeActor = FindActor(existingLine.Addressee, actorOptions);
         }
         else
         {
@@ -105,7 +111,7 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     /// The entry the scene already carries for this line. Null for a new line, and for a choice
     /// option - nothing plays an option, so there is nothing to do with one the scene has.
     /// </summary>
-    public ExistingSceneLine? ExistingLine { get; }
+    public scnscreenplayDialogLine? ExistingLine { get; }
 
     /// <summary>
     /// Whether taking this line only feeds a section, leaving the screenplay store alone. The scene
@@ -117,7 +123,8 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     /// Whether the entry the scene has carries no item id yet. Taking the line gives it one, since
     /// a section's event has to have something to point at.
     /// </summary>
-    public bool NeedsItemId => ExistingLine is { ScreenplayLineId: null };
+    public bool NeedsItemId =>
+        ExistingLine is not null && !SceneEditingHelper.HasAssignedItemId(ExistingLine.ItemId);
 
     /// <summary>
     /// Whether the line is the user's to take. A duplicate line is, for a section's sake; a
@@ -242,16 +249,20 @@ public partial class DialogueImportEntryViewModel : ObservableObject
     }
 
     /// <summary>The dropdown entry for an actor id, or "no actor" where there is none.</summary>
-    private static SceneActorOption FindActor(uint? actorId, IReadOnlyList<SceneActorOption> actorOptions)
+    /// <param name="actorId">The actor id to find.</param>
+    /// <param name="actorOptions">Available actor choices.</param>
+    private static SceneActorOption FindActor(
+        scnActorId? actorId, IReadOnlyList<SceneActorOption> actorOptions)
     {
-        if (actorId is not { } id || id == SceneActorOption.NoActorId)
+        if (actorId is null || actorId.Id == SceneActorOption.NoActorId)
         {
             return SceneActorOption.None;
         }
 
         // An id the scene's cast no longer runs to shows as unset: the dropdown can only offer
         // actors the scene has.
-        return actorOptions.FirstOrDefault(option => option.ActorId == id) ?? SceneActorOption.None;
+        return actorOptions.FirstOrDefault(option => option.ActorId == actorId.Id) ??
+               SceneActorOption.None;
     }
 }
 
@@ -262,8 +273,8 @@ public partial class DialogueImportEntryViewModel : ObservableObject
 /// </summary>
 public partial class DialogueImportDialogViewModel : DialogViewModel
 {
-    private readonly IReadOnlyDictionary<ulong, ExistingSceneLine> _existingLines;
-    private readonly HashSet<ulong> _existingOptionLocStrings;
+    private readonly IReadOnlyDictionary<CRUID, scnscreenplayDialogLine> _existingLines;
+    private readonly HashSet<CRUID> _existingOptionLocStrings;
     private readonly DialogueSpeakerResolver _speakerResolver;
 
     /// <summary>Where the payload being read came from, named once in the status line.</summary>
@@ -540,20 +551,21 @@ public partial class DialogueImportDialogViewModel : DialogViewModel
             .Select(entry => new DialogueImportSelection
             {
                 Line = entry.Line,
-                SpeakerActorId = ActorIdOf(entry.SpeakerActor),
-                AddresseeActorId = ActorIdOf(entry.AddresseeActor),
-                IsAlreadyInScene = entry.IsSectionOnly,
-                ExistingScreenplayLineId = entry.ExistingLine?.ScreenplayLineId
+                Speaker = ActorIdOf(entry.SpeakerActor),
+                Addressee = ActorIdOf(entry.AddresseeActor),
+                ExistingLine = entry.ExistingLine
             })
             .ToList();
 
     /// <summary>The entry the scene has for a locstring, or null where it has none.</summary>
-    private ExistingSceneLine? FindExistingLine(ulong locStringId) =>
+    /// <param name="locStringId">The locstring id to look up.</param>
+    private scnscreenplayDialogLine? FindExistingLine(CRUID locStringId) =>
         _existingLines.TryGetValue(locStringId, out var existingLine) ? existingLine : null;
 
     /// <summary>An actor id to write, or null where the user left the line unassigned.</summary>
-    private static uint? ActorIdOf(SceneActorOption? option) =>
-        option is null || option.IsNone ? null : option.ActorId;
+    /// <param name="option">Selected actor option.</param>
+    private static scnActorId? ActorIdOf(SceneActorOption? option) =>
+        option is null || option.IsNone ? null : new scnActorId { Id = option.ActorId };
 
     private void SetSelection(bool isSelected)
     {

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -609,8 +609,8 @@ namespace WolvenKit.App.ViewModels.Documents
 
                 var dialog = Interactions.ShowDialogueImport(new DialogueImportDialogOptions(
                     FileName,
-                    GetExistingSceneLines(screenplayLines),
-                    existingOptionLocStrings,
+                    screenplayLines,
+                    screenplayOptions,
                     GetSceneActorOptions()));
 
                 // Cancelled.
@@ -658,21 +658,18 @@ namespace WolvenKit.App.ViewModels.Documents
                     // Nothing is written for it - not the entry, and not its embedded text, which is
                     // not this import's to change. An entry with no item id gets one, since an event
                     // needs a target.
-                    if (selection.IsAlreadyInScene)
+                    if (selection.ExistingLine is { } existingLine)
                     {
-                        var itemId = selection.ExistingScreenplayLineId;
-
-                        if (itemId is null && FindScreenplayLine(screenplayLines, line.LocStringId) is { } entry)
+                        if (!SceneEditingHelper.HasAssignedItemId(existingLine.ItemId))
                         {
-                            entry.ItemId = new scnscreenplayItemId { Id = nextLineItemId };
-                            itemId = nextLineItemId;
-                            nextLineItemId += 256;
+                            existingLine.ItemId = new scnscreenplayItemId { Id = nextLineItemId };
+                            nextLineItemId += SceneEditingHelper.ScreenplayItemIdStep;
                             repairedLines++;
                         }
 
-                        if (itemId is { } id && dialog.CreateSectionNode)
+                        if (dialog.CreateSectionNode)
                         {
-                            sectionLines.Add(selection.ToSectionLine(id));
+                            sectionLines.Add(selection.ToSectionLine(existingLine.ItemId));
                         }
 
                         reusedLines++;
@@ -694,11 +691,11 @@ namespace WolvenKit.App.ViewModels.Documents
                         screenplayOptions.Add(new scnscreenplayChoiceOption
                         {
                             ItemId = new scnscreenplayItemId { Id = nextOptionItemId },
-                            LocstringId = new scnlocLocstringId { Ruid = (CRUID)line.LocStringId },
+                            LocstringId = new scnlocLocstringId { Ruid = line.LocStringId },
                             Usage = new scnscreenplayOptionUsage { PlayerGenderMask = new scnGenderMask { Mask = 3 } }
                         });
 
-                        nextOptionItemId += 256;
+                        nextOptionItemId += SceneEditingHelper.ScreenplayItemIdStep;
                         addedOptions++;
                     }
                     else
@@ -706,7 +703,7 @@ namespace WolvenKit.App.ViewModels.Documents
                         var dialogueLine = new scnscreenplayDialogLine
                         {
                             ItemId = new scnscreenplayItemId { Id = nextLineItemId },
-                            LocstringId = new scnlocLocstringId { Ruid = (CRUID)line.LocStringId },
+                            LocstringId = new scnlocLocstringId { Ruid = line.LocStringId },
                             Usage = new scnscreenplayLineUsage { PlayerGenderMask = new scnGenderMask { Mask = 3 } }
                         };
 
@@ -714,15 +711,15 @@ namespace WolvenKit.App.ViewModels.Documents
                         // against the scene's cast by name, then whatever the user picked instead.
                         // A line they left unassigned keeps the default, which is the same "no
                         // actor" a line added by hand starts out with.
-                        if (selection.SpeakerActorId is { } speakerActorId)
+                        if (selection.Speaker is { } speaker)
                         {
-                            dialogueLine.Speaker = new scnActorId { Id = speakerActorId };
+                            dialogueLine.Speaker = speaker;
                             addedActors++;
                         }
 
-                        if (selection.AddresseeActorId is { } addresseeActorId)
+                        if (selection.Addressee is { } addressee)
                         {
-                            dialogueLine.Addressee = new scnActorId { Id = addresseeActorId };
+                            dialogueLine.Addressee = addressee;
                             addedActors++;
                         }
 
@@ -743,10 +740,10 @@ namespace WolvenKit.App.ViewModels.Documents
 
                         if (dialog.CreateSectionNode)
                         {
-                            sectionLines.Add(selection.ToSectionLine(nextLineItemId));
+                            sectionLines.Add(selection.ToSectionLine(dialogueLine.ItemId));
                         }
 
-                        nextLineItemId += 256;
+                        nextLineItemId += SceneEditingHelper.ScreenplayItemIdStep;
                         addedLines++;
                     }
 
@@ -805,21 +802,20 @@ namespace WolvenKit.App.ViewModels.Documents
                 _logger?.Success(
                     (wroteToStore
                         ? $"Imported {addedLines} dialogue line(s)" +
-                          (addedOptions > 0 ? $" and {addedOptions} choice option(s)" : "") +
+                          (addedOptions > 0 ? $", {addedOptions} choice option(s)" : "") +
                           (createEmbeddedText ? $", {addedTexts} with embedded text" : "") +
-                          (addedActors > 0 ? $", {addedActors} speaker/addressee assignment(s)" : "") +
-                          (reusedLines > 0 ? $". Reused {reusedLines} line(s) the scene already had" : "")
-                        : $"Reused {reusedLines} line(s) the scene already had, writing nothing to the " +
-                          "screenplay store") +
+                          (addedActors > 0 ? $", and {addedActors} speaker/addressee assignment(s)" : "") +
+                          (reusedLines > 0 ? $".\n Reused {reusedLines} line(s)" : "")
+                        : $"Reused {reusedLines} line(s), no new lines added") +
                     (repairedLines > 0
-                        ? $". Gave an item id to {repairedLines} existing screenplay entr" +
+                        ? $".\n Gave an item id to {repairedLines} existing screenplay entr" +
                           (repairedLines == 1 ? "y" : "ies")
                         : "") +
                     (section is not null
-                        ? $". Section node created, running {section.DurationMs}ms" +
+                        ? $".\n Section node created, running {section.DurationMs}ms" +
                           $" over {section.ActorCount} actor(s)"
                         : "") +
-                    (skipped > 0 ? $". Skipped {skipped} already in the scene" : ""));
+                    (skipped > 0 ? $".\n Skipped {skipped} already in the scene" : ""));
             }
             catch (Exception ex)
             {
@@ -830,6 +826,9 @@ namespace WolvenKit.App.ViewModels.Documents
         /// <summary>
         /// Lays an import out as a section node in the graph, where the user asked for one.
         /// </summary>
+        /// <param name="dialog">
+        /// Dialog state used to name the section node.
+        /// </param>
         /// <param name="lines">
         /// The lines, each already carrying the item id it plays. Empty for an import of nothing but
         /// choice options, since an option is picked rather than played.
@@ -858,7 +857,7 @@ namespace WolvenKit.App.ViewModels.Documents
                 MainGraph.AddSceneNode(
                     section.Node,
                     MainGraph.GetFreeCanvasPoint(),
-                    SceneSectionBuilder.GetNotablePointName(dialog.ConversationName));
+                    SceneSectionBuilder.SanitizeNotablePointName(dialog.ConversationName));
 
                 OnPropertyChanged(nameof(TotalNodes));
 
@@ -924,85 +923,28 @@ namespace WolvenKit.App.ViewModels.Documents
         }
 
         /// <summary>
-        /// The screenplay lines the scene already carries: matched against an import by locstring,
-        /// and carrying the item id and actors a section needs to play one.
-        /// </summary>
-        private static List<ExistingSceneLine> GetExistingSceneLines(
-            IEnumerable<scnscreenplayDialogLine>? screenplayLines)
-        {
-            var lines = new List<ExistingSceneLine>();
-
-            if (screenplayLines is null)
-            {
-                return lines;
-            }
-
-            foreach (var line in screenplayLines)
-            {
-                // An entry with no item id is still carried, so an import matching its locstring is
-                // recognised as a duplicate rather than written again.
-                if (line?.LocstringId is null)
-                {
-                    continue;
-                }
-
-                lines.Add(new ExistingSceneLine
-                {
-                    LocStringId = line.LocstringId.Ruid,
-                    ScreenplayLineId = ItemIdOrNull(line.ItemId),
-                    SpeakerActorId = ActorIdOrNull(line.Speaker),
-                    AddresseeActorId = ActorIdOrNull(line.Addressee)
-                });
-            }
-
-            return lines;
-        }
-
-        /// <summary>
-        /// An entry's actor, or null where it names none. A scene writes uint.MaxValue for a line
-        /// nobody is assigned to, which is an absence rather than an actor.
-        /// </summary>
-        private static uint? ActorIdOrNull(scnActorId? actorId) =>
-            actorId is null || actorId.Id == SceneActorOption.NoActorId ? null : actorId.Id;
-
-        /// <summary>
-        /// The scene's screenplay entry for a locstring, so one with no item id can be given one.
-        /// The first match wins, as everywhere else an import matches on locstring.
-        /// </summary>
-        private static scnscreenplayDialogLine? FindScreenplayLine(
-            IEnumerable<scnscreenplayDialogLine>? screenplayLines, ulong locStringId) =>
-            screenplayLines?.FirstOrDefault(
-                line => line?.LocstringId is not null && line.LocstringId.Ruid == locStringId);
-
-        /// <summary>
-        /// An entry's item id, or null where it has none a section could point at. A line added
-        /// through the raw chunk editor keeps the id its constructor writes, which is the one a
-        /// dialogue event means "points at nothing" by.
-        /// </summary>
-        private static uint? ItemIdOrNull(scnscreenplayItemId? itemId) =>
-            itemId is null || itemId.Id == SceneEditingHelper.UnassignedScreenplayItemId
-                ? null
-                : itemId.Id;
-
-        /// <summary>
         /// Locstring ids of a screenplay collection, as something an import can be checked against.
         /// </summary>
-        private static HashSet<ulong> GetLocStringIds(IEnumerable<scnlocLocstringId?>? locStringIds) =>
+        private static HashSet<CRUID> GetLocStringIds(IEnumerable<scnlocLocstringId?>? locStringIds) =>
             locStringIds?
                 .Where(locStringId => locStringId != null)
-                .Select(locStringId => (ulong)locStringId!.Ruid)
+                .Select(locStringId => locStringId!.Ruid)
                 .ToHashSet() ?? [];
 
         /// <summary>
         /// Embeds a line's text into the scene's locStore, as a payload entry plus the descriptor
         /// that points a locstring at it.
         /// </summary>
+        /// <param name="locStringId">Locstring id to describe.</param>
+        /// <param name="text">Text to embed.</param>
+        /// <param name="random">Random source for variant ids.</param>
         /// <param name="describedLocStrings">
         /// The locstrings the locStore already describes, which this adds to. Handed in rather than
         /// read from the store so that importing n lines does not walk it n times.
         /// </param>
         /// <returns>False when there was nothing to embed, or the locStore already describes this locstring.</returns>
-        private bool AddEmbeddedText(ulong locStringId, string text, Random random, HashSet<ulong> describedLocStrings)
+        private bool AddEmbeddedText(
+            CRUID locStringId, string text, Random random, HashSet<CRUID> describedLocStrings)
         {
             if (string.IsNullOrEmpty(text))
             {
@@ -1028,7 +970,7 @@ namespace WolvenKit.App.ViewModels.Documents
             // Create VdEntry (descriptor entry) linking locStringId to the payload with en_us locale
             _sceneData.LocStore.VdEntries.Add(new scnlocLocStoreEmbeddedVariantDescriptorEntry
             {
-                LocstringId = new scnlocLocstringId { Ruid = (CRUID)locStringId },
+                LocstringId = new scnlocLocstringId { Ruid = locStringId },
                 VariantId = new scnlocVariantId { Ruid = variantCruid },
                 VpeIndex = (uint)(_sceneData.LocStore.VpEntries.Count - 1),
                 Signature = new scnlocSignature { Val = 3 }, // gender mask: 1 = male, 2 = female, 3 = both

--- a/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
+++ b/WolvenKit.App/ViewModels/Documents/SceneGraphViewModel.cs
@@ -586,7 +586,8 @@ namespace WolvenKit.App.ViewModels.Documents
         /// <summary>
         /// Takes a dialogue export written by another tool - the Dialogue Browser CET mod writes
         /// one from its conversation panel - and adds its lines to the screenplay store, with
-        /// their embedded text and lipsync animations.
+        /// their embedded text and lipsync animations. Where the user asks for it, the same lines
+        /// are also laid out as a section node in the graph.
         /// </summary>
         [RelayCommand]
         private void ImportDialogue()
@@ -608,7 +609,7 @@ namespace WolvenKit.App.ViewModels.Documents
 
                 var dialog = Interactions.ShowDialogueImport(new DialogueImportDialogOptions(
                     FileName,
-                    existingLineLocStrings,
+                    GetExistingSceneLines(screenplayLines),
                     existingOptionLocStrings,
                     GetSceneActorOptions()));
 
@@ -641,15 +642,45 @@ namespace WolvenKit.App.ViewModels.Documents
                 var addedOptions = 0;
                 var addedTexts = 0;
                 var addedActors = 0;
+                var reusedLines = 0;
+                var repairedLines = 0;
                 var skipped = 0;
+
+                // The lines as a section plays them, gathered as they are dealt with so each is
+                // paired with the item id it actually plays. Empty when no section was asked for.
+                var sectionLines = new List<SectionDialogueLine>();
 
                 foreach (var selection in importedLines)
                 {
                     var line = selection.Line;
 
-                    // Checked again here rather than trusted from the dialog: its list was built
-                    // when it opened, and the same locstring must never end up with two screenplay
-                    // entries pointing at it.
+                    // Already in the scene, taken so a section can play the entry that is there.
+                    // Nothing is written for it - not the entry, and not its embedded text, which is
+                    // not this import's to change. An entry with no item id gets one, since an event
+                    // needs a target.
+                    if (selection.IsAlreadyInScene)
+                    {
+                        var itemId = selection.ExistingScreenplayLineId;
+
+                        if (itemId is null && FindScreenplayLine(screenplayLines, line.LocStringId) is { } entry)
+                        {
+                            entry.ItemId = new scnscreenplayItemId { Id = nextLineItemId };
+                            itemId = nextLineItemId;
+                            nextLineItemId += 256;
+                            repairedLines++;
+                        }
+
+                        if (itemId is { } id && dialog.CreateSectionNode)
+                        {
+                            sectionLines.Add(selection.ToSectionLine(id));
+                        }
+
+                        reusedLines++;
+                        continue;
+                    }
+
+                    // Checked again rather than trusted from the dialog, whose list was built when
+                    // it opened: one locstring must never get two screenplay entries.
                     var known = line.IsChoiceOption ? existingOptionLocStrings : existingLineLocStrings;
 
                     if (!known.Add(line.LocStringId))
@@ -710,6 +741,11 @@ namespace WolvenKit.App.ViewModels.Documents
 
                         screenplayLines.Add(dialogueLine);
 
+                        if (dialog.CreateSectionNode)
+                        {
+                            sectionLines.Add(selection.ToSectionLine(nextLineItemId));
+                        }
+
                         nextLineItemId += 256;
                         addedLines++;
                     }
@@ -720,7 +756,9 @@ namespace WolvenKit.App.ViewModels.Documents
                     }
                 }
 
-                if (addedLines == 0 && addedOptions == 0)
+                // Nothing written, nothing repaired and nothing to lay out: the import had no
+                // effect at all.
+                if (addedLines == 0 && addedOptions == 0 && repairedLines == 0 && sectionLines.Count == 0)
                 {
                     _logger?.Warning("Dialogue import: every line was already in the scene.");
                     return;
@@ -742,8 +780,8 @@ namespace WolvenKit.App.ViewModels.Documents
                     UpdateTabContent(SelectedTab);
                 }
 
-                // Auto-expand to show what came in. A payload can hold both, and both halves of the
-                // store are worth revealing when it does.
+                // Auto-expand to show what came in - both halves, where a payload held both. A run
+                // that only reused what was there reveals neither.
                 if (addedLines > 0)
                 {
                     ExpandToNewEntry("screenplayStore", "lines");
@@ -758,16 +796,96 @@ namespace WolvenKit.App.ViewModels.Documents
                 OnPropertyChanged(nameof(TotalDialogues));
                 OnPropertyChanged(nameof(TotalChoices));
 
+                var section = CreateSectionForImport(dialog, sectionLines);
+
+                // A run that wrote nothing to the store should not lead with "Imported 0 dialogue
+                // line(s)".
+                var wroteToStore = addedLines > 0 || addedOptions > 0;
+
                 _logger?.Success(
-                    $"Imported {addedLines} dialogue line(s)" +
-                    (addedOptions > 0 ? $" and {addedOptions} choice option(s)" : "") +
-                    (createEmbeddedText ? $", {addedTexts} with embedded text" : "") +
-                    (addedActors > 0 ? $", {addedActors} speaker/addressee assignment(s)" : "") +
+                    (wroteToStore
+                        ? $"Imported {addedLines} dialogue line(s)" +
+                          (addedOptions > 0 ? $" and {addedOptions} choice option(s)" : "") +
+                          (createEmbeddedText ? $", {addedTexts} with embedded text" : "") +
+                          (addedActors > 0 ? $", {addedActors} speaker/addressee assignment(s)" : "") +
+                          (reusedLines > 0 ? $". Reused {reusedLines} line(s) the scene already had" : "")
+                        : $"Reused {reusedLines} line(s) the scene already had, writing nothing to the " +
+                          "screenplay store") +
+                    (repairedLines > 0
+                        ? $". Gave an item id to {repairedLines} existing screenplay entr" +
+                          (repairedLines == 1 ? "y" : "ies")
+                        : "") +
+                    (section is not null
+                        ? $". Section node created, running {section.DurationMs}ms" +
+                          $" over {section.ActorCount} actor(s)"
+                        : "") +
                     (skipped > 0 ? $". Skipped {skipped} already in the scene" : ""));
             }
             catch (Exception ex)
             {
                 _logger?.Error($"Failed to import dialogue: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Lays an import out as a section node in the graph, where the user asked for one.
+        /// </summary>
+        /// <param name="lines">
+        /// The lines, each already carrying the item id it plays. Empty for an import of nothing but
+        /// choice options, since an option is picked rather than played.
+        /// </param>
+        /// <returns>What was built, or null where nothing was.</returns>
+        private BuiltDialogueSection? CreateSectionForImport(
+            DialogueImportDialogViewModel dialog,
+            List<SectionDialogueLine> lines)
+        {
+            if (!dialog.CreateSectionNode)
+            {
+                return null;
+            }
+
+            if (lines.Count == 0)
+            {
+                _logger?.Warning(
+                    "Dialogue import: nothing to lay out as a section - a choice option is picked, not played.");
+                return null;
+            }
+
+            try
+            {
+                var section = SceneSectionBuilder.Build(lines);
+
+                MainGraph.AddSceneNode(
+                    section.Node,
+                    MainGraph.GetFreeCanvasPoint(),
+                    SceneSectionBuilder.GetNotablePointName(dialog.ConversationName));
+
+                OnPropertyChanged(nameof(TotalNodes));
+
+                if (section.EstimatedDurationCount > 0)
+                {
+                    _logger?.Info(
+                        $"Dialogue import: the export gave no length for {section.EstimatedDurationCount} " +
+                        "line(s), so the section estimated them from their text. Check them on the timeline.");
+                }
+
+                // An export with no start times loses the original conversation's pacing, which is
+                // worth saying before the user wonders where it went.
+                if (section.PlacedByExportCount < lines.Count)
+                {
+                    _logger?.Info(
+                        $"Dialogue import: the export placed {section.PlacedByExportCount} of {lines.Count} " +
+                        "line(s) on its own timeline; the rest were laid end to end. A newer Dialogue " +
+                        "Browser exports the conversation's own timings.");
+                }
+
+                return section;
+            }
+            catch (Exception ex)
+            {
+                // The lines are in the store either way; only the section is lost.
+                _logger?.Error($"Imported the lines, but could not lay them out as a section: {ex.Message}");
+                return null;
             }
         }
 
@@ -804,6 +922,67 @@ namespace WolvenKit.App.ViewModels.Documents
 
             return actors;
         }
+
+        /// <summary>
+        /// The screenplay lines the scene already carries: matched against an import by locstring,
+        /// and carrying the item id and actors a section needs to play one.
+        /// </summary>
+        private static List<ExistingSceneLine> GetExistingSceneLines(
+            IEnumerable<scnscreenplayDialogLine>? screenplayLines)
+        {
+            var lines = new List<ExistingSceneLine>();
+
+            if (screenplayLines is null)
+            {
+                return lines;
+            }
+
+            foreach (var line in screenplayLines)
+            {
+                // An entry with no item id is still carried, so an import matching its locstring is
+                // recognised as a duplicate rather than written again.
+                if (line?.LocstringId is null)
+                {
+                    continue;
+                }
+
+                lines.Add(new ExistingSceneLine
+                {
+                    LocStringId = line.LocstringId.Ruid,
+                    ScreenplayLineId = ItemIdOrNull(line.ItemId),
+                    SpeakerActorId = ActorIdOrNull(line.Speaker),
+                    AddresseeActorId = ActorIdOrNull(line.Addressee)
+                });
+            }
+
+            return lines;
+        }
+
+        /// <summary>
+        /// An entry's actor, or null where it names none. A scene writes uint.MaxValue for a line
+        /// nobody is assigned to, which is an absence rather than an actor.
+        /// </summary>
+        private static uint? ActorIdOrNull(scnActorId? actorId) =>
+            actorId is null || actorId.Id == SceneActorOption.NoActorId ? null : actorId.Id;
+
+        /// <summary>
+        /// The scene's screenplay entry for a locstring, so one with no item id can be given one.
+        /// The first match wins, as everywhere else an import matches on locstring.
+        /// </summary>
+        private static scnscreenplayDialogLine? FindScreenplayLine(
+            IEnumerable<scnscreenplayDialogLine>? screenplayLines, ulong locStringId) =>
+            screenplayLines?.FirstOrDefault(
+                line => line?.LocstringId is not null && line.LocstringId.Ruid == locStringId);
+
+        /// <summary>
+        /// An entry's item id, or null where it has none a section could point at. A line added
+        /// through the raw chunk editor keeps the id its constructor writes, which is the one a
+        /// dialogue event means "points at nothing" by.
+        /// </summary>
+        private static uint? ItemIdOrNull(scnscreenplayItemId? itemId) =>
+            itemId is null || itemId.Id == SceneEditingHelper.UnassignedScreenplayItemId
+                ? null
+                : itemId.Id;
 
         /// <summary>
         /// Locstring ids of a screenplay collection, as something an import can be checked against.

--- a/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
+++ b/WolvenKit.App/ViewModels/GraphEditor/RedGraph.Scene.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -85,6 +85,75 @@ public partial class RedGraph
         DocumentViewModel?.SetIsDirty(true);
 
         return instance.NodeId.Id;
+    }
+
+    /// <summary>
+    /// Puts a node somebody else built into the graph: gives it an id, names it in the scene's
+    /// notable points, and wraps it for the canvas.
+    /// </summary>
+    /// <param name="node">The node, filled in but for its id, which is overwritten here.</param>
+    /// <param name="notablePointName">
+    /// A name to list the node under in the scene's notable points, which the canvas shows on the
+    /// node's marker bar. Null for a node not worth marking.
+    /// </param>
+    /// <returns>The node's wrapper, already on the canvas.</returns>
+    public BaseSceneViewModel AddSceneNode(scnSceneGraphNode node, System.Windows.Point point, string? notablePointName = null)
+    {
+        var sceneResource = (scnSceneResource)_data;
+
+        var nodeId = GetNextAvailableSceneNodeId();
+        node.NodeId = new scnNodeId { Id = nodeId };
+        _currentSceneNodeId = Math.Max(_currentSceneNodeId, nodeId);
+
+        // Before the wrapper: a wrapper reads its notable point once, when it is built.
+        if (!string.IsNullOrWhiteSpace(notablePointName))
+        {
+            sceneResource.NotablePoints.Add(new scnNotablePoint
+            {
+                Name = notablePointName,
+                NodeId = new scnNodeId { Id = nodeId }
+            });
+
+            RefreshSpecificProperties("notablePoints");
+        }
+
+        var wrappedInstance = WrapSceneNode(node);
+        wrappedInstance.Location = point;
+
+        sceneResource.SceneGraph.Chunk!.Graph.Add(new CHandle<scnSceneGraphNode>(node));
+
+        if (GetSceneNodesChunkViewModel() is { } nodes)
+        {
+            nodes.RecalculateProperties();
+        }
+
+        Nodes.Add(wrappedInstance);
+
+        DocumentViewModel?.SetIsDirty(true);
+
+        return wrappedInstance;
+    }
+
+    /// <summary>
+    /// Somewhere to put a new node without landing on an existing one: off the right edge of
+    /// everything already on the canvas.
+    /// </summary>
+    public System.Windows.Point GetFreeCanvasPoint()
+    {
+        const double spacing = 200;
+
+        // A node the canvas has not laid out yet measures 0 wide, so assume a plausible width -
+        // the same floor the comment boxes use.
+        const double assumedNodeWidth = 260;
+
+        if (Nodes.Count == 0)
+        {
+            return new System.Windows.Point();
+        }
+
+        return new System.Windows.Point(
+            Nodes.Max(node => node.Location.X + Math.Max(node.Size.Width, assumedNodeWidth)) + spacing,
+            Nodes.Min(node => node.Location.Y));
     }
 
     private scnSceneGraphNode InternalCreateSceneNode(Type type, RedTypeTemplateSelectionOption? templateDesc = null)

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
@@ -524,9 +524,11 @@
                             </TextBlock>
                         </StackPanel>
 
-                        <StackPanel Grid.Column="2">
+                        <StackPanel
+                            Grid.Column="2"
+                            HorizontalAlignment="Right">
                             <CheckBox
-                                HorizontalAlignment="Right"
+                                HorizontalAlignment="Left"
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
                                 Content="Embed the text into the scene"
                                 ToolTip="Writes each line's subtitle into the scene's locStore"
@@ -534,7 +536,7 @@
 
                             <CheckBox
                                 Margin="{DynamicResource WolvenKitMarginTinyTop}"
-                                HorizontalAlignment="Right"
+                                HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontSize="{DynamicResource WolvenKitFontSubTitle}"
                                 Content="Create a section node"

--- a/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
+++ b/WolvenKit/Views/Dialogs/DialogueImportDialogView.xaml
@@ -1,4 +1,4 @@
-<Window
+﻿<Window
     x:Class="WolvenKit.Views.Dialogs.DialogueImportDialogView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -372,8 +372,9 @@
                                         <ColumnDefinition Width="Auto" SharedSizeGroup="Status" />
                                     </Grid.ColumnDefinitions>
 
-                                    <!-- A duplicate cannot be taken, so its box is locked rather
-                                         than merely cleared -->
+                                    <!-- A line the scene already has can still be taken, for a
+                                         section to play; a choice option cannot, so that box is
+                                         locked rather than merely cleared -->
                                     <CheckBox
                                         Grid.Column="0"
                                         Width="24"
@@ -381,7 +382,8 @@
                                         IsChecked="{Binding IsSelected,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
-                                        IsEnabled="{Binding CanImport}" />
+                                        IsEnabled="{Binding CanImport}"
+                                        ToolTip="{Binding StatusToolTip}" />
 
                                     <TextBlock
                                         Grid.Column="1"
@@ -442,7 +444,8 @@
                                     <TextBlock
                                         Grid.Column="6"
                                         Width="110"
-                                        Text="{Binding Status}">
+                                        Text="{Binding Status}"
+                                        ToolTip="{Binding StatusToolTip}">
                                         <TextBlock.Style>
                                             <Style
                                                 BasedOn="{StaticResource ImportCellStyle}"
@@ -490,29 +493,54 @@
                                 Command="{Binding SelectNoneCommand}" />
                         </StackPanel>
 
-                        <TextBlock
+                        <StackPanel
                             Grid.Column="1"
                             Margin="{DynamicResource WolvenKitMarginTinyRight}"
                             VerticalAlignment="Center"
-                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                            Foreground="{DynamicResource ForegroundColor_Grey_Dark}"
                             Visibility="{Binding HasEntries,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}">
-                            <Run Text="{Binding SelectedCount, Mode=OneWay}" />
-                            <Run Text="of" />
-                            <Run Text="{Binding EntryCount, Mode=OneWay}" />
-                            <Run Text="selected," />
-                            <Run Text="{Binding DuplicateCount, Mode=OneWay}" />
-                            <Run Text="already in the scene" />
-                        </TextBlock>
+                            <TextBlock
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Foreground="{DynamicResource ForegroundColor_Grey_Dark}">
+                                <Run Text="{Binding SelectedCount, Mode=OneWay}" />
+                                <Run Text="of" />
+                                <Run Text="{Binding EntryCount, Mode=OneWay}" />
+                                <Run Text="selected," />
+                                <Run Text="{Binding SelectedNewCount, Mode=OneWay}" />
+                                <Run Text="to import," />
+                                <Run Text="{Binding DuplicateCount, Mode=OneWay}" />
+                                <Run Text="already in the scene" />
+                            </TextBlock>
 
-                        <CheckBox
-                            Grid.Column="2"
-                            VerticalAlignment="Center"
-                            FontSize="{DynamicResource WolvenKitFontSubTitle}"
-                            Content="Embed the text into the scene"
-                            ToolTip="Writes each line's subtitle into the scene's locStore, the way the Add Dialogue button does"
-                            IsChecked="{Binding CreateEmbeddedText}" />
+                            <!-- Taking a line the scene already has writes nothing on its own, so
+                                 what makes it worth taking is spelled out here -->
+                            <TextBlock
+                                Style="{StaticResource ImportHintStyle}"
+                                Foreground="{DynamicResource WolvenKitYellow}"
+                                Visibility="{Binding HasSectionOnlySelection,
+                                                     Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Run Text="{Binding SelectedExistingCount, Mode=OneWay}" />
+                                <Run Text="already in the scene - not imported again, only played by the section" />
+                            </TextBlock>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <CheckBox
+                                HorizontalAlignment="Right"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Content="Embed the text into the scene"
+                                ToolTip="Writes each line's subtitle into the scene's locStore"
+                                IsChecked="{Binding CreateEmbeddedText}" />
+
+                            <CheckBox
+                                Margin="{DynamicResource WolvenKitMarginTinyTop}"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                FontSize="{DynamicResource WolvenKitFontSubTitle}"
+                                Content="Create a section node"
+                                ToolTip="Adds a section node to the graph that plays the imported lines"
+                                IsChecked="{Binding CreateSectionNode}" />
+                        </StackPanel>
                     </Grid>
                 </Grid>
             </syncfusion:WizardPage>

--- a/changelog/unreleased/3159.yaml
+++ b/changelog/unreleased/3159.yaml
@@ -1,0 +1,6 @@
+changes:
+    - type: "added"
+      packages: ["App"]
+      pr-number: 3159
+      author: "Akiway"
+      description: "Importing a dialogue in the Scene Editor now creates a section node in the scene graph."


### PR DESCRIPTION
# Scene Editor: Import dialogue creates section node

**Implemented :**
- Importing dialogues now creates a pre-filled section node (optional, enabled by default)

**Changed :** 
- Import format changed (v1 -> v2) :
  - Added property `startTime` to dialogue lines
  - Durations properties are now in milliseconds (they were in seconds before)


https://github.com/user-attachments/assets/c5b4d932-7272-41de-a304-034c4dff2163

