### PR TITLE
Disable hardware enforced stack protection

### DIFF
--- a/WolvenKit/WolvenKit.csproj
+++ b/WolvenKit/WolvenKit.csproj
@@ -18,6 +18,7 @@
     <Product>WolvenKit</Product>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Nullable>Disable</Nullable>
+    <CetCompat>false</CetCompat>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Disable hardware enforced stack protection

This disables cet / amd shadow stacks which were enabled by default as part of the .net10 upgrade to maintain mo2 compatibility out of the box.
With these protections enabled wolvenkit simply doesn't launch when run through mo2 which is rightfully very confusing to the end users.
As there is no place in that lifetime to communicate to the end user why it failed to launch and hardware enforced stack protections not being critical to our security model disabling it is the best approach.